### PR TITLE
Add multi-backend RHI abstraction layer with Vulkan/OpenGL support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ option(ENABLE_TERRAIN_SYSTEM "Enable terrain system" ON)
 option(ENABLE_POST_PROCESSING "Enable post-processing effects" ON)
 option(ENABLE_LIGHTING_SYSTEM "Enable advanced lighting" ON)
 option(ENABLE_ADVANCED_INPUT "Enable advanced input features" ON)
+option(ENABLE_VULKAN "Enable Vulkan graphics backend" ON)
+option(ENABLE_OPENGL "Enable OpenGL graphics backend" ON)
 
 # ---------------------------------------------------------------------
 # 4) C++ standard and in-source build guard
@@ -155,6 +157,83 @@ if(TINYOBJLOADER_INCLUDE_DIR)
 else()
     set(TINYOBJ_FOUND FALSE)
     message(WARNING "TinyObjLoader not found")
+endif()
+
+# ---------------------------------------------------------------------
+# 7.5) Graphics API backend detection (Vulkan, OpenGL)
+# ---------------------------------------------------------------------
+
+# --- Vulkan ---
+if(ENABLE_VULKAN)
+    find_package(Vulkan QUIET)
+    if(Vulkan_FOUND)
+        set(SPARK_VULKAN_AVAILABLE TRUE)
+        message(STATUS "Vulkan found: ${Vulkan_LIBRARY}")
+        message(STATUS "Vulkan include: ${Vulkan_INCLUDE_DIR}")
+    else()
+        # Check for Vulkan SDK via environment variable
+        if(DEFINED ENV{VULKAN_SDK})
+            set(Vulkan_INCLUDE_DIR "$ENV{VULKAN_SDK}/Include")
+            if(WIN32)
+                set(Vulkan_LIBRARY "$ENV{VULKAN_SDK}/Lib/vulkan-1.lib")
+            else()
+                set(Vulkan_LIBRARY "$ENV{VULKAN_SDK}/lib/libvulkan.so")
+            endif()
+            if(EXISTS "${Vulkan_INCLUDE_DIR}" AND EXISTS "${Vulkan_LIBRARY}")
+                set(SPARK_VULKAN_AVAILABLE TRUE)
+                message(STATUS "Vulkan SDK found via environment: $ENV{VULKAN_SDK}")
+            else()
+                set(SPARK_VULKAN_AVAILABLE FALSE)
+                message(STATUS "Vulkan SDK path set but libraries not found")
+            endif()
+        else()
+            set(SPARK_VULKAN_AVAILABLE FALSE)
+            message(STATUS "Vulkan not found - Vulkan backend disabled")
+        endif()
+    endif()
+else()
+    set(SPARK_VULKAN_AVAILABLE FALSE)
+    message(STATUS "Vulkan backend disabled by option")
+endif()
+
+# --- OpenGL ---
+if(ENABLE_OPENGL)
+    find_package(OpenGL QUIET)
+    if(OpenGL_FOUND)
+        set(SPARK_OPENGL_AVAILABLE TRUE)
+        message(STATUS "OpenGL found: ${OPENGL_gl_LIBRARY}")
+    else()
+        set(SPARK_OPENGL_AVAILABLE FALSE)
+        message(STATUS "OpenGL not found - OpenGL backend disabled")
+    endif()
+
+    # Look for GLAD loader in ThirdParty
+    find_path(GLAD_INCLUDE_DIR
+        NAMES glad/glad.h
+        PATHS
+            "${CMAKE_SOURCE_DIR}/ThirdParty/glad/include"
+            "${CMAKE_SOURCE_DIR}/ThirdParty/Graphics/glad/include"
+            "${CMAKE_SOURCE_DIR}/ThirdParty/OpenGL/glad/include"
+        DOC "GLAD include directory"
+    )
+    find_path(GLAD_SOURCE_DIR
+        NAMES glad.c
+        PATHS
+            "${CMAKE_SOURCE_DIR}/ThirdParty/glad/src"
+            "${CMAKE_SOURCE_DIR}/ThirdParty/Graphics/glad/src"
+            "${CMAKE_SOURCE_DIR}/ThirdParty/OpenGL/glad/src"
+        DOC "GLAD source directory"
+    )
+    if(GLAD_INCLUDE_DIR AND GLAD_SOURCE_DIR)
+        set(GLAD_FOUND TRUE)
+        message(STATUS "GLAD found at: ${GLAD_INCLUDE_DIR}")
+    else()
+        set(GLAD_FOUND FALSE)
+        message(STATUS "GLAD not found - OpenGL loader unavailable (download GLAD for OpenGL support)")
+    endif()
+else()
+    set(SPARK_OPENGL_AVAILABLE FALSE)
+    message(STATUS "OpenGL backend disabled by option")
 endif()
 
 # ---------------------------------------------------------------------
@@ -267,6 +346,36 @@ foreach(SHADER_FILE ${SHADER_FILES})
     )
 endforeach()
 
+# Copy GLSL shaders to output directory
+if(EXISTS "${CMAKE_SOURCE_DIR}/Shaders/GLSL")
+    file(GLOB GLSL_SHADER_FILES "${CMAKE_SOURCE_DIR}/Shaders/GLSL/*.glsl")
+    foreach(SHADER_FILE ${GLSL_SHADER_FILES})
+        get_filename_component(SHADER_NAME ${SHADER_FILE} NAME)
+        add_custom_command(TARGET SparkEngine POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:SparkEngine>/Shaders/GLSL"
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                ${SHADER_FILE}
+                "$<TARGET_FILE_DIR:SparkEngine>/Shaders/GLSL/${SHADER_NAME}"
+            COMMENT "Copying GLSL shader ${SHADER_NAME}"
+        )
+    endforeach()
+endif()
+
+# Copy SPIR-V compiled shaders to output directory
+if(EXISTS "${CMAKE_SOURCE_DIR}/Shaders/SPIRV")
+    file(GLOB SPIRV_SHADER_FILES "${CMAKE_SOURCE_DIR}/Shaders/SPIRV/*.spv")
+    foreach(SHADER_FILE ${SPIRV_SHADER_FILES})
+        get_filename_component(SHADER_NAME ${SHADER_FILE} NAME)
+        add_custom_command(TARGET SparkEngine POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:SparkEngine>/Shaders/SPIRV"
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                ${SHADER_FILE}
+                "$<TARGET_FILE_DIR:SparkEngine>/Shaders/SPIRV/${SHADER_NAME}"
+            COMMENT "Copying SPIR-V shader ${SHADER_NAME}"
+        )
+    endforeach()
+endif()
+
 # Exclude shader files from automatic compilation by setting them as None instead of FxCompile
 file(GLOB_RECURSE ALL_SHADER_FILES "*.hlsl")
 set_source_files_properties(${ALL_SHADER_FILES} PROPERTIES
@@ -308,6 +417,36 @@ target_link_libraries(SparkEngine PRIVATE
 # Add legacy stdio for compatibility
 if(MSVC)
     target_link_libraries(SparkEngine PRIVATE legacy_stdio_definitions)
+endif()
+
+# --- Vulkan backend libraries ---
+if(SPARK_VULKAN_AVAILABLE)
+    target_compile_definitions(SparkEngine PRIVATE SPARK_VULKAN_SUPPORT)
+    if(Vulkan_FOUND)
+        target_link_libraries(SparkEngine PRIVATE Vulkan::Vulkan)
+    else()
+        target_include_directories(SparkEngine PRIVATE ${Vulkan_INCLUDE_DIR})
+        target_link_libraries(SparkEngine PRIVATE ${Vulkan_LIBRARY})
+    endif()
+    message(STATUS "SparkEngine: Vulkan backend ENABLED")
+endif()
+
+# --- OpenGL backend libraries ---
+if(SPARK_OPENGL_AVAILABLE)
+    target_compile_definitions(SparkEngine PRIVATE SPARK_OPENGL_SUPPORT)
+    target_link_libraries(SparkEngine PRIVATE OpenGL::GL)
+
+    if(GLAD_FOUND)
+        # Build GLAD as a static library
+        add_library(glad STATIC "${GLAD_SOURCE_DIR}/glad.c")
+        target_include_directories(glad PUBLIC "${GLAD_INCLUDE_DIR}")
+        if(MSVC)
+            set_property(TARGET glad PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+        endif()
+        target_link_libraries(SparkEngine PRIVATE glad)
+    endif()
+
+    message(STATUS "SparkEngine: OpenGL backend ENABLED")
 endif()
 
 # ---------------------------------------------------------------------
@@ -393,6 +532,14 @@ if(ENABLE_ADVANCED_INPUT)
     list(APPEND FEATURE_DEFINITIONS "ADVANCED_INPUT_ENABLED")
 endif()
 
+if(SPARK_VULKAN_AVAILABLE)
+    list(APPEND FEATURE_DEFINITIONS "VULKAN_BACKEND_AVAILABLE")
+endif()
+
+if(SPARK_OPENGL_AVAILABLE)
+    list(APPEND FEATURE_DEFINITIONS "OPENGL_BACKEND_AVAILABLE")
+endif()
+
 # Apply feature definitions to target
 if(FEATURE_DEFINITIONS)
     target_compile_definitions(SparkEngine PRIVATE ${FEATURE_DEFINITIONS})
@@ -426,7 +573,18 @@ if(MSVC)
     source_group("Assets\\\\Config" FILES "*.ini" "*.json" "*.cfg" "*.xml" "*.properties")
 endif()
 
-message(STATUS "SPARKENGINE CONFIGURED SUCCESSFULLY")
-message(STATUS "SparkEngine and SparkConsole will be built to: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
-message(STATUS "Networking is ${ENABLE_NETWORKING} (disabled to avoid CURL linking issues)")
-message(STATUS "All hacky configurations have been removed and replaced with proper CMake practices")
+message(STATUS "=== SPARKENGINE CONFIGURED SUCCESSFULLY ===")
+message(STATUS "Output: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+message(STATUS "Graphics Backends:")
+message(STATUS "  DirectX 11 : ENABLED (always on Windows)")
+if(SPARK_VULKAN_AVAILABLE)
+    message(STATUS "  Vulkan     : ENABLED")
+else()
+    message(STATUS "  Vulkan     : DISABLED")
+endif()
+if(SPARK_OPENGL_AVAILABLE)
+    message(STATUS "  OpenGL     : ENABLED")
+else()
+    message(STATUS "  OpenGL     : DISABLED")
+endif()
+message(STATUS "Networking: ${ENABLE_NETWORKING}")

--- a/Shaders/GLSL/BasicPS.glsl
+++ b/Shaders/GLSL/BasicPS.glsl
@@ -1,0 +1,245 @@
+/**
+ * BasicPS.glsl - Basic Pixel/Fragment Shader (OpenGL/Vulkan GLSL equivalent of HLSL BasicPS)
+ * Spark Engine - Cross-platform shader
+ *
+ * GLSL 460 Core with PBR lighting support.
+ * Matches the HLSL BasicPS.hlsl constant buffer layout.
+ */
+#version 460 core
+
+// ============================================================================
+// FRAGMENT INPUT (from vertex shader)
+// ============================================================================
+layout(location = 0) in vec3 fragWorldPos;
+layout(location = 1) in vec3 fragNormal;
+layout(location = 2) in vec2 fragTexCoord;
+layout(location = 3) in vec3 fragViewDir;
+layout(location = 4) in vec4 fragPrevClipPos;
+
+// ============================================================================
+// FRAGMENT OUTPUT
+// ============================================================================
+layout(location = 0) out vec4 outColor;
+
+// ============================================================================
+// UNIFORM BUFFERS
+// ============================================================================
+
+// Per-Frame Constants (b0)
+layout(std140, binding = 0) uniform PerFrameConstants
+{
+    mat4 u_ViewMatrix;
+    mat4 u_ProjectionMatrix;
+    mat4 u_ViewProjectionMatrix;
+    vec3 u_CameraPosition;
+    float u_Time;
+    vec3 u_CameraDirection;
+    float u_DeltaTime;
+    vec2 u_ScreenResolution;
+    vec2 u_InvScreenResolution;
+
+    vec3 u_DirectionalLightDir;
+    float u_DirectionalLightIntensity;
+    vec3 u_DirectionalLightColor;
+    float u_AmbientIntensity;
+    vec3 u_AmbientColor;
+    float _padding1;
+};
+
+// Per-Object Constants (b1)
+layout(std140, binding = 1) uniform PerObjectConstants
+{
+    mat4 u_WorldMatrix;
+    mat4 u_WorldViewProjectionMatrix;
+    mat4 u_WorldInverseTransposeMatrix;
+    mat4 u_PreviousWorldMatrix;
+    vec3 u_ObjectPosition;
+    float u_ObjectScale;
+    vec4 u_ObjectColor;
+    vec4 u_MaterialProperties;
+    vec4 u_UVTiling;
+};
+
+// Per-Material Constants (b2)
+layout(std140, binding = 2) uniform PerMaterialConstants
+{
+    vec4 u_AlbedoColor;
+    float u_MetallicFactor;
+    float u_RoughnessFactor;
+    float u_NormalScale;
+    float u_OcclusionStrength;
+    float u_EmissiveFactor;
+    float u_AlphaCutoff;
+    vec2 _materialPadding;
+};
+
+// ============================================================================
+// TEXTURE SAMPLERS
+// ============================================================================
+layout(binding = 0) uniform sampler2D u_AlbedoTexture;
+layout(binding = 1) uniform sampler2D u_NormalTexture;
+layout(binding = 2) uniform sampler2D u_MetallicRoughnessTexture;
+layout(binding = 3) uniform sampler2D u_OcclusionTexture;
+layout(binding = 4) uniform sampler2D u_EmissiveTexture;
+
+// ============================================================================
+// PBR CONSTANTS
+// ============================================================================
+const float PI = 3.14159265359;
+const float EPSILON = 0.0001;
+const vec3 F0_DIELECTRIC = vec3(0.04);
+
+// ============================================================================
+// PBR FUNCTIONS
+// ============================================================================
+
+// Normal Distribution Function (GGX/Trowbridge-Reitz)
+float DistributionGGX(vec3 N, vec3 H, float roughness)
+{
+    float a = roughness * roughness;
+    float a2 = a * a;
+    float NdotH = max(dot(N, H), 0.0);
+    float NdotH2 = NdotH * NdotH;
+
+    float denom = NdotH2 * (a2 - 1.0) + 1.0;
+    denom = PI * denom * denom;
+
+    return a2 / max(denom, EPSILON);
+}
+
+// Geometry Function (Schlick-GGX)
+float GeometrySchlickGGX(float NdotV, float roughness)
+{
+    float r = roughness + 1.0;
+    float k = (r * r) / 8.0;
+    return NdotV / (NdotV * (1.0 - k) + k);
+}
+
+// Smith's method for geometry
+float GeometrySmith(vec3 N, vec3 V, vec3 L, float roughness)
+{
+    float NdotV = max(dot(N, V), 0.0);
+    float NdotL = max(dot(N, L), 0.0);
+    return GeometrySchlickGGX(NdotV, roughness) * GeometrySchlickGGX(NdotL, roughness);
+}
+
+// Fresnel (Schlick approximation)
+vec3 FresnelSchlick(float cosTheta, vec3 F0)
+{
+    return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+}
+
+// Fresnel with roughness for IBL
+vec3 FresnelSchlickRoughness(float cosTheta, vec3 F0, float roughness)
+{
+    return F0 + (max(vec3(1.0 - roughness), F0) - F0) *
+           pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+}
+
+// ============================================================================
+// NORMAL MAPPING
+// ============================================================================
+vec3 GetNormalFromMap()
+{
+    vec3 tangentNormal = texture(u_NormalTexture, fragTexCoord).xyz * 2.0 - 1.0;
+
+    // Calculate TBN matrix from derivatives
+    vec3 Q1 = dFdx(fragWorldPos);
+    vec3 Q2 = dFdy(fragWorldPos);
+    vec2 st1 = dFdx(fragTexCoord);
+    vec2 st2 = dFdy(fragTexCoord);
+
+    vec3 N = normalize(fragNormal);
+    vec3 T = normalize(Q1 * st2.t - Q2 * st1.t);
+    vec3 B = -normalize(cross(N, T));
+    mat3 TBN = mat3(T, B, N);
+
+    return normalize(TBN * (tangentNormal * vec3(u_NormalScale, u_NormalScale, 1.0)));
+}
+
+// ============================================================================
+// TONEMAPPING
+// ============================================================================
+vec3 ACESFilm(vec3 x)
+{
+    float a = 2.51;
+    float b = 0.03;
+    float c = 2.43;
+    float d = 0.59;
+    float e = 0.14;
+    return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0, 1.0);
+}
+
+// ============================================================================
+// MAIN FRAGMENT SHADER
+// ============================================================================
+void main()
+{
+    // Sample textures
+    vec4 albedoSample = texture(u_AlbedoTexture, fragTexCoord);
+    vec3 albedo = albedoSample.rgb * u_AlbedoColor.rgb * u_ObjectColor.rgb;
+    float alpha = albedoSample.a * u_AlbedoColor.a * u_ObjectColor.a;
+
+    // Alpha cutoff test
+    if (alpha < u_AlphaCutoff)
+        discard;
+
+    // PBR properties
+    float metallic = u_MetallicFactor * u_MaterialProperties.x;
+    float roughness = u_RoughnessFactor * u_MaterialProperties.y;
+    float ao = texture(u_OcclusionTexture, fragTexCoord).r * u_OcclusionStrength;
+
+    // Normals
+    vec3 N = GetNormalFromMap();
+    vec3 V = normalize(fragViewDir);
+
+    // Calculate F0 (reflectance at normal incidence)
+    vec3 F0 = mix(F0_DIELECTRIC, albedo, metallic);
+
+    // ========================================================================
+    // DIRECT LIGHTING (Directional Light)
+    // ========================================================================
+    vec3 Lo = vec3(0.0);
+
+    vec3 L = normalize(-u_DirectionalLightDir);
+    vec3 H = normalize(V + L);
+    vec3 radiance = u_DirectionalLightColor * u_DirectionalLightIntensity;
+
+    // Cook-Torrance BRDF
+    float NDF = DistributionGGX(N, H, roughness);
+    float G = GeometrySmith(N, V, L, roughness);
+    vec3 F = FresnelSchlick(max(dot(H, V), 0.0), F0);
+
+    vec3 numerator = NDF * G * F;
+    float denominator = 4.0 * max(dot(N, V), 0.0) * max(dot(N, L), 0.0) + EPSILON;
+    vec3 specular = numerator / denominator;
+
+    // Energy conservation
+    vec3 kS = F;
+    vec3 kD = (1.0 - kS) * (1.0 - metallic);
+
+    float NdotL = max(dot(N, L), 0.0);
+    Lo += (kD * albedo / PI + specular) * radiance * NdotL;
+
+    // ========================================================================
+    // AMBIENT LIGHTING
+    // ========================================================================
+    vec3 ambient = u_AmbientColor * u_AmbientIntensity * albedo * ao;
+
+    // Emissive
+    vec3 emissive = texture(u_EmissiveTexture, fragTexCoord).rgb *
+                    u_EmissiveFactor * u_MaterialProperties.z;
+
+    // ========================================================================
+    // FINAL COLOR
+    // ========================================================================
+    vec3 color = ambient + Lo + emissive;
+
+    // Tone mapping (ACES)
+    color = ACESFilm(color);
+
+    // Gamma correction
+    color = pow(color, vec3(1.0 / 2.2));
+
+    outColor = vec4(color, alpha);
+}

--- a/Shaders/GLSL/BasicVS.glsl
+++ b/Shaders/GLSL/BasicVS.glsl
@@ -1,0 +1,89 @@
+/**
+ * BasicVS.glsl - Basic Vertex Shader (OpenGL/Vulkan GLSL equivalent of HLSL BasicVS)
+ * Spark Engine - Cross-platform shader
+ *
+ * GLSL 460 Core with Vulkan SPIR-V compatibility.
+ * Matches the HLSL BasicVS.hlsl constant buffer layout.
+ */
+#version 460 core
+
+// ============================================================================
+// VERTEX INPUT
+// ============================================================================
+layout(location = 0) in vec3 inPosition;
+layout(location = 1) in vec3 inNormal;
+layout(location = 2) in vec2 inTexCoord;
+
+// ============================================================================
+// VERTEX OUTPUT
+// ============================================================================
+layout(location = 0) out vec3 fragWorldPos;
+layout(location = 1) out vec3 fragNormal;
+layout(location = 2) out vec2 fragTexCoord;
+layout(location = 3) out vec3 fragViewDir;
+layout(location = 4) out vec4 fragPrevClipPos;
+
+// ============================================================================
+// UNIFORM BUFFERS (matching HLSL constant buffer slots)
+// ============================================================================
+
+// Per-Frame Constants (b0)
+layout(std140, binding = 0) uniform PerFrameConstants
+{
+    mat4 u_ViewMatrix;
+    mat4 u_ProjectionMatrix;
+    mat4 u_ViewProjectionMatrix;
+    vec3 u_CameraPosition;
+    float u_Time;
+    vec3 u_CameraDirection;
+    float u_DeltaTime;
+    vec2 u_ScreenResolution;
+    vec2 u_InvScreenResolution;
+
+    // Lighting parameters
+    vec3 u_DirectionalLightDir;
+    float u_DirectionalLightIntensity;
+    vec3 u_DirectionalLightColor;
+    float u_AmbientIntensity;
+    vec3 u_AmbientColor;
+    float _padding1;
+};
+
+// Per-Object Constants (b1)
+layout(std140, binding = 1) uniform PerObjectConstants
+{
+    mat4 u_WorldMatrix;
+    mat4 u_WorldViewProjectionMatrix;
+    mat4 u_WorldInverseTransposeMatrix;
+    mat4 u_PreviousWorldMatrix;
+    vec3 u_ObjectPosition;
+    float u_ObjectScale;
+    vec4 u_ObjectColor;
+    vec4 u_MaterialProperties;  // x: metallic, y: roughness, z: emissive, w: alpha
+    vec4 u_UVTiling;            // xy: tiling, zw: offset
+};
+
+// ============================================================================
+// MAIN VERTEX SHADER
+// ============================================================================
+void main()
+{
+    // Transform position to world space
+    vec4 worldPos = u_WorldMatrix * vec4(inPosition, 1.0);
+    fragWorldPos = worldPos.xyz;
+
+    // Transform position to clip space
+    gl_Position = u_WorldViewProjectionMatrix * vec4(inPosition, 1.0);
+
+    // Transform normal to world space (using inverse transpose for non-uniform scaling)
+    fragNormal = normalize(mat3(u_WorldInverseTransposeMatrix) * inNormal);
+
+    // Apply UV tiling and offset
+    fragTexCoord = inTexCoord * u_UVTiling.xy + u_UVTiling.zw;
+
+    // Calculate view direction
+    fragViewDir = normalize(u_CameraPosition - worldPos.xyz);
+
+    // Previous frame clip position for motion vectors / TAA
+    fragPrevClipPos = u_ViewProjectionMatrix * u_PreviousWorldMatrix * vec4(inPosition, 1.0);
+}

--- a/Shaders/GLSL/BloomExtract.glsl
+++ b/Shaders/GLSL/BloomExtract.glsl
@@ -1,0 +1,37 @@
+/**
+ * BloomExtract.glsl - Bloom Bright-Pass Extraction
+ * Spark Engine - Cross-platform shader (GLSL equivalent of HLSL BloomExtract)
+ *
+ * GLSL 460 Core - Extracts bright pixels above a luminance threshold.
+ */
+#version 460 core
+
+layout(location = 0) in vec2 fragTexCoord;
+layout(location = 0) out vec4 outColor;
+
+layout(std140, binding = 1) uniform BloomConstants
+{
+    float u_Threshold;
+    float u_SoftThreshold;
+    float u_Intensity;
+    float _bloomPad;
+};
+
+layout(binding = 0) uniform sampler2D u_InputTexture;
+
+void main()
+{
+    vec3 color = texture(u_InputTexture, fragTexCoord).rgb;
+    float luminance = dot(color, vec3(0.299, 0.587, 0.114));
+
+    // Soft knee threshold for smoother bloom
+    float knee = u_Threshold * u_SoftThreshold;
+    float soft = luminance - u_Threshold + knee;
+    soft = clamp(soft, 0.0, 2.0 * knee);
+    soft = soft * soft / (4.0 * knee + 0.00001);
+
+    float contribution = max(soft, luminance - u_Threshold);
+    contribution /= max(luminance, 0.00001);
+
+    outColor = vec4(color * contribution * u_Intensity, 1.0);
+}

--- a/Shaders/GLSL/DebugVisualize.glsl
+++ b/Shaders/GLSL/DebugVisualize.glsl
@@ -1,0 +1,91 @@
+/**
+ * DebugVisualize.glsl - Debug Visualization Shader
+ * Spark Engine - Cross-platform shader (GLSL equivalent of HLSL DebugVisualize)
+ *
+ * GLSL 460 Core - Visualize various G-buffer channels, depth, normals,
+ * wireframe, and other debug outputs.
+ *
+ * Select mode via MODE define:
+ *   0 = Depth, 1 = Normals, 2 = UV, 3 = Wireframe, 4 = Overdraw
+ */
+#version 460 core
+
+layout(location = 0) in vec2 fragTexCoord;
+layout(location = 0) out vec4 outColor;
+
+layout(std140, binding = 1) uniform DebugConstants
+{
+    int u_DebugMode;       // 0=depth, 1=normals, 2=uv, 3=wireframe, 4=overdraw
+    float u_NearPlane;
+    float u_FarPlane;
+    float u_DepthScale;
+};
+
+layout(binding = 0) uniform sampler2D u_DepthTexture;
+layout(binding = 1) uniform sampler2D u_NormalTexture;
+layout(binding = 2) uniform sampler2D u_AlbedoTexture;
+
+// Linearize depth from non-linear depth buffer
+float LinearizeDepth(float depth)
+{
+    float z = depth * 2.0 - 1.0; // Back to NDC
+    return (2.0 * u_NearPlane * u_FarPlane) /
+           (u_FarPlane + u_NearPlane - z * (u_FarPlane - u_NearPlane));
+}
+
+// Heat map color ramp
+vec3 HeatMap(float value)
+{
+    value = clamp(value, 0.0, 1.0);
+    vec3 color;
+    if (value < 0.25)
+        color = mix(vec3(0.0, 0.0, 1.0), vec3(0.0, 1.0, 1.0), value * 4.0);
+    else if (value < 0.5)
+        color = mix(vec3(0.0, 1.0, 1.0), vec3(0.0, 1.0, 0.0), (value - 0.25) * 4.0);
+    else if (value < 0.75)
+        color = mix(vec3(0.0, 1.0, 0.0), vec3(1.0, 1.0, 0.0), (value - 0.5) * 4.0);
+    else
+        color = mix(vec3(1.0, 1.0, 0.0), vec3(1.0, 0.0, 0.0), (value - 0.75) * 4.0);
+    return color;
+}
+
+void main()
+{
+    // Depth visualization
+    if (u_DebugMode == 0)
+    {
+        float depth = texture(u_DepthTexture, fragTexCoord).r;
+        float linearDepth = LinearizeDepth(depth) / u_FarPlane;
+        linearDepth = pow(linearDepth, u_DepthScale);
+        outColor = vec4(vec3(linearDepth), 1.0);
+    }
+    // Normal visualization
+    else if (u_DebugMode == 1)
+    {
+        vec3 normal = texture(u_NormalTexture, fragTexCoord).rgb;
+        outColor = vec4(normal * 0.5 + 0.5, 1.0);
+    }
+    // UV visualization
+    else if (u_DebugMode == 2)
+    {
+        outColor = vec4(fragTexCoord, 0.0, 1.0);
+    }
+    // Wireframe (checkerboard approximation)
+    else if (u_DebugMode == 3)
+    {
+        vec2 grid = fract(fragTexCoord * 50.0);
+        float line = step(0.98, grid.x) + step(0.98, grid.y);
+        vec3 albedo = texture(u_AlbedoTexture, fragTexCoord).rgb;
+        outColor = vec4(mix(albedo * 0.3, vec3(0.0, 1.0, 0.0), min(line, 1.0)), 1.0);
+    }
+    // Overdraw heat map
+    else if (u_DebugMode == 4)
+    {
+        float overdraw = texture(u_AlbedoTexture, fragTexCoord).a;
+        outColor = vec4(HeatMap(overdraw), 1.0);
+    }
+    else
+    {
+        outColor = texture(u_AlbedoTexture, fragTexCoord);
+    }
+}

--- a/Shaders/GLSL/EnvReflection.glsl
+++ b/Shaders/GLSL/EnvReflection.glsl
@@ -1,0 +1,75 @@
+/**
+ * EnvReflection.glsl - Environment Cubemap Reflection Shader
+ * Spark Engine - Cross-platform shader (GLSL equivalent of HLSL EnvReflection)
+ *
+ * GLSL 460 Core - Cubemap-based environment reflections with roughness LOD.
+ * Contains both vertex and fragment stages separated by preprocessor.
+ */
+#version 460 core
+
+#ifdef VERTEX_SHADER
+
+layout(location = 0) in vec3 inPosition;
+layout(location = 1) in vec3 inNormal;
+
+layout(location = 0) out vec3 fragWorldPos;
+layout(location = 1) out vec3 fragNormal;
+
+layout(std140, binding = 1) uniform EnvReflectionConstants
+{
+    mat4 u_WorldViewProjection;
+    vec3 u_CameraPosition;
+    float u_Roughness;
+    float u_ReflectionIntensity;
+    float u_FresnelBias;
+    float u_FresnelScale;
+    float u_FresnelPower;
+};
+
+void main()
+{
+    gl_Position = u_WorldViewProjection * vec4(inPosition, 1.0);
+    fragWorldPos = inPosition;
+    fragNormal = normalize(inNormal);
+}
+
+#endif // VERTEX_SHADER
+
+#ifdef FRAGMENT_SHADER
+
+layout(location = 0) in vec3 fragWorldPos;
+layout(location = 1) in vec3 fragNormal;
+
+layout(location = 0) out vec4 outColor;
+
+layout(std140, binding = 1) uniform EnvReflectionConstants
+{
+    mat4 u_WorldViewProjection;
+    vec3 u_CameraPosition;
+    float u_Roughness;
+    float u_ReflectionIntensity;
+    float u_FresnelBias;
+    float u_FresnelScale;
+    float u_FresnelPower;
+};
+
+layout(binding = 0) uniform samplerCube u_EnvMap;
+
+void main()
+{
+    vec3 V = normalize(fragWorldPos - u_CameraPosition);
+    vec3 N = normalize(fragNormal);
+    vec3 R = reflect(V, N);
+
+    // Sample cubemap with roughness-based LOD
+    float mipLevel = u_Roughness * 6.0; // Assuming 7 mip levels
+    vec3 envColor = textureLod(u_EnvMap, R, mipLevel).rgb;
+
+    // Fresnel
+    float fresnel = u_FresnelBias + u_FresnelScale *
+                    pow(1.0 - clamp(dot(-V, N), 0.0, 1.0), u_FresnelPower);
+
+    outColor = vec4(envColor * u_ReflectionIntensity * fresnel, 1.0);
+}
+
+#endif // FRAGMENT_SHADER

--- a/Shaders/GLSL/FullscreenQuad.glsl
+++ b/Shaders/GLSL/FullscreenQuad.glsl
@@ -1,0 +1,20 @@
+/**
+ * FullscreenQuad.glsl - Fullscreen Triangle/Quad Vertex Shader
+ * Spark Engine - Cross-platform shader
+ *
+ * GLSL 460 Core - Procedurally generates a fullscreen triangle
+ * without requiring vertex buffer input. Used by all post-processing passes.
+ */
+#version 460 core
+
+layout(location = 0) out vec2 fragTexCoord;
+
+void main()
+{
+    // Generate fullscreen triangle from vertex ID (no vertex buffer needed)
+    // Vertices: (-1,-1), (3,-1), (-1,3) - oversized triangle covers the screen
+    fragTexCoord = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);
+    gl_Position = vec4(fragTexCoord * 2.0 - 1.0, 0.0, 1.0);
+    // Flip Y for OpenGL convention (bottom-left origin)
+    fragTexCoord.y = 1.0 - fragTexCoord.y;
+}

--- a/Shaders/GLSL/GaussianBlur.glsl
+++ b/Shaders/GLSL/GaussianBlur.glsl
@@ -1,0 +1,47 @@
+/**
+ * GaussianBlur.glsl - Separable Gaussian Blur
+ * Spark Engine - Cross-platform shader (GLSL equivalent of HLSL GaussianBlur)
+ *
+ * GLSL 460 Core - Two-pass separable Gaussian blur (horizontal + vertical).
+ * Use BLUR_HORIZONTAL define for horizontal pass, otherwise vertical.
+ */
+#version 460 core
+
+layout(location = 0) in vec2 fragTexCoord;
+layout(location = 0) out vec4 outColor;
+
+layout(std140, binding = 1) uniform BlurConstants
+{
+    vec2 u_TexelSize;
+    vec2 _blurPad;
+};
+
+layout(binding = 0) uniform sampler2D u_InputTexture;
+
+// 9-tap Gaussian weights (sigma ~1.8)
+const float weights[5] = float[5](
+    0.204164, 0.304005, 0.193783, 0.0727, 0.0155
+);
+
+void main()
+{
+    vec4 color = texture(u_InputTexture, fragTexCoord) * weights[0];
+
+#ifdef BLUR_HORIZONTAL
+    for (int i = 1; i < 5; i++)
+    {
+        vec2 offset = vec2(u_TexelSize.x * float(i), 0.0);
+        color += texture(u_InputTexture, fragTexCoord + offset) * weights[i];
+        color += texture(u_InputTexture, fragTexCoord - offset) * weights[i];
+    }
+#else
+    for (int i = 1; i < 5; i++)
+    {
+        vec2 offset = vec2(0.0, u_TexelSize.y * float(i));
+        color += texture(u_InputTexture, fragTexCoord + offset) * weights[i];
+        color += texture(u_InputTexture, fragTexCoord - offset) * weights[i];
+    }
+#endif
+
+    outColor = color;
+}

--- a/Shaders/GLSL/PBRSurface.glsl
+++ b/Shaders/GLSL/PBRSurface.glsl
@@ -1,0 +1,262 @@
+/**
+ * PBRSurface.glsl - Advanced PBR Surface Shader for OpenGL/Vulkan
+ * Spark Engine - Cross-platform shader
+ *
+ * Full PBR implementation with clearcoat, subsurface scattering,
+ * anisotropy, and IBL support.
+ */
+#version 460 core
+
+// ============================================================================
+// FRAGMENT INPUT
+// ============================================================================
+layout(location = 0) in vec3 fragWorldPos;
+layout(location = 1) in vec3 fragNormal;
+layout(location = 2) in vec2 fragTexCoord;
+layout(location = 3) in vec3 fragViewDir;
+layout(location = 4) in vec4 fragPrevClipPos;
+
+// ============================================================================
+// FRAGMENT OUTPUT (MRT for deferred rendering)
+// ============================================================================
+layout(location = 0) out vec4 outAlbedo;      // RGB: albedo, A: metallic
+layout(location = 1) out vec4 outNormal;      // RGB: world normal, A: roughness
+layout(location = 2) out vec4 outMaterial;    // R: occlusion, G: emissive, BA: motion vectors
+
+// ============================================================================
+// UNIFORM BUFFERS
+// ============================================================================
+
+layout(std140, binding = 0) uniform PerFrameConstants
+{
+    mat4 u_ViewMatrix;
+    mat4 u_ProjectionMatrix;
+    mat4 u_ViewProjectionMatrix;
+    vec3 u_CameraPosition;
+    float u_Time;
+    vec3 u_CameraDirection;
+    float u_DeltaTime;
+    vec2 u_ScreenResolution;
+    vec2 u_InvScreenResolution;
+    vec3 u_DirectionalLightDir;
+    float u_DirectionalLightIntensity;
+    vec3 u_DirectionalLightColor;
+    float u_AmbientIntensity;
+    vec3 u_AmbientColor;
+    float _padding1;
+};
+
+layout(std140, binding = 1) uniform PerObjectConstants
+{
+    mat4 u_WorldMatrix;
+    mat4 u_WorldViewProjectionMatrix;
+    mat4 u_WorldInverseTransposeMatrix;
+    mat4 u_PreviousWorldMatrix;
+    vec3 u_ObjectPosition;
+    float u_ObjectScale;
+    vec4 u_ObjectColor;
+    vec4 u_MaterialProperties;
+    vec4 u_UVTiling;
+};
+
+layout(std140, binding = 2) uniform PerMaterialConstants
+{
+    vec4 u_AlbedoColor;
+    float u_MetallicFactor;
+    float u_RoughnessFactor;
+    float u_NormalScale;
+    float u_OcclusionStrength;
+    float u_EmissiveFactor;
+    float u_AlphaCutoff;
+    vec2 _materialPadding;
+};
+
+// Advanced PBR parameters (b3)
+layout(std140, binding = 3) uniform AdvancedPBRConstants
+{
+    // Clearcoat
+    float u_ClearcoatFactor;
+    float u_ClearcoatRoughness;
+
+    // Subsurface
+    vec3 u_SubsurfaceColor;
+    float u_SubsurfaceRadius;
+
+    // Anisotropy
+    float u_AnisotropyFactor;
+    vec2 u_AnisotropyDirection;
+
+    // Sheen
+    vec3 u_SheenColor;
+    float u_SheenRoughness;
+
+    // Iridescence
+    float u_IridescenceFactor;
+    float u_IridescenceIOR;
+    float u_IridescenceThickness;
+
+    // Transmission
+    float u_TransmissionFactor;
+    vec3 u_TransmissionColor;
+};
+
+// ============================================================================
+// TEXTURE SAMPLERS
+// ============================================================================
+layout(binding = 0) uniform sampler2D u_AlbedoTexture;
+layout(binding = 1) uniform sampler2D u_NormalTexture;
+layout(binding = 2) uniform sampler2D u_MetallicRoughnessTexture;
+layout(binding = 3) uniform sampler2D u_OcclusionTexture;
+layout(binding = 4) uniform sampler2D u_EmissiveTexture;
+layout(binding = 5) uniform sampler2D u_ClearcoatTexture;
+layout(binding = 6) uniform sampler2D u_SubsurfaceTexture;
+layout(binding = 7) uniform samplerCube u_EnvironmentMap;
+layout(binding = 8) uniform samplerCube u_IrradianceMap;
+layout(binding = 9) uniform sampler2D u_BRDFLookup;
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+const float PI = 3.14159265359;
+const float TWO_PI = 6.28318530718;
+const float INV_PI = 0.31830988618;
+const float EPSILON = 0.0001;
+
+// ============================================================================
+// PBR CORE FUNCTIONS
+// ============================================================================
+
+float D_GGX(float NdotH, float roughness)
+{
+    float a2 = roughness * roughness;
+    float f = (NdotH * a2 - NdotH) * NdotH + 1.0;
+    return a2 / (PI * f * f + EPSILON);
+}
+
+float V_SmithGGXCorrelated(float NdotV, float NdotL, float roughness)
+{
+    float a2 = roughness * roughness;
+    float GGXV = NdotL * sqrt(NdotV * NdotV * (1.0 - a2) + a2);
+    float GGXL = NdotV * sqrt(NdotL * NdotL * (1.0 - a2) + a2);
+    return 0.5 / (GGXV + GGXL + EPSILON);
+}
+
+vec3 F_Schlick(float u, vec3 f0)
+{
+    return f0 + (vec3(1.0) - f0) * pow(1.0 - u, 5.0);
+}
+
+float F_Schlick(float u, float f0, float f90)
+{
+    return f0 + (f90 - f0) * pow(1.0 - u, 5.0);
+}
+
+// Charlie distribution for sheen
+float D_Charlie(float roughness, float NdotH)
+{
+    float invAlpha = 1.0 / roughness;
+    float cos2h = NdotH * NdotH;
+    float sin2h = max(1.0 - cos2h, 0.0078125);
+    return (2.0 + invAlpha) * pow(sin2h, invAlpha * 0.5) / TWO_PI;
+}
+
+// Ashikhmin visibility for sheen
+float V_Ashikhmin(float NdotL, float NdotV)
+{
+    return 1.0 / (4.0 * (NdotL + NdotV - NdotL * NdotV));
+}
+
+// ============================================================================
+// CLEARCOAT
+// ============================================================================
+float D_GGX_Clearcoat(float NdotH, float clearcoatRoughness)
+{
+    return D_GGX(NdotH, clearcoatRoughness);
+}
+
+float V_Kelemen(float LdotH)
+{
+    return 0.25 / (LdotH * LdotH + EPSILON);
+}
+
+// ============================================================================
+// ANISOTROPIC GGX
+// ============================================================================
+float D_GGX_Anisotropic(float NdotH, float TdotH, float BdotH,
+                          float roughnessT, float roughnessB)
+{
+    float a2 = roughnessT * roughnessB;
+    vec3 v = vec3(roughnessB * TdotH, roughnessT * BdotH, a2 * NdotH);
+    float v2 = dot(v, v);
+    float w2 = a2 / v2;
+    return a2 * w2 * w2 * INV_PI;
+}
+
+// ============================================================================
+// NORMAL MAPPING
+// ============================================================================
+vec3 GetNormalFromMap()
+{
+    vec3 tangentNormal = texture(u_NormalTexture, fragTexCoord).xyz * 2.0 - 1.0;
+
+    vec3 Q1 = dFdx(fragWorldPos);
+    vec3 Q2 = dFdy(fragWorldPos);
+    vec2 st1 = dFdx(fragTexCoord);
+    vec2 st2 = dFdy(fragTexCoord);
+
+    vec3 N = normalize(fragNormal);
+    vec3 T = normalize(Q1 * st2.t - Q2 * st1.t);
+    vec3 B = -normalize(cross(N, T));
+    mat3 TBN = mat3(T, B, N);
+
+    return normalize(TBN * (tangentNormal * vec3(u_NormalScale, u_NormalScale, 1.0)));
+}
+
+// ============================================================================
+// MOTION VECTORS
+// ============================================================================
+vec2 ComputeMotionVector()
+{
+    vec2 currentPos = gl_FragCoord.xy * u_InvScreenResolution;
+    vec2 previousPos = (fragPrevClipPos.xy / fragPrevClipPos.w) * 0.5 + 0.5;
+    return currentPos - previousPos;
+}
+
+// ============================================================================
+// MAIN FRAGMENT SHADER (G-Buffer output for deferred rendering)
+// ============================================================================
+void main()
+{
+    // Sample base textures
+    vec4 albedoSample = texture(u_AlbedoTexture, fragTexCoord);
+    vec3 albedo = albedoSample.rgb * u_AlbedoColor.rgb;
+    float alpha = albedoSample.a * u_AlbedoColor.a;
+
+    if (alpha < u_AlphaCutoff)
+        discard;
+
+    // PBR material properties
+    vec4 metallicRoughness = texture(u_MetallicRoughnessTexture, fragTexCoord);
+    float metallic = metallicRoughness.b * u_MetallicFactor;
+    float roughness = metallicRoughness.g * u_RoughnessFactor;
+    roughness = clamp(roughness, 0.045, 1.0);  // Prevent zero roughness
+
+    float ao = texture(u_OcclusionTexture, fragTexCoord).r;
+    ao = mix(1.0, ao, u_OcclusionStrength);
+
+    float emissive = u_EmissiveFactor;
+    vec3 emissiveColor = texture(u_EmissiveTexture, fragTexCoord).rgb * emissive;
+
+    // Get world-space normal
+    vec3 N = GetNormalFromMap();
+
+    // Motion vectors
+    vec2 motionVec = ComputeMotionVector();
+
+    // ========================================================================
+    // G-BUFFER OUTPUT
+    // ========================================================================
+    outAlbedo = vec4(albedo, metallic);
+    outNormal = vec4(N * 0.5 + 0.5, roughness);
+    outMaterial = vec4(ao, length(emissiveColor), motionVec);
+}

--- a/Shaders/GLSL/Phong.glsl
+++ b/Shaders/GLSL/Phong.glsl
@@ -1,0 +1,74 @@
+/**
+ * Phong.glsl - Blinn-Phong Lighting Shader
+ * Spark Engine - Cross-platform shader (GLSL equivalent of HLSL Phong)
+ *
+ * GLSL 460 Core - Classic Blinn-Phong shading model.
+ * Contains both vertex and fragment stages separated by preprocessor.
+ */
+#version 460 core
+
+#ifdef VERTEX_SHADER
+
+layout(location = 0) in vec3 inPosition;
+layout(location = 1) in vec3 inNormal;
+
+layout(location = 0) out vec3 fragWorldNormal;
+layout(location = 1) out vec3 fragViewDir;
+
+layout(std140, binding = 1) uniform PhongConstants
+{
+    mat4 u_WorldMatrix;
+    mat4 u_ViewProjection;
+    vec3 u_LightDirection;
+    float _phongPad1;
+    vec3 u_LightColor;
+    float u_SpecularPower;
+};
+
+void main()
+{
+    vec4 worldPos = u_WorldMatrix * vec4(inPosition, 1.0);
+    gl_Position = u_ViewProjection * worldPos;
+    fragWorldNormal = normalize(mat3(u_WorldMatrix) * inNormal);
+    fragViewDir = normalize(-worldPos.xyz);
+}
+
+#endif // VERTEX_SHADER
+
+#ifdef FRAGMENT_SHADER
+
+layout(location = 0) in vec3 fragWorldNormal;
+layout(location = 1) in vec3 fragViewDir;
+
+layout(location = 0) out vec4 outColor;
+
+layout(std140, binding = 1) uniform PhongConstants
+{
+    mat4 u_WorldMatrix;
+    mat4 u_ViewProjection;
+    vec3 u_LightDirection;
+    float _phongPad1;
+    vec3 u_LightColor;
+    float u_SpecularPower;
+};
+
+void main()
+{
+    vec3 N = normalize(fragWorldNormal);
+    vec3 L = normalize(-u_LightDirection);
+    vec3 V = normalize(fragViewDir);
+    vec3 H = normalize(L + V);
+
+    // Diffuse
+    float NdotL = max(dot(N, L), 0.0);
+    vec3 diffuse = NdotL * u_LightColor;
+
+    // Specular (Blinn-Phong)
+    float NdotH = max(dot(N, H), 0.0);
+    float spec = pow(NdotH, u_SpecularPower);
+    vec3 specular = spec * u_LightColor;
+
+    outColor = vec4(diffuse + specular, 1.0);
+}
+
+#endif // FRAGMENT_SHADER

--- a/Shaders/GLSL/PostProcess.glsl
+++ b/Shaders/GLSL/PostProcess.glsl
@@ -1,0 +1,210 @@
+/**
+ * PostProcess.glsl - Post-Processing Effects Collection
+ * Spark Engine - Cross-platform shader
+ *
+ * GLSL 460 Core - Fullscreen post-processing effects:
+ * - Tone mapping (ACES, Reinhard, Uncharted2)
+ * - Gamma correction
+ * - Vignette
+ * - Chromatic aberration
+ * - Film grain
+ * - FXAA (Fast Approximate Anti-Aliasing)
+ *
+ * Select effect via preprocessor defines: TONEMAP, VIGNETTE, CHROMATIC, GRAIN, FXAA
+ */
+#version 460 core
+
+layout(location = 0) in vec2 fragTexCoord;
+layout(location = 0) out vec4 outColor;
+
+layout(std140, binding = 1) uniform PostProcessConstants
+{
+    vec2 u_ScreenSize;
+    vec2 u_InvScreenSize;
+    float u_Exposure;
+    float u_Gamma;
+    float u_VignetteStrength;
+    float u_VignetteRadius;
+    float u_ChromaticStrength;
+    float u_GrainStrength;
+    float u_Time;
+    float u_Saturation;
+};
+
+layout(binding = 0) uniform sampler2D u_InputTexture;
+
+// ============================================================================
+// TONEMAPPING OPERATORS
+// ============================================================================
+
+// ACES Filmic Tonemapping
+vec3 ACESFilm(vec3 x)
+{
+    float a = 2.51;
+    float b = 0.03;
+    float c = 2.43;
+    float d = 0.59;
+    float e = 0.14;
+    return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0, 1.0);
+}
+
+// Reinhard Tonemapping
+vec3 Reinhard(vec3 color)
+{
+    return color / (color + vec3(1.0));
+}
+
+// Uncharted 2 Tonemapping
+vec3 Uncharted2Tonemap(vec3 x)
+{
+    float A = 0.15;
+    float B = 0.50;
+    float C = 0.10;
+    float D = 0.20;
+    float E = 0.02;
+    float F = 0.30;
+    return ((x * (A * x + C * B) + D * E) / (x * (A * x + B) + D * F)) - E / F;
+}
+
+// ============================================================================
+// EFFECTS
+// ============================================================================
+
+// Vignette effect
+vec3 ApplyVignette(vec3 color, vec2 uv)
+{
+    vec2 center = uv - 0.5;
+    float dist = length(center);
+    float vignette = smoothstep(u_VignetteRadius, u_VignetteRadius - u_VignetteStrength, dist);
+    return color * vignette;
+}
+
+// Chromatic aberration
+vec3 ApplyChromaticAberration(vec2 uv)
+{
+    vec2 dir = uv - 0.5;
+    float dist = length(dir);
+    vec2 offset = dir * dist * u_ChromaticStrength * u_InvScreenSize;
+
+    float r = texture(u_InputTexture, uv + offset).r;
+    float g = texture(u_InputTexture, uv).g;
+    float b = texture(u_InputTexture, uv - offset).b;
+
+    return vec3(r, g, b);
+}
+
+// Film grain
+float Random(vec2 co)
+{
+    return fract(sin(dot(co, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+vec3 ApplyGrain(vec3 color, vec2 uv)
+{
+    float noise = Random(uv + vec2(u_Time)) * 2.0 - 1.0;
+    return color + noise * u_GrainStrength;
+}
+
+// Saturation adjustment
+vec3 ApplySaturation(vec3 color)
+{
+    float luma = dot(color, vec3(0.299, 0.587, 0.114));
+    return mix(vec3(luma), color, u_Saturation);
+}
+
+// ============================================================================
+// FXAA (Simplified)
+// ============================================================================
+
+vec3 ApplyFXAA(vec2 uv)
+{
+    vec3 rgbNW = textureOffset(u_InputTexture, uv, ivec2(-1, -1)).rgb;
+    vec3 rgbNE = textureOffset(u_InputTexture, uv, ivec2( 1, -1)).rgb;
+    vec3 rgbSW = textureOffset(u_InputTexture, uv, ivec2(-1,  1)).rgb;
+    vec3 rgbSE = textureOffset(u_InputTexture, uv, ivec2( 1,  1)).rgb;
+    vec3 rgbM  = texture(u_InputTexture, uv).rgb;
+
+    vec3 luma = vec3(0.299, 0.587, 0.114);
+    float lumaNW = dot(rgbNW, luma);
+    float lumaNE = dot(rgbNE, luma);
+    float lumaSW = dot(rgbSW, luma);
+    float lumaSE = dot(rgbSE, luma);
+    float lumaM  = dot(rgbM,  luma);
+
+    float lumaMin = min(lumaM, min(min(lumaNW, lumaNE), min(lumaSW, lumaSE)));
+    float lumaMax = max(lumaM, max(max(lumaNW, lumaNE), max(lumaSW, lumaSE)));
+
+    float lumaRange = lumaMax - lumaMin;
+
+    if (lumaRange < max(0.0312, lumaMax * 0.125))
+        return rgbM;
+
+    vec2 dir;
+    dir.x = -((lumaNW + lumaNE) - (lumaSW + lumaSE));
+    dir.y =  ((lumaNW + lumaSW) - (lumaNE + lumaSE));
+
+    float dirReduce = max((lumaNW + lumaNE + lumaSW + lumaSE) * 0.25 * 0.25, 1.0 / 128.0);
+    float rcpDirMin = 1.0 / (min(abs(dir.x), abs(dir.y)) + dirReduce);
+    dir = min(vec2(8.0), max(vec2(-8.0), dir * rcpDirMin)) * u_InvScreenSize;
+
+    vec3 rgbA = 0.5 * (
+        texture(u_InputTexture, uv + dir * (1.0 / 3.0 - 0.5)).rgb +
+        texture(u_InputTexture, uv + dir * (2.0 / 3.0 - 0.5)).rgb);
+    vec3 rgbB = rgbA * 0.5 + 0.25 * (
+        texture(u_InputTexture, uv + dir * -0.5).rgb +
+        texture(u_InputTexture, uv + dir *  0.5).rgb);
+
+    float lumaB = dot(rgbB, luma);
+
+    if (lumaB < lumaMin || lumaB > lumaMax)
+        return rgbA;
+
+    return rgbB;
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+void main()
+{
+    vec3 color;
+
+#ifdef FXAA_PASS
+    color = ApplyFXAA(fragTexCoord);
+#elif defined(CHROMATIC_PASS)
+    color = ApplyChromaticAberration(fragTexCoord);
+#else
+    color = texture(u_InputTexture, fragTexCoord).rgb;
+#endif
+
+    // Apply exposure
+    color *= u_Exposure;
+
+    // Tonemapping
+#ifdef TONEMAP_REINHARD
+    color = Reinhard(color);
+#elif defined(TONEMAP_UNCHARTED2)
+    vec3 W = vec3(11.2);
+    color = Uncharted2Tonemap(color * 2.0) / Uncharted2Tonemap(W);
+#else
+    color = ACESFilm(color);
+#endif
+
+    // Saturation
+    color = ApplySaturation(color);
+
+    // Vignette
+#ifdef VIGNETTE_PASS
+    color = ApplyVignette(color, fragTexCoord);
+#endif
+
+    // Film grain
+#ifdef GRAIN_PASS
+    color = ApplyGrain(color, fragTexCoord);
+#endif
+
+    // Gamma correction
+    color = pow(color, vec3(1.0 / u_Gamma));
+
+    outColor = vec4(color, 1.0);
+}

--- a/Shaders/GLSL/Rim.glsl
+++ b/Shaders/GLSL/Rim.glsl
@@ -1,0 +1,63 @@
+/**
+ * Rim.glsl - Rim Lighting Shader
+ * Spark Engine - Cross-platform shader (GLSL equivalent of HLSL Rim)
+ *
+ * GLSL 460 Core - Fresnel-based rim/edge lighting effect.
+ * Contains both vertex and fragment stages separated by preprocessor.
+ */
+#version 460 core
+
+#ifdef VERTEX_SHADER
+
+layout(location = 0) in vec3 inPosition;
+layout(location = 1) in vec3 inNormal;
+
+layout(location = 0) out vec3 fragNormal;
+layout(location = 1) out vec3 fragViewDir;
+
+layout(std140, binding = 1) uniform RimConstants
+{
+    mat4 u_WorldViewProjection;
+    vec3 u_CameraPosition;
+    float u_RimPower;
+    vec3 u_RimColor;
+    float u_RimIntensity;
+};
+
+void main()
+{
+    gl_Position = u_WorldViewProjection * vec4(inPosition, 1.0);
+    fragNormal = normalize(inNormal);
+    fragViewDir = normalize(u_CameraPosition - inPosition);
+}
+
+#endif // VERTEX_SHADER
+
+#ifdef FRAGMENT_SHADER
+
+layout(location = 0) in vec3 fragNormal;
+layout(location = 1) in vec3 fragViewDir;
+
+layout(location = 0) out vec4 outColor;
+
+layout(std140, binding = 1) uniform RimConstants
+{
+    mat4 u_WorldViewProjection;
+    vec3 u_CameraPosition;
+    float u_RimPower;
+    vec3 u_RimColor;
+    float u_RimIntensity;
+};
+
+void main()
+{
+    vec3 N = normalize(fragNormal);
+    vec3 V = normalize(fragViewDir);
+
+    float rim = pow(1.0 - clamp(dot(N, V), 0.0, 1.0), u_RimPower);
+    vec3 color = u_RimColor * rim * u_RimIntensity;
+
+    outColor = vec4(color, 1.0);
+}
+
+#endif // FRAGMENT_SHADER

--- a/Shaders/GLSL/SSAO.glsl
+++ b/Shaders/GLSL/SSAO.glsl
@@ -1,0 +1,66 @@
+/**
+ * SSAO.glsl - Screen Space Ambient Occlusion
+ * Spark Engine - Cross-platform shader (GLSL equivalent of HLSL SSAO)
+ *
+ * GLSL 460 Core - 16-sample kernel SSAO pass.
+ */
+#version 460 core
+
+// Fragment input (fullscreen quad)
+layout(location = 0) in vec2 fragTexCoord;
+
+// Fragment output
+layout(location = 0) out vec4 outColor;
+
+// Uniform buffer (matches HLSL register(b1))
+layout(std140, binding = 1) uniform SSAOConstants
+{
+    mat4 u_InvProjection;
+    vec2 u_ScreenSize;
+    float u_Radius;
+    float u_Bias;
+};
+
+// Depth texture
+layout(binding = 0) uniform sampler2D u_DepthTexture;
+
+// SSAO kernel samples
+const vec2 samples[16] = vec2[16](
+    vec2( 1.0,  0.0),   vec2(-1.0,  0.0),
+    vec2( 0.0,  1.0),   vec2( 0.0, -1.0),
+    vec2( 0.707,  0.707), vec2(-0.707,  0.707),
+    vec2( 0.707, -0.707), vec2(-0.707, -0.707),
+    vec2( 1.0,  1.0),   vec2(-1.0,  1.0),
+    vec2( 1.0, -1.0),   vec2(-1.0, -1.0),
+    vec2( 0.5,  0.0),   vec2(-0.5,  0.0),
+    vec2( 0.0,  0.5),   vec2( 0.0, -0.5)
+);
+
+vec3 ReconstructViewPos(vec2 uv, float depth)
+{
+    vec4 clipPos = vec4(uv * 2.0 - 1.0, depth, 1.0);
+    vec4 viewPos = u_InvProjection * clipPos;
+    return viewPos.xyz / viewPos.w;
+}
+
+void main()
+{
+    float z = texture(u_DepthTexture, fragTexCoord).r;
+    vec3 pos = ReconstructViewPos(fragTexCoord, z);
+
+    float occlusion = 0.0;
+
+    for (int i = 0; i < 16; i++)
+    {
+        vec2 offset = samples[i] / u_ScreenSize * u_Radius;
+        float z2 = texture(u_DepthTexture, fragTexCoord + offset).r;
+        vec3 pos2 = ReconstructViewPos(fragTexCoord + offset, z2);
+
+        occlusion += (pos.z - pos2.z > u_Bias) ? 1.0 : 0.0;
+    }
+
+    occlusion /= 16.0;
+    float ao = 1.0 - occlusion;
+
+    outColor = vec4(ao, ao, ao, 1.0);
+}

--- a/Shaders/GLSL/Utils.glsl
+++ b/Shaders/GLSL/Utils.glsl
@@ -1,0 +1,172 @@
+/**
+ * Utils.glsl - Shared Utility Functions
+ * Spark Engine - Cross-platform shader (GLSL equivalent of HLSL Utils)
+ *
+ * GLSL 460 Core - Common utility functions shared across shaders.
+ * Include via #include "Utils.glsl" or copy needed functions.
+ */
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+const float PI         = 3.14159265359;
+const float TWO_PI     = 6.28318530718;
+const float HALF_PI    = 1.57079632679;
+const float INV_PI     = 0.31830988618;
+const float INV_TWO_PI = 0.15915494309;
+const float EPSILON    = 0.0001;
+
+// ============================================================================
+// COLOR SPACE CONVERSIONS
+// ============================================================================
+
+// Linear to sRGB
+vec3 LinearToSRGB(vec3 color)
+{
+    return pow(color, vec3(1.0 / 2.2));
+}
+
+// sRGB to Linear
+vec3 SRGBToLinear(vec3 color)
+{
+    return pow(color, vec3(2.2));
+}
+
+// RGB to luminance
+float Luminance(vec3 color)
+{
+    return dot(color, vec3(0.2126, 0.7152, 0.0722));
+}
+
+// RGB to HSV
+vec3 RGBToHSV(vec3 c)
+{
+    vec4 K = vec4(0.0, -1.0/3.0, 2.0/3.0, -1.0);
+    vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+    vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+    float d = q.x - min(q.w, q.y);
+    float e = 1.0e-10;
+    return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+// HSV to RGB
+vec3 HSVToRGB(vec3 c)
+{
+    vec4 K = vec4(1.0, 2.0/3.0, 1.0/3.0, 3.0);
+    vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+// ============================================================================
+// MATH UTILITIES
+// ============================================================================
+
+// Remap value from one range to another
+float Remap(float value, float inMin, float inMax, float outMin, float outMax)
+{
+    return outMin + (value - inMin) * (outMax - outMin) / (inMax - inMin);
+}
+
+// Smooth minimum (for smooth blending)
+float SmoothMin(float a, float b, float k)
+{
+    float h = clamp(0.5 + 0.5 * (b - a) / k, 0.0, 1.0);
+    return mix(b, a, h) - k * h * (1.0 - h);
+}
+
+// Inverse lerp
+float InverseLerp(float a, float b, float v)
+{
+    return clamp((v - a) / (b - a), 0.0, 1.0);
+}
+
+// ============================================================================
+// NOISE FUNCTIONS
+// ============================================================================
+
+// Simple hash for noise generation
+float Hash(vec2 p)
+{
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+// Value noise
+float ValueNoise(vec2 p)
+{
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f); // Hermite interpolation
+
+    float a = Hash(i);
+    float b = Hash(i + vec2(1.0, 0.0));
+    float c = Hash(i + vec2(0.0, 1.0));
+    float d = Hash(i + vec2(1.0, 1.0));
+
+    return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+// Fractal Brownian Motion
+float FBM(vec2 p, int octaves)
+{
+    float value = 0.0;
+    float amplitude = 0.5;
+    float frequency = 1.0;
+
+    for (int i = 0; i < octaves; i++)
+    {
+        value += amplitude * ValueNoise(p * frequency);
+        frequency *= 2.0;
+        amplitude *= 0.5;
+    }
+
+    return value;
+}
+
+// ============================================================================
+// TEXTURE UTILITIES
+// ============================================================================
+
+// Parallax occlusion mapping offset
+vec2 ParallaxOffset(float height, float scale, vec3 viewDir)
+{
+    float h = height * scale - scale * 0.5;
+    return viewDir.xy / viewDir.z * h;
+}
+
+// Normal map decode (standard tangent-space)
+vec3 UnpackNormal(vec2 encoded)
+{
+    vec3 n;
+    n.xy = encoded * 2.0 - 1.0;
+    n.z = sqrt(max(1.0 - dot(n.xy, n.xy), 0.0));
+    return n;
+}
+
+// Encode normal for G-buffer storage
+vec2 PackNormal(vec3 n)
+{
+    return n.xy * 0.5 + 0.5;
+}
+
+// ============================================================================
+// SHADOW UTILITIES
+// ============================================================================
+
+// PCF shadow sampling (4-tap)
+float ShadowPCF4(sampler2D shadowMap, vec3 shadowCoord, float bias)
+{
+    float shadow = 0.0;
+    vec2 texelSize = 1.0 / vec2(textureSize(shadowMap, 0));
+
+    for (int x = -1; x <= 1; x += 2)
+    {
+        for (int y = -1; y <= 1; y += 2)
+        {
+            vec2 offset = vec2(float(x), float(y)) * texelSize;
+            float depth = texture(shadowMap, shadowCoord.xy + offset).r;
+            shadow += (shadowCoord.z - bias > depth) ? 0.0 : 1.0;
+        }
+    }
+
+    return shadow / 4.0;
+}

--- a/Shaders/GLSL/Water.glsl
+++ b/Shaders/GLSL/Water.glsl
@@ -1,0 +1,94 @@
+/**
+ * Water.glsl - Water Surface Shader
+ * Spark Engine - Cross-platform shader (GLSL equivalent of HLSL Water)
+ *
+ * GLSL 460 Core - Animated water with Fresnel reflections and refraction.
+ * Contains both vertex and fragment stages separated by preprocessor.
+ */
+#version 460 core
+
+#ifdef VERTEX_SHADER
+
+layout(location = 0) in vec3 inPosition;
+layout(location = 1) in vec2 inTexCoord;
+
+layout(location = 0) out vec2 fragUV_Refraction;
+layout(location = 1) out vec2 fragUV_Reflection;
+layout(location = 2) out vec3 fragViewDir;
+layout(location = 3) out vec2 fragBaseUV;
+
+layout(std140, binding = 1) uniform WaterConstants
+{
+    mat4 u_WorldViewProjection;
+    vec3 u_CameraPosition;
+    float u_Time;
+    vec2 u_WaveSpeed;
+    float u_DistortionStrength;
+    float u_FresnelPower;
+    vec3 u_WaterColor;
+    float u_WaterAlpha;
+};
+
+layout(binding = 2) uniform sampler2D u_NormalMap;
+
+void main()
+{
+    vec4 worldPos = vec4(inPosition, 1.0);
+    gl_Position = u_WorldViewProjection * worldPos;
+
+    // Scrolling UV for normal map distortion
+    vec2 scrollUV = inTexCoord + vec2(u_Time * u_WaveSpeed.x, u_Time * u_WaveSpeed.y);
+    vec2 distortion = texture(u_NormalMap, scrollUV).rg * 2.0 - 1.0;
+
+    fragUV_Refraction = inTexCoord + distortion * u_DistortionStrength;
+    fragUV_Reflection = inTexCoord - distortion * u_DistortionStrength;
+    fragViewDir = normalize(u_CameraPosition - inPosition);
+    fragBaseUV = inTexCoord;
+}
+
+#endif // VERTEX_SHADER
+
+#ifdef FRAGMENT_SHADER
+
+layout(location = 0) in vec2 fragUV_Refraction;
+layout(location = 1) in vec2 fragUV_Reflection;
+layout(location = 2) in vec3 fragViewDir;
+layout(location = 3) in vec2 fragBaseUV;
+
+layout(location = 0) out vec4 outColor;
+
+layout(std140, binding = 1) uniform WaterConstants
+{
+    mat4 u_WorldViewProjection;
+    vec3 u_CameraPosition;
+    float u_Time;
+    vec2 u_WaveSpeed;
+    float u_DistortionStrength;
+    float u_FresnelPower;
+    vec3 u_WaterColor;
+    float u_WaterAlpha;
+};
+
+layout(binding = 0) uniform sampler2D u_RefractionMap;
+layout(binding = 1) uniform sampler2D u_ReflectionMap;
+
+void main()
+{
+    // Fresnel effect
+    float fresnel = pow(1.0 - clamp(dot(fragViewDir, vec3(0.0, 1.0, 0.0)), 0.0, 1.0),
+                        u_FresnelPower);
+
+    // Sample refraction and reflection
+    vec4 refraction = texture(u_RefractionMap, fragUV_Refraction);
+    vec4 reflection = texture(u_ReflectionMap, fragUV_Reflection);
+
+    // Blend based on Fresnel
+    vec4 color = mix(refraction, reflection, fresnel);
+
+    // Tint with water color
+    color.rgb = mix(color.rgb, u_WaterColor, u_WaterAlpha);
+
+    outColor = vec4(color.rgb, 1.0);
+}
+
+#endif // FRAGMENT_SHADER

--- a/Shaders/compile_shaders.bat
+++ b/Shaders/compile_shaders.bat
@@ -1,0 +1,114 @@
+@echo off
+REM ============================================================================
+REM Spark Engine - Shader Compilation Pipeline (Windows)
+REM ============================================================================
+REM
+REM Compiles GLSL shaders to SPIR-V for Vulkan backend.
+REM Requires Vulkan SDK installed with glslangValidator in PATH.
+REM
+REM Usage:
+REM   compile_shaders.bat              - Compile all shaders
+REM   compile_shaders.bat --clean      - Remove compiled shaders
+REM ============================================================================
+
+setlocal EnableDelayedExpansion
+
+set SCRIPT_DIR=%~dp0
+set GLSL_DIR=%SCRIPT_DIR%GLSL
+set SPIRV_DIR=%SCRIPT_DIR%SPIRV
+set PASS=0
+set FAIL=0
+
+REM Find glslangValidator
+set GLSLANG=glslangValidator
+where glslangValidator >nul 2>&1
+if errorlevel 1 (
+    if defined VULKAN_SDK (
+        set GLSLANG=%VULKAN_SDK%\Bin\glslangValidator.exe
+        if not exist "!GLSLANG!" (
+            echo ERROR: glslangValidator not found. Install the Vulkan SDK.
+            exit /b 1
+        )
+    ) else (
+        echo ERROR: glslangValidator not found. Install the Vulkan SDK.
+        exit /b 1
+    )
+)
+
+if "%1"=="--clean" (
+    echo Cleaning compiled shaders...
+    if exist "%SPIRV_DIR%\*.spv" del /q "%SPIRV_DIR%\*.spv"
+    echo Done.
+    exit /b 0
+)
+
+echo === Spark Engine Shader Compilation ===
+if not exist "%SPIRV_DIR%" mkdir "%SPIRV_DIR%"
+
+REM --- Vertex Shaders ---
+echo.
+echo --- Vertex Shaders ---
+call :compile "%GLSL_DIR%\BasicVS.glsl" vert "" "BasicVS_VS"
+call :compile "%GLSL_DIR%\FullscreenQuad.glsl" vert "" "FullscreenQuad_VS"
+
+REM --- Fragment Shaders ---
+echo.
+echo --- Fragment Shaders ---
+call :compile "%GLSL_DIR%\BasicPS.glsl" frag "" "BasicPS_PS"
+call :compile "%GLSL_DIR%\PBRSurface.glsl" frag "" "PBRSurface_PS"
+call :compile "%GLSL_DIR%\SSAO.glsl" frag "" "SSAO_PS"
+call :compile "%GLSL_DIR%\BloomExtract.glsl" frag "" "BloomExtract_PS"
+call :compile "%GLSL_DIR%\DebugVisualize.glsl" frag "" "DebugVisualize_PS"
+
+REM --- Post-Processing ---
+echo.
+echo --- Post-Processing ---
+call :compile "%GLSL_DIR%\PostProcess.glsl" frag "" "PostProcess_PS"
+call :compile "%GLSL_DIR%\PostProcess.glsl" frag "-DFXAA_PASS" "PostProcess_FXAA_PS"
+
+REM --- Gaussian Blur ---
+echo.
+echo --- Gaussian Blur ---
+call :compile "%GLSL_DIR%\GaussianBlur.glsl" frag "-DBLUR_HORIZONTAL" "GaussianBlur_BlurH_PS"
+call :compile "%GLSL_DIR%\GaussianBlur.glsl" frag "" "GaussianBlur_BlurV_PS"
+
+REM --- Multi-Stage Shaders ---
+echo.
+echo --- Multi-Stage Shaders ---
+for %%S in (Phong Rim Water EnvReflection) do (
+    if exist "%GLSL_DIR%\%%S.glsl" (
+        call :compile "%GLSL_DIR%\%%S.glsl" vert "-DVERTEX_SHADER" "%%S_VS"
+        call :compile "%GLSL_DIR%\%%S.glsl" frag "-DFRAGMENT_SHADER" "%%S_PS"
+    )
+)
+
+REM --- Summary ---
+echo.
+echo === Compilation Summary ===
+echo   Passed: %PASS%
+echo   Failed: %FAIL%
+
+if %FAIL% gtr 0 (
+    echo Some shaders failed. Check output above.
+    exit /b 1
+)
+
+echo All shaders compiled successfully!
+exit /b 0
+
+:compile
+set SRC=%~1
+set STAGE=%~2
+set DEFINES=%~3
+set OUTPUT=%~4
+
+echo   Compiling %OUTPUT% (%STAGE%)...
+%GLSLANG% -V -S %STAGE% %DEFINES% -o "%SPIRV_DIR%\%OUTPUT%.spv" "%SRC%" >nul 2>&1
+if errorlevel 1 (
+    echo     FAIL
+    set /a FAIL+=1
+) else (
+    echo     OK
+    set /a PASS+=1
+)
+goto :eof

--- a/Shaders/compile_shaders.sh
+++ b/Shaders/compile_shaders.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# ============================================================================
+# Spark Engine - Cross-Platform Shader Compilation Pipeline
+# ============================================================================
+#
+# Compiles GLSL shaders to SPIR-V for Vulkan backend using glslangValidator.
+# Also validates GLSL shaders for OpenGL correctness.
+#
+# Prerequisites:
+#   - glslangValidator (from Vulkan SDK or standalone)
+#   - spirv-opt (optional, from SPIRV-Tools for optimization)
+#
+# Usage:
+#   ./compile_shaders.sh              # Compile all shaders
+#   ./compile_shaders.sh --validate   # Validate only, don't compile
+#   ./compile_shaders.sh --optimize   # Compile with SPIR-V optimization
+#   ./compile_shaders.sh --clean      # Remove compiled shaders
+# ============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GLSL_DIR="$SCRIPT_DIR/GLSL"
+SPIRV_DIR="$SCRIPT_DIR/SPIRV"
+HLSL_DIR="$SCRIPT_DIR/HLSL"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Options
+VALIDATE_ONLY=false
+OPTIMIZE=false
+CLEAN=false
+VERBOSE=false
+
+for arg in "$@"; do
+    case $arg in
+        --validate) VALIDATE_ONLY=true ;;
+        --optimize) OPTIMIZE=true ;;
+        --clean)    CLEAN=true ;;
+        --verbose)  VERBOSE=true ;;
+        --help)
+            echo "Usage: $0 [--validate] [--optimize] [--clean] [--verbose]"
+            exit 0
+            ;;
+    esac
+done
+
+# ============================================================================
+# CLEAN
+# ============================================================================
+if [ "$CLEAN" = true ]; then
+    echo -e "${YELLOW}Cleaning compiled shaders...${NC}"
+    rm -rf "$SPIRV_DIR"/*.spv
+    echo -e "${GREEN}Done.${NC}"
+    exit 0
+fi
+
+# ============================================================================
+# FIND TOOLS
+# ============================================================================
+GLSLANG=$(command -v glslangValidator 2>/dev/null || echo "")
+SPIRV_OPT=$(command -v spirv-opt 2>/dev/null || echo "")
+
+# Check Vulkan SDK
+if [ -z "$GLSLANG" ] && [ -n "$VULKAN_SDK" ]; then
+    GLSLANG="$VULKAN_SDK/bin/glslangValidator"
+fi
+
+if [ -z "$GLSLANG" ] || [ ! -f "$GLSLANG" ]; then
+    echo -e "${RED}Error: glslangValidator not found.${NC}"
+    echo "Install the Vulkan SDK or glslang standalone."
+    echo "  Ubuntu/Debian: sudo apt install glslang-tools"
+    echo "  Arch:          sudo pacman -S glslang"
+    echo "  macOS:         brew install glslang"
+    exit 1
+fi
+
+echo -e "${BLUE}=== Spark Engine Shader Compilation ===${NC}"
+echo -e "glslangValidator: $GLSLANG"
+[ -n "$SPIRV_OPT" ] && echo -e "spirv-opt: $SPIRV_OPT"
+
+mkdir -p "$SPIRV_DIR"
+
+# ============================================================================
+# COMPILE GLSL -> SPIR-V
+# ============================================================================
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+compile_shader() {
+    local src="$1"
+    local stage="$2"
+    local defines="$3"
+    local basename=$(basename "$src" .glsl)
+    local suffix="$4"
+    local output="$SPIRV_DIR/${basename}${suffix}.spv"
+
+    if [ "$VALIDATE_ONLY" = true ]; then
+        echo -n "  Validating $basename${suffix} ($stage)... "
+        if $GLSLANG -S "$stage" $defines "$src" > /dev/null 2>&1; then
+            echo -e "${GREEN}OK${NC}"
+            PASS_COUNT=$((PASS_COUNT + 1))
+        else
+            echo -e "${RED}FAIL${NC}"
+            if [ "$VERBOSE" = true ]; then
+                $GLSLANG -S "$stage" $defines "$src" 2>&1 || true
+            fi
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+        fi
+        return
+    fi
+
+    echo -n "  Compiling $basename${suffix} ($stage)... "
+
+    local error_output
+    if error_output=$($GLSLANG -V -S "$stage" $defines -o "$output" "$src" 2>&1); then
+        # Optimize if requested
+        if [ "$OPTIMIZE" = true ] && [ -n "$SPIRV_OPT" ]; then
+            $SPIRV_OPT -O "$output" -o "$output" 2>/dev/null || true
+        fi
+        local size=$(stat -c%s "$output" 2>/dev/null || stat -f%z "$output" 2>/dev/null || echo "?")
+        echo -e "${GREEN}OK${NC} (${size} bytes)"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo -e "${RED}FAIL${NC}"
+        if [ "$VERBOSE" = true ]; then
+            echo "$error_output"
+        fi
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+echo ""
+echo -e "${BLUE}--- Vertex Shaders ---${NC}"
+compile_shader "$GLSL_DIR/BasicVS.glsl" "vert" "" "_VS"
+compile_shader "$GLSL_DIR/FullscreenQuad.glsl" "vert" "" "_VS"
+
+echo ""
+echo -e "${BLUE}--- Fragment Shaders ---${NC}"
+compile_shader "$GLSL_DIR/BasicPS.glsl" "frag" "" "_PS"
+compile_shader "$GLSL_DIR/PBRSurface.glsl" "frag" "" "_PS"
+compile_shader "$GLSL_DIR/SSAO.glsl" "frag" "" "_PS"
+compile_shader "$GLSL_DIR/BloomExtract.glsl" "frag" "" "_PS"
+compile_shader "$GLSL_DIR/DebugVisualize.glsl" "frag" "" "_PS"
+
+echo ""
+echo -e "${BLUE}--- Post-Processing ---${NC}"
+compile_shader "$GLSL_DIR/PostProcess.glsl" "frag" "" "_PS"
+compile_shader "$GLSL_DIR/PostProcess.glsl" "frag" "-DFXAA_PASS" "_FXAA_PS"
+compile_shader "$GLSL_DIR/PostProcess.glsl" "frag" "-DVIGNETTE_PASS" "_Vignette_PS"
+compile_shader "$GLSL_DIR/PostProcess.glsl" "frag" "-DGRAIN_PASS" "_Grain_PS"
+compile_shader "$GLSL_DIR/PostProcess.glsl" "frag" "-DCHROMATIC_PASS" "_Chromatic_PS"
+
+echo ""
+echo -e "${BLUE}--- Gaussian Blur ---${NC}"
+compile_shader "$GLSL_DIR/GaussianBlur.glsl" "frag" "-DBLUR_HORIZONTAL" "_BlurH_PS"
+compile_shader "$GLSL_DIR/GaussianBlur.glsl" "frag" "" "_BlurV_PS"
+
+echo ""
+echo -e "${BLUE}--- Multi-Stage Shaders (Vertex) ---${NC}"
+for shader in Phong Rim Water EnvReflection; do
+    if [ -f "$GLSL_DIR/$shader.glsl" ]; then
+        compile_shader "$GLSL_DIR/$shader.glsl" "vert" "-DVERTEX_SHADER" "_VS"
+    fi
+done
+
+echo ""
+echo -e "${BLUE}--- Multi-Stage Shaders (Fragment) ---${NC}"
+for shader in Phong Rim Water EnvReflection; do
+    if [ -f "$GLSL_DIR/$shader.glsl" ]; then
+        compile_shader "$GLSL_DIR/$shader.glsl" "frag" "-DFRAGMENT_SHADER" "_PS"
+    fi
+done
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+echo ""
+echo -e "${BLUE}=== Compilation Summary ===${NC}"
+echo -e "  Passed: ${GREEN}${PASS_COUNT}${NC}"
+echo -e "  Failed: ${RED}${FAIL_COUNT}${NC}"
+[ "$SKIP_COUNT" -gt 0 ] && echo -e "  Skipped: ${YELLOW}${SKIP_COUNT}${NC}"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo -e "${RED}Some shaders failed to compile. Run with --verbose for details.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}All shaders compiled successfully!${NC}"

--- a/Spark Engine/Source/Graphics/RHI/D3D11/D3D11Device.cpp
+++ b/Spark Engine/Source/Graphics/RHI/D3D11/D3D11Device.cpp
@@ -1,0 +1,1104 @@
+/**
+ * @file D3D11Device.cpp
+ * @brief DirectX 11 RHI backend implementation
+ * @author Spark Engine Team
+ * @date 2025
+ */
+
+#ifdef _WIN32
+
+#include "D3D11Device.h"
+#include <algorithm>
+#include <cassert>
+
+#pragma comment(lib, "d3d11.lib")
+#pragma comment(lib, "dxgi.lib")
+#pragma comment(lib, "d3dcompiler.lib")
+#pragma comment(lib, "dxguid.lib")
+
+namespace Spark { namespace RHI { namespace D3D11 {
+
+// ============================================================================
+// D3D11 BUFFER
+// ============================================================================
+
+D3D11Buffer::D3D11Buffer(const RHIBufferDesc& desc, ComPtr<ID3D11Buffer> buffer)
+    : m_desc(desc), m_buffer(std::move(buffer))
+{
+}
+
+// ============================================================================
+// D3D11 TEXTURE
+// ============================================================================
+
+D3D11Texture::D3D11Texture(const RHITextureDesc& desc,
+                           ComPtr<ID3D11Resource> resource,
+                           ComPtr<ID3D11ShaderResourceView> srv,
+                           ComPtr<ID3D11RenderTargetView> rtv,
+                           ComPtr<ID3D11DepthStencilView> dsv)
+    : m_desc(desc)
+    , m_resource(std::move(resource))
+    , m_srv(std::move(srv))
+    , m_rtv(std::move(rtv))
+    , m_dsv(std::move(dsv))
+{
+}
+
+// ============================================================================
+// D3D11 SHADER
+// ============================================================================
+
+D3D11Shader::D3D11Shader(const RHIShaderDesc& desc,
+                         ComPtr<ID3D11DeviceChild> shader,
+                         ComPtr<ID3DBlob> bytecodeBlob)
+    : m_desc(desc)
+    , m_shader(std::move(shader))
+    , m_bytecodeBlob(std::move(bytecodeBlob))
+{
+}
+
+const void* D3D11Shader::GetBytecode() const
+{
+    return m_bytecodeBlob ? m_bytecodeBlob->GetBufferPointer() : nullptr;
+}
+
+size_t D3D11Shader::GetBytecodeSize() const
+{
+    return m_bytecodeBlob ? m_bytecodeBlob->GetBufferSize() : 0;
+}
+
+ID3D11VertexShader* D3D11Shader::GetVertexShader() const
+{
+    if (m_desc.stage != RHIShaderStage::Vertex) return nullptr;
+    ComPtr<ID3D11VertexShader> vs;
+    m_shader.As(&vs);
+    return vs.Get();
+}
+
+ID3D11PixelShader* D3D11Shader::GetPixelShader() const
+{
+    if (m_desc.stage != RHIShaderStage::Pixel) return nullptr;
+    ComPtr<ID3D11PixelShader> ps;
+    m_shader.As(&ps);
+    return ps.Get();
+}
+
+ID3D11GeometryShader* D3D11Shader::GetGeometryShader() const
+{
+    if (m_desc.stage != RHIShaderStage::Geometry) return nullptr;
+    ComPtr<ID3D11GeometryShader> gs;
+    m_shader.As(&gs);
+    return gs.Get();
+}
+
+ID3D11HullShader* D3D11Shader::GetHullShader() const
+{
+    if (m_desc.stage != RHIShaderStage::Hull) return nullptr;
+    ComPtr<ID3D11HullShader> hs;
+    m_shader.As(&hs);
+    return hs.Get();
+}
+
+ID3D11DomainShader* D3D11Shader::GetDomainShader() const
+{
+    if (m_desc.stage != RHIShaderStage::Domain) return nullptr;
+    ComPtr<ID3D11DomainShader> ds;
+    m_shader.As(&ds);
+    return ds.Get();
+}
+
+ID3D11ComputeShader* D3D11Shader::GetComputeShader() const
+{
+    if (m_desc.stage != RHIShaderStage::Compute) return nullptr;
+    ComPtr<ID3D11ComputeShader> cs;
+    m_shader.As(&cs);
+    return cs.Get();
+}
+
+// ============================================================================
+// D3D11 SAMPLER
+// ============================================================================
+
+D3D11Sampler::D3D11Sampler(const RHISamplerDesc& desc, ComPtr<ID3D11SamplerState> sampler)
+    : m_desc(desc), m_sampler(std::move(sampler))
+{
+}
+
+// ============================================================================
+// D3D11 PIPELINE STATE
+// ============================================================================
+
+D3D11PipelineState::D3D11PipelineState(const RHIPipelineStateDesc& desc,
+                                       ComPtr<ID3D11InputLayout> inputLayout,
+                                       ComPtr<ID3D11RasterizerState> rasterizerState,
+                                       ComPtr<ID3D11DepthStencilState> depthStencilState,
+                                       ComPtr<ID3D11BlendState> blendState,
+                                       D3D11Shader* vs, D3D11Shader* ps)
+    : m_desc(desc)
+    , m_inputLayout(std::move(inputLayout))
+    , m_rasterizerState(std::move(rasterizerState))
+    , m_depthStencilState(std::move(depthStencilState))
+    , m_blendState(std::move(blendState))
+    , m_vertexShader(vs)
+    , m_pixelShader(ps)
+{
+}
+
+// ============================================================================
+// D3D11 SWAP CHAIN
+// ============================================================================
+
+D3D11SwapChain::D3D11SwapChain(ID3D11Device* device, const RHISwapChainDesc& desc)
+    : m_desc(desc), m_device(device)
+{
+    ComPtr<IDXGIDevice> dxgiDevice;
+    device->QueryInterface(__uuidof(IDXGIDevice), &dxgiDevice);
+
+    ComPtr<IDXGIAdapter> dxgiAdapter;
+    dxgiDevice->GetAdapter(&dxgiAdapter);
+
+    ComPtr<IDXGIFactory2> dxgiFactory;
+    dxgiAdapter->GetParent(__uuidof(IDXGIFactory2), &dxgiFactory);
+
+    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+    swapChainDesc.Width = desc.width;
+    swapChainDesc.Height = desc.height;
+    swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    swapChainDesc.SampleDesc.Count = desc.sampleCount;
+    swapChainDesc.SampleDesc.Quality = 0;
+    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+    swapChainDesc.BufferCount = desc.bufferCount;
+    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+
+    HWND hwnd = static_cast<HWND>(desc.windowHandle);
+    dxgiFactory->CreateSwapChainForHwnd(device, hwnd, &swapChainDesc, nullptr, nullptr,
+                                        &m_swapChain);
+
+    CreateBackBufferViews();
+}
+
+D3D11SwapChain::~D3D11SwapChain()
+{
+    m_backBuffer.reset();
+}
+
+bool D3D11SwapChain::Present(bool vsync)
+{
+    HRESULT hr = m_swapChain->Present(vsync ? 1 : 0, 0);
+    return SUCCEEDED(hr);
+}
+
+bool D3D11SwapChain::Resize(uint32_t width, uint32_t height)
+{
+    m_backBuffer.reset();
+    m_desc.width = width;
+    m_desc.height = height;
+
+    HRESULT hr = m_swapChain->ResizeBuffers(0, width, height, DXGI_FORMAT_UNKNOWN, 0);
+    if (FAILED(hr)) return false;
+
+    return CreateBackBufferViews();
+}
+
+IRHITexture* D3D11SwapChain::GetBackBuffer()
+{
+    return m_backBuffer.get();
+}
+
+bool D3D11SwapChain::CreateBackBufferViews()
+{
+    ComPtr<ID3D11Texture2D> backBufferTex;
+    HRESULT hr = m_swapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), &backBufferTex);
+    if (FAILED(hr)) return false;
+
+    ComPtr<ID3D11RenderTargetView> rtv;
+    hr = m_device->CreateRenderTargetView(backBufferTex.Get(), nullptr, &rtv);
+    if (FAILED(hr)) return false;
+
+    RHITextureDesc desc;
+    desc.width = m_desc.width;
+    desc.height = m_desc.height;
+    desc.format = m_desc.format;
+    desc.usage = RHITextureUsage::RenderTarget;
+    desc.debugName = "BackBuffer";
+
+    m_backBuffer = std::make_unique<D3D11Texture>(desc, backBufferTex, nullptr, rtv, nullptr);
+    return true;
+}
+
+// ============================================================================
+// D3D11 COMMAND LIST
+// ============================================================================
+
+D3D11CommandList::D3D11CommandList(ID3D11DeviceContext* context, bool isImmediate)
+    : m_context(context), m_isImmediate(isImmediate)
+{
+}
+
+void D3D11CommandList::Begin() {}
+void D3D11CommandList::End() {}
+void D3D11CommandList::Reset() {}
+
+void D3D11CommandList::SetRenderTargets(IRHITexture** renderTargets, uint32_t count,
+                                        IRHITexture* depthStencil)
+{
+    ID3D11RenderTargetView* rtvs[8] = {};
+    for (uint32_t i = 0; i < count && i < 8; ++i)
+    {
+        if (renderTargets[i])
+        {
+            auto* d3dTex = static_cast<D3D11Texture*>(renderTargets[i]);
+            rtvs[i] = d3dTex->GetD3D11RTV();
+        }
+    }
+
+    ID3D11DepthStencilView* dsv = nullptr;
+    if (depthStencil)
+    {
+        auto* d3dDS = static_cast<D3D11Texture*>(depthStencil);
+        dsv = d3dDS->GetD3D11DSV();
+    }
+
+    m_context->OMSetRenderTargets(count, rtvs, dsv);
+}
+
+void D3D11CommandList::ClearRenderTarget(IRHITexture* target, const float color[4])
+{
+    if (!target) return;
+    auto* d3dTex = static_cast<D3D11Texture*>(target);
+    if (d3dTex->GetD3D11RTV())
+        m_context->ClearRenderTargetView(d3dTex->GetD3D11RTV(), color);
+}
+
+void D3D11CommandList::ClearDepthStencil(IRHITexture* target, float depth, uint8_t stencil)
+{
+    if (!target) return;
+    auto* d3dTex = static_cast<D3D11Texture*>(target);
+    if (d3dTex->GetD3D11DSV())
+        m_context->ClearDepthStencilView(d3dTex->GetD3D11DSV(),
+                                         D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL,
+                                         depth, stencil);
+}
+
+void D3D11CommandList::SetViewport(const RHIViewport& viewport)
+{
+    D3D11_VIEWPORT vp;
+    vp.TopLeftX = viewport.x;
+    vp.TopLeftY = viewport.y;
+    vp.Width = viewport.width;
+    vp.Height = viewport.height;
+    vp.MinDepth = viewport.minDepth;
+    vp.MaxDepth = viewport.maxDepth;
+    m_context->RSSetViewports(1, &vp);
+}
+
+void D3D11CommandList::SetScissorRect(const RHIScissorRect& rect)
+{
+    D3D11_RECT r;
+    r.left = rect.left;
+    r.top = rect.top;
+    r.right = rect.right;
+    r.bottom = rect.bottom;
+    m_context->RSSetScissorRects(1, &r);
+}
+
+void D3D11CommandList::SetPipelineState(IRHIPipelineState* pipelineState)
+{
+    if (!pipelineState) return;
+    auto* d3dPSO = static_cast<D3D11PipelineState*>(pipelineState);
+
+    m_context->IASetInputLayout(d3dPSO->GetInputLayout());
+    m_context->RSSetState(d3dPSO->GetRasterizerState());
+    m_context->OMSetDepthStencilState(d3dPSO->GetDepthStencilState(), 0);
+
+    float blendFactor[4] = { 0, 0, 0, 0 };
+    m_context->OMSetBlendState(d3dPSO->GetBlendState(), blendFactor, 0xFFFFFFFF);
+
+    if (d3dPSO->GetVertexShader())
+    {
+        auto* vs = d3dPSO->GetVertexShader()->GetVertexShader();
+        m_context->VSSetShader(vs, nullptr, 0);
+    }
+    if (d3dPSO->GetPixelShader())
+    {
+        auto* ps = d3dPSO->GetPixelShader()->GetPixelShader();
+        m_context->PSSetShader(ps, nullptr, 0);
+    }
+}
+
+void D3D11CommandList::SetPrimitiveTopology(RHIPrimitiveTopology topology)
+{
+    static const D3D11_PRIMITIVE_TOPOLOGY d3dTopology[] = {
+        D3D11_PRIMITIVE_TOPOLOGY_POINTLIST,
+        D3D11_PRIMITIVE_TOPOLOGY_LINELIST,
+        D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP,
+        D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST,
+        D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,
+        D3D11_PRIMITIVE_TOPOLOGY_UNDEFINED
+    };
+    m_context->IASetPrimitiveTopology(d3dTopology[static_cast<int>(topology)]);
+}
+
+void D3D11CommandList::SetVertexBuffer(IRHIBuffer* buffer, uint32_t slot, uint32_t offset)
+{
+    if (!buffer) return;
+    auto* d3dBuf = static_cast<D3D11Buffer*>(buffer);
+    ID3D11Buffer* buf = d3dBuf->GetD3D11Buffer();
+    UINT stride = d3dBuf->GetStride();
+    UINT off = offset;
+    m_context->IASetVertexBuffers(slot, 1, &buf, &stride, &off);
+}
+
+void D3D11CommandList::SetIndexBuffer(IRHIBuffer* buffer, uint32_t offset)
+{
+    if (!buffer) return;
+    auto* d3dBuf = static_cast<D3D11Buffer*>(buffer);
+    DXGI_FORMAT fmt = (d3dBuf->GetStride() == 4) ? DXGI_FORMAT_R32_UINT : DXGI_FORMAT_R16_UINT;
+    m_context->IASetIndexBuffer(d3dBuf->GetD3D11Buffer(), fmt, offset);
+}
+
+void D3D11CommandList::SetConstantBuffer(RHIShaderStage stage, uint32_t slot, IRHIBuffer* buffer)
+{
+    if (!buffer) return;
+    auto* d3dBuf = static_cast<D3D11Buffer*>(buffer);
+    ID3D11Buffer* buf = d3dBuf->GetD3D11Buffer();
+
+    switch (stage)
+    {
+    case RHIShaderStage::Vertex:   m_context->VSSetConstantBuffers(slot, 1, &buf); break;
+    case RHIShaderStage::Pixel:    m_context->PSSetConstantBuffers(slot, 1, &buf); break;
+    case RHIShaderStage::Geometry: m_context->GSSetConstantBuffers(slot, 1, &buf); break;
+    case RHIShaderStage::Hull:     m_context->HSSetConstantBuffers(slot, 1, &buf); break;
+    case RHIShaderStage::Domain:   m_context->DSSetConstantBuffers(slot, 1, &buf); break;
+    case RHIShaderStage::Compute:  m_context->CSSetConstantBuffers(slot, 1, &buf); break;
+    }
+}
+
+void D3D11CommandList::SetShaderResource(RHIShaderStage stage, uint32_t slot, IRHITexture* texture)
+{
+    ID3D11ShaderResourceView* srv = nullptr;
+    if (texture)
+    {
+        auto* d3dTex = static_cast<D3D11Texture*>(texture);
+        srv = d3dTex->GetD3D11SRV();
+    }
+
+    switch (stage)
+    {
+    case RHIShaderStage::Vertex:   m_context->VSSetShaderResources(slot, 1, &srv); break;
+    case RHIShaderStage::Pixel:    m_context->PSSetShaderResources(slot, 1, &srv); break;
+    case RHIShaderStage::Geometry: m_context->GSSetShaderResources(slot, 1, &srv); break;
+    case RHIShaderStage::Hull:     m_context->HSSetShaderResources(slot, 1, &srv); break;
+    case RHIShaderStage::Domain:   m_context->DSSetShaderResources(slot, 1, &srv); break;
+    case RHIShaderStage::Compute:  m_context->CSSetShaderResources(slot, 1, &srv); break;
+    }
+}
+
+void D3D11CommandList::SetSampler(RHIShaderStage stage, uint32_t slot, IRHISampler* sampler)
+{
+    ID3D11SamplerState* ss = nullptr;
+    if (sampler)
+    {
+        auto* d3dSamp = static_cast<D3D11Sampler*>(sampler);
+        ss = d3dSamp->GetD3D11Sampler();
+    }
+
+    switch (stage)
+    {
+    case RHIShaderStage::Vertex:   m_context->VSSetSamplers(slot, 1, &ss); break;
+    case RHIShaderStage::Pixel:    m_context->PSSetSamplers(slot, 1, &ss); break;
+    case RHIShaderStage::Geometry: m_context->GSSetSamplers(slot, 1, &ss); break;
+    case RHIShaderStage::Compute:  m_context->CSSetSamplers(slot, 1, &ss); break;
+    default: break;
+    }
+}
+
+void D3D11CommandList::Draw(uint32_t vertexCount, uint32_t startVertex)
+{
+    m_context->Draw(vertexCount, startVertex);
+}
+
+void D3D11CommandList::DrawIndexed(uint32_t indexCount, uint32_t startIndex, int32_t baseVertex)
+{
+    m_context->DrawIndexed(indexCount, startIndex, baseVertex);
+}
+
+void D3D11CommandList::DrawInstanced(uint32_t vertexCount, uint32_t instanceCount,
+                                     uint32_t startVertex, uint32_t startInstance)
+{
+    m_context->DrawInstanced(vertexCount, instanceCount, startVertex, startInstance);
+}
+
+void D3D11CommandList::DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
+                                            uint32_t startIndex, int32_t baseVertex,
+                                            uint32_t startInstance)
+{
+    m_context->DrawIndexedInstanced(indexCount, instanceCount, startIndex, baseVertex, startInstance);
+}
+
+void D3D11CommandList::Dispatch(uint32_t x, uint32_t y, uint32_t z)
+{
+    m_context->Dispatch(x, y, z);
+}
+
+void D3D11CommandList::BeginEvent(const char*) {}
+void D3D11CommandList::EndEvent() {}
+void D3D11CommandList::SetMarker(const char*) {}
+
+// ============================================================================
+// D3D11 DEVICE
+// ============================================================================
+
+D3D11Device::D3D11Device()
+{
+    m_capabilities.backend = GraphicsBackend::D3D11;
+}
+
+D3D11Device::~D3D11Device()
+{
+    Shutdown();
+}
+
+bool D3D11Device::Initialize(const RHIDeviceDesc& desc)
+{
+    m_debugEnabled = desc.enableDebugLayer;
+
+    UINT createFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+    if (desc.enableDebugLayer)
+        createFlags |= D3D11_CREATE_DEVICE_DEBUG;
+
+    D3D_FEATURE_LEVEL featureLevels[] = {
+        D3D_FEATURE_LEVEL_11_1,
+        D3D_FEATURE_LEVEL_11_0,
+        D3D_FEATURE_LEVEL_10_1,
+        D3D_FEATURE_LEVEL_10_0
+    };
+
+    ComPtr<ID3D11Device> device;
+    ComPtr<ID3D11DeviceContext> context;
+    D3D_FEATURE_LEVEL achievedLevel;
+
+    HRESULT hr = D3D11CreateDevice(
+        nullptr,
+        D3D_DRIVER_TYPE_HARDWARE,
+        nullptr,
+        createFlags,
+        featureLevels,
+        _countof(featureLevels),
+        D3D11_SDK_VERSION,
+        &device,
+        &achievedLevel,
+        &context
+    );
+
+    if (FAILED(hr)) return false;
+
+    hr = device.As(&m_device);
+    if (FAILED(hr)) return false;
+
+    hr = context.As(&m_immediateContext);
+    if (FAILED(hr)) return false;
+
+    // Get DXGI factory
+    ComPtr<IDXGIDevice> dxgiDevice;
+    m_device.As(&dxgiDevice);
+    ComPtr<IDXGIAdapter> adapter;
+    dxgiDevice->GetAdapter(&adapter);
+    adapter->GetParent(__uuidof(IDXGIFactory2), &m_dxgiFactory);
+
+    // Query capabilities
+    DXGI_ADAPTER_DESC adapterDesc;
+    adapter->GetDesc(&adapterDesc);
+
+    char deviceName[256];
+    wcstombs(deviceName, adapterDesc.Description, 256);
+    m_capabilities.deviceName = deviceName;
+    m_capabilities.dedicatedVideoMemory = adapterDesc.DedicatedVideoMemory;
+    m_capabilities.sharedSystemMemory = adapterDesc.SharedSystemMemory;
+
+    m_capabilities.tessellationSupport = (achievedLevel >= D3D_FEATURE_LEVEL_11_0);
+    m_capabilities.computeShaderSupport = (achievedLevel >= D3D_FEATURE_LEVEL_11_0);
+    m_capabilities.geometryShaderSupport = (achievedLevel >= D3D_FEATURE_LEVEL_10_0);
+    m_capabilities.maxTextureSize = (achievedLevel >= D3D_FEATURE_LEVEL_11_0) ? 16384 : 8192;
+    m_capabilities.maxRenderTargets = 8;
+    m_capabilities.maxAnisotropy = 16.0f;
+    m_capabilities.apiVersion = "DirectX 11.1";
+
+    // Create immediate command list wrapper
+    m_immediateCommandList = std::make_unique<D3D11CommandList>(m_immediateContext.Get(), true);
+
+    return true;
+}
+
+void D3D11Device::Shutdown()
+{
+    m_immediateCommandList.reset();
+    m_immediateContext.Reset();
+    m_dxgiFactory.Reset();
+    m_device.Reset();
+}
+
+std::unique_ptr<IRHISwapChain> D3D11Device::CreateSwapChain(const RHISwapChainDesc& desc)
+{
+    return std::make_unique<D3D11SwapChain>(m_device.Get(), desc);
+}
+
+IRHIBuffer* D3D11Device::CreateBuffer(const RHIBufferDesc& desc)
+{
+    D3D11_BUFFER_DESC d3dDesc = {};
+    d3dDesc.ByteWidth = static_cast<UINT>(desc.size);
+    d3dDesc.StructureByteStride = desc.stride;
+
+    if (desc.usage & RHIBufferUsage::Vertex) d3dDesc.BindFlags |= D3D11_BIND_VERTEX_BUFFER;
+    if (desc.usage & RHIBufferUsage::Index) d3dDesc.BindFlags |= D3D11_BIND_INDEX_BUFFER;
+    if (desc.usage & RHIBufferUsage::Constant) d3dDesc.BindFlags |= D3D11_BIND_CONSTANT_BUFFER;
+    if (desc.usage & RHIBufferUsage::Structured) d3dDesc.BindFlags |= D3D11_BIND_SHADER_RESOURCE;
+
+    switch (desc.access)
+    {
+    case RHIBufferAccess::Static:
+        d3dDesc.Usage = D3D11_USAGE_DEFAULT;
+        break;
+    case RHIBufferAccess::Dynamic:
+        d3dDesc.Usage = D3D11_USAGE_DYNAMIC;
+        d3dDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+        break;
+    case RHIBufferAccess::Staging:
+        d3dDesc.Usage = D3D11_USAGE_STAGING;
+        d3dDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ | D3D11_CPU_ACCESS_WRITE;
+        d3dDesc.BindFlags = 0;
+        break;
+    case RHIBufferAccess::ReadBack:
+        d3dDesc.Usage = D3D11_USAGE_STAGING;
+        d3dDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+        d3dDesc.BindFlags = 0;
+        break;
+    }
+
+    D3D11_SUBRESOURCE_DATA initData = {};
+    initData.pSysMem = desc.initialData;
+
+    ComPtr<ID3D11Buffer> buffer;
+    HRESULT hr = m_device->CreateBuffer(&d3dDesc,
+                                        desc.initialData ? &initData : nullptr,
+                                        &buffer);
+    if (FAILED(hr)) return nullptr;
+
+    return new D3D11Buffer(desc, std::move(buffer));
+}
+
+IRHITexture* D3D11Device::CreateTexture(const RHITextureDesc& desc)
+{
+    DXGI_FORMAT format = ConvertFormat(desc.format);
+
+    D3D11_TEXTURE2D_DESC texDesc = {};
+    texDesc.Width = desc.width;
+    texDesc.Height = desc.height;
+    texDesc.MipLevels = desc.mipLevels;
+    texDesc.ArraySize = desc.arraySize;
+    texDesc.Format = format;
+    texDesc.SampleDesc.Count = desc.sampleCount;
+    texDesc.SampleDesc.Quality = 0;
+    texDesc.Usage = D3D11_USAGE_DEFAULT;
+
+    if (desc.usage & RHITextureUsage::ShaderResource) texDesc.BindFlags |= D3D11_BIND_SHADER_RESOURCE;
+    if (desc.usage & RHITextureUsage::RenderTarget) texDesc.BindFlags |= D3D11_BIND_RENDER_TARGET;
+    if (desc.usage & RHITextureUsage::DepthStencil) texDesc.BindFlags |= D3D11_BIND_DEPTH_STENCIL;
+    if (desc.usage & RHITextureUsage::UnorderedAccess) texDesc.BindFlags |= D3D11_BIND_UNORDERED_ACCESS;
+
+    ComPtr<ID3D11Texture2D> texture;
+    HRESULT hr = m_device->CreateTexture2D(&texDesc, nullptr, &texture);
+    if (FAILED(hr)) return nullptr;
+
+    ComPtr<ID3D11ShaderResourceView> srv;
+    if (desc.usage & RHITextureUsage::ShaderResource)
+    {
+        D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+        srvDesc.Format = format;
+        srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+        srvDesc.Texture2D.MipLevels = desc.mipLevels;
+        m_device->CreateShaderResourceView(texture.Get(), &srvDesc, &srv);
+    }
+
+    ComPtr<ID3D11RenderTargetView> rtv;
+    if (desc.usage & RHITextureUsage::RenderTarget)
+    {
+        m_device->CreateRenderTargetView(texture.Get(), nullptr, &rtv);
+    }
+
+    ComPtr<ID3D11DepthStencilView> dsv;
+    if (desc.usage & RHITextureUsage::DepthStencil)
+    {
+        D3D11_DEPTH_STENCIL_VIEW_DESC dsvDesc = {};
+        dsvDesc.Format = format;
+        dsvDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2D;
+        m_device->CreateDepthStencilView(texture.Get(), &dsvDesc, &dsv);
+    }
+
+    return new D3D11Texture(desc, texture, std::move(srv), std::move(rtv), std::move(dsv));
+}
+
+IRHIShader* D3D11Device::CreateShader(const RHIShaderDesc& desc)
+{
+    ComPtr<ID3DBlob> bytecodeBlob;
+    ComPtr<ID3DBlob> errorBlob;
+
+    // Compile from source if provided
+    if (!desc.sourceCode.empty())
+    {
+        const char* target = nullptr;
+        switch (desc.stage)
+        {
+        case RHIShaderStage::Vertex:   target = "vs_5_0"; break;
+        case RHIShaderStage::Pixel:    target = "ps_5_0"; break;
+        case RHIShaderStage::Geometry: target = "gs_5_0"; break;
+        case RHIShaderStage::Hull:     target = "hs_5_0"; break;
+        case RHIShaderStage::Domain:   target = "ds_5_0"; break;
+        case RHIShaderStage::Compute:  target = "cs_5_0"; break;
+        }
+
+        UINT flags = D3DCOMPILE_ENABLE_STRICTNESS | D3DCOMPILE_OPTIMIZATION_LEVEL3;
+
+        HRESULT hr = D3DCompile(desc.sourceCode.c_str(), desc.sourceCode.size(),
+                                desc.debugName.c_str(), nullptr,
+                                D3D_COMPILE_STANDARD_FILE_INCLUDE,
+                                desc.entryPoint.c_str(), target, flags, 0,
+                                &bytecodeBlob, &errorBlob);
+        if (FAILED(hr)) return nullptr;
+    }
+    else if (desc.bytecode && desc.bytecodeSize > 0)
+    {
+        D3DCreateBlob(desc.bytecodeSize, &bytecodeBlob);
+        memcpy(bytecodeBlob->GetBufferPointer(), desc.bytecode, desc.bytecodeSize);
+    }
+    else
+    {
+        return nullptr;
+    }
+
+    ComPtr<ID3D11DeviceChild> shaderObj;
+    HRESULT hr = E_FAIL;
+
+    switch (desc.stage)
+    {
+    case RHIShaderStage::Vertex:
+    {
+        ComPtr<ID3D11VertexShader> vs;
+        hr = m_device->CreateVertexShader(bytecodeBlob->GetBufferPointer(),
+                                          bytecodeBlob->GetBufferSize(), nullptr, &vs);
+        if (SUCCEEDED(hr)) vs.As(&shaderObj);
+        break;
+    }
+    case RHIShaderStage::Pixel:
+    {
+        ComPtr<ID3D11PixelShader> ps;
+        hr = m_device->CreatePixelShader(bytecodeBlob->GetBufferPointer(),
+                                         bytecodeBlob->GetBufferSize(), nullptr, &ps);
+        if (SUCCEEDED(hr)) ps.As(&shaderObj);
+        break;
+    }
+    case RHIShaderStage::Geometry:
+    {
+        ComPtr<ID3D11GeometryShader> gs;
+        hr = m_device->CreateGeometryShader(bytecodeBlob->GetBufferPointer(),
+                                            bytecodeBlob->GetBufferSize(), nullptr, &gs);
+        if (SUCCEEDED(hr)) gs.As(&shaderObj);
+        break;
+    }
+    case RHIShaderStage::Hull:
+    {
+        ComPtr<ID3D11HullShader> hs;
+        hr = m_device->CreateHullShader(bytecodeBlob->GetBufferPointer(),
+                                        bytecodeBlob->GetBufferSize(), nullptr, &hs);
+        if (SUCCEEDED(hr)) hs.As(&shaderObj);
+        break;
+    }
+    case RHIShaderStage::Domain:
+    {
+        ComPtr<ID3D11DomainShader> ds;
+        hr = m_device->CreateDomainShader(bytecodeBlob->GetBufferPointer(),
+                                          bytecodeBlob->GetBufferSize(), nullptr, &ds);
+        if (SUCCEEDED(hr)) ds.As(&shaderObj);
+        break;
+    }
+    case RHIShaderStage::Compute:
+    {
+        ComPtr<ID3D11ComputeShader> cs;
+        hr = m_device->CreateComputeShader(bytecodeBlob->GetBufferPointer(),
+                                           bytecodeBlob->GetBufferSize(), nullptr, &cs);
+        if (SUCCEEDED(hr)) cs.As(&shaderObj);
+        break;
+    }
+    }
+
+    if (FAILED(hr) || !shaderObj) return nullptr;
+
+    return new D3D11Shader(desc, std::move(shaderObj), std::move(bytecodeBlob));
+}
+
+IRHISampler* D3D11Device::CreateSampler(const RHISamplerDesc& desc)
+{
+    D3D11_SAMPLER_DESC d3dDesc = {};
+    d3dDesc.Filter = ConvertFilter(desc);
+    d3dDesc.AddressU = ConvertAddressMode(desc.addressU);
+    d3dDesc.AddressV = ConvertAddressMode(desc.addressV);
+    d3dDesc.AddressW = ConvertAddressMode(desc.addressW);
+    d3dDesc.MipLODBias = desc.mipLodBias;
+    d3dDesc.MaxAnisotropy = desc.maxAnisotropy;
+    d3dDesc.ComparisonFunc = ConvertCompareOp(desc.compareOp);
+    memcpy(d3dDesc.BorderColor, desc.borderColor, sizeof(float) * 4);
+    d3dDesc.MinLOD = desc.minLod;
+    d3dDesc.MaxLOD = desc.maxLod;
+
+    ComPtr<ID3D11SamplerState> sampler;
+    HRESULT hr = m_device->CreateSamplerState(&d3dDesc, &sampler);
+    if (FAILED(hr)) return nullptr;
+
+    return new D3D11Sampler(desc, std::move(sampler));
+}
+
+IRHIPipelineState* D3D11Device::CreatePipelineState(const RHIPipelineStateDesc& desc,
+                                                     IRHIShader* vertexShader,
+                                                     IRHIShader* pixelShader)
+{
+    auto* d3dVS = static_cast<D3D11Shader*>(vertexShader);
+    auto* d3dPS = static_cast<D3D11Shader*>(pixelShader);
+
+    // Create input layout
+    std::vector<D3D11_INPUT_ELEMENT_DESC> elements;
+    for (const auto& elem : desc.inputLayout.elements)
+    {
+        D3D11_INPUT_ELEMENT_DESC d3dElem = {};
+        d3dElem.SemanticName = elem.semanticName.c_str();
+        d3dElem.SemanticIndex = elem.semanticIndex;
+        d3dElem.Format = ConvertVertexFormat(elem.format);
+        d3dElem.InputSlot = elem.inputSlot;
+        d3dElem.AlignedByteOffset = elem.byteOffset;
+        d3dElem.InputSlotClass = elem.perInstance ?
+            D3D11_INPUT_PER_INSTANCE_DATA : D3D11_INPUT_PER_VERTEX_DATA;
+        d3dElem.InstanceDataStepRate = elem.instanceStepRate;
+        elements.push_back(d3dElem);
+    }
+
+    ComPtr<ID3D11InputLayout> inputLayout;
+    if (!elements.empty() && d3dVS)
+    {
+        m_device->CreateInputLayout(elements.data(), static_cast<UINT>(elements.size()),
+                                    d3dVS->GetBytecode(), d3dVS->GetBytecodeSize(),
+                                    &inputLayout);
+    }
+
+    // Create rasterizer state
+    D3D11_RASTERIZER_DESC rasterDesc = {};
+    rasterDesc.FillMode = (desc.rasterizer.fillMode == RHIFillMode::Wireframe) ?
+        D3D11_FILL_WIREFRAME : D3D11_FILL_SOLID;
+    rasterDesc.CullMode = (desc.rasterizer.cullMode == RHICullMode::None) ? D3D11_CULL_NONE :
+        (desc.rasterizer.cullMode == RHICullMode::Front) ? D3D11_CULL_FRONT : D3D11_CULL_BACK;
+    rasterDesc.FrontCounterClockwise = desc.rasterizer.frontCounterClockwise;
+    rasterDesc.DepthBias = desc.rasterizer.depthBias;
+    rasterDesc.DepthBiasClamp = desc.rasterizer.depthBiasClamp;
+    rasterDesc.SlopeScaledDepthBias = desc.rasterizer.slopeScaledDepthBias;
+    rasterDesc.DepthClipEnable = desc.rasterizer.depthClipEnable;
+    rasterDesc.ScissorEnable = desc.rasterizer.scissorEnable;
+    rasterDesc.MultisampleEnable = desc.rasterizer.multisampleEnable;
+    rasterDesc.AntialiasedLineEnable = desc.rasterizer.antialiasedLineEnable;
+
+    ComPtr<ID3D11RasterizerState> rasterizerState;
+    m_device->CreateRasterizerState(&rasterDesc, &rasterizerState);
+
+    // Create depth stencil state
+    D3D11_DEPTH_STENCIL_DESC dsDesc = {};
+    dsDesc.DepthEnable = desc.depthStencil.depthEnable;
+    dsDesc.DepthWriteMask = desc.depthStencil.depthWrite ?
+        D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
+    dsDesc.DepthFunc = ConvertCompareOp(desc.depthStencil.depthFunc);
+    dsDesc.StencilEnable = desc.depthStencil.stencilEnable;
+    dsDesc.StencilReadMask = desc.depthStencil.stencilReadMask;
+    dsDesc.StencilWriteMask = desc.depthStencil.stencilWriteMask;
+
+    dsDesc.FrontFace.StencilFailOp = ConvertStencilOp(desc.depthStencil.frontFace.stencilFail);
+    dsDesc.FrontFace.StencilDepthFailOp = ConvertStencilOp(desc.depthStencil.frontFace.stencilDepthFail);
+    dsDesc.FrontFace.StencilPassOp = ConvertStencilOp(desc.depthStencil.frontFace.stencilPass);
+    dsDesc.FrontFace.StencilFunc = ConvertCompareOp(desc.depthStencil.frontFace.stencilFunc);
+
+    dsDesc.BackFace.StencilFailOp = ConvertStencilOp(desc.depthStencil.backFace.stencilFail);
+    dsDesc.BackFace.StencilDepthFailOp = ConvertStencilOp(desc.depthStencil.backFace.stencilDepthFail);
+    dsDesc.BackFace.StencilPassOp = ConvertStencilOp(desc.depthStencil.backFace.stencilPass);
+    dsDesc.BackFace.StencilFunc = ConvertCompareOp(desc.depthStencil.backFace.stencilFunc);
+
+    ComPtr<ID3D11DepthStencilState> depthStencilState;
+    m_device->CreateDepthStencilState(&dsDesc, &depthStencilState);
+
+    // Create blend state
+    D3D11_BLEND_DESC blendDesc = {};
+    blendDesc.AlphaToCoverageEnable = desc.blend.alphaToCoverageEnable;
+    blendDesc.IndependentBlendEnable = desc.blend.independentBlendEnable;
+
+    for (int i = 0; i < 8; ++i)
+    {
+        blendDesc.RenderTarget[i].BlendEnable = desc.blend.renderTargets[i].blendEnable;
+        blendDesc.RenderTarget[i].SrcBlend = ConvertBlendFactor(desc.blend.renderTargets[i].srcBlend);
+        blendDesc.RenderTarget[i].DestBlend = ConvertBlendFactor(desc.blend.renderTargets[i].dstBlend);
+        blendDesc.RenderTarget[i].BlendOp = ConvertBlendOp(desc.blend.renderTargets[i].blendOp);
+        blendDesc.RenderTarget[i].SrcBlendAlpha = ConvertBlendFactor(desc.blend.renderTargets[i].srcBlendAlpha);
+        blendDesc.RenderTarget[i].DestBlendAlpha = ConvertBlendFactor(desc.blend.renderTargets[i].dstBlendAlpha);
+        blendDesc.RenderTarget[i].BlendOpAlpha = ConvertBlendOp(desc.blend.renderTargets[i].blendOpAlpha);
+        blendDesc.RenderTarget[i].RenderTargetWriteMask = desc.blend.renderTargets[i].writeMask;
+    }
+
+    ComPtr<ID3D11BlendState> blendState;
+    m_device->CreateBlendState(&blendDesc, &blendState);
+
+    return new D3D11PipelineState(desc, std::move(inputLayout), std::move(rasterizerState),
+                                  std::move(depthStencilState), std::move(blendState),
+                                  d3dVS, d3dPS);
+}
+
+void D3D11Device::DestroyBuffer(IRHIBuffer* buffer)       { delete buffer; }
+void D3D11Device::DestroyTexture(IRHITexture* texture)     { delete texture; }
+void D3D11Device::DestroyShader(IRHIShader* shader)        { delete shader; }
+void D3D11Device::DestroySampler(IRHISampler* sampler)     { delete sampler; }
+void D3D11Device::DestroyPipelineState(IRHIPipelineState* state) { delete state; }
+
+void* D3D11Device::MapBuffer(IRHIBuffer* buffer)
+{
+    auto* d3dBuf = static_cast<D3D11Buffer*>(buffer);
+    D3D11_MAPPED_SUBRESOURCE mapped;
+    HRESULT hr = m_immediateContext->Map(d3dBuf->GetD3D11Buffer(), 0,
+                                         D3D11_MAP_WRITE_DISCARD, 0, &mapped);
+    return SUCCEEDED(hr) ? mapped.pData : nullptr;
+}
+
+void D3D11Device::UnmapBuffer(IRHIBuffer* buffer)
+{
+    auto* d3dBuf = static_cast<D3D11Buffer*>(buffer);
+    m_immediateContext->Unmap(d3dBuf->GetD3D11Buffer(), 0);
+}
+
+void D3D11Device::UpdateBuffer(IRHIBuffer* buffer, const void* data, size_t size, size_t offset)
+{
+    auto* d3dBuf = static_cast<D3D11Buffer*>(buffer);
+    if (d3dBuf->GetDesc().access == RHIBufferAccess::Dynamic)
+    {
+        void* mapped = MapBuffer(buffer);
+        if (mapped)
+        {
+            memcpy(static_cast<uint8_t*>(mapped) + offset, data, size);
+            UnmapBuffer(buffer);
+        }
+    }
+    else
+    {
+        m_immediateContext->UpdateSubresource(d3dBuf->GetD3D11Buffer(), 0, nullptr, data, 0, 0);
+    }
+}
+
+void D3D11Device::UpdateTexture(IRHITexture* texture, const void* data,
+                                uint32_t mipLevel, uint32_t arraySlice)
+{
+    auto* d3dTex = static_cast<D3D11Texture*>(texture);
+    uint32_t subresource = D3D11CalcSubresource(mipLevel, arraySlice, d3dTex->GetMipLevels());
+    uint32_t rowPitch = d3dTex->GetWidth() * GetFormatSize(d3dTex->GetFormat());
+    m_immediateContext->UpdateSubresource(d3dTex->GetD3D11Resource(), subresource,
+                                          nullptr, data, rowPitch, 0);
+}
+
+IRHICommandList* D3D11Device::GetImmediateCommandList()
+{
+    return m_immediateCommandList.get();
+}
+
+IRHICommandList* D3D11Device::CreateDeferredCommandList()
+{
+    ComPtr<ID3D11DeviceContext> deferredContext;
+    HRESULT hr = m_device->CreateDeferredContext(0, &deferredContext);
+    if (FAILED(hr)) return nullptr;
+    return new D3D11CommandList(deferredContext.Get(), false);
+}
+
+void D3D11Device::ExecuteCommandList(IRHICommandList*) {}
+void D3D11Device::DestroyCommandList(IRHICommandList* commandList) { delete commandList; }
+
+void D3D11Device::BeginFrame() { ResetStatistics(); }
+void D3D11Device::EndFrame() {}
+void D3D11Device::WaitForIdle() { m_immediateContext->Flush(); }
+
+void D3D11Device::ResetStatistics() { m_statistics = {}; }
+
+std::string D3D11Device::GetDeviceInfo() const
+{
+    std::string info = "=== D3D11 Device Info ===\n";
+    info += "Device: " + m_capabilities.deviceName + "\n";
+    info += "API: " + m_capabilities.apiVersion + "\n";
+    info += "VRAM: " + std::to_string(m_capabilities.dedicatedVideoMemory / (1024 * 1024)) + " MB\n";
+    info += "Max Texture Size: " + std::to_string(m_capabilities.maxTextureSize) + "\n";
+    info += "Compute Shaders: " + std::string(m_capabilities.computeShaderSupport ? "Yes" : "No") + "\n";
+    info += "Tessellation: " + std::string(m_capabilities.tessellationSupport ? "Yes" : "No") + "\n";
+    return info;
+}
+
+// ============================================================================
+// FORMAT CONVERSION HELPERS
+// ============================================================================
+
+DXGI_FORMAT D3D11Device::ConvertFormat(PixelFormat format) const
+{
+    switch (format)
+    {
+    case PixelFormat::R8_UNORM:              return DXGI_FORMAT_R8_UNORM;
+    case PixelFormat::R8G8_UNORM:            return DXGI_FORMAT_R8G8_UNORM;
+    case PixelFormat::R8G8B8A8_UNORM:        return DXGI_FORMAT_R8G8B8A8_UNORM;
+    case PixelFormat::R8G8B8A8_UNORM_SRGB:   return DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+    case PixelFormat::B8G8R8A8_UNORM:        return DXGI_FORMAT_B8G8R8A8_UNORM;
+    case PixelFormat::R10G10B10A2_UNORM:     return DXGI_FORMAT_R10G10B10A2_UNORM;
+    case PixelFormat::R11G11B10_FLOAT:       return DXGI_FORMAT_R11G11B10_FLOAT;
+    case PixelFormat::R16_FLOAT:             return DXGI_FORMAT_R16_FLOAT;
+    case PixelFormat::R16G16_FLOAT:          return DXGI_FORMAT_R16G16_FLOAT;
+    case PixelFormat::R16G16B16A16_FLOAT:    return DXGI_FORMAT_R16G16B16A16_FLOAT;
+    case PixelFormat::R32_FLOAT:             return DXGI_FORMAT_R32_FLOAT;
+    case PixelFormat::R32G32_FLOAT:          return DXGI_FORMAT_R32G32_FLOAT;
+    case PixelFormat::R32G32B32_FLOAT:       return DXGI_FORMAT_R32G32B32_FLOAT;
+    case PixelFormat::R32G32B32A32_FLOAT:    return DXGI_FORMAT_R32G32B32A32_FLOAT;
+    case PixelFormat::BC1_UNORM:             return DXGI_FORMAT_BC1_UNORM;
+    case PixelFormat::BC3_UNORM:             return DXGI_FORMAT_BC3_UNORM;
+    case PixelFormat::BC5_UNORM:             return DXGI_FORMAT_BC5_UNORM;
+    case PixelFormat::BC6H_UF16:             return DXGI_FORMAT_BC6H_UF16;
+    case PixelFormat::BC7_UNORM:             return DXGI_FORMAT_BC7_UNORM;
+    case PixelFormat::D16_UNORM:             return DXGI_FORMAT_D16_UNORM;
+    case PixelFormat::D24_UNORM_S8_UINT:     return DXGI_FORMAT_D24_UNORM_S8_UINT;
+    case PixelFormat::D32_FLOAT:             return DXGI_FORMAT_D32_FLOAT;
+    default:                                 return DXGI_FORMAT_UNKNOWN;
+    }
+}
+
+uint32_t D3D11Device::GetFormatSize(PixelFormat format) const
+{
+    switch (format)
+    {
+    case PixelFormat::R8_UNORM:             return 1;
+    case PixelFormat::R8G8_UNORM:           return 2;
+    case PixelFormat::R16_FLOAT:            return 2;
+    case PixelFormat::R8G8B8A8_UNORM:       return 4;
+    case PixelFormat::R8G8B8A8_UNORM_SRGB:  return 4;
+    case PixelFormat::B8G8R8A8_UNORM:       return 4;
+    case PixelFormat::R10G10B10A2_UNORM:    return 4;
+    case PixelFormat::R11G11B10_FLOAT:      return 4;
+    case PixelFormat::R32_FLOAT:            return 4;
+    case PixelFormat::R16G16_FLOAT:         return 4;
+    case PixelFormat::D24_UNORM_S8_UINT:    return 4;
+    case PixelFormat::D32_FLOAT:            return 4;
+    case PixelFormat::R16G16B16A16_FLOAT:   return 8;
+    case PixelFormat::R32G32_FLOAT:         return 8;
+    case PixelFormat::R32G32B32_FLOAT:      return 12;
+    case PixelFormat::R32G32B32A32_FLOAT:   return 16;
+    default:                                return 4;
+    }
+}
+
+D3D11_FILTER D3D11Device::ConvertFilter(const RHISamplerDesc& desc) const
+{
+    if (desc.minFilter == RHIFilterMode::Anisotropic || desc.magFilter == RHIFilterMode::Anisotropic)
+        return D3D11_FILTER_ANISOTROPIC;
+    if (desc.minFilter == RHIFilterMode::Linear && desc.magFilter == RHIFilterMode::Linear)
+        return D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+    if (desc.minFilter == RHIFilterMode::Nearest && desc.magFilter == RHIFilterMode::Nearest)
+        return D3D11_FILTER_MIN_MAG_MIP_POINT;
+    return D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+}
+
+D3D11_TEXTURE_ADDRESS_MODE D3D11Device::ConvertAddressMode(RHIAddressMode mode) const
+{
+    switch (mode)
+    {
+    case RHIAddressMode::Wrap:       return D3D11_TEXTURE_ADDRESS_WRAP;
+    case RHIAddressMode::Clamp:      return D3D11_TEXTURE_ADDRESS_CLAMP;
+    case RHIAddressMode::Mirror:     return D3D11_TEXTURE_ADDRESS_MIRROR;
+    case RHIAddressMode::Border:     return D3D11_TEXTURE_ADDRESS_BORDER;
+    case RHIAddressMode::MirrorOnce: return D3D11_TEXTURE_ADDRESS_MIRROR_ONCE;
+    default:                         return D3D11_TEXTURE_ADDRESS_WRAP;
+    }
+}
+
+D3D11_COMPARISON_FUNC D3D11Device::ConvertCompareOp(RHICompareOp op) const
+{
+    switch (op)
+    {
+    case RHICompareOp::Never:        return D3D11_COMPARISON_NEVER;
+    case RHICompareOp::Less:         return D3D11_COMPARISON_LESS;
+    case RHICompareOp::Equal:        return D3D11_COMPARISON_EQUAL;
+    case RHICompareOp::LessEqual:    return D3D11_COMPARISON_LESS_EQUAL;
+    case RHICompareOp::Greater:      return D3D11_COMPARISON_GREATER;
+    case RHICompareOp::NotEqual:     return D3D11_COMPARISON_NOT_EQUAL;
+    case RHICompareOp::GreaterEqual: return D3D11_COMPARISON_GREATER_EQUAL;
+    case RHICompareOp::Always:       return D3D11_COMPARISON_ALWAYS;
+    default:                         return D3D11_COMPARISON_LESS;
+    }
+}
+
+D3D11_STENCIL_OP D3D11Device::ConvertStencilOp(RHIStencilOp op) const
+{
+    switch (op)
+    {
+    case RHIStencilOp::Keep:     return D3D11_STENCIL_OP_KEEP;
+    case RHIStencilOp::Zero:     return D3D11_STENCIL_OP_ZERO;
+    case RHIStencilOp::Replace:  return D3D11_STENCIL_OP_REPLACE;
+    case RHIStencilOp::IncrSat:  return D3D11_STENCIL_OP_INCR_SAT;
+    case RHIStencilOp::DecrSat:  return D3D11_STENCIL_OP_DECR_SAT;
+    case RHIStencilOp::Invert:   return D3D11_STENCIL_OP_INVERT;
+    case RHIStencilOp::IncrWrap: return D3D11_STENCIL_OP_INCR;
+    case RHIStencilOp::DecrWrap: return D3D11_STENCIL_OP_DECR;
+    default:                     return D3D11_STENCIL_OP_KEEP;
+    }
+}
+
+D3D11_BLEND D3D11Device::ConvertBlendFactor(RHIBlendFactor factor) const
+{
+    switch (factor)
+    {
+    case RHIBlendFactor::Zero:        return D3D11_BLEND_ZERO;
+    case RHIBlendFactor::One:         return D3D11_BLEND_ONE;
+    case RHIBlendFactor::SrcColor:    return D3D11_BLEND_SRC_COLOR;
+    case RHIBlendFactor::InvSrcColor: return D3D11_BLEND_INV_SRC_COLOR;
+    case RHIBlendFactor::SrcAlpha:    return D3D11_BLEND_SRC_ALPHA;
+    case RHIBlendFactor::InvSrcAlpha: return D3D11_BLEND_INV_SRC_ALPHA;
+    case RHIBlendFactor::DstAlpha:    return D3D11_BLEND_DEST_ALPHA;
+    case RHIBlendFactor::InvDstAlpha: return D3D11_BLEND_INV_DEST_ALPHA;
+    case RHIBlendFactor::DstColor:    return D3D11_BLEND_DEST_COLOR;
+    case RHIBlendFactor::InvDstColor: return D3D11_BLEND_INV_DEST_COLOR;
+    default:                          return D3D11_BLEND_ZERO;
+    }
+}
+
+D3D11_BLEND_OP D3D11Device::ConvertBlendOp(RHIBlendOp op) const
+{
+    switch (op)
+    {
+    case RHIBlendOp::Add:         return D3D11_BLEND_OP_ADD;
+    case RHIBlendOp::Subtract:    return D3D11_BLEND_OP_SUBTRACT;
+    case RHIBlendOp::RevSubtract: return D3D11_BLEND_OP_REV_SUBTRACT;
+    case RHIBlendOp::Min:         return D3D11_BLEND_OP_MIN;
+    case RHIBlendOp::Max:         return D3D11_BLEND_OP_MAX;
+    default:                      return D3D11_BLEND_OP_ADD;
+    }
+}
+
+DXGI_FORMAT D3D11Device::ConvertVertexFormat(RHIVertexFormat format) const
+{
+    switch (format)
+    {
+    case RHIVertexFormat::Float1:   return DXGI_FORMAT_R32_FLOAT;
+    case RHIVertexFormat::Float2:   return DXGI_FORMAT_R32G32_FLOAT;
+    case RHIVertexFormat::Float3:   return DXGI_FORMAT_R32G32B32_FLOAT;
+    case RHIVertexFormat::Float4:   return DXGI_FORMAT_R32G32B32A32_FLOAT;
+    case RHIVertexFormat::Int1:     return DXGI_FORMAT_R32_SINT;
+    case RHIVertexFormat::Int2:     return DXGI_FORMAT_R32G32_SINT;
+    case RHIVertexFormat::Int4:     return DXGI_FORMAT_R32G32B32A32_SINT;
+    case RHIVertexFormat::UInt1:    return DXGI_FORMAT_R32_UINT;
+    case RHIVertexFormat::UNorm8x4: return DXGI_FORMAT_R8G8B8A8_UNORM;
+    default:                        return DXGI_FORMAT_R32G32B32_FLOAT;
+    }
+}
+
+}}} // namespace Spark::RHI::D3D11
+
+#endif // _WIN32

--- a/Spark Engine/Source/Graphics/RHI/D3D11/D3D11Device.h
+++ b/Spark Engine/Source/Graphics/RHI/D3D11/D3D11Device.h
@@ -1,0 +1,340 @@
+/**
+ * @file D3D11Device.h
+ * @brief DirectX 11 implementation of the RHI device interface
+ * @author Spark Engine Team
+ * @date 2025
+ *
+ * Wraps the existing DirectX 11 rendering functionality through the
+ * platform-agnostic RHI abstraction layer, enabling multi-API support.
+ */
+
+#pragma once
+
+#ifdef _WIN32
+
+#include "../RHIDevice.h"
+#include "../RHIResources.h"
+
+#include <d3d11_1.h>
+#include <dxgi1_3.h>
+#include <d3dcompiler.h>
+#include <wrl/client.h>
+#include <unordered_map>
+#include <vector>
+
+using Microsoft::WRL::ComPtr;
+
+namespace Spark { namespace RHI { namespace D3D11 {
+
+// ============================================================================
+// D3D11 RESOURCE IMPLEMENTATIONS
+// ============================================================================
+
+class D3D11Buffer : public IRHIBuffer
+{
+public:
+    D3D11Buffer(const RHIBufferDesc& desc, ComPtr<ID3D11Buffer> buffer);
+    ~D3D11Buffer() override = default;
+
+    const std::string& GetDebugName() const override { return m_desc.debugName; }
+    void SetDebugName(const std::string& name) override { m_desc.debugName = name; }
+    bool IsValid() const override { return m_buffer != nullptr; }
+
+    const RHIBufferDesc& GetDesc() const override { return m_desc; }
+    uint64_t GetSize() const override { return m_desc.size; }
+    uint32_t GetStride() const override { return m_desc.stride; }
+    void* GetNativeHandle() const override { return m_buffer.Get(); }
+
+    ID3D11Buffer* GetD3D11Buffer() const { return m_buffer.Get(); }
+
+private:
+    RHIBufferDesc m_desc;
+    ComPtr<ID3D11Buffer> m_buffer;
+};
+
+class D3D11Texture : public IRHITexture
+{
+public:
+    D3D11Texture(const RHITextureDesc& desc,
+                 ComPtr<ID3D11Resource> resource,
+                 ComPtr<ID3D11ShaderResourceView> srv = nullptr,
+                 ComPtr<ID3D11RenderTargetView> rtv = nullptr,
+                 ComPtr<ID3D11DepthStencilView> dsv = nullptr);
+    ~D3D11Texture() override = default;
+
+    const std::string& GetDebugName() const override { return m_desc.debugName; }
+    void SetDebugName(const std::string& name) override { m_desc.debugName = name; }
+    bool IsValid() const override { return m_resource != nullptr; }
+
+    const RHITextureDesc& GetDesc() const override { return m_desc; }
+    uint32_t GetWidth() const override { return m_desc.width; }
+    uint32_t GetHeight() const override { return m_desc.height; }
+    uint32_t GetDepth() const override { return m_desc.depth; }
+    uint32_t GetMipLevels() const override { return m_desc.mipLevels; }
+    PixelFormat GetFormat() const override { return m_desc.format; }
+    void* GetNativeHandle() const override { return m_resource.Get(); }
+    void* GetShaderResourceView() const override { return m_srv.Get(); }
+    void* GetRenderTargetView() const override { return m_rtv.Get(); }
+    void* GetDepthStencilView() const override { return m_dsv.Get(); }
+
+    ID3D11Resource* GetD3D11Resource() const { return m_resource.Get(); }
+    ID3D11ShaderResourceView* GetD3D11SRV() const { return m_srv.Get(); }
+    ID3D11RenderTargetView* GetD3D11RTV() const { return m_rtv.Get(); }
+    ID3D11DepthStencilView* GetD3D11DSV() const { return m_dsv.Get(); }
+
+    void SetSRV(ComPtr<ID3D11ShaderResourceView> srv) { m_srv = srv; }
+    void SetRTV(ComPtr<ID3D11RenderTargetView> rtv) { m_rtv = rtv; }
+    void SetDSV(ComPtr<ID3D11DepthStencilView> dsv) { m_dsv = dsv; }
+
+private:
+    RHITextureDesc m_desc;
+    ComPtr<ID3D11Resource> m_resource;
+    ComPtr<ID3D11ShaderResourceView> m_srv;
+    ComPtr<ID3D11RenderTargetView> m_rtv;
+    ComPtr<ID3D11DepthStencilView> m_dsv;
+};
+
+class D3D11Shader : public IRHIShader
+{
+public:
+    D3D11Shader(const RHIShaderDesc& desc,
+                ComPtr<ID3D11DeviceChild> shader,
+                ComPtr<ID3DBlob> bytecodeBlob);
+    ~D3D11Shader() override = default;
+
+    const std::string& GetDebugName() const override { return m_desc.debugName; }
+    void SetDebugName(const std::string& name) override { m_desc.debugName = name; }
+    bool IsValid() const override { return m_shader != nullptr; }
+
+    RHIShaderStage GetStage() const override { return m_desc.stage; }
+    const std::string& GetEntryPoint() const override { return m_desc.entryPoint; }
+    void* GetNativeHandle() const override { return m_shader.Get(); }
+    const void* GetBytecode() const override;
+    size_t GetBytecodeSize() const override;
+
+    ID3D11VertexShader* GetVertexShader() const;
+    ID3D11PixelShader* GetPixelShader() const;
+    ID3D11GeometryShader* GetGeometryShader() const;
+    ID3D11HullShader* GetHullShader() const;
+    ID3D11DomainShader* GetDomainShader() const;
+    ID3D11ComputeShader* GetComputeShader() const;
+    ID3DBlob* GetBlob() const { return m_bytecodeBlob.Get(); }
+
+private:
+    RHIShaderDesc m_desc;
+    ComPtr<ID3D11DeviceChild> m_shader;
+    ComPtr<ID3DBlob> m_bytecodeBlob;
+};
+
+class D3D11Sampler : public IRHISampler
+{
+public:
+    D3D11Sampler(const RHISamplerDesc& desc, ComPtr<ID3D11SamplerState> sampler);
+    ~D3D11Sampler() override = default;
+
+    const std::string& GetDebugName() const override { return m_debugName; }
+    void SetDebugName(const std::string& name) override { m_debugName = name; }
+    bool IsValid() const override { return m_sampler != nullptr; }
+
+    const RHISamplerDesc& GetDesc() const override { return m_desc; }
+    void* GetNativeHandle() const override { return m_sampler.Get(); }
+
+    ID3D11SamplerState* GetD3D11Sampler() const { return m_sampler.Get(); }
+
+private:
+    RHISamplerDesc m_desc;
+    ComPtr<ID3D11SamplerState> m_sampler;
+    std::string m_debugName;
+};
+
+class D3D11PipelineState : public IRHIPipelineState
+{
+public:
+    D3D11PipelineState(const RHIPipelineStateDesc& desc,
+                       ComPtr<ID3D11InputLayout> inputLayout,
+                       ComPtr<ID3D11RasterizerState> rasterizerState,
+                       ComPtr<ID3D11DepthStencilState> depthStencilState,
+                       ComPtr<ID3D11BlendState> blendState,
+                       D3D11Shader* vs, D3D11Shader* ps);
+    ~D3D11PipelineState() override = default;
+
+    const std::string& GetDebugName() const override { return m_desc.debugName; }
+    void SetDebugName(const std::string& name) override { m_desc.debugName = name; }
+    bool IsValid() const override { return m_inputLayout != nullptr; }
+
+    const RHIPipelineStateDesc& GetDesc() const override { return m_desc; }
+    void* GetNativeHandle() const override { return nullptr; }
+
+    ID3D11InputLayout* GetInputLayout() const { return m_inputLayout.Get(); }
+    ID3D11RasterizerState* GetRasterizerState() const { return m_rasterizerState.Get(); }
+    ID3D11DepthStencilState* GetDepthStencilState() const { return m_depthStencilState.Get(); }
+    ID3D11BlendState* GetBlendState() const { return m_blendState.Get(); }
+    D3D11Shader* GetVertexShader() const { return m_vertexShader; }
+    D3D11Shader* GetPixelShader() const { return m_pixelShader; }
+
+private:
+    RHIPipelineStateDesc m_desc;
+    ComPtr<ID3D11InputLayout> m_inputLayout;
+    ComPtr<ID3D11RasterizerState> m_rasterizerState;
+    ComPtr<ID3D11DepthStencilState> m_depthStencilState;
+    ComPtr<ID3D11BlendState> m_blendState;
+    D3D11Shader* m_vertexShader;
+    D3D11Shader* m_pixelShader;
+};
+
+// ============================================================================
+// D3D11 SWAP CHAIN
+// ============================================================================
+
+class D3D11SwapChain : public IRHISwapChain
+{
+public:
+    D3D11SwapChain(ID3D11Device* device, const RHISwapChainDesc& desc);
+    ~D3D11SwapChain() override;
+
+    bool Present(bool vsync) override;
+    bool Resize(uint32_t width, uint32_t height) override;
+    IRHITexture* GetBackBuffer() override;
+    PixelFormat GetFormat() const override { return m_desc.format; }
+    uint32_t GetWidth() const override { return m_desc.width; }
+    uint32_t GetHeight() const override { return m_desc.height; }
+    uint32_t GetCurrentBufferIndex() const override { return 0; }
+
+private:
+    bool CreateBackBufferViews();
+
+    RHISwapChainDesc m_desc;
+    ID3D11Device* m_device;
+    ComPtr<IDXGISwapChain1> m_swapChain;
+    std::unique_ptr<D3D11Texture> m_backBuffer;
+};
+
+// ============================================================================
+// D3D11 COMMAND LIST
+// ============================================================================
+
+class D3D11CommandList : public IRHICommandList
+{
+public:
+    D3D11CommandList(ID3D11DeviceContext* context, bool isImmediate);
+    ~D3D11CommandList() override = default;
+
+    void Begin() override;
+    void End() override;
+    void Reset() override;
+
+    void SetRenderTargets(IRHITexture** renderTargets, uint32_t count,
+                          IRHITexture* depthStencil) override;
+    void ClearRenderTarget(IRHITexture* target, const float color[4]) override;
+    void ClearDepthStencil(IRHITexture* target, float depth, uint8_t stencil) override;
+
+    void SetViewport(const RHIViewport& viewport) override;
+    void SetScissorRect(const RHIScissorRect& rect) override;
+
+    void SetPipelineState(IRHIPipelineState* pipelineState) override;
+    void SetPrimitiveTopology(RHIPrimitiveTopology topology) override;
+
+    void SetVertexBuffer(IRHIBuffer* buffer, uint32_t slot, uint32_t offset) override;
+    void SetIndexBuffer(IRHIBuffer* buffer, uint32_t offset) override;
+    void SetConstantBuffer(RHIShaderStage stage, uint32_t slot, IRHIBuffer* buffer) override;
+    void SetShaderResource(RHIShaderStage stage, uint32_t slot, IRHITexture* texture) override;
+    void SetSampler(RHIShaderStage stage, uint32_t slot, IRHISampler* sampler) override;
+
+    void Draw(uint32_t vertexCount, uint32_t startVertex) override;
+    void DrawIndexed(uint32_t indexCount, uint32_t startIndex, int32_t baseVertex) override;
+    void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount,
+                       uint32_t startVertex, uint32_t startInstance) override;
+    void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
+                              uint32_t startIndex, int32_t baseVertex,
+                              uint32_t startInstance) override;
+
+    void Dispatch(uint32_t x, uint32_t y, uint32_t z) override;
+
+    void BeginEvent(const char* name) override;
+    void EndEvent() override;
+    void SetMarker(const char* name) override;
+
+private:
+    ID3D11DeviceContext* m_context;
+    bool m_isImmediate;
+};
+
+// ============================================================================
+// D3D11 DEVICE
+// ============================================================================
+
+class D3D11Device : public IRHIDevice
+{
+public:
+    D3D11Device();
+    ~D3D11Device() override;
+
+    bool Initialize(const RHIDeviceDesc& desc) override;
+    void Shutdown() override;
+
+    std::unique_ptr<IRHISwapChain> CreateSwapChain(const RHISwapChainDesc& desc) override;
+
+    IRHIBuffer* CreateBuffer(const RHIBufferDesc& desc) override;
+    IRHITexture* CreateTexture(const RHITextureDesc& desc) override;
+    IRHIShader* CreateShader(const RHIShaderDesc& desc) override;
+    IRHISampler* CreateSampler(const RHISamplerDesc& desc) override;
+    IRHIPipelineState* CreatePipelineState(const RHIPipelineStateDesc& desc,
+                                           IRHIShader* vertexShader,
+                                           IRHIShader* pixelShader) override;
+
+    void DestroyBuffer(IRHIBuffer* buffer) override;
+    void DestroyTexture(IRHITexture* texture) override;
+    void DestroyShader(IRHIShader* shader) override;
+    void DestroySampler(IRHISampler* sampler) override;
+    void DestroyPipelineState(IRHIPipelineState* state) override;
+
+    void* MapBuffer(IRHIBuffer* buffer) override;
+    void UnmapBuffer(IRHIBuffer* buffer) override;
+    void UpdateBuffer(IRHIBuffer* buffer, const void* data, size_t size, size_t offset) override;
+    void UpdateTexture(IRHITexture* texture, const void* data,
+                       uint32_t mipLevel, uint32_t arraySlice) override;
+
+    IRHICommandList* GetImmediateCommandList() override;
+    IRHICommandList* CreateDeferredCommandList() override;
+    void ExecuteCommandList(IRHICommandList* commandList) override;
+    void DestroyCommandList(IRHICommandList* commandList) override;
+
+    void BeginFrame() override;
+    void EndFrame() override;
+    void WaitForIdle() override;
+
+    GraphicsBackend GetBackendType() const override { return GraphicsBackend::D3D11; }
+    const RHIDeviceCapabilities& GetCapabilities() const override { return m_capabilities; }
+    const RHIStatistics& GetStatistics() const override { return m_statistics; }
+    void ResetStatistics() override;
+    std::string GetDeviceInfo() const override;
+
+    // D3D11-specific accessors
+    ID3D11Device1* GetD3D11Device() const { return m_device.Get(); }
+    ID3D11DeviceContext1* GetD3D11Context() const { return m_immediateContext.Get(); }
+
+private:
+    DXGI_FORMAT ConvertFormat(PixelFormat format) const;
+    D3D11_FILTER ConvertFilter(const RHISamplerDesc& desc) const;
+    D3D11_TEXTURE_ADDRESS_MODE ConvertAddressMode(RHIAddressMode mode) const;
+    D3D11_COMPARISON_FUNC ConvertCompareOp(RHICompareOp op) const;
+    D3D11_STENCIL_OP ConvertStencilOp(RHIStencilOp op) const;
+    D3D11_BLEND ConvertBlendFactor(RHIBlendFactor factor) const;
+    D3D11_BLEND_OP ConvertBlendOp(RHIBlendOp op) const;
+    DXGI_FORMAT ConvertVertexFormat(RHIVertexFormat format) const;
+    uint32_t GetFormatSize(PixelFormat format) const;
+
+    ComPtr<ID3D11Device1> m_device;
+    ComPtr<ID3D11DeviceContext1> m_immediateContext;
+    ComPtr<IDXGIFactory2> m_dxgiFactory;
+
+    std::unique_ptr<D3D11CommandList> m_immediateCommandList;
+
+    RHIDeviceCapabilities m_capabilities;
+    RHIStatistics m_statistics;
+    bool m_debugEnabled = false;
+};
+
+}}} // namespace Spark::RHI::D3D11
+
+#endif // _WIN32

--- a/Spark Engine/Source/Graphics/RHI/OpenGL/OpenGLDevice.cpp
+++ b/Spark Engine/Source/Graphics/RHI/OpenGL/OpenGLDevice.cpp
@@ -1,0 +1,982 @@
+/**
+ * @file OpenGLDevice.cpp
+ * @brief OpenGL 4.6 Core Profile RHI backend implementation
+ * @author Spark Engine Team
+ * @date 2025
+ *
+ * Modern OpenGL implementation using DSA (Direct State Access),
+ * SPIR-V shader support, and GL 4.6 Core Profile features.
+ */
+
+#ifdef SPARK_OPENGL_SUPPORT
+
+#include "OpenGLDevice.h"
+#include <cassert>
+#include <cstring>
+#include <iostream>
+
+namespace Spark { namespace RHI { namespace OpenGL {
+
+// ============================================================================
+// GL BUFFER
+// ============================================================================
+
+GLBuffer::GLBuffer(const RHIBufferDesc& desc, GLuint buffer)
+    : m_desc(desc), m_buffer(buffer)
+{
+}
+
+GLBuffer::~GLBuffer()
+{
+    if (m_buffer != 0)
+    {
+        glDeleteBuffers(1, &m_buffer);
+        m_buffer = 0;
+    }
+}
+
+void GLBuffer::SetDebugName(const std::string& name)
+{
+    m_desc.debugName = name;
+    if (m_buffer != 0)
+    {
+        glObjectLabel(GL_BUFFER, m_buffer, static_cast<GLsizei>(name.size()), name.c_str());
+    }
+}
+
+// ============================================================================
+// GL TEXTURE
+// ============================================================================
+
+GLTexture::GLTexture(const RHITextureDesc& desc, GLuint texture, GLuint framebuffer)
+    : m_desc(desc), m_texture(texture), m_framebuffer(framebuffer)
+{
+}
+
+GLTexture::~GLTexture()
+{
+    if (m_framebuffer != 0)
+    {
+        glDeleteFramebuffers(1, &m_framebuffer);
+    }
+    if (m_texture != 0)
+    {
+        glDeleteTextures(1, &m_texture);
+    }
+}
+
+void GLTexture::SetDebugName(const std::string& name)
+{
+    m_desc.debugName = name;
+    if (m_texture != 0)
+    {
+        glObjectLabel(GL_TEXTURE, m_texture, static_cast<GLsizei>(name.size()), name.c_str());
+    }
+}
+
+// ============================================================================
+// GL SHADER
+// ============================================================================
+
+GLShader::GLShader(const RHIShaderDesc& desc, GLuint shader, std::string compiledSource)
+    : m_desc(desc), m_shader(shader), m_compiledSource(std::move(compiledSource))
+{
+}
+
+GLShader::~GLShader()
+{
+    if (m_shader != 0)
+    {
+        glDeleteShader(m_shader);
+    }
+}
+
+// ============================================================================
+// GL SAMPLER
+// ============================================================================
+
+GLSampler::GLSampler(const RHISamplerDesc& desc, GLuint sampler)
+    : m_desc(desc), m_sampler(sampler)
+{
+}
+
+GLSampler::~GLSampler()
+{
+    if (m_sampler != 0)
+    {
+        glDeleteSamplers(1, &m_sampler);
+    }
+}
+
+// ============================================================================
+// GL PIPELINE STATE
+// ============================================================================
+
+GLPipelineState::GLPipelineState(const RHIPipelineStateDesc& desc, GLuint program, GLuint vao)
+    : m_desc(desc), m_program(program), m_vao(vao)
+{
+}
+
+GLPipelineState::~GLPipelineState()
+{
+    if (m_program != 0)
+        glDeleteProgram(m_program);
+    if (m_vao != 0)
+        glDeleteVertexArrays(1, &m_vao);
+}
+
+void GLPipelineState::ApplyRasterizerState() const
+{
+    // Fill mode
+    glPolygonMode(GL_FRONT_AND_BACK,
+                  m_desc.rasterizer.fillMode == RHIFillMode::Wireframe ? GL_LINE : GL_FILL);
+
+    // Cull mode
+    if (m_desc.rasterizer.cullMode == RHICullMode::None)
+    {
+        glDisable(GL_CULL_FACE);
+    }
+    else
+    {
+        glEnable(GL_CULL_FACE);
+        glCullFace(m_desc.rasterizer.cullMode == RHICullMode::Front ? GL_FRONT : GL_BACK);
+    }
+
+    // Front face
+    glFrontFace(m_desc.rasterizer.frontCounterClockwise ? GL_CCW : GL_CW);
+
+    // Depth bias
+    if (m_desc.rasterizer.depthBias != 0 || m_desc.rasterizer.slopeScaledDepthBias != 0)
+    {
+        glEnable(GL_POLYGON_OFFSET_FILL);
+        glPolygonOffset(m_desc.rasterizer.slopeScaledDepthBias,
+                        static_cast<float>(m_desc.rasterizer.depthBias));
+    }
+    else
+    {
+        glDisable(GL_POLYGON_OFFSET_FILL);
+    }
+
+    // Scissor
+    if (m_desc.rasterizer.scissorEnable)
+        glEnable(GL_SCISSOR_TEST);
+    else
+        glDisable(GL_SCISSOR_TEST);
+
+    // Depth clamp
+    if (!m_desc.rasterizer.depthClipEnable)
+        glEnable(GL_DEPTH_CLAMP);
+    else
+        glDisable(GL_DEPTH_CLAMP);
+}
+
+void GLPipelineState::ApplyDepthStencilState() const
+{
+    // Depth test
+    if (m_desc.depthStencil.depthEnable)
+    {
+        glEnable(GL_DEPTH_TEST);
+
+        GLenum depthFunc = GL_LESS;
+        switch (m_desc.depthStencil.depthFunc)
+        {
+        case RHICompareOp::Never:        depthFunc = GL_NEVER; break;
+        case RHICompareOp::Less:         depthFunc = GL_LESS; break;
+        case RHICompareOp::Equal:        depthFunc = GL_EQUAL; break;
+        case RHICompareOp::LessEqual:    depthFunc = GL_LEQUAL; break;
+        case RHICompareOp::Greater:      depthFunc = GL_GREATER; break;
+        case RHICompareOp::NotEqual:     depthFunc = GL_NOTEQUAL; break;
+        case RHICompareOp::GreaterEqual: depthFunc = GL_GEQUAL; break;
+        case RHICompareOp::Always:       depthFunc = GL_ALWAYS; break;
+        }
+        glDepthFunc(depthFunc);
+    }
+    else
+    {
+        glDisable(GL_DEPTH_TEST);
+    }
+
+    // Depth write
+    glDepthMask(m_desc.depthStencil.depthWrite ? GL_TRUE : GL_FALSE);
+
+    // Stencil test
+    if (m_desc.depthStencil.stencilEnable)
+    {
+        glEnable(GL_STENCIL_TEST);
+        glStencilMask(m_desc.depthStencil.stencilWriteMask);
+    }
+    else
+    {
+        glDisable(GL_STENCIL_TEST);
+    }
+}
+
+void GLPipelineState::ApplyBlendState() const
+{
+    const auto& rt0 = m_desc.blend.renderTargets[0];
+    if (rt0.blendEnable)
+    {
+        glEnable(GL_BLEND);
+
+        auto convertBlend = [](RHIBlendFactor f) -> GLenum {
+            switch (f) {
+            case RHIBlendFactor::Zero:        return GL_ZERO;
+            case RHIBlendFactor::One:         return GL_ONE;
+            case RHIBlendFactor::SrcColor:    return GL_SRC_COLOR;
+            case RHIBlendFactor::InvSrcColor: return GL_ONE_MINUS_SRC_COLOR;
+            case RHIBlendFactor::SrcAlpha:    return GL_SRC_ALPHA;
+            case RHIBlendFactor::InvSrcAlpha: return GL_ONE_MINUS_SRC_ALPHA;
+            case RHIBlendFactor::DstAlpha:    return GL_DST_ALPHA;
+            case RHIBlendFactor::InvDstAlpha: return GL_ONE_MINUS_DST_ALPHA;
+            case RHIBlendFactor::DstColor:    return GL_DST_COLOR;
+            case RHIBlendFactor::InvDstColor: return GL_ONE_MINUS_DST_COLOR;
+            default: return GL_ZERO;
+            }
+        };
+
+        auto convertOp = [](RHIBlendOp op) -> GLenum {
+            switch (op) {
+            case RHIBlendOp::Add:         return GL_FUNC_ADD;
+            case RHIBlendOp::Subtract:    return GL_FUNC_SUBTRACT;
+            case RHIBlendOp::RevSubtract: return GL_FUNC_REVERSE_SUBTRACT;
+            case RHIBlendOp::Min:         return GL_MIN;
+            case RHIBlendOp::Max:         return GL_MAX;
+            default: return GL_FUNC_ADD;
+            }
+        };
+
+        glBlendFuncSeparate(convertBlend(rt0.srcBlend), convertBlend(rt0.dstBlend),
+                            convertBlend(rt0.srcBlendAlpha), convertBlend(rt0.dstBlendAlpha));
+        glBlendEquationSeparate(convertOp(rt0.blendOp), convertOp(rt0.blendOpAlpha));
+    }
+    else
+    {
+        glDisable(GL_BLEND);
+    }
+
+    glColorMask(
+        (rt0.writeMask & 0x01) ? GL_TRUE : GL_FALSE,
+        (rt0.writeMask & 0x02) ? GL_TRUE : GL_FALSE,
+        (rt0.writeMask & 0x04) ? GL_TRUE : GL_FALSE,
+        (rt0.writeMask & 0x08) ? GL_TRUE : GL_FALSE
+    );
+}
+
+// ============================================================================
+// GL SWAP CHAIN
+// ============================================================================
+
+GLSwapChain::GLSwapChain(const RHISwapChainDesc& desc)
+    : m_desc(desc)
+{
+    // Create a texture wrapper for the default framebuffer
+    RHITextureDesc texDesc;
+    texDesc.width = desc.width;
+    texDesc.height = desc.height;
+    texDesc.format = desc.format;
+    texDesc.usage = RHITextureUsage::RenderTarget;
+    texDesc.debugName = "DefaultFramebuffer";
+
+    m_backBuffer = std::make_unique<GLTexture>(texDesc, 0, 0); // FBO 0 = default
+
+#ifdef _WIN32
+    HWND hwnd = static_cast<HWND>(desc.windowHandle);
+    m_hdc = GetDC(hwnd);
+
+    PIXELFORMATDESCRIPTOR pfd = {};
+    pfd.nSize = sizeof(pfd);
+    pfd.nVersion = 1;
+    pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+    pfd.iPixelType = PFD_TYPE_RGBA;
+    pfd.cColorBits = 32;
+    pfd.cDepthBits = 24;
+    pfd.cStencilBits = 8;
+
+    int pixelFormat = ChoosePixelFormat(m_hdc, &pfd);
+    SetPixelFormat(m_hdc, pixelFormat, &pfd);
+
+    m_hglrc = wglCreateContext(m_hdc);
+    wglMakeCurrent(m_hdc, m_hglrc);
+#endif
+}
+
+GLSwapChain::~GLSwapChain()
+{
+#ifdef _WIN32
+    if (m_hglrc)
+    {
+        wglMakeCurrent(nullptr, nullptr);
+        wglDeleteContext(m_hglrc);
+    }
+#endif
+}
+
+bool GLSwapChain::Present(bool)
+{
+#ifdef _WIN32
+    if (m_hdc)
+    {
+        SwapBuffers(m_hdc);
+        return true;
+    }
+#endif
+    return false;
+}
+
+bool GLSwapChain::Resize(uint32_t width, uint32_t height)
+{
+    m_desc.width = width;
+    m_desc.height = height;
+    glViewport(0, 0, width, height);
+    return true;
+}
+
+IRHITexture* GLSwapChain::GetBackBuffer()
+{
+    return m_backBuffer.get();
+}
+
+// ============================================================================
+// GL COMMAND LIST
+// ============================================================================
+
+GLCommandList::GLCommandList(bool isImmediate)
+    : m_isImmediate(isImmediate)
+{
+}
+
+void GLCommandList::Begin() {}
+void GLCommandList::End() { glFlush(); }
+void GLCommandList::Reset() {}
+
+void GLCommandList::SetRenderTargets(IRHITexture** renderTargets, uint32_t count,
+                                     IRHITexture* depthStencil)
+{
+    if (count == 0 || !renderTargets[0])
+    {
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        return;
+    }
+
+    auto* glTex = static_cast<GLTexture*>(renderTargets[0]);
+    GLuint fbo = glTex->GetGLFramebuffer();
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+
+    // Set draw buffers
+    std::vector<GLenum> drawBuffers(count);
+    for (uint32_t i = 0; i < count; ++i)
+        drawBuffers[i] = GL_COLOR_ATTACHMENT0 + i;
+    glDrawBuffers(count, drawBuffers.data());
+}
+
+void GLCommandList::ClearRenderTarget(IRHITexture*, const float color[4])
+{
+    glClearColor(color[0], color[1], color[2], color[3]);
+    glClear(GL_COLOR_BUFFER_BIT);
+}
+
+void GLCommandList::ClearDepthStencil(IRHITexture*, float depth, uint8_t stencil)
+{
+    glClearDepth(depth);
+    glClearStencil(stencil);
+    glClear(GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+}
+
+void GLCommandList::SetViewport(const RHIViewport& viewport)
+{
+    glViewport(static_cast<GLint>(viewport.x), static_cast<GLint>(viewport.y),
+               static_cast<GLsizei>(viewport.width), static_cast<GLsizei>(viewport.height));
+    glDepthRange(viewport.minDepth, viewport.maxDepth);
+}
+
+void GLCommandList::SetScissorRect(const RHIScissorRect& rect)
+{
+    glScissor(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
+}
+
+void GLCommandList::SetPipelineState(IRHIPipelineState* pipelineState)
+{
+    if (!pipelineState) return;
+    auto* glPSO = static_cast<GLPipelineState*>(pipelineState);
+
+    m_currentProgram = glPSO->GetGLProgram();
+    m_currentVAO = glPSO->GetGLVAO();
+
+    glUseProgram(m_currentProgram);
+    glBindVertexArray(m_currentVAO);
+
+    glPSO->ApplyRasterizerState();
+    glPSO->ApplyDepthStencilState();
+    glPSO->ApplyBlendState();
+}
+
+void GLCommandList::SetPrimitiveTopology(RHIPrimitiveTopology topology)
+{
+    switch (topology)
+    {
+    case RHIPrimitiveTopology::PointList:      m_currentTopology = GL_POINTS; break;
+    case RHIPrimitiveTopology::LineList:        m_currentTopology = GL_LINES; break;
+    case RHIPrimitiveTopology::LineStrip:       m_currentTopology = GL_LINE_STRIP; break;
+    case RHIPrimitiveTopology::TriangleList:    m_currentTopology = GL_TRIANGLES; break;
+    case RHIPrimitiveTopology::TriangleStrip:   m_currentTopology = GL_TRIANGLE_STRIP; break;
+    case RHIPrimitiveTopology::PatchList:       m_currentTopology = GL_PATCHES; break;
+    }
+}
+
+void GLCommandList::SetVertexBuffer(IRHIBuffer* buffer, uint32_t, uint32_t)
+{
+    if (!buffer) return;
+    auto* glBuf = static_cast<GLBuffer*>(buffer);
+    glBindBuffer(GL_ARRAY_BUFFER, glBuf->GetGLBuffer());
+}
+
+void GLCommandList::SetIndexBuffer(IRHIBuffer* buffer, uint32_t)
+{
+    if (!buffer) return;
+    auto* glBuf = static_cast<GLBuffer*>(buffer);
+    m_boundIndexBuffer = glBuf->GetGLBuffer();
+    m_indexStride = glBuf->GetStride();
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_boundIndexBuffer);
+}
+
+void GLCommandList::SetConstantBuffer(RHIShaderStage, uint32_t slot, IRHIBuffer* buffer)
+{
+    if (!buffer) return;
+    auto* glBuf = static_cast<GLBuffer*>(buffer);
+    glBindBufferBase(GL_UNIFORM_BUFFER, slot, glBuf->GetGLBuffer());
+}
+
+void GLCommandList::SetShaderResource(RHIShaderStage, uint32_t slot, IRHITexture* texture)
+{
+    if (texture)
+    {
+        auto* glTex = static_cast<GLTexture*>(texture);
+        glActiveTexture(GL_TEXTURE0 + slot);
+        glBindTexture(GL_TEXTURE_2D, glTex->GetGLTexture());
+    }
+    else
+    {
+        glActiveTexture(GL_TEXTURE0 + slot);
+        glBindTexture(GL_TEXTURE_2D, 0);
+    }
+}
+
+void GLCommandList::SetSampler(RHIShaderStage, uint32_t slot, IRHISampler* sampler)
+{
+    if (sampler)
+    {
+        auto* glSamp = static_cast<GLSampler*>(sampler);
+        glBindSampler(slot, glSamp->GetGLSampler());
+    }
+    else
+    {
+        glBindSampler(slot, 0);
+    }
+}
+
+void GLCommandList::Draw(uint32_t vertexCount, uint32_t startVertex)
+{
+    glDrawArrays(m_currentTopology, startVertex, vertexCount);
+}
+
+void GLCommandList::DrawIndexed(uint32_t indexCount, uint32_t startIndex, int32_t baseVertex)
+{
+    GLenum indexType = (m_indexStride == 4) ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT;
+    size_t offset = startIndex * m_indexStride;
+    glDrawElementsBaseVertex(m_currentTopology, indexCount, indexType,
+                             reinterpret_cast<void*>(offset), baseVertex);
+}
+
+void GLCommandList::DrawInstanced(uint32_t vertexCount, uint32_t instanceCount,
+                                  uint32_t startVertex, uint32_t startInstance)
+{
+    glDrawArraysInstancedBaseInstance(m_currentTopology, startVertex, vertexCount,
+                                     instanceCount, startInstance);
+}
+
+void GLCommandList::DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
+                                         uint32_t startIndex, int32_t baseVertex,
+                                         uint32_t startInstance)
+{
+    GLenum indexType = (m_indexStride == 4) ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT;
+    size_t offset = startIndex * m_indexStride;
+    glDrawElementsInstancedBaseVertexBaseInstance(m_currentTopology, indexCount, indexType,
+                                                  reinterpret_cast<void*>(offset), instanceCount,
+                                                  baseVertex, startInstance);
+}
+
+void GLCommandList::Dispatch(uint32_t x, uint32_t y, uint32_t z)
+{
+    glDispatchCompute(x, y, z);
+    glMemoryBarrier(GL_ALL_BARRIER_BITS);
+}
+
+void GLCommandList::BeginEvent(const char* name)
+{
+    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, name);
+}
+
+void GLCommandList::EndEvent()
+{
+    glPopDebugGroup();
+}
+
+void GLCommandList::SetMarker(const char* name)
+{
+    glDebugMessageInsert(GL_DEBUG_SOURCE_APPLICATION, GL_DEBUG_TYPE_MARKER, 0,
+                         GL_DEBUG_SEVERITY_NOTIFICATION, -1, name);
+}
+
+// ============================================================================
+// GL DEVICE
+// ============================================================================
+
+GLDevice::GLDevice()
+{
+    m_capabilities.backend = GraphicsBackend::OpenGL;
+}
+
+GLDevice::~GLDevice()
+{
+    Shutdown();
+}
+
+bool GLDevice::Initialize(const RHIDeviceDesc& desc)
+{
+    m_debugEnabled = desc.enableDebugLayer;
+
+    // GLAD must be loaded before any GL calls
+    // In a real implementation, context creation happens first
+    if (!gladLoadGL())
+    {
+        return false;
+    }
+
+    if (m_debugEnabled)
+    {
+        glEnable(GL_DEBUG_OUTPUT);
+        glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+    }
+
+    QueryCapabilities();
+
+    m_immediateCommandList = std::make_unique<GLCommandList>(true);
+
+    return true;
+}
+
+void GLDevice::Shutdown()
+{
+    m_immediateCommandList.reset();
+}
+
+void GLDevice::QueryCapabilities()
+{
+    m_capabilities.deviceName = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
+    m_capabilities.vendorName = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
+    m_capabilities.apiVersion = reinterpret_cast<const char*>(glGetString(GL_VERSION));
+
+    GLint maxTextureSize;
+    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
+    m_capabilities.maxTextureSize = maxTextureSize;
+
+    GLint maxColorAttachments;
+    glGetIntegerv(GL_MAX_COLOR_ATTACHMENTS, &maxColorAttachments);
+    m_capabilities.maxRenderTargets = maxColorAttachments;
+
+    GLint maxSamplers;
+    glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &maxSamplers);
+    m_capabilities.maxSamplers = maxSamplers;
+
+    GLfloat maxAniso;
+    glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY, &maxAniso);
+    m_capabilities.maxAnisotropy = maxAniso;
+
+    m_capabilities.tessellationSupport = true;
+    m_capabilities.computeShaderSupport = true;
+    m_capabilities.geometryShaderSupport = true;
+}
+
+std::unique_ptr<IRHISwapChain> GLDevice::CreateSwapChain(const RHISwapChainDesc& desc)
+{
+    return std::make_unique<GLSwapChain>(desc);
+}
+
+IRHIBuffer* GLDevice::CreateBuffer(const RHIBufferDesc& desc)
+{
+    GLuint buffer;
+    glCreateBuffers(1, &buffer);
+
+    GLenum usage = GL_STATIC_DRAW;
+    GLbitfield flags = 0;
+
+    switch (desc.access)
+    {
+    case RHIBufferAccess::Static:
+        usage = GL_STATIC_DRAW;
+        break;
+    case RHIBufferAccess::Dynamic:
+        usage = GL_DYNAMIC_DRAW;
+        flags = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT;
+        break;
+    case RHIBufferAccess::Staging:
+        flags = GL_MAP_READ_BIT | GL_MAP_WRITE_BIT;
+        break;
+    case RHIBufferAccess::ReadBack:
+        flags = GL_MAP_READ_BIT;
+        break;
+    }
+
+    if (flags != 0)
+    {
+        glNamedBufferStorage(buffer, desc.size, desc.initialData, flags);
+    }
+    else
+    {
+        glNamedBufferData(buffer, desc.size, desc.initialData, usage);
+    }
+
+    return new GLBuffer(desc, buffer);
+}
+
+IRHITexture* GLDevice::CreateTexture(const RHITextureDesc& desc)
+{
+    GLuint texture;
+    glCreateTextures(GL_TEXTURE_2D, 1, &texture);
+
+    GLenum internalFormat = ConvertInternalFormat(desc.format);
+
+    glTextureStorage2D(texture, desc.mipLevels, internalFormat, desc.width, desc.height);
+
+    // Create framebuffer if render target
+    GLuint fbo = 0;
+    if (desc.usage & RHITextureUsage::RenderTarget)
+    {
+        glCreateFramebuffers(1, &fbo);
+        glNamedFramebufferTexture(fbo, GL_COLOR_ATTACHMENT0, texture, 0);
+    }
+    else if (desc.usage & RHITextureUsage::DepthStencil)
+    {
+        glCreateFramebuffers(1, &fbo);
+        glNamedFramebufferTexture(fbo, GL_DEPTH_STENCIL_ATTACHMENT, texture, 0);
+    }
+
+    return new GLTexture(desc, texture, fbo);
+}
+
+IRHIShader* GLDevice::CreateShader(const RHIShaderDesc& desc)
+{
+    GLenum shaderType;
+    switch (desc.stage)
+    {
+    case RHIShaderStage::Vertex:   shaderType = GL_VERTEX_SHADER; break;
+    case RHIShaderStage::Pixel:    shaderType = GL_FRAGMENT_SHADER; break;
+    case RHIShaderStage::Geometry: shaderType = GL_GEOMETRY_SHADER; break;
+    case RHIShaderStage::Hull:     shaderType = GL_TESS_CONTROL_SHADER; break;
+    case RHIShaderStage::Domain:   shaderType = GL_TESS_EVALUATION_SHADER; break;
+    case RHIShaderStage::Compute:  shaderType = GL_COMPUTE_SHADER; break;
+    default: return nullptr;
+    }
+
+    GLuint shader = glCreateShader(shaderType);
+
+    if (desc.language == ShaderLanguage::SPIRV && desc.bytecode && desc.bytecodeSize > 0)
+    {
+        // SPIR-V shader loading (GL_ARB_gl_spirv)
+        glShaderBinary(1, &shader, GL_SHADER_BINARY_FORMAT_SPIR_V,
+                       desc.bytecode, static_cast<GLsizei>(desc.bytecodeSize));
+        glSpecializeShader(shader, desc.entryPoint.c_str(), 0, nullptr, nullptr);
+    }
+    else if (!desc.sourceCode.empty())
+    {
+        // GLSL source compilation
+        const char* src = desc.sourceCode.c_str();
+        glShaderSource(shader, 1, &src, nullptr);
+        glCompileShader(shader);
+
+        GLint success;
+        glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+        if (!success)
+        {
+            char infoLog[1024];
+            glGetShaderInfoLog(shader, sizeof(infoLog), nullptr, infoLog);
+            std::cerr << "[OpenGL] Shader compilation failed: " << infoLog << std::endl;
+            glDeleteShader(shader);
+            return nullptr;
+        }
+    }
+    else
+    {
+        glDeleteShader(shader);
+        return nullptr;
+    }
+
+    return new GLShader(desc, shader, desc.sourceCode);
+}
+
+IRHISampler* GLDevice::CreateSampler(const RHISamplerDesc& desc)
+{
+    GLuint sampler;
+    glCreateSamplers(1, &sampler);
+
+    // Min filter
+    GLenum minFilter;
+    if (desc.minFilter == RHIFilterMode::Nearest)
+        minFilter = (desc.mipFilter == RHIFilterMode::Nearest) ?
+            GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST_MIPMAP_LINEAR;
+    else
+        minFilter = (desc.mipFilter == RHIFilterMode::Nearest) ?
+            GL_LINEAR_MIPMAP_NEAREST : GL_LINEAR_MIPMAP_LINEAR;
+
+    glSamplerParameteri(sampler, GL_TEXTURE_MIN_FILTER, minFilter);
+    glSamplerParameteri(sampler, GL_TEXTURE_MAG_FILTER,
+                        desc.magFilter == RHIFilterMode::Nearest ? GL_NEAREST : GL_LINEAR);
+
+    glSamplerParameteri(sampler, GL_TEXTURE_WRAP_S, ConvertAddressMode(desc.addressU));
+    glSamplerParameteri(sampler, GL_TEXTURE_WRAP_T, ConvertAddressMode(desc.addressV));
+    glSamplerParameteri(sampler, GL_TEXTURE_WRAP_R, ConvertAddressMode(desc.addressW));
+
+    glSamplerParameterf(sampler, GL_TEXTURE_LOD_BIAS, desc.mipLodBias);
+    glSamplerParameterf(sampler, GL_TEXTURE_MIN_LOD, desc.minLod);
+    glSamplerParameterf(sampler, GL_TEXTURE_MAX_LOD, desc.maxLod);
+
+    if (desc.minFilter == RHIFilterMode::Anisotropic || desc.magFilter == RHIFilterMode::Anisotropic)
+    {
+        glSamplerParameterf(sampler, GL_TEXTURE_MAX_ANISOTROPY,
+                            static_cast<float>(desc.maxAnisotropy));
+    }
+
+    glSamplerParameterfv(sampler, GL_TEXTURE_BORDER_COLOR, desc.borderColor);
+
+    return new GLSampler(desc, sampler);
+}
+
+IRHIPipelineState* GLDevice::CreatePipelineState(const RHIPipelineStateDesc& desc,
+                                                  IRHIShader* vertexShader,
+                                                  IRHIShader* pixelShader)
+{
+    auto* glVS = static_cast<GLShader*>(vertexShader);
+    auto* glPS = static_cast<GLShader*>(pixelShader);
+
+    // Create and link program
+    GLuint program = glCreateProgram();
+    glAttachShader(program, glVS->GetGLShader());
+    glAttachShader(program, glPS->GetGLShader());
+    glLinkProgram(program);
+
+    GLint success;
+    glGetProgramiv(program, GL_LINK_STATUS, &success);
+    if (!success)
+    {
+        char infoLog[1024];
+        glGetProgramInfoLog(program, sizeof(infoLog), nullptr, infoLog);
+        std::cerr << "[OpenGL] Program link failed: " << infoLog << std::endl;
+        glDeleteProgram(program);
+        return nullptr;
+    }
+
+    // Create VAO from input layout
+    GLuint vao;
+    glCreateVertexArrays(1, &vao);
+
+    uint32_t totalStride = 0;
+    for (const auto& elem : desc.inputLayout.elements)
+    {
+        uint32_t elemSize = 0;
+        switch (elem.format)
+        {
+        case RHIVertexFormat::Float1: elemSize = 4; break;
+        case RHIVertexFormat::Float2: elemSize = 8; break;
+        case RHIVertexFormat::Float3: elemSize = 12; break;
+        case RHIVertexFormat::Float4: elemSize = 16; break;
+        default: elemSize = 4; break;
+        }
+        totalStride = std::max(totalStride, elem.byteOffset + elemSize);
+    }
+
+    for (size_t i = 0; i < desc.inputLayout.elements.size(); ++i)
+    {
+        const auto& elem = desc.inputLayout.elements[i];
+        GLuint index = static_cast<GLuint>(i);
+
+        glEnableVertexArrayAttrib(vao, index);
+        glVertexArrayAttribBinding(vao, index, elem.inputSlot);
+
+        GLint numComponents = 3;
+        GLenum type = GL_FLOAT;
+
+        switch (elem.format)
+        {
+        case RHIVertexFormat::Float1: numComponents = 1; type = GL_FLOAT; break;
+        case RHIVertexFormat::Float2: numComponents = 2; type = GL_FLOAT; break;
+        case RHIVertexFormat::Float3: numComponents = 3; type = GL_FLOAT; break;
+        case RHIVertexFormat::Float4: numComponents = 4; type = GL_FLOAT; break;
+        case RHIVertexFormat::Int1:   numComponents = 1; type = GL_INT; break;
+        case RHIVertexFormat::Int2:   numComponents = 2; type = GL_INT; break;
+        case RHIVertexFormat::Int4:   numComponents = 4; type = GL_INT; break;
+        case RHIVertexFormat::UInt1:  numComponents = 1; type = GL_UNSIGNED_INT; break;
+        case RHIVertexFormat::UNorm8x4: numComponents = 4; type = GL_UNSIGNED_BYTE; break;
+        default: break;
+        }
+
+        glVertexArrayAttribFormat(vao, index, numComponents, type, GL_FALSE, elem.byteOffset);
+    }
+
+    return new GLPipelineState(desc, program, vao);
+}
+
+void GLDevice::DestroyBuffer(IRHIBuffer* buffer) { delete buffer; }
+void GLDevice::DestroyTexture(IRHITexture* texture) { delete texture; }
+void GLDevice::DestroyShader(IRHIShader* shader) { delete shader; }
+void GLDevice::DestroySampler(IRHISampler* sampler) { delete sampler; }
+void GLDevice::DestroyPipelineState(IRHIPipelineState* state) { delete state; }
+
+void* GLDevice::MapBuffer(IRHIBuffer* buffer)
+{
+    auto* glBuf = static_cast<GLBuffer*>(buffer);
+    return glMapNamedBuffer(glBuf->GetGLBuffer(), GL_WRITE_ONLY);
+}
+
+void GLDevice::UnmapBuffer(IRHIBuffer* buffer)
+{
+    auto* glBuf = static_cast<GLBuffer*>(buffer);
+    glUnmapNamedBuffer(glBuf->GetGLBuffer());
+}
+
+void GLDevice::UpdateBuffer(IRHIBuffer* buffer, const void* data, size_t size, size_t offset)
+{
+    auto* glBuf = static_cast<GLBuffer*>(buffer);
+    glNamedBufferSubData(glBuf->GetGLBuffer(), offset, size, data);
+}
+
+void GLDevice::UpdateTexture(IRHITexture* texture, const void* data,
+                             uint32_t mipLevel, uint32_t)
+{
+    auto* glTex = static_cast<GLTexture*>(texture);
+    GLenum format = ConvertFormat(glTex->GetFormat());
+    GLenum type = ConvertFormatType(glTex->GetFormat());
+
+    uint32_t w = std::max(1u, glTex->GetWidth() >> mipLevel);
+    uint32_t h = std::max(1u, glTex->GetHeight() >> mipLevel);
+
+    glTextureSubImage2D(glTex->GetGLTexture(), mipLevel, 0, 0, w, h, format, type, data);
+}
+
+IRHICommandList* GLDevice::GetImmediateCommandList()
+{
+    return m_immediateCommandList.get();
+}
+
+IRHICommandList* GLDevice::CreateDeferredCommandList()
+{
+    return new GLCommandList(false);
+}
+
+void GLDevice::ExecuteCommandList(IRHICommandList*) {}
+void GLDevice::DestroyCommandList(IRHICommandList* commandList) { delete commandList; }
+
+void GLDevice::BeginFrame() { ResetStatistics(); }
+void GLDevice::EndFrame() {}
+void GLDevice::WaitForIdle() { glFinish(); }
+
+void GLDevice::ResetStatistics() { m_statistics = {}; }
+
+std::string GLDevice::GetDeviceInfo() const
+{
+    std::string info = "=== OpenGL Device Info ===\n";
+    info += "Renderer: " + m_capabilities.deviceName + "\n";
+    info += "Vendor: " + m_capabilities.vendorName + "\n";
+    info += "Version: " + m_capabilities.apiVersion + "\n";
+    info += "Max Texture Size: " + std::to_string(m_capabilities.maxTextureSize) + "\n";
+    info += "Max Color Attachments: " + std::to_string(m_capabilities.maxRenderTargets) + "\n";
+    info += "Max Anisotropy: " + std::to_string(m_capabilities.maxAnisotropy) + "\n";
+    return info;
+}
+
+// ============================================================================
+// FORMAT CONVERSION HELPERS
+// ============================================================================
+
+GLenum GLDevice::ConvertFormat(PixelFormat format) const
+{
+    switch (format)
+    {
+    case PixelFormat::R8_UNORM:              return GL_RED;
+    case PixelFormat::R8G8_UNORM:            return GL_RG;
+    case PixelFormat::R8G8B8A8_UNORM:        return GL_RGBA;
+    case PixelFormat::R8G8B8A8_UNORM_SRGB:   return GL_RGBA;
+    case PixelFormat::R16_FLOAT:             return GL_RED;
+    case PixelFormat::R16G16_FLOAT:          return GL_RG;
+    case PixelFormat::R16G16B16A16_FLOAT:    return GL_RGBA;
+    case PixelFormat::R32_FLOAT:             return GL_RED;
+    case PixelFormat::R32G32_FLOAT:          return GL_RG;
+    case PixelFormat::R32G32B32_FLOAT:       return GL_RGB;
+    case PixelFormat::R32G32B32A32_FLOAT:    return GL_RGBA;
+    case PixelFormat::D16_UNORM:             return GL_DEPTH_COMPONENT;
+    case PixelFormat::D24_UNORM_S8_UINT:     return GL_DEPTH_STENCIL;
+    case PixelFormat::D32_FLOAT:             return GL_DEPTH_COMPONENT;
+    default:                                 return GL_RGBA;
+    }
+}
+
+GLenum GLDevice::ConvertInternalFormat(PixelFormat format) const
+{
+    switch (format)
+    {
+    case PixelFormat::R8_UNORM:              return GL_R8;
+    case PixelFormat::R8G8_UNORM:            return GL_RG8;
+    case PixelFormat::R8G8B8A8_UNORM:        return GL_RGBA8;
+    case PixelFormat::R8G8B8A8_UNORM_SRGB:   return GL_SRGB8_ALPHA8;
+    case PixelFormat::R10G10B10A2_UNORM:     return GL_RGB10_A2;
+    case PixelFormat::R11G11B10_FLOAT:       return GL_R11F_G11F_B10F;
+    case PixelFormat::R16_FLOAT:             return GL_R16F;
+    case PixelFormat::R16G16_FLOAT:          return GL_RG16F;
+    case PixelFormat::R16G16B16A16_FLOAT:    return GL_RGBA16F;
+    case PixelFormat::R32_FLOAT:             return GL_R32F;
+    case PixelFormat::R32G32_FLOAT:          return GL_RG32F;
+    case PixelFormat::R32G32B32_FLOAT:       return GL_RGB32F;
+    case PixelFormat::R32G32B32A32_FLOAT:    return GL_RGBA32F;
+    case PixelFormat::D16_UNORM:             return GL_DEPTH_COMPONENT16;
+    case PixelFormat::D24_UNORM_S8_UINT:     return GL_DEPTH24_STENCIL8;
+    case PixelFormat::D32_FLOAT:             return GL_DEPTH_COMPONENT32F;
+    default:                                 return GL_RGBA8;
+    }
+}
+
+GLenum GLDevice::ConvertFormatType(PixelFormat format) const
+{
+    switch (format)
+    {
+    case PixelFormat::R8_UNORM:
+    case PixelFormat::R8G8_UNORM:
+    case PixelFormat::R8G8B8A8_UNORM:
+    case PixelFormat::R8G8B8A8_UNORM_SRGB:  return GL_UNSIGNED_BYTE;
+    case PixelFormat::R16_FLOAT:
+    case PixelFormat::R16G16_FLOAT:
+    case PixelFormat::R16G16B16A16_FLOAT:    return GL_HALF_FLOAT;
+    case PixelFormat::R32_FLOAT:
+    case PixelFormat::R32G32_FLOAT:
+    case PixelFormat::R32G32B32_FLOAT:
+    case PixelFormat::R32G32B32A32_FLOAT:
+    case PixelFormat::D32_FLOAT:             return GL_FLOAT;
+    case PixelFormat::D24_UNORM_S8_UINT:     return GL_UNSIGNED_INT_24_8;
+    default:                                 return GL_UNSIGNED_BYTE;
+    }
+}
+
+GLenum GLDevice::ConvertAddressMode(RHIAddressMode mode) const
+{
+    switch (mode)
+    {
+    case RHIAddressMode::Wrap:       return GL_REPEAT;
+    case RHIAddressMode::Clamp:      return GL_CLAMP_TO_EDGE;
+    case RHIAddressMode::Mirror:     return GL_MIRRORED_REPEAT;
+    case RHIAddressMode::Border:     return GL_CLAMP_TO_BORDER;
+    case RHIAddressMode::MirrorOnce: return GL_MIRROR_CLAMP_TO_EDGE;
+    default:                         return GL_REPEAT;
+    }
+}
+
+}}} // namespace Spark::RHI::OpenGL
+
+#endif // SPARK_OPENGL_SUPPORT

--- a/Spark Engine/Source/Graphics/RHI/OpenGL/OpenGLDevice.h
+++ b/Spark Engine/Source/Graphics/RHI/OpenGL/OpenGLDevice.h
@@ -1,0 +1,315 @@
+/**
+ * @file OpenGLDevice.h
+ * @brief OpenGL 4.6 Core Profile implementation of the RHI device interface
+ * @author Spark Engine Team
+ * @date 2025
+ *
+ * Full OpenGL 4.6 Core Profile backend supporting DSA (Direct State Access),
+ * SPIR-V shaders, compute shaders, and modern OpenGL features.
+ */
+
+#pragma once
+
+#include "../RHIDevice.h"
+#include "../RHIResources.h"
+
+#ifdef SPARK_OPENGL_SUPPORT
+
+// OpenGL headers - using GLAD loader
+#include <glad/glad.h>
+
+#ifdef _WIN32
+#include <Windows.h>
+#elif defined(__linux__)
+#include <GL/glx.h>
+#endif
+
+#include <vector>
+#include <unordered_map>
+#include <string>
+
+namespace Spark { namespace RHI { namespace OpenGL {
+
+// ============================================================================
+// OPENGL RESOURCE IMPLEMENTATIONS
+// ============================================================================
+
+class GLBuffer : public IRHIBuffer
+{
+public:
+    GLBuffer(const RHIBufferDesc& desc, GLuint buffer);
+    ~GLBuffer() override;
+
+    const std::string& GetDebugName() const override { return m_desc.debugName; }
+    void SetDebugName(const std::string& name) override;
+    bool IsValid() const override { return m_buffer != 0; }
+
+    const RHIBufferDesc& GetDesc() const override { return m_desc; }
+    uint64_t GetSize() const override { return m_desc.size; }
+    uint32_t GetStride() const override { return m_desc.stride; }
+    void* GetNativeHandle() const override { return reinterpret_cast<void*>(static_cast<uintptr_t>(m_buffer)); }
+
+    GLuint GetGLBuffer() const { return m_buffer; }
+
+private:
+    RHIBufferDesc m_desc;
+    GLuint m_buffer;
+};
+
+class GLTexture : public IRHITexture
+{
+public:
+    GLTexture(const RHITextureDesc& desc, GLuint texture, GLuint framebuffer = 0);
+    ~GLTexture() override;
+
+    const std::string& GetDebugName() const override { return m_desc.debugName; }
+    void SetDebugName(const std::string& name) override;
+    bool IsValid() const override { return m_texture != 0; }
+
+    const RHITextureDesc& GetDesc() const override { return m_desc; }
+    uint32_t GetWidth() const override { return m_desc.width; }
+    uint32_t GetHeight() const override { return m_desc.height; }
+    uint32_t GetDepth() const override { return m_desc.depth; }
+    uint32_t GetMipLevels() const override { return m_desc.mipLevels; }
+    PixelFormat GetFormat() const override { return m_desc.format; }
+    void* GetNativeHandle() const override { return reinterpret_cast<void*>(static_cast<uintptr_t>(m_texture)); }
+    void* GetShaderResourceView() const override { return GetNativeHandle(); }
+    void* GetRenderTargetView() const override { return reinterpret_cast<void*>(static_cast<uintptr_t>(m_framebuffer)); }
+    void* GetDepthStencilView() const override { return GetNativeHandle(); }
+
+    GLuint GetGLTexture() const { return m_texture; }
+    GLuint GetGLFramebuffer() const { return m_framebuffer; }
+    void SetFramebuffer(GLuint fbo) { m_framebuffer = fbo; }
+
+private:
+    RHITextureDesc m_desc;
+    GLuint m_texture;
+    GLuint m_framebuffer;
+};
+
+class GLShader : public IRHIShader
+{
+public:
+    GLShader(const RHIShaderDesc& desc, GLuint shader, std::string compiledSource);
+    ~GLShader() override;
+
+    const std::string& GetDebugName() const override { return m_desc.debugName; }
+    void SetDebugName(const std::string& name) override { m_desc.debugName = name; }
+    bool IsValid() const override { return m_shader != 0; }
+
+    RHIShaderStage GetStage() const override { return m_desc.stage; }
+    const std::string& GetEntryPoint() const override { return m_desc.entryPoint; }
+    void* GetNativeHandle() const override { return reinterpret_cast<void*>(static_cast<uintptr_t>(m_shader)); }
+    const void* GetBytecode() const override { return m_compiledSource.data(); }
+    size_t GetBytecodeSize() const override { return m_compiledSource.size(); }
+
+    GLuint GetGLShader() const { return m_shader; }
+
+private:
+    RHIShaderDesc m_desc;
+    GLuint m_shader;
+    std::string m_compiledSource;
+};
+
+class GLSampler : public IRHISampler
+{
+public:
+    GLSampler(const RHISamplerDesc& desc, GLuint sampler);
+    ~GLSampler() override;
+
+    const std::string& GetDebugName() const override { return m_debugName; }
+    void SetDebugName(const std::string& name) override { m_debugName = name; }
+    bool IsValid() const override { return m_sampler != 0; }
+
+    const RHISamplerDesc& GetDesc() const override { return m_desc; }
+    void* GetNativeHandle() const override { return reinterpret_cast<void*>(static_cast<uintptr_t>(m_sampler)); }
+
+    GLuint GetGLSampler() const { return m_sampler; }
+
+private:
+    RHISamplerDesc m_desc;
+    GLuint m_sampler;
+    std::string m_debugName;
+};
+
+class GLPipelineState : public IRHIPipelineState
+{
+public:
+    GLPipelineState(const RHIPipelineStateDesc& desc, GLuint program, GLuint vao);
+    ~GLPipelineState() override;
+
+    const std::string& GetDebugName() const override { return m_desc.debugName; }
+    void SetDebugName(const std::string& name) override { m_desc.debugName = name; }
+    bool IsValid() const override { return m_program != 0; }
+
+    const RHIPipelineStateDesc& GetDesc() const override { return m_desc; }
+    void* GetNativeHandle() const override { return reinterpret_cast<void*>(static_cast<uintptr_t>(m_program)); }
+
+    GLuint GetGLProgram() const { return m_program; }
+    GLuint GetGLVAO() const { return m_vao; }
+
+    void ApplyRasterizerState() const;
+    void ApplyDepthStencilState() const;
+    void ApplyBlendState() const;
+
+private:
+    RHIPipelineStateDesc m_desc;
+    GLuint m_program;
+    GLuint m_vao;
+};
+
+// ============================================================================
+// OPENGL SWAP CHAIN
+// ============================================================================
+
+class GLSwapChain : public IRHISwapChain
+{
+public:
+    GLSwapChain(const RHISwapChainDesc& desc);
+    ~GLSwapChain() override;
+
+    bool Present(bool vsync) override;
+    bool Resize(uint32_t width, uint32_t height) override;
+    IRHITexture* GetBackBuffer() override;
+    PixelFormat GetFormat() const override { return m_desc.format; }
+    uint32_t GetWidth() const override { return m_desc.width; }
+    uint32_t GetHeight() const override { return m_desc.height; }
+    uint32_t GetCurrentBufferIndex() const override { return 0; }
+
+private:
+    RHISwapChainDesc m_desc;
+    std::unique_ptr<GLTexture> m_backBuffer;
+
+#ifdef _WIN32
+    HDC m_hdc = nullptr;
+    HGLRC m_hglrc = nullptr;
+#endif
+};
+
+// ============================================================================
+// OPENGL COMMAND LIST
+// ============================================================================
+
+class GLCommandList : public IRHICommandList
+{
+public:
+    GLCommandList(bool isImmediate);
+    ~GLCommandList() override = default;
+
+    void Begin() override;
+    void End() override;
+    void Reset() override;
+
+    void SetRenderTargets(IRHITexture** renderTargets, uint32_t count,
+                          IRHITexture* depthStencil) override;
+    void ClearRenderTarget(IRHITexture* target, const float color[4]) override;
+    void ClearDepthStencil(IRHITexture* target, float depth, uint8_t stencil) override;
+
+    void SetViewport(const RHIViewport& viewport) override;
+    void SetScissorRect(const RHIScissorRect& rect) override;
+
+    void SetPipelineState(IRHIPipelineState* pipelineState) override;
+    void SetPrimitiveTopology(RHIPrimitiveTopology topology) override;
+
+    void SetVertexBuffer(IRHIBuffer* buffer, uint32_t slot, uint32_t offset) override;
+    void SetIndexBuffer(IRHIBuffer* buffer, uint32_t offset) override;
+    void SetConstantBuffer(RHIShaderStage stage, uint32_t slot, IRHIBuffer* buffer) override;
+    void SetShaderResource(RHIShaderStage stage, uint32_t slot, IRHITexture* texture) override;
+    void SetSampler(RHIShaderStage stage, uint32_t slot, IRHISampler* sampler) override;
+
+    void Draw(uint32_t vertexCount, uint32_t startVertex) override;
+    void DrawIndexed(uint32_t indexCount, uint32_t startIndex, int32_t baseVertex) override;
+    void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount,
+                       uint32_t startVertex, uint32_t startInstance) override;
+    void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
+                              uint32_t startIndex, int32_t baseVertex,
+                              uint32_t startInstance) override;
+
+    void Dispatch(uint32_t x, uint32_t y, uint32_t z) override;
+
+    void BeginEvent(const char* name) override;
+    void EndEvent() override;
+    void SetMarker(const char* name) override;
+
+private:
+    bool m_isImmediate;
+    GLenum m_currentTopology = GL_TRIANGLES;
+    GLuint m_currentVAO = 0;
+    GLuint m_currentProgram = 0;
+    GLuint m_boundIndexBuffer = 0;
+    uint32_t m_indexStride = 4;
+};
+
+// ============================================================================
+// OPENGL DEVICE
+// ============================================================================
+
+class GLDevice : public IRHIDevice
+{
+public:
+    GLDevice();
+    ~GLDevice() override;
+
+    bool Initialize(const RHIDeviceDesc& desc) override;
+    void Shutdown() override;
+
+    std::unique_ptr<IRHISwapChain> CreateSwapChain(const RHISwapChainDesc& desc) override;
+
+    IRHIBuffer* CreateBuffer(const RHIBufferDesc& desc) override;
+    IRHITexture* CreateTexture(const RHITextureDesc& desc) override;
+    IRHIShader* CreateShader(const RHIShaderDesc& desc) override;
+    IRHISampler* CreateSampler(const RHISamplerDesc& desc) override;
+    IRHIPipelineState* CreatePipelineState(const RHIPipelineStateDesc& desc,
+                                           IRHIShader* vertexShader,
+                                           IRHIShader* pixelShader) override;
+
+    void DestroyBuffer(IRHIBuffer* buffer) override;
+    void DestroyTexture(IRHITexture* texture) override;
+    void DestroyShader(IRHIShader* shader) override;
+    void DestroySampler(IRHISampler* sampler) override;
+    void DestroyPipelineState(IRHIPipelineState* state) override;
+
+    void* MapBuffer(IRHIBuffer* buffer) override;
+    void UnmapBuffer(IRHIBuffer* buffer) override;
+    void UpdateBuffer(IRHIBuffer* buffer, const void* data, size_t size, size_t offset) override;
+    void UpdateTexture(IRHITexture* texture, const void* data,
+                       uint32_t mipLevel, uint32_t arraySlice) override;
+
+    IRHICommandList* GetImmediateCommandList() override;
+    IRHICommandList* CreateDeferredCommandList() override;
+    void ExecuteCommandList(IRHICommandList* commandList) override;
+    void DestroyCommandList(IRHICommandList* commandList) override;
+
+    void BeginFrame() override;
+    void EndFrame() override;
+    void WaitForIdle() override;
+
+    GraphicsBackend GetBackendType() const override { return GraphicsBackend::OpenGL; }
+    const RHIDeviceCapabilities& GetCapabilities() const override { return m_capabilities; }
+    const RHIStatistics& GetStatistics() const override { return m_statistics; }
+    void ResetStatistics() override;
+    std::string GetDeviceInfo() const override;
+
+private:
+    GLenum ConvertFormat(PixelFormat format) const;
+    GLenum ConvertInternalFormat(PixelFormat format) const;
+    GLenum ConvertFormatType(PixelFormat format) const;
+    GLenum ConvertFilter(RHIFilterMode mode) const;
+    GLenum ConvertAddressMode(RHIAddressMode mode) const;
+    GLenum ConvertCompareOp(RHICompareOp op) const;
+    GLenum ConvertStencilOp(RHIStencilOp op) const;
+    GLenum ConvertBlendFactor(RHIBlendFactor factor) const;
+    GLenum ConvertBlendOp(RHIBlendOp op) const;
+    GLenum ConvertTopology(RHIPrimitiveTopology topology) const;
+
+    void QueryCapabilities();
+
+    std::unique_ptr<GLCommandList> m_immediateCommandList;
+    RHIDeviceCapabilities m_capabilities;
+    RHIStatistics m_statistics;
+    bool m_debugEnabled = false;
+};
+
+}}} // namespace Spark::RHI::OpenGL
+
+#endif // SPARK_OPENGL_SUPPORT

--- a/Spark Engine/Source/Graphics/RHI/RHI.h
+++ b/Spark Engine/Source/Graphics/RHI/RHI.h
@@ -1,0 +1,41 @@
+/**
+ * @file RHI.h
+ * @brief Master include for the Rendering Hardware Interface
+ * @author Spark Engine Team
+ * @date 2025
+ *
+ * Single-include header that pulls in the entire RHI abstraction layer.
+ * Use this header in application code instead of including individual RHI headers.
+ *
+ * Supported backends:
+ *   - D3D11  (Windows, always available)
+ *   - Vulkan (Windows/Linux/macOS via MoltenVK, requires SPARK_VULKAN_SUPPORT)
+ *   - OpenGL (Windows/Linux, requires SPARK_OPENGL_SUPPORT)
+ *
+ * Usage:
+ *   #include "Graphics/RHI/RHI.h"
+ *
+ *   // Create a device with auto-detection
+ *   auto device = Spark::RHI::RHIFactory::CreateDevice(Spark::RHI::GraphicsBackend::Auto);
+ *
+ *   // Or use the bridge for a higher-level API
+ *   Spark::RHI::RHIBridge bridge;
+ *   bridge.Initialize(hwnd, 1280, 720, Spark::RHI::GraphicsBackend::Vulkan);
+ */
+
+#pragma once
+
+// Core RHI types and enumerations
+#include "RHITypes.h"
+
+// Abstract resource interfaces
+#include "RHIResources.h"
+
+// Abstract device and command list interfaces
+#include "RHIDevice.h"
+
+// Backend factory and shader compilation
+#include "RHIFactory.h"
+
+// High-level integration bridge
+#include "RHIBridge.h"

--- a/Spark Engine/Source/Graphics/RHI/RHIBridge.cpp
+++ b/Spark Engine/Source/Graphics/RHI/RHIBridge.cpp
@@ -1,0 +1,502 @@
+/**
+ * @file RHIBridge.cpp
+ * @brief Implementation of the RHI bridge layer
+ * @author Spark Engine Team
+ * @date 2025
+ */
+
+#include "RHIBridge.h"
+#include "RHIFactory.h"
+#include <cassert>
+#include <fstream>
+#include <algorithm>
+
+namespace Spark { namespace RHI {
+
+// ============================================================================
+// SHADER CACHE
+// ============================================================================
+
+void ShaderCache::RegisterShader(const std::string& name, const ShaderEntry& entry)
+{
+    m_entries[name] = entry;
+}
+
+IRHIShader* ShaderCache::GetShader(const std::string& name, IRHIDevice* device)
+{
+    auto cached = m_loadedShaders.find(name);
+    if (cached != m_loadedShaders.end())
+        return cached->second;
+
+    auto entry = m_entries.find(name);
+    if (entry == m_entries.end())
+        return nullptr;
+
+    const auto& e = entry->second;
+    RHIShaderDesc desc;
+    desc.stage = e.stage;
+    desc.entryPoint = e.entryPoint;
+    desc.debugName = name;
+
+    // Select shader source based on backend
+    GraphicsBackend backend = device->GetBackendType();
+    std::string filePath;
+
+    switch (backend)
+    {
+    case GraphicsBackend::D3D11:
+    case GraphicsBackend::D3D12:
+        filePath = e.hlslPath;
+        desc.language = ShaderLanguage::HLSL;
+        break;
+    case GraphicsBackend::Vulkan:
+        filePath = !e.spirvPath.empty() ? e.spirvPath : e.glslPath;
+        desc.language = !e.spirvPath.empty() ? ShaderLanguage::SPIRV : ShaderLanguage::GLSL;
+        break;
+    case GraphicsBackend::OpenGL:
+        filePath = e.glslPath;
+        desc.language = ShaderLanguage::GLSL;
+        break;
+    default:
+        return nullptr;
+    }
+
+    if (filePath.empty())
+        return nullptr;
+
+    // Load shader source
+    if (desc.language == ShaderLanguage::SPIRV)
+    {
+        std::ifstream file(filePath, std::ios::binary | std::ios::ate);
+        if (!file.is_open()) return nullptr;
+
+        size_t size = file.tellg();
+        file.seekg(0);
+        std::vector<uint8_t> buffer(size);
+        file.read(reinterpret_cast<char*>(buffer.data()), size);
+        desc.bytecode = buffer.data();
+        desc.bytecodeSize = size;
+
+        IRHIShader* shader = device->CreateShader(desc);
+        if (shader)
+            m_loadedShaders[name] = shader;
+        return shader;
+    }
+    else
+    {
+        std::ifstream file(filePath);
+        if (!file.is_open()) return nullptr;
+
+        desc.sourceCode = std::string(
+            std::istreambuf_iterator<char>(file),
+            std::istreambuf_iterator<char>());
+        desc.filePath = filePath;
+
+        IRHIShader* shader = device->CreateShader(desc);
+        if (shader)
+            m_loadedShaders[name] = shader;
+        return shader;
+    }
+}
+
+void ShaderCache::Clear(IRHIDevice* device)
+{
+    for (auto& [name, shader] : m_loadedShaders)
+    {
+        device->DestroyShader(shader);
+    }
+    m_loadedShaders.clear();
+}
+
+void ShaderCache::ReloadAll(IRHIDevice* device)
+{
+    // Destroy existing shaders
+    Clear(device);
+
+    // Reload all registered shaders
+    for (const auto& [name, entry] : m_entries)
+    {
+        GetShader(name, device);
+    }
+}
+
+// ============================================================================
+// RHI BRIDGE
+// ============================================================================
+
+RHIBridge::RHIBridge() = default;
+
+RHIBridge::~RHIBridge()
+{
+    Shutdown();
+}
+
+bool RHIBridge::Initialize(void* windowHandle, uint32_t width, uint32_t height,
+                            GraphicsBackend backend, bool enableDebug)
+{
+    if (m_initialized)
+        Shutdown();
+
+    m_windowHandle = windowHandle;
+    m_width = width;
+    m_height = height;
+
+    // Auto-select backend if requested
+    if (backend == GraphicsBackend::Auto)
+        backend = SelectBestBackend();
+
+    // Create the device via factory
+    m_device = RHIFactory::CreateDevice(backend);
+    if (!m_device)
+        return false;
+
+    // Initialize device
+    RHIDeviceDesc deviceDesc;
+    deviceDesc.preferredBackend = backend;
+    deviceDesc.enableDebugLayer = enableDebug;
+    deviceDesc.enableGPUValidation = enableDebug;
+    deviceDesc.windowHandle = windowHandle;
+    deviceDesc.applicationName = "SparkEngine";
+
+    if (!m_device->Initialize(deviceDesc))
+    {
+        m_device.reset();
+        return false;
+    }
+
+    // Create swap chain
+    RHISwapChainDesc swapDesc;
+    swapDesc.windowHandle = windowHandle;
+    swapDesc.width = width;
+    swapDesc.height = height;
+    swapDesc.format = PixelFormat::R8G8B8A8_UNORM;
+    swapDesc.bufferCount = 2;
+    swapDesc.windowed = true;
+    swapDesc.vsync = true;
+
+    m_swapChain = m_device->CreateSwapChain(swapDesc);
+    if (!m_swapChain)
+    {
+        m_device->Shutdown();
+        m_device.reset();
+        return false;
+    }
+
+    // Create depth buffer
+    if (!CreateDepthBufferInternal(width, height))
+    {
+        m_swapChain.reset();
+        m_device->Shutdown();
+        m_device.reset();
+        return false;
+    }
+
+    m_initialized = true;
+    return true;
+}
+
+void RHIBridge::Shutdown()
+{
+    if (!m_initialized) return;
+
+    m_shaderCache.Clear(m_device.get());
+
+    if (m_depthBuffer)
+    {
+        m_device->DestroyTexture(m_depthBuffer);
+        m_depthBuffer = nullptr;
+    }
+
+    m_swapChain.reset();
+
+    if (m_device)
+    {
+        m_device->WaitForIdle();
+        m_device->Shutdown();
+        m_device.reset();
+    }
+
+    m_initialized = false;
+}
+
+bool RHIBridge::Resize(uint32_t width, uint32_t height)
+{
+    if (!m_initialized) return false;
+    if (width == 0 || height == 0) return false;
+
+    m_device->WaitForIdle();
+
+    // Destroy old depth buffer
+    if (m_depthBuffer)
+    {
+        m_device->DestroyTexture(m_depthBuffer);
+        m_depthBuffer = nullptr;
+    }
+
+    // Resize swap chain
+    if (!m_swapChain->Resize(width, height))
+        return false;
+
+    m_width = width;
+    m_height = height;
+
+    // Recreate depth buffer
+    return CreateDepthBufferInternal(width, height);
+}
+
+void RHIBridge::BeginFrame()
+{
+    if (m_device) m_device->BeginFrame();
+}
+
+void RHIBridge::EndFrame()
+{
+    if (m_device) m_device->EndFrame();
+}
+
+bool RHIBridge::Present(bool vsync)
+{
+    return m_swapChain ? m_swapChain->Present(vsync) : false;
+}
+
+IRHICommandList* RHIBridge::GetCommandList() const
+{
+    return m_device ? m_device->GetImmediateCommandList() : nullptr;
+}
+
+IRHITexture* RHIBridge::GetBackBuffer() const
+{
+    return m_swapChain ? m_swapChain->GetBackBuffer() : nullptr;
+}
+
+GraphicsBackend RHIBridge::GetActiveBackend() const
+{
+    return m_device ? m_device->GetBackendType() : GraphicsBackend::Auto;
+}
+
+// ============================================================================
+// RESOURCE CONVENIENCE METHODS
+// ============================================================================
+
+IRHIBuffer* RHIBridge::CreateVertexBuffer(const void* data, uint64_t size, uint32_t stride)
+{
+    RHIBufferDesc desc;
+    desc.size = size;
+    desc.stride = stride;
+    desc.usage = RHIBufferUsage::Vertex;
+    desc.access = data ? RHIBufferAccess::Static : RHIBufferAccess::Dynamic;
+    desc.initialData = data;
+    return m_device->CreateBuffer(desc);
+}
+
+IRHIBuffer* RHIBridge::CreateIndexBuffer(const void* data, uint64_t size, uint32_t stride)
+{
+    RHIBufferDesc desc;
+    desc.size = size;
+    desc.stride = stride;
+    desc.usage = RHIBufferUsage::Index;
+    desc.access = data ? RHIBufferAccess::Static : RHIBufferAccess::Dynamic;
+    desc.initialData = data;
+    return m_device->CreateBuffer(desc);
+}
+
+IRHIBuffer* RHIBridge::CreateConstantBuffer(uint64_t size)
+{
+    RHIBufferDesc desc;
+    desc.size = size;
+    desc.usage = RHIBufferUsage::Constant;
+    desc.access = RHIBufferAccess::Dynamic;
+    return m_device->CreateBuffer(desc);
+}
+
+IRHITexture* RHIBridge::CreateTexture2D(uint32_t width, uint32_t height, PixelFormat format,
+                                          RHITextureUsage usage, const void* data)
+{
+    RHITextureDesc desc;
+    desc.width = width;
+    desc.height = height;
+    desc.format = format;
+    desc.usage = usage;
+    desc.mipLevels = 1;
+    return m_device->CreateTexture(desc);
+}
+
+IRHITexture* RHIBridge::CreateDepthBuffer(uint32_t width, uint32_t height, PixelFormat format)
+{
+    RHITextureDesc desc;
+    desc.width = width;
+    desc.height = height;
+    desc.format = format;
+    desc.usage = RHITextureUsage::DepthStencil;
+    desc.mipLevels = 1;
+    return m_device->CreateTexture(desc);
+}
+
+IRHITexture* RHIBridge::CreateRenderTarget(uint32_t width, uint32_t height, PixelFormat format)
+{
+    RHITextureDesc desc;
+    desc.width = width;
+    desc.height = height;
+    desc.format = format;
+    desc.usage = RHITextureUsage::RenderTarget | RHITextureUsage::ShaderResource;
+    desc.mipLevels = 1;
+    return m_device->CreateTexture(desc);
+}
+
+IRHISampler* RHIBridge::CreateSamplerLinearWrap()
+{
+    RHISamplerDesc desc;
+    desc.minFilter = RHIFilterMode::Linear;
+    desc.magFilter = RHIFilterMode::Linear;
+    desc.mipFilter = RHIFilterMode::Linear;
+    desc.addressU = RHIAddressMode::Wrap;
+    desc.addressV = RHIAddressMode::Wrap;
+    desc.addressW = RHIAddressMode::Wrap;
+    return m_device->CreateSampler(desc);
+}
+
+IRHISampler* RHIBridge::CreateSamplerLinearClamp()
+{
+    RHISamplerDesc desc;
+    desc.minFilter = RHIFilterMode::Linear;
+    desc.magFilter = RHIFilterMode::Linear;
+    desc.mipFilter = RHIFilterMode::Linear;
+    desc.addressU = RHIAddressMode::Clamp;
+    desc.addressV = RHIAddressMode::Clamp;
+    desc.addressW = RHIAddressMode::Clamp;
+    return m_device->CreateSampler(desc);
+}
+
+IRHISampler* RHIBridge::CreateSamplerPointClamp()
+{
+    RHISamplerDesc desc;
+    desc.minFilter = RHIFilterMode::Nearest;
+    desc.magFilter = RHIFilterMode::Nearest;
+    desc.mipFilter = RHIFilterMode::Nearest;
+    desc.addressU = RHIAddressMode::Clamp;
+    desc.addressV = RHIAddressMode::Clamp;
+    desc.addressW = RHIAddressMode::Clamp;
+    return m_device->CreateSampler(desc);
+}
+
+IRHISampler* RHIBridge::CreateSamplerAnisotropic(uint32_t maxAnisotropy)
+{
+    RHISamplerDesc desc;
+    desc.minFilter = RHIFilterMode::Anisotropic;
+    desc.magFilter = RHIFilterMode::Anisotropic;
+    desc.mipFilter = RHIFilterMode::Linear;
+    desc.addressU = RHIAddressMode::Wrap;
+    desc.addressV = RHIAddressMode::Wrap;
+    desc.addressW = RHIAddressMode::Wrap;
+    desc.maxAnisotropy = maxAnisotropy;
+    return m_device->CreateSampler(desc);
+}
+
+// ============================================================================
+// SHADER MANAGEMENT
+// ============================================================================
+
+void RHIBridge::RegisterShader(const std::string& name, RHIShaderStage stage,
+                                const std::string& hlslPath, const std::string& glslPath,
+                                const std::string& spirvPath, const std::string& entryPoint)
+{
+    ShaderCache::ShaderEntry entry;
+    entry.hlslPath = hlslPath;
+    entry.glslPath = glslPath;
+    entry.spirvPath = spirvPath;
+    entry.entryPoint = entryPoint;
+    entry.stage = stage;
+    m_shaderCache.RegisterShader(name, entry);
+}
+
+IRHIShader* RHIBridge::GetShader(const std::string& name)
+{
+    return m_shaderCache.GetShader(name, m_device.get());
+}
+
+// ============================================================================
+// CAPABILITIES & INFO
+// ============================================================================
+
+const RHIDeviceCapabilities& RHIBridge::GetCapabilities() const
+{
+    return m_device->GetCapabilities();
+}
+
+const RHIStatistics& RHIBridge::GetFrameStatistics() const
+{
+    return m_device->GetStatistics();
+}
+
+std::string RHIBridge::GetDeviceInfo() const
+{
+    return m_device ? m_device->GetDeviceInfo() : "No device";
+}
+
+std::string RHIBridge::GetBackendName() const
+{
+    switch (GetActiveBackend())
+    {
+    case GraphicsBackend::D3D11:  return "DirectX 11";
+    case GraphicsBackend::D3D12:  return "DirectX 12";
+    case GraphicsBackend::Vulkan: return "Vulkan";
+    case GraphicsBackend::OpenGL: return "OpenGL";
+    case GraphicsBackend::Metal:  return "Metal";
+    default:                      return "Unknown";
+    }
+}
+
+bool RHIBridge::IsBackendAvailable(GraphicsBackend backend)
+{
+    auto available = GetAvailableBackends();
+    return std::find(available.begin(), available.end(), backend) != available.end();
+}
+
+std::vector<GraphicsBackend> RHIBridge::GetAvailableBackends()
+{
+    std::vector<GraphicsBackend> backends;
+
+#ifdef _WIN32
+    backends.push_back(GraphicsBackend::D3D11);
+#endif
+
+#ifdef SPARK_VULKAN_SUPPORT
+    backends.push_back(GraphicsBackend::Vulkan);
+#endif
+
+#ifdef SPARK_OPENGL_SUPPORT
+    backends.push_back(GraphicsBackend::OpenGL);
+#endif
+
+    return backends;
+}
+
+GraphicsBackend RHIBridge::GetRecommendedBackend()
+{
+#ifdef _WIN32
+    return GraphicsBackend::D3D11;
+#elif defined(SPARK_VULKAN_SUPPORT)
+    return GraphicsBackend::Vulkan;
+#elif defined(SPARK_OPENGL_SUPPORT)
+    return GraphicsBackend::OpenGL;
+#else
+    return GraphicsBackend::Auto;
+#endif
+}
+
+// ============================================================================
+// PRIVATE
+// ============================================================================
+
+GraphicsBackend RHIBridge::SelectBestBackend() const
+{
+    return GetRecommendedBackend();
+}
+
+bool RHIBridge::CreateDepthBufferInternal(uint32_t width, uint32_t height)
+{
+    m_depthBuffer = CreateDepthBuffer(width, height);
+    return m_depthBuffer != nullptr;
+}
+
+}} // namespace Spark::RHI

--- a/Spark Engine/Source/Graphics/RHI/RHIBridge.h
+++ b/Spark Engine/Source/Graphics/RHI/RHIBridge.h
@@ -1,0 +1,221 @@
+/**
+ * @file RHIBridge.h
+ * @brief Integration bridge between the RHI abstraction and the existing GraphicsEngine
+ * @author Spark Engine Team
+ * @date 2025
+ *
+ * Provides the glue layer that allows the legacy DirectX 11 GraphicsEngine to
+ * operate through the new RHI abstraction, enabling transparent backend switching
+ * between D3D11, Vulkan, and OpenGL without modifying existing rendering code.
+ *
+ * Usage:
+ *   // At initialization (replaces direct D3D11 creation):
+ *   RHIBridge bridge;
+ *   bridge.Initialize(hwnd, GraphicsBackend::Vulkan);
+ *
+ *   // During rendering (existing code works through bridge):
+ *   auto* cmd = bridge.GetCommandList();
+ *   cmd->SetRenderTargets(&backBuffer, 1, depthBuffer);
+ *   cmd->ClearRenderTarget(backBuffer, clearColor);
+ *   // ... draw calls ...
+ *   bridge.Present(true);
+ */
+
+#pragma once
+
+#include "RHIDevice.h"
+#include "RHIResources.h"
+#include "RHITypes.h"
+#include <memory>
+#include <string>
+#include <functional>
+#include <unordered_map>
+
+namespace Spark { namespace RHI {
+
+// ============================================================================
+// SHADER CACHE
+// ============================================================================
+
+/**
+ * @brief Cross-platform shader cache that loads the correct shader variant
+ *        based on the active graphics backend.
+ */
+class ShaderCache
+{
+public:
+    struct ShaderEntry
+    {
+        std::string hlslPath;
+        std::string glslPath;
+        std::string spirvPath;
+        std::string entryPoint;
+        RHIShaderStage stage;
+    };
+
+    void RegisterShader(const std::string& name, const ShaderEntry& entry);
+    IRHIShader* GetShader(const std::string& name, IRHIDevice* device);
+    void Clear(IRHIDevice* device);
+    void ReloadAll(IRHIDevice* device);
+
+private:
+    std::unordered_map<std::string, ShaderEntry> m_entries;
+    std::unordered_map<std::string, IRHIShader*> m_loadedShaders;
+};
+
+// ============================================================================
+// RHI BRIDGE
+// ============================================================================
+
+class RHIBridge
+{
+public:
+    RHIBridge();
+    ~RHIBridge();
+
+    /**
+     * @brief Initialize the RHI with the specified backend
+     * @param windowHandle Platform window handle (HWND on Windows)
+     * @param width Initial window width
+     * @param height Initial window height
+     * @param backend Graphics backend to use (Auto = best available)
+     * @param enableDebug Enable GPU debug/validation layers
+     * @return true on success
+     */
+    bool Initialize(void* windowHandle, uint32_t width, uint32_t height,
+                    GraphicsBackend backend = GraphicsBackend::Auto,
+                    bool enableDebug = false);
+
+    /**
+     * @brief Shutdown and release all RHI resources
+     */
+    void Shutdown();
+
+    /**
+     * @brief Resize the swap chain and related render targets
+     */
+    bool Resize(uint32_t width, uint32_t height);
+
+    // ========================================================================
+    // FRAME MANAGEMENT
+    // ========================================================================
+
+    void BeginFrame();
+    void EndFrame();
+    bool Present(bool vsync = true);
+
+    // ========================================================================
+    // DEVICE ACCESS
+    // ========================================================================
+
+    IRHIDevice* GetDevice() const { return m_device.get(); }
+    IRHISwapChain* GetSwapChain() const { return m_swapChain.get(); }
+    IRHICommandList* GetCommandList() const;
+    IRHITexture* GetBackBuffer() const;
+    IRHITexture* GetDepthBuffer() const { return m_depthBuffer; }
+    GraphicsBackend GetActiveBackend() const;
+
+    // ========================================================================
+    // RESOURCE CONVENIENCE METHODS
+    // ========================================================================
+
+    /**
+     * @brief Create a vertex buffer from data
+     */
+    IRHIBuffer* CreateVertexBuffer(const void* data, uint64_t size, uint32_t stride);
+
+    /**
+     * @brief Create an index buffer from data
+     */
+    IRHIBuffer* CreateIndexBuffer(const void* data, uint64_t size, uint32_t stride = 4);
+
+    /**
+     * @brief Create a constant buffer
+     */
+    IRHIBuffer* CreateConstantBuffer(uint64_t size);
+
+    /**
+     * @brief Create a 2D texture with optional initial data
+     */
+    IRHITexture* CreateTexture2D(uint32_t width, uint32_t height, PixelFormat format,
+                                  RHITextureUsage usage, const void* data = nullptr);
+
+    /**
+     * @brief Create a depth buffer
+     */
+    IRHITexture* CreateDepthBuffer(uint32_t width, uint32_t height,
+                                    PixelFormat format = PixelFormat::D24_UNORM_S8_UINT);
+
+    /**
+     * @brief Create a render target texture
+     */
+    IRHITexture* CreateRenderTarget(uint32_t width, uint32_t height,
+                                     PixelFormat format = PixelFormat::R8G8B8A8_UNORM);
+
+    /**
+     * @brief Create a sampler state with common presets
+     */
+    IRHISampler* CreateSamplerLinearWrap();
+    IRHISampler* CreateSamplerLinearClamp();
+    IRHISampler* CreateSamplerPointClamp();
+    IRHISampler* CreateSamplerAnisotropic(uint32_t maxAnisotropy = 16);
+
+    // ========================================================================
+    // SHADER CACHE
+    // ========================================================================
+
+    ShaderCache& GetShaderCache() { return m_shaderCache; }
+
+    /**
+     * @brief Register a shader pair (HLSL + GLSL)
+     */
+    void RegisterShader(const std::string& name, RHIShaderStage stage,
+                        const std::string& hlslPath, const std::string& glslPath,
+                        const std::string& spirvPath = "",
+                        const std::string& entryPoint = "main");
+
+    /**
+     * @brief Get a loaded shader by name
+     */
+    IRHIShader* GetShader(const std::string& name);
+
+    // ========================================================================
+    // CAPABILITIES & INFO
+    // ========================================================================
+
+    const RHIDeviceCapabilities& GetCapabilities() const;
+    const RHIStatistics& GetFrameStatistics() const;
+    std::string GetDeviceInfo() const;
+    std::string GetBackendName() const;
+
+    /**
+     * @brief Check if a specific backend is available on this system
+     */
+    static bool IsBackendAvailable(GraphicsBackend backend);
+
+    /**
+     * @brief Get a list of all available backends
+     */
+    static std::vector<GraphicsBackend> GetAvailableBackends();
+
+    /**
+     * @brief Get the recommended backend for this system
+     */
+    static GraphicsBackend GetRecommendedBackend();
+
+private:
+    GraphicsBackend SelectBestBackend() const;
+    bool CreateDepthBufferInternal(uint32_t width, uint32_t height);
+
+    std::unique_ptr<IRHIDevice> m_device;
+    std::unique_ptr<IRHISwapChain> m_swapChain;
+    IRHITexture* m_depthBuffer = nullptr;
+    ShaderCache m_shaderCache;
+
+    void* m_windowHandle = nullptr;
+    uint32_t m_width = 0;
+    uint32_t m_height = 0;
+    bool m_initialized = false;
+};
+
+}} // namespace Spark::RHI

--- a/Spark Engine/Source/Graphics/RHI/RHIDevice.h
+++ b/Spark Engine/Source/Graphics/RHI/RHIDevice.h
@@ -1,0 +1,189 @@
+/**
+ * @file RHIDevice.h
+ * @brief Abstract Rendering Hardware Interface device
+ * @author Spark Engine Team
+ * @date 2025
+ *
+ * The RHI Device is the central abstraction for all graphics API backends.
+ * It manages resource creation, command submission, and device lifetime.
+ */
+
+#pragma once
+
+#include "RHITypes.h"
+#include "RHIResources.h"
+#include <memory>
+#include <string>
+
+namespace Spark { namespace RHI {
+
+/**
+ * @brief Swap chain creation descriptor
+ */
+struct RHISwapChainDesc
+{
+    void*       windowHandle = nullptr;
+    uint32_t    width = 1280;
+    uint32_t    height = 720;
+    PixelFormat format = PixelFormat::R8G8B8A8_UNORM;
+    uint32_t    bufferCount = 2;
+    bool        vsync = true;
+    bool        fullscreen = false;
+    uint32_t    sampleCount = 1;
+};
+
+/**
+ * @brief Device creation descriptor
+ */
+struct RHIDeviceDesc
+{
+    GraphicsBackend  preferredBackend = GraphicsBackend::Auto;
+    bool             enableDebugLayer = false;
+    bool             enableGPUValidation = false;
+    std::string      applicationName = "SparkEngine";
+    uint32_t         applicationVersion = 1;
+};
+
+/**
+ * @brief Abstract RHI swap chain
+ */
+class IRHISwapChain
+{
+public:
+    virtual ~IRHISwapChain() = default;
+
+    virtual bool Present(bool vsync) = 0;
+    virtual bool Resize(uint32_t width, uint32_t height) = 0;
+    virtual IRHITexture* GetBackBuffer() = 0;
+    virtual PixelFormat GetFormat() const = 0;
+    virtual uint32_t GetWidth() const = 0;
+    virtual uint32_t GetHeight() const = 0;
+    virtual uint32_t GetCurrentBufferIndex() const = 0;
+};
+
+/**
+ * @brief Abstract RHI command list for recording GPU commands
+ */
+class IRHICommandList
+{
+public:
+    virtual ~IRHICommandList() = default;
+
+    // State
+    virtual void Begin() = 0;
+    virtual void End() = 0;
+    virtual void Reset() = 0;
+
+    // Render targets
+    virtual void SetRenderTargets(IRHITexture** renderTargets, uint32_t count,
+                                  IRHITexture* depthStencil) = 0;
+    virtual void ClearRenderTarget(IRHITexture* target, const float color[4]) = 0;
+    virtual void ClearDepthStencil(IRHITexture* target, float depth, uint8_t stencil) = 0;
+
+    // Viewport and scissor
+    virtual void SetViewport(const RHIViewport& viewport) = 0;
+    virtual void SetScissorRect(const RHIScissorRect& rect) = 0;
+
+    // Pipeline
+    virtual void SetPipelineState(IRHIPipelineState* pipelineState) = 0;
+    virtual void SetPrimitiveTopology(RHIPrimitiveTopology topology) = 0;
+
+    // Resources
+    virtual void SetVertexBuffer(IRHIBuffer* buffer, uint32_t slot = 0, uint32_t offset = 0) = 0;
+    virtual void SetIndexBuffer(IRHIBuffer* buffer, uint32_t offset = 0) = 0;
+    virtual void SetConstantBuffer(RHIShaderStage stage, uint32_t slot, IRHIBuffer* buffer) = 0;
+    virtual void SetShaderResource(RHIShaderStage stage, uint32_t slot, IRHITexture* texture) = 0;
+    virtual void SetSampler(RHIShaderStage stage, uint32_t slot, IRHISampler* sampler) = 0;
+
+    // Draw commands
+    virtual void Draw(uint32_t vertexCount, uint32_t startVertex = 0) = 0;
+    virtual void DrawIndexed(uint32_t indexCount, uint32_t startIndex = 0,
+                             int32_t baseVertex = 0) = 0;
+    virtual void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount,
+                               uint32_t startVertex = 0, uint32_t startInstance = 0) = 0;
+    virtual void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
+                                      uint32_t startIndex = 0, int32_t baseVertex = 0,
+                                      uint32_t startInstance = 0) = 0;
+
+    // Compute
+    virtual void Dispatch(uint32_t x, uint32_t y, uint32_t z) = 0;
+
+    // Debug
+    virtual void BeginEvent(const char* name) = 0;
+    virtual void EndEvent() = 0;
+    virtual void SetMarker(const char* name) = 0;
+};
+
+/**
+ * @brief Abstract RHI Device - core interface for all graphics operations
+ */
+class IRHIDevice
+{
+public:
+    virtual ~IRHIDevice() = default;
+
+    // Initialization
+    virtual bool Initialize(const RHIDeviceDesc& desc) = 0;
+    virtual void Shutdown() = 0;
+
+    // Swap chain
+    virtual std::unique_ptr<IRHISwapChain> CreateSwapChain(const RHISwapChainDesc& desc) = 0;
+
+    // Resource creation
+    virtual IRHIBuffer* CreateBuffer(const RHIBufferDesc& desc) = 0;
+    virtual IRHITexture* CreateTexture(const RHITextureDesc& desc) = 0;
+    virtual IRHIShader* CreateShader(const RHIShaderDesc& desc) = 0;
+    virtual IRHISampler* CreateSampler(const RHISamplerDesc& desc) = 0;
+    virtual IRHIPipelineState* CreatePipelineState(const RHIPipelineStateDesc& desc,
+                                                    IRHIShader* vertexShader,
+                                                    IRHIShader* pixelShader) = 0;
+
+    // Resource destruction
+    virtual void DestroyBuffer(IRHIBuffer* buffer) = 0;
+    virtual void DestroyTexture(IRHITexture* texture) = 0;
+    virtual void DestroyShader(IRHIShader* shader) = 0;
+    virtual void DestroySampler(IRHISampler* sampler) = 0;
+    virtual void DestroyPipelineState(IRHIPipelineState* state) = 0;
+
+    // Resource updates
+    virtual void* MapBuffer(IRHIBuffer* buffer) = 0;
+    virtual void UnmapBuffer(IRHIBuffer* buffer) = 0;
+    virtual void UpdateBuffer(IRHIBuffer* buffer, const void* data, size_t size, size_t offset = 0) = 0;
+    virtual void UpdateTexture(IRHITexture* texture, const void* data, uint32_t mipLevel = 0,
+                               uint32_t arraySlice = 0) = 0;
+
+    // Command lists
+    virtual IRHICommandList* GetImmediateCommandList() = 0;
+    virtual IRHICommandList* CreateDeferredCommandList() = 0;
+    virtual void ExecuteCommandList(IRHICommandList* commandList) = 0;
+    virtual void DestroyCommandList(IRHICommandList* commandList) = 0;
+
+    // Frame management
+    virtual void BeginFrame() = 0;
+    virtual void EndFrame() = 0;
+    virtual void WaitForIdle() = 0;
+
+    // Device info
+    virtual GraphicsBackend GetBackendType() const = 0;
+    virtual const RHIDeviceCapabilities& GetCapabilities() const = 0;
+    virtual const RHIStatistics& GetStatistics() const = 0;
+    virtual void ResetStatistics() = 0;
+    virtual std::string GetDeviceInfo() const = 0;
+};
+
+/**
+ * @brief Factory function to create the appropriate RHI device
+ */
+std::unique_ptr<IRHIDevice> CreateRHIDevice(GraphicsBackend backend);
+
+/**
+ * @brief Query available graphics backends on the current system
+ */
+std::vector<GraphicsBackend> GetAvailableBackends();
+
+/**
+ * @brief Get a string name for a graphics backend
+ */
+const char* GetBackendName(GraphicsBackend backend);
+
+}} // namespace Spark::RHI

--- a/Spark Engine/Source/Graphics/RHI/RHIFactory.cpp
+++ b/Spark Engine/Source/Graphics/RHI/RHIFactory.cpp
@@ -1,0 +1,413 @@
+/**
+ * @file RHIFactory.cpp
+ * @brief RHI factory and utility implementation
+ * @author Spark Engine Team
+ * @date 2025
+ */
+
+#include "RHIFactory.h"
+#include <iostream>
+#include <fstream>
+#include <algorithm>
+
+// Backend headers (conditionally included)
+#ifdef _WIN32
+#include "D3D11/D3D11Device.h"
+#endif
+
+#ifdef SPARK_VULKAN_SUPPORT
+#include "Vulkan/VulkanDevice.h"
+#endif
+
+#ifdef SPARK_OPENGL_SUPPORT
+#include "OpenGL/OpenGLDevice.h"
+#endif
+
+namespace Spark { namespace RHI {
+
+// ============================================================================
+// BACKEND DETECTION
+// ============================================================================
+
+std::vector<GraphicsBackend> DetectAvailableBackends()
+{
+    std::vector<GraphicsBackend> backends;
+
+#ifdef _WIN32
+    // D3D11 is always available on Windows
+    backends.push_back(GraphicsBackend::D3D11);
+#endif
+
+#ifdef SPARK_VULKAN_SUPPORT
+    // Check if Vulkan runtime is available
+    backends.push_back(GraphicsBackend::Vulkan);
+#endif
+
+#ifdef SPARK_OPENGL_SUPPORT
+    backends.push_back(GraphicsBackend::OpenGL);
+#endif
+
+    return backends;
+}
+
+GraphicsBackend GetRecommendedBackend()
+{
+    auto backends = DetectAvailableBackends();
+
+    if (backends.empty())
+        return GraphicsBackend::Auto;
+
+    // Priority: D3D11 on Windows, Vulkan on Linux, OpenGL as fallback
+#ifdef _WIN32
+    for (auto b : backends)
+        if (b == GraphicsBackend::D3D11) return GraphicsBackend::D3D11;
+#else
+    for (auto b : backends)
+        if (b == GraphicsBackend::Vulkan) return GraphicsBackend::Vulkan;
+#endif
+
+    return backends[0];
+}
+
+std::unique_ptr<IRHIDevice> CreateDevice(GraphicsBackend backend)
+{
+    if (backend == GraphicsBackend::Auto)
+        backend = GetRecommendedBackend();
+
+    std::unique_ptr<IRHIDevice> device;
+
+    switch (backend)
+    {
+#ifdef _WIN32
+    case GraphicsBackend::D3D11:
+        device = std::make_unique<D3D11::D3D11Device>();
+        break;
+#endif
+
+#ifdef SPARK_VULKAN_SUPPORT
+    case GraphicsBackend::Vulkan:
+        device = std::make_unique<Vulkan::VulkanDevice>();
+        break;
+#endif
+
+#ifdef SPARK_OPENGL_SUPPORT
+    case GraphicsBackend::OpenGL:
+        device = std::make_unique<OpenGL::GLDevice>();
+        break;
+#endif
+
+    default:
+        std::cerr << "[RHI] Backend '" << GetBackendName(backend)
+                  << "' is not available on this platform." << std::endl;
+        return nullptr;
+    }
+
+    return device;
+}
+
+const char* GetBackendName(GraphicsBackend backend)
+{
+    switch (backend)
+    {
+    case GraphicsBackend::D3D11:  return "DirectX 11";
+    case GraphicsBackend::D3D12:  return "DirectX 12";
+    case GraphicsBackend::Vulkan: return "Vulkan";
+    case GraphicsBackend::OpenGL: return "OpenGL";
+    case GraphicsBackend::Metal:  return "Metal";
+    case GraphicsBackend::Auto:   return "Auto";
+    default:                      return "Unknown";
+    }
+}
+
+bool IsBackendAvailable(GraphicsBackend backend)
+{
+    auto available = DetectAvailableBackends();
+    return std::find(available.begin(), available.end(), backend) != available.end();
+}
+
+// ============================================================================
+// SHADER COMPILATION
+// ============================================================================
+
+ShaderCompileResult CompileShader(const ShaderCompileOptions& options)
+{
+    ShaderCompileResult result;
+
+    // Determine target language based on backend
+    ShaderLanguage target = options.targetLanguage;
+    if (target == ShaderLanguage::Auto)
+    {
+        switch (options.targetBackend)
+        {
+        case GraphicsBackend::D3D11:
+        case GraphicsBackend::D3D12:
+            target = ShaderLanguage::HLSL;
+            break;
+        case GraphicsBackend::Vulkan:
+            target = ShaderLanguage::SPIRV;
+            break;
+        case GraphicsBackend::OpenGL:
+            target = ShaderLanguage::GLSL;
+            break;
+        default:
+            target = ShaderLanguage::HLSL;
+            break;
+        }
+    }
+
+    // Source language detection
+    ShaderLanguage source = options.sourceLanguage;
+    if (source == ShaderLanguage::Auto)
+    {
+        if (!options.sourceFile.empty())
+        {
+            std::string ext = options.sourceFile.substr(options.sourceFile.find_last_of('.'));
+            if (ext == ".hlsl" || ext == ".fx") source = ShaderLanguage::HLSL;
+            else if (ext == ".glsl" || ext == ".vert" || ext == ".frag") source = ShaderLanguage::GLSL;
+            else if (ext == ".spv") source = ShaderLanguage::SPIRV;
+            else source = ShaderLanguage::HLSL; // Default to HLSL
+        }
+        else
+        {
+            source = ShaderLanguage::HLSL;
+        }
+    }
+
+    std::string sourceCode = options.sourceCode;
+
+    // Load from file if needed
+    if (sourceCode.empty() && !options.sourceFile.empty())
+    {
+        std::ifstream file(options.sourceFile, std::ios::binary);
+        if (file.is_open())
+        {
+            sourceCode.assign((std::istreambuf_iterator<char>(file)),
+                              std::istreambuf_iterator<char>());
+        }
+        else
+        {
+            result.errorMessage = "Failed to open shader file: " + options.sourceFile;
+            return result;
+        }
+    }
+
+    if (sourceCode.empty() && source != ShaderLanguage::SPIRV)
+    {
+        result.errorMessage = "No shader source code provided";
+        return result;
+    }
+
+    // Same language - passthrough
+    if (source == target && source != ShaderLanguage::SPIRV)
+    {
+        result.bytecode.assign(sourceCode.begin(), sourceCode.end());
+        result.success = true;
+        return result;
+    }
+
+    // Cross-compilation paths
+    if (source == ShaderLanguage::HLSL && target == ShaderLanguage::SPIRV)
+    {
+        result.bytecode = CrossCompileHLSLtoSPIRV(sourceCode, options.stage, options.entryPoint);
+        result.success = !result.bytecode.empty();
+    }
+    else if (source == ShaderLanguage::HLSL && target == ShaderLanguage::GLSL)
+    {
+        std::string glsl = CrossCompileHLSLtoGLSL(sourceCode, options.stage, options.entryPoint);
+        result.bytecode.assign(glsl.begin(), glsl.end());
+        result.success = !glsl.empty();
+    }
+    else if (source == ShaderLanguage::GLSL && target == ShaderLanguage::SPIRV)
+    {
+        result.bytecode = CompileGLSLtoSPIRV(sourceCode, options.stage, options.entryPoint);
+        result.success = !result.bytecode.empty();
+    }
+    else if (source == ShaderLanguage::GLSL && target == ShaderLanguage::GLSL)
+    {
+        result.bytecode.assign(sourceCode.begin(), sourceCode.end());
+        result.success = true;
+    }
+    else
+    {
+        result.errorMessage = "Unsupported shader cross-compilation path";
+    }
+
+    return result;
+}
+
+ShaderCompileResult LoadPrecompiledShader(const std::string& filePath)
+{
+    ShaderCompileResult result;
+
+    std::ifstream file(filePath, std::ios::binary | std::ios::ate);
+    if (!file.is_open())
+    {
+        result.errorMessage = "Failed to open shader file: " + filePath;
+        return result;
+    }
+
+    size_t fileSize = static_cast<size_t>(file.tellg());
+    file.seekg(0, std::ios::beg);
+
+    result.bytecode.resize(fileSize);
+    file.read(reinterpret_cast<char*>(result.bytecode.data()), fileSize);
+    result.success = true;
+
+    return result;
+}
+
+bool SaveCompiledShader(const std::string& filePath, const std::vector<uint8_t>& bytecode)
+{
+    std::ofstream file(filePath, std::ios::binary);
+    if (!file.is_open()) return false;
+
+    file.write(reinterpret_cast<const char*>(bytecode.data()), bytecode.size());
+    return file.good();
+}
+
+// ============================================================================
+// CROSS-COMPILATION STUBS
+// (These would use glslang, SPIRV-Cross, DXC in a full implementation)
+// ============================================================================
+
+std::string CrossCompileHLSLtoGLSL(const std::string&, RHIShaderStage, const std::string&)
+{
+    // In a full implementation, this would use SPIRV-Cross:
+    // 1. Compile HLSL -> SPIR-V (via DXC)
+    // 2. Cross-compile SPIR-V -> GLSL (via spirv-cross)
+    return "";
+}
+
+std::vector<uint8_t> CrossCompileHLSLtoSPIRV(const std::string&, RHIShaderStage, const std::string&)
+{
+    // In a full implementation, this would use DXC (DirectX Shader Compiler):
+    // dxc -T vs_6_0 -E main -spirv -fvk-use-gl-layout shader.hlsl
+    return {};
+}
+
+std::vector<uint8_t> CompileGLSLtoSPIRV(const std::string&, RHIShaderStage, const std::string&)
+{
+    // In a full implementation, this would use glslang:
+    // glslangValidator -V -S vert shader.vert -o shader.spv
+    return {};
+}
+
+ShaderReflection ReflectSPIRV(const std::vector<uint8_t>&)
+{
+    // In a full implementation, this would use SPIRV-Reflect or spirv-cross
+    return {};
+}
+
+// ============================================================================
+// UTILITY FUNCTIONS
+// ============================================================================
+
+const char* GetShaderExtension(GraphicsBackend backend)
+{
+    switch (backend)
+    {
+    case GraphicsBackend::D3D11:
+    case GraphicsBackend::D3D12:  return ".hlsl";
+    case GraphicsBackend::Vulkan: return ".spv";
+    case GraphicsBackend::OpenGL: return ".glsl";
+    default:                      return ".hlsl";
+    }
+}
+
+std::string GetShaderSearchPath(GraphicsBackend backend)
+{
+    switch (backend)
+    {
+    case GraphicsBackend::D3D11:
+    case GraphicsBackend::D3D12:  return "Shaders/HLSL/";
+    case GraphicsBackend::Vulkan: return "Shaders/SPIRV/";
+    case GraphicsBackend::OpenGL: return "Shaders/GLSL/";
+    default:                      return "Shaders/";
+    }
+}
+
+uint32_t GetPixelFormatSize(PixelFormat format)
+{
+    switch (format)
+    {
+    case PixelFormat::R8_UNORM:              return 1;
+    case PixelFormat::R8G8_UNORM:            return 2;
+    case PixelFormat::R16_FLOAT:             return 2;
+    case PixelFormat::D16_UNORM:             return 2;
+    case PixelFormat::R8G8B8A8_UNORM:
+    case PixelFormat::R8G8B8A8_UNORM_SRGB:
+    case PixelFormat::B8G8R8A8_UNORM:
+    case PixelFormat::R10G10B10A2_UNORM:
+    case PixelFormat::R11G11B10_FLOAT:
+    case PixelFormat::R16G16_FLOAT:
+    case PixelFormat::R32_FLOAT:
+    case PixelFormat::D24_UNORM_S8_UINT:
+    case PixelFormat::D32_FLOAT:             return 4;
+    case PixelFormat::R16G16B16A16_FLOAT:
+    case PixelFormat::R32G32_FLOAT:          return 8;
+    case PixelFormat::R32G32B32_FLOAT:       return 12;
+    case PixelFormat::R32G32B32A32_FLOAT:    return 16;
+    default:                                 return 4;
+    }
+}
+
+bool IsCompressedFormat(PixelFormat format)
+{
+    switch (format)
+    {
+    case PixelFormat::BC1_UNORM:
+    case PixelFormat::BC1_UNORM_SRGB:
+    case PixelFormat::BC2_UNORM:
+    case PixelFormat::BC3_UNORM:
+    case PixelFormat::BC3_UNORM_SRGB:
+    case PixelFormat::BC4_UNORM:
+    case PixelFormat::BC5_UNORM:
+    case PixelFormat::BC6H_UF16:
+    case PixelFormat::BC7_UNORM:
+    case PixelFormat::BC7_UNORM_SRGB:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool IsDepthStencilFormat(PixelFormat format)
+{
+    switch (format)
+    {
+    case PixelFormat::D16_UNORM:
+    case PixelFormat::D24_UNORM_S8_UINT:
+    case PixelFormat::D32_FLOAT:
+    case PixelFormat::D32_FLOAT_S8_UINT:
+        return true;
+    default:
+        return false;
+    }
+}
+
+const char* GetPixelFormatName(PixelFormat format)
+{
+    switch (format)
+    {
+    case PixelFormat::R8_UNORM:              return "R8_UNORM";
+    case PixelFormat::R8G8_UNORM:            return "R8G8_UNORM";
+    case PixelFormat::R8G8B8A8_UNORM:        return "R8G8B8A8_UNORM";
+    case PixelFormat::R8G8B8A8_UNORM_SRGB:   return "R8G8B8A8_UNORM_SRGB";
+    case PixelFormat::B8G8R8A8_UNORM:        return "B8G8R8A8_UNORM";
+    case PixelFormat::R10G10B10A2_UNORM:     return "R10G10B10A2_UNORM";
+    case PixelFormat::R11G11B10_FLOAT:       return "R11G11B10_FLOAT";
+    case PixelFormat::R16_FLOAT:             return "R16_FLOAT";
+    case PixelFormat::R16G16_FLOAT:          return "R16G16_FLOAT";
+    case PixelFormat::R16G16B16A16_FLOAT:    return "R16G16B16A16_FLOAT";
+    case PixelFormat::R32_FLOAT:             return "R32_FLOAT";
+    case PixelFormat::R32G32_FLOAT:          return "R32G32_FLOAT";
+    case PixelFormat::R32G32B32_FLOAT:       return "R32G32B32_FLOAT";
+    case PixelFormat::R32G32B32A32_FLOAT:    return "R32G32B32A32_FLOAT";
+    case PixelFormat::D16_UNORM:             return "D16_UNORM";
+    case PixelFormat::D24_UNORM_S8_UINT:     return "D24_UNORM_S8_UINT";
+    case PixelFormat::D32_FLOAT:             return "D32_FLOAT";
+    default:                                 return "Unknown";
+    }
+}
+
+}} // namespace Spark::RHI

--- a/Spark Engine/Source/Graphics/RHI/RHIFactory.h
+++ b/Spark Engine/Source/Graphics/RHI/RHIFactory.h
@@ -1,0 +1,219 @@
+/**
+ * @file RHIFactory.h
+ * @brief Factory and utility functions for RHI backend selection
+ * @author Spark Engine Team
+ * @date 2025
+ *
+ * Provides runtime graphics API selection, backend detection,
+ * and cross-platform shader compilation utilities.
+ */
+
+#pragma once
+
+#include "RHIDevice.h"
+#include "RHITypes.h"
+#include <memory>
+#include <string>
+#include <vector>
+#include <functional>
+
+namespace Spark { namespace RHI {
+
+// ============================================================================
+// BACKEND DETECTION & CREATION
+// ============================================================================
+
+/**
+ * @brief Detect and return all available graphics backends on the system
+ */
+std::vector<GraphicsBackend> DetectAvailableBackends();
+
+/**
+ * @brief Get the recommended backend for the current platform
+ */
+GraphicsBackend GetRecommendedBackend();
+
+/**
+ * @brief Create an RHI device for the specified backend
+ * @param backend Graphics API to use (Auto will pick the best available)
+ * @return Unique pointer to the created device, or nullptr on failure
+ */
+std::unique_ptr<IRHIDevice> CreateDevice(GraphicsBackend backend = GraphicsBackend::Auto);
+
+/**
+ * @brief Get a human-readable name for a graphics backend
+ */
+const char* GetBackendName(GraphicsBackend backend);
+
+/**
+ * @brief Check if a specific backend is available on the current system
+ */
+bool IsBackendAvailable(GraphicsBackend backend);
+
+// ============================================================================
+// CROSS-PLATFORM SHADER COMPILATION
+// ============================================================================
+
+/**
+ * @brief Shader compilation result
+ */
+struct ShaderCompileResult
+{
+    bool success = false;
+    std::vector<uint8_t> bytecode;
+    std::string errorMessage;
+    std::string warningMessage;
+    std::string infoLog;
+};
+
+/**
+ * @brief Cross-platform shader compilation options
+ */
+struct ShaderCompileOptions
+{
+    RHIShaderStage stage = RHIShaderStage::Vertex;
+    ShaderLanguage sourceLanguage = ShaderLanguage::Auto;
+    ShaderLanguage targetLanguage = ShaderLanguage::Auto;
+    GraphicsBackend targetBackend = GraphicsBackend::Auto;
+    std::string entryPoint = "main";
+    std::string sourceFile;
+    std::string sourceCode;
+    std::vector<std::string> defines;
+    std::vector<std::string> includePaths;
+    bool optimizationEnabled = true;
+    bool debugInfoEnabled = false;
+    bool generateReflection = false;
+};
+
+/**
+ * @brief Compile a shader for a specific backend
+ *
+ * Handles cross-compilation between shader languages:
+ * - HLSL -> DXBC (D3D11/D3D12)
+ * - HLSL -> SPIR-V (via DXC for Vulkan)
+ * - GLSL -> SPIR-V (via glslang for Vulkan)
+ * - GLSL -> native (for OpenGL)
+ * - SPIR-V -> SPIR-V (passthrough for Vulkan)
+ */
+ShaderCompileResult CompileShader(const ShaderCompileOptions& options);
+
+/**
+ * @brief Load pre-compiled shader bytecode from file
+ */
+ShaderCompileResult LoadPrecompiledShader(const std::string& filePath);
+
+/**
+ * @brief Save compiled shader bytecode to file
+ */
+bool SaveCompiledShader(const std::string& filePath,
+                        const std::vector<uint8_t>& bytecode);
+
+// ============================================================================
+// SHADER CROSS-COMPILATION PIPELINE
+// ============================================================================
+
+/**
+ * @brief Cross-compile HLSL to GLSL
+ */
+std::string CrossCompileHLSLtoGLSL(const std::string& hlslSource,
+                                    RHIShaderStage stage,
+                                    const std::string& entryPoint = "main");
+
+/**
+ * @brief Cross-compile HLSL to SPIR-V
+ */
+std::vector<uint8_t> CrossCompileHLSLtoSPIRV(const std::string& hlslSource,
+                                               RHIShaderStage stage,
+                                               const std::string& entryPoint = "main");
+
+/**
+ * @brief Compile GLSL to SPIR-V using glslang
+ */
+std::vector<uint8_t> CompileGLSLtoSPIRV(const std::string& glslSource,
+                                          RHIShaderStage stage,
+                                          const std::string& entryPoint = "main");
+
+// ============================================================================
+// SHADER REFLECTION
+// ============================================================================
+
+/**
+ * @brief Reflected shader resource binding
+ */
+struct ShaderResourceBinding
+{
+    std::string name;
+    uint32_t binding = 0;
+    uint32_t set = 0;
+    uint32_t size = 0;
+    enum class Type {
+        ConstantBuffer,
+        Texture,
+        Sampler,
+        StorageBuffer,
+        StorageImage
+    } type = Type::ConstantBuffer;
+};
+
+/**
+ * @brief Reflected vertex input attribute
+ */
+struct ShaderInputAttribute
+{
+    std::string semanticName;
+    uint32_t location = 0;
+    RHIVertexFormat format = RHIVertexFormat::Float3;
+};
+
+/**
+ * @brief Complete shader reflection data
+ */
+struct ShaderReflection
+{
+    std::vector<ShaderResourceBinding> resources;
+    std::vector<ShaderInputAttribute> inputs;
+    uint32_t threadGroupSizeX = 0;
+    uint32_t threadGroupSizeY = 0;
+    uint32_t threadGroupSizeZ = 0;
+};
+
+/**
+ * @brief Reflect SPIR-V shader to get binding information
+ */
+ShaderReflection ReflectSPIRV(const std::vector<uint8_t>& spirvCode);
+
+// ============================================================================
+// UTILITY FUNCTIONS
+// ============================================================================
+
+/**
+ * @brief Get the appropriate shader file extension for a backend
+ */
+const char* GetShaderExtension(GraphicsBackend backend);
+
+/**
+ * @brief Get the shader search path for a backend
+ */
+std::string GetShaderSearchPath(GraphicsBackend backend);
+
+/**
+ * @brief Calculate the size of a pixel format in bytes
+ */
+uint32_t GetPixelFormatSize(PixelFormat format);
+
+/**
+ * @brief Check if a pixel format is a compressed format
+ */
+bool IsCompressedFormat(PixelFormat format);
+
+/**
+ * @brief Check if a pixel format is a depth/stencil format
+ */
+bool IsDepthStencilFormat(PixelFormat format);
+
+/**
+ * @brief Get a human-readable name for a pixel format
+ */
+const char* GetPixelFormatName(PixelFormat format);
+
+}} // namespace Spark::RHI

--- a/Spark Engine/Source/Graphics/RHI/RHIResources.h
+++ b/Spark Engine/Source/Graphics/RHI/RHIResources.h
@@ -1,0 +1,102 @@
+/**
+ * @file RHIResources.h
+ * @brief Abstract resource interfaces for the Rendering Hardware Interface
+ * @author Spark Engine Team
+ * @date 2025
+ *
+ * Defines the abstract base classes for all GPU resources managed by
+ * the RHI backends (buffers, textures, shaders, samplers, pipeline states).
+ */
+
+#pragma once
+
+#include "RHITypes.h"
+
+namespace Spark { namespace RHI {
+
+/**
+ * @brief Base class for all RHI resources
+ */
+class IRHIResource
+{
+public:
+    virtual ~IRHIResource() = default;
+    virtual const std::string& GetDebugName() const = 0;
+    virtual void SetDebugName(const std::string& name) = 0;
+    virtual bool IsValid() const = 0;
+};
+
+/**
+ * @brief Abstract GPU buffer resource
+ */
+class IRHIBuffer : public IRHIResource
+{
+public:
+    virtual ~IRHIBuffer() = default;
+
+    virtual const RHIBufferDesc& GetDesc() const = 0;
+    virtual uint64_t GetSize() const = 0;
+    virtual uint32_t GetStride() const = 0;
+    virtual void* GetNativeHandle() const = 0;
+};
+
+/**
+ * @brief Abstract GPU texture resource
+ */
+class IRHITexture : public IRHIResource
+{
+public:
+    virtual ~IRHITexture() = default;
+
+    virtual const RHITextureDesc& GetDesc() const = 0;
+    virtual uint32_t GetWidth() const = 0;
+    virtual uint32_t GetHeight() const = 0;
+    virtual uint32_t GetDepth() const = 0;
+    virtual uint32_t GetMipLevels() const = 0;
+    virtual PixelFormat GetFormat() const = 0;
+    virtual void* GetNativeHandle() const = 0;
+    virtual void* GetShaderResourceView() const = 0;
+    virtual void* GetRenderTargetView() const = 0;
+    virtual void* GetDepthStencilView() const = 0;
+};
+
+/**
+ * @brief Abstract GPU shader resource
+ */
+class IRHIShader : public IRHIResource
+{
+public:
+    virtual ~IRHIShader() = default;
+
+    virtual RHIShaderStage GetStage() const = 0;
+    virtual const std::string& GetEntryPoint() const = 0;
+    virtual void* GetNativeHandle() const = 0;
+    virtual const void* GetBytecode() const = 0;
+    virtual size_t GetBytecodeSize() const = 0;
+};
+
+/**
+ * @brief Abstract GPU sampler state
+ */
+class IRHISampler : public IRHIResource
+{
+public:
+    virtual ~IRHISampler() = default;
+
+    virtual const RHISamplerDesc& GetDesc() const = 0;
+    virtual void* GetNativeHandle() const = 0;
+};
+
+/**
+ * @brief Abstract graphics pipeline state
+ */
+class IRHIPipelineState : public IRHIResource
+{
+public:
+    virtual ~IRHIPipelineState() = default;
+
+    virtual const RHIPipelineStateDesc& GetDesc() const = 0;
+    virtual void* GetNativeHandle() const = 0;
+};
+
+}} // namespace Spark::RHI

--- a/Spark Engine/Source/Graphics/RHI/RHITypes.h
+++ b/Spark Engine/Source/Graphics/RHI/RHITypes.h
@@ -1,0 +1,526 @@
+/**
+ * @file RHITypes.h
+ * @brief Core types and enumerations for the Rendering Hardware Interface
+ * @author Spark Engine Team
+ * @date 2025
+ *
+ * Platform-agnostic type definitions used across all graphics API backends.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <array>
+#include <memory>
+#include <functional>
+
+namespace Spark { namespace RHI {
+
+// ============================================================================
+// GRAPHICS API ENUM
+// ============================================================================
+
+enum class GraphicsBackend
+{
+    D3D11,
+    D3D12,
+    Vulkan,
+    OpenGL,
+    Metal,
+    Auto  // Auto-detect best available
+};
+
+// ============================================================================
+// FORMAT ENUMS
+// ============================================================================
+
+enum class PixelFormat
+{
+    Unknown = 0,
+
+    // 8-bit per channel
+    R8_UNORM,
+    R8_SNORM,
+    R8_UINT,
+    R8G8_UNORM,
+    R8G8B8A8_UNORM,
+    R8G8B8A8_UNORM_SRGB,
+    R8G8B8A8_SNORM,
+    B8G8R8A8_UNORM,
+    B8G8R8A8_UNORM_SRGB,
+
+    // 10/11-bit packed
+    R10G10B10A2_UNORM,
+    R11G11B10_FLOAT,
+
+    // 16-bit per channel
+    R16_FLOAT,
+    R16_UINT,
+    R16G16_FLOAT,
+    R16G16B16A16_FLOAT,
+    R16G16B16A16_UNORM,
+
+    // 32-bit per channel
+    R32_FLOAT,
+    R32_UINT,
+    R32G32_FLOAT,
+    R32G32B32_FLOAT,
+    R32G32B32A32_FLOAT,
+
+    // Compressed formats
+    BC1_UNORM,
+    BC1_UNORM_SRGB,
+    BC2_UNORM,
+    BC3_UNORM,
+    BC3_UNORM_SRGB,
+    BC4_UNORM,
+    BC5_UNORM,
+    BC6H_UF16,
+    BC7_UNORM,
+    BC7_UNORM_SRGB,
+
+    // Depth/Stencil
+    D16_UNORM,
+    D24_UNORM_S8_UINT,
+    D32_FLOAT,
+    D32_FLOAT_S8_UINT,
+
+    Count
+};
+
+// ============================================================================
+// SHADER TYPES
+// ============================================================================
+
+enum class RHIShaderStage
+{
+    Vertex,
+    Pixel,
+    Geometry,
+    Hull,
+    Domain,
+    Compute
+};
+
+enum class ShaderLanguage
+{
+    HLSL,
+    GLSL,
+    SPIRV,
+    Auto
+};
+
+// ============================================================================
+// BUFFER TYPES
+// ============================================================================
+
+enum class RHIBufferUsage : uint32_t
+{
+    Vertex       = 1 << 0,
+    Index        = 1 << 1,
+    Constant     = 1 << 2,
+    Structured   = 1 << 3,
+    IndirectArgs = 1 << 4,
+    Storage      = 1 << 5,
+    CopySrc      = 1 << 6,
+    CopyDst      = 1 << 7
+};
+
+inline RHIBufferUsage operator|(RHIBufferUsage a, RHIBufferUsage b) {
+    return static_cast<RHIBufferUsage>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+}
+inline bool operator&(RHIBufferUsage a, RHIBufferUsage b) {
+    return (static_cast<uint32_t>(a) & static_cast<uint32_t>(b)) != 0;
+}
+
+enum class RHIBufferAccess
+{
+    Static,        // GPU only, immutable after creation
+    Dynamic,       // CPU write, GPU read (every frame)
+    Staging,       // CPU read/write
+    ReadBack       // GPU write, CPU read
+};
+
+// ============================================================================
+// TEXTURE TYPES
+// ============================================================================
+
+enum class RHITextureType
+{
+    Texture1D,
+    Texture2D,
+    Texture3D,
+    TextureCube,
+    Texture2DArray,
+    TextureCubeArray
+};
+
+enum class RHITextureUsage : uint32_t
+{
+    ShaderResource  = 1 << 0,
+    RenderTarget    = 1 << 1,
+    DepthStencil    = 1 << 2,
+    UnorderedAccess = 1 << 3,
+    TransferSrc     = 1 << 4,
+    TransferDst     = 1 << 5
+};
+
+inline RHITextureUsage operator|(RHITextureUsage a, RHITextureUsage b) {
+    return static_cast<RHITextureUsage>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+}
+inline bool operator&(RHITextureUsage a, RHITextureUsage b) {
+    return (static_cast<uint32_t>(a) & static_cast<uint32_t>(b)) != 0;
+}
+
+// ============================================================================
+// SAMPLER TYPES
+// ============================================================================
+
+enum class RHIFilterMode
+{
+    Nearest,
+    Linear,
+    Anisotropic
+};
+
+enum class RHIAddressMode
+{
+    Wrap,
+    Clamp,
+    Mirror,
+    Border,
+    MirrorOnce
+};
+
+enum class RHICompareOp
+{
+    Never,
+    Less,
+    Equal,
+    LessEqual,
+    Greater,
+    NotEqual,
+    GreaterEqual,
+    Always
+};
+
+// ============================================================================
+// PIPELINE STATE TYPES
+// ============================================================================
+
+enum class RHIPrimitiveTopology
+{
+    PointList,
+    LineList,
+    LineStrip,
+    TriangleList,
+    TriangleStrip,
+    PatchList
+};
+
+enum class RHIFillMode
+{
+    Solid,
+    Wireframe
+};
+
+enum class RHICullMode
+{
+    None,
+    Front,
+    Back
+};
+
+enum class RHIBlendFactor
+{
+    Zero,
+    One,
+    SrcColor,
+    InvSrcColor,
+    SrcAlpha,
+    InvSrcAlpha,
+    DstAlpha,
+    InvDstAlpha,
+    DstColor,
+    InvDstColor
+};
+
+enum class RHIBlendOp
+{
+    Add,
+    Subtract,
+    RevSubtract,
+    Min,
+    Max
+};
+
+enum class RHIStencilOp
+{
+    Keep,
+    Zero,
+    Replace,
+    IncrSat,
+    DecrSat,
+    Invert,
+    IncrWrap,
+    DecrWrap
+};
+
+// ============================================================================
+// DESCRIPTOR STRUCTURES
+// ============================================================================
+
+struct RHIBufferDesc
+{
+    uint64_t         size = 0;
+    uint32_t         stride = 0;
+    RHIBufferUsage   usage = RHIBufferUsage::Vertex;
+    RHIBufferAccess  access = RHIBufferAccess::Static;
+    const void*      initialData = nullptr;
+    std::string      debugName;
+};
+
+struct RHITextureDesc
+{
+    uint32_t         width = 1;
+    uint32_t         height = 1;
+    uint32_t         depth = 1;
+    uint32_t         mipLevels = 1;
+    uint32_t         arraySize = 1;
+    uint32_t         sampleCount = 1;
+    PixelFormat      format = PixelFormat::R8G8B8A8_UNORM;
+    RHITextureType   type = RHITextureType::Texture2D;
+    RHITextureUsage  usage = RHITextureUsage::ShaderResource;
+    float            clearColor[4] = { 0, 0, 0, 1 };
+    float            clearDepth = 1.0f;
+    uint8_t          clearStencil = 0;
+    std::string      debugName;
+};
+
+struct RHISamplerDesc
+{
+    RHIFilterMode    minFilter = RHIFilterMode::Linear;
+    RHIFilterMode    magFilter = RHIFilterMode::Linear;
+    RHIFilterMode    mipFilter = RHIFilterMode::Linear;
+    RHIAddressMode   addressU = RHIAddressMode::Wrap;
+    RHIAddressMode   addressV = RHIAddressMode::Wrap;
+    RHIAddressMode   addressW = RHIAddressMode::Wrap;
+    float            mipLodBias = 0.0f;
+    uint32_t         maxAnisotropy = 16;
+    RHICompareOp     compareOp = RHICompareOp::Never;
+    float            borderColor[4] = { 0, 0, 0, 0 };
+    float            minLod = 0.0f;
+    float            maxLod = 1000.0f;
+};
+
+struct RHIShaderDesc
+{
+    RHIShaderStage   stage = RHIShaderStage::Vertex;
+    const void*      bytecode = nullptr;
+    size_t           bytecodeSize = 0;
+    std::string      sourceCode;
+    std::string      entryPoint = "main";
+    std::string      filePath;
+    ShaderLanguage   language = ShaderLanguage::Auto;
+    std::vector<std::string> defines;
+    std::string      debugName;
+};
+
+// ============================================================================
+// INPUT LAYOUT
+// ============================================================================
+
+enum class RHIVertexFormat
+{
+    Float1,
+    Float2,
+    Float3,
+    Float4,
+    Int1,
+    Int2,
+    Int3,
+    Int4,
+    UInt1,
+    UInt2,
+    UInt3,
+    UInt4,
+    UNorm8x4,
+    SNorm8x4
+};
+
+struct RHIInputElement
+{
+    std::string      semanticName;
+    uint32_t         semanticIndex = 0;
+    RHIVertexFormat  format = RHIVertexFormat::Float3;
+    uint32_t         inputSlot = 0;
+    uint32_t         byteOffset = 0;
+    bool             perInstance = false;
+    uint32_t         instanceStepRate = 0;
+};
+
+struct RHIInputLayoutDesc
+{
+    std::vector<RHIInputElement> elements;
+};
+
+// ============================================================================
+// PIPELINE STATE
+// ============================================================================
+
+struct RHIRasterizerDesc
+{
+    RHIFillMode      fillMode = RHIFillMode::Solid;
+    RHICullMode      cullMode = RHICullMode::Back;
+    bool             frontCounterClockwise = false;
+    int32_t          depthBias = 0;
+    float            depthBiasClamp = 0.0f;
+    float            slopeScaledDepthBias = 0.0f;
+    bool             depthClipEnable = true;
+    bool             scissorEnable = false;
+    bool             multisampleEnable = false;
+    bool             antialiasedLineEnable = false;
+};
+
+struct RHIBlendTargetDesc
+{
+    bool             blendEnable = false;
+    RHIBlendFactor   srcBlend = RHIBlendFactor::One;
+    RHIBlendFactor   dstBlend = RHIBlendFactor::Zero;
+    RHIBlendOp       blendOp = RHIBlendOp::Add;
+    RHIBlendFactor   srcBlendAlpha = RHIBlendFactor::One;
+    RHIBlendFactor   dstBlendAlpha = RHIBlendFactor::Zero;
+    RHIBlendOp       blendOpAlpha = RHIBlendOp::Add;
+    uint8_t          writeMask = 0x0F;
+};
+
+struct RHIBlendDesc
+{
+    bool             alphaToCoverageEnable = false;
+    bool             independentBlendEnable = false;
+    RHIBlendTargetDesc renderTargets[8];
+};
+
+struct RHIDepthStencilOpDesc
+{
+    RHIStencilOp     stencilFail = RHIStencilOp::Keep;
+    RHIStencilOp     stencilDepthFail = RHIStencilOp::Keep;
+    RHIStencilOp     stencilPass = RHIStencilOp::Keep;
+    RHICompareOp     stencilFunc = RHICompareOp::Always;
+};
+
+struct RHIDepthStencilDesc
+{
+    bool             depthEnable = true;
+    bool             depthWrite = true;
+    RHICompareOp     depthFunc = RHICompareOp::Less;
+    bool             stencilEnable = false;
+    uint8_t          stencilReadMask = 0xFF;
+    uint8_t          stencilWriteMask = 0xFF;
+    RHIDepthStencilOpDesc frontFace;
+    RHIDepthStencilOpDesc backFace;
+};
+
+struct RHIPipelineStateDesc
+{
+    RHIInputLayoutDesc   inputLayout;
+    RHIRasterizerDesc    rasterizer;
+    RHIBlendDesc         blend;
+    RHIDepthStencilDesc  depthStencil;
+    RHIPrimitiveTopology topology = RHIPrimitiveTopology::TriangleList;
+    uint32_t             sampleCount = 1;
+    PixelFormat          renderTargetFormats[8] = {};
+    uint32_t             numRenderTargets = 1;
+    PixelFormat          depthStencilFormat = PixelFormat::D24_UNORM_S8_UINT;
+    std::string          debugName;
+};
+
+// ============================================================================
+// VIEWPORT AND SCISSOR
+// ============================================================================
+
+struct RHIViewport
+{
+    float x = 0.0f;
+    float y = 0.0f;
+    float width = 0.0f;
+    float height = 0.0f;
+    float minDepth = 0.0f;
+    float maxDepth = 1.0f;
+};
+
+struct RHIScissorRect
+{
+    int32_t left = 0;
+    int32_t top = 0;
+    int32_t right = 0;
+    int32_t bottom = 0;
+};
+
+// ============================================================================
+// DEVICE CAPABILITIES
+// ============================================================================
+
+struct RHIDeviceCapabilities
+{
+    std::string      deviceName;
+    std::string      vendorName;
+    std::string      apiVersion;
+    GraphicsBackend  backend = GraphicsBackend::Auto;
+
+    uint64_t         dedicatedVideoMemory = 0;
+    uint64_t         sharedSystemMemory = 0;
+
+    uint32_t         maxTextureSize = 16384;
+    uint32_t         maxRenderTargets = 8;
+    uint32_t         maxSamplers = 16;
+    uint32_t         maxConstantBuffers = 14;
+    uint32_t         maxVertexAttributes = 32;
+
+    bool             tessellationSupport = false;
+    bool             computeShaderSupport = false;
+    bool             geometryShaderSupport = false;
+    bool             multiDrawIndirectSupport = false;
+    bool             conservativeRasterSupport = false;
+    bool             meshShaderSupport = false;
+    bool             rayTracingSupport = false;
+    bool             variableRateShadingSupport = false;
+    bool             bindlessResourceSupport = false;
+
+    uint32_t         maxMSAASamples = 8;
+    float            maxAnisotropy = 16.0f;
+};
+
+// ============================================================================
+// STATISTICS
+// ============================================================================
+
+struct RHIStatistics
+{
+    uint32_t drawCalls = 0;
+    uint32_t dispatchCalls = 0;
+    uint32_t trianglesRendered = 0;
+    uint32_t verticesProcessed = 0;
+    uint32_t textureBinds = 0;
+    uint32_t bufferBinds = 0;
+    uint32_t pipelineChanges = 0;
+    uint32_t renderTargetChanges = 0;
+    size_t   gpuMemoryUsed = 0;
+    float    gpuFrameTime = 0.0f;
+};
+
+// ============================================================================
+// HANDLE TYPES
+// ============================================================================
+
+using RHIBufferHandle   = uint64_t;
+using RHITextureHandle  = uint64_t;
+using RHIShaderHandle   = uint64_t;
+using RHISamplerHandle  = uint64_t;
+using RHIPipelineHandle = uint64_t;
+
+constexpr uint64_t RHI_INVALID_HANDLE = 0;
+
+}} // namespace Spark::RHI

--- a/Spark Engine/Source/Graphics/RHI/Vulkan/VulkanDevice.cpp
+++ b/Spark Engine/Source/Graphics/RHI/Vulkan/VulkanDevice.cpp
@@ -1,0 +1,1496 @@
+/**
+ * @file VulkanDevice.cpp
+ * @brief Vulkan RHI backend implementation
+ * @author Spark Engine Team
+ * @date 2025
+ *
+ * Complete Vulkan 1.3 device implementation with instance creation,
+ * physical device selection, logical device, command pools, and
+ * all resource creation/management functionality.
+ */
+
+#ifdef SPARK_VULKAN_SUPPORT
+
+#include "VulkanDevice.h"
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <set>
+#include <iostream>
+
+namespace Spark { namespace RHI { namespace Vulkan {
+
+// ============================================================================
+// VALIDATION LAYER CALLBACK
+// ============================================================================
+
+static VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugCallback(
+    VkDebugUtilsMessageSeverityFlagBitsEXT severity,
+    VkDebugUtilsMessageTypeFlagsEXT type,
+    const VkDebugUtilsMessengerCallbackDataEXT* callbackData,
+    void* userData)
+{
+    if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
+    {
+        std::cerr << "[Vulkan Validation] " << callbackData->pMessage << std::endl;
+    }
+    return VK_FALSE;
+}
+
+// ============================================================================
+// VULKAN BUFFER
+// ============================================================================
+
+VulkanBuffer::VulkanBuffer(const RHIBufferDesc& desc, VkBuffer buffer,
+                           VkDeviceMemory memory, VkDevice device)
+    : m_desc(desc), m_buffer(buffer), m_memory(memory), m_deviceRef(device)
+{
+}
+
+VulkanBuffer::~VulkanBuffer()
+{
+    if (m_buffer != VK_NULL_HANDLE)
+    {
+        vkDestroyBuffer(m_deviceRef, m_buffer, nullptr);
+        m_buffer = VK_NULL_HANDLE;
+    }
+    if (m_memory != VK_NULL_HANDLE)
+    {
+        vkFreeMemory(m_deviceRef, m_memory, nullptr);
+        m_memory = VK_NULL_HANDLE;
+    }
+}
+
+// ============================================================================
+// VULKAN TEXTURE
+// ============================================================================
+
+VulkanTexture::VulkanTexture(const RHITextureDesc& desc, VkImage image,
+                             VkDeviceMemory memory, VkImageView imageView,
+                             VkDevice device, bool ownsImage)
+    : m_desc(desc), m_image(image), m_memory(memory), m_imageView(imageView)
+    , m_deviceRef(device), m_ownsImage(ownsImage)
+{
+}
+
+VulkanTexture::~VulkanTexture()
+{
+    if (m_imageView != VK_NULL_HANDLE)
+    {
+        vkDestroyImageView(m_deviceRef, m_imageView, nullptr);
+    }
+    if (m_ownsImage)
+    {
+        if (m_image != VK_NULL_HANDLE)
+            vkDestroyImage(m_deviceRef, m_image, nullptr);
+        if (m_memory != VK_NULL_HANDLE)
+            vkFreeMemory(m_deviceRef, m_memory, nullptr);
+    }
+}
+
+// ============================================================================
+// VULKAN SHADER
+// ============================================================================
+
+VulkanShader::VulkanShader(const RHIShaderDesc& desc, VkShaderModule module,
+                           VkDevice device, std::vector<uint8_t> spirvCode)
+    : m_desc(desc), m_module(module), m_deviceRef(device), m_spirvCode(std::move(spirvCode))
+{
+}
+
+VulkanShader::~VulkanShader()
+{
+    if (m_module != VK_NULL_HANDLE)
+    {
+        vkDestroyShaderModule(m_deviceRef, m_module, nullptr);
+    }
+}
+
+// ============================================================================
+// VULKAN SAMPLER
+// ============================================================================
+
+VulkanSampler::VulkanSampler(const RHISamplerDesc& desc, VkSampler sampler, VkDevice device)
+    : m_desc(desc), m_sampler(sampler), m_deviceRef(device)
+{
+}
+
+VulkanSampler::~VulkanSampler()
+{
+    if (m_sampler != VK_NULL_HANDLE)
+    {
+        vkDestroySampler(m_deviceRef, m_sampler, nullptr);
+    }
+}
+
+// ============================================================================
+// VULKAN PIPELINE STATE
+// ============================================================================
+
+VulkanPipelineState::VulkanPipelineState(const RHIPipelineStateDesc& desc,
+                                         VkPipeline pipeline,
+                                         VkPipelineLayout layout,
+                                         VkDevice device)
+    : m_desc(desc), m_pipeline(pipeline), m_layout(layout), m_deviceRef(device)
+{
+}
+
+VulkanPipelineState::~VulkanPipelineState()
+{
+    if (m_pipeline != VK_NULL_HANDLE)
+        vkDestroyPipeline(m_deviceRef, m_pipeline, nullptr);
+    if (m_layout != VK_NULL_HANDLE)
+        vkDestroyPipelineLayout(m_deviceRef, m_layout, nullptr);
+}
+
+// ============================================================================
+// VULKAN SWAP CHAIN
+// ============================================================================
+
+VulkanSwapChain::VulkanSwapChain(VkDevice device, VkPhysicalDevice physDevice,
+                                 VkSurfaceKHR surface, const RHISwapChainDesc& desc,
+                                 const QueueFamilyIndices& queueFamilies)
+    : m_desc(desc), m_device(device), m_physDevice(physDevice)
+    , m_surface(surface), m_queueFamilies(queueFamilies)
+{
+    CreateSwapChain();
+    CreateImageViews();
+    CreateSyncObjects();
+}
+
+VulkanSwapChain::~VulkanSwapChain()
+{
+    Cleanup();
+}
+
+bool VulkanSwapChain::CreateSwapChain()
+{
+    VkSurfaceCapabilitiesKHR capabilities;
+    vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_physDevice, m_surface, &capabilities);
+
+    VkSwapchainCreateInfoKHR createInfo = {};
+    createInfo.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+    createInfo.surface = m_surface;
+    createInfo.minImageCount = m_desc.bufferCount;
+    createInfo.imageFormat = VK_FORMAT_B8G8R8A8_UNORM;
+    createInfo.imageColorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+    createInfo.imageExtent = { m_desc.width, m_desc.height };
+    createInfo.imageArrayLayers = 1;
+    createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+
+    uint32_t queueFamilyIndices[] = {
+        m_queueFamilies.graphicsFamily.value(),
+        m_queueFamilies.presentFamily.value()
+    };
+
+    if (m_queueFamilies.graphicsFamily != m_queueFamilies.presentFamily)
+    {
+        createInfo.imageSharingMode = VK_SHARING_MODE_CONCURRENT;
+        createInfo.queueFamilyIndexCount = 2;
+        createInfo.pQueueFamilyIndices = queueFamilyIndices;
+    }
+    else
+    {
+        createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    }
+
+    createInfo.preTransform = capabilities.currentTransform;
+    createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+    createInfo.presentMode = m_desc.vsync ?
+        VK_PRESENT_MODE_FIFO_KHR : VK_PRESENT_MODE_MAILBOX_KHR;
+    createInfo.clipped = VK_TRUE;
+    createInfo.oldSwapchain = VK_NULL_HANDLE;
+
+    VkResult result = vkCreateSwapchainKHR(m_device, &createInfo, nullptr, &m_swapChain);
+    if (result != VK_SUCCESS) return false;
+
+    uint32_t imageCount;
+    vkGetSwapchainImagesKHR(m_device, m_swapChain, &imageCount, nullptr);
+    m_swapChainImages.resize(imageCount);
+    vkGetSwapchainImagesKHR(m_device, m_swapChain, &imageCount, m_swapChainImages.data());
+
+    return true;
+}
+
+bool VulkanSwapChain::CreateImageViews()
+{
+    m_swapChainImageViews.resize(m_swapChainImages.size());
+    m_backBuffers.resize(m_swapChainImages.size());
+
+    for (size_t i = 0; i < m_swapChainImages.size(); ++i)
+    {
+        VkImageViewCreateInfo viewInfo = {};
+        viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        viewInfo.image = m_swapChainImages[i];
+        viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        viewInfo.format = VK_FORMAT_B8G8R8A8_UNORM;
+        viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        viewInfo.subresourceRange.baseMipLevel = 0;
+        viewInfo.subresourceRange.levelCount = 1;
+        viewInfo.subresourceRange.baseArrayLayer = 0;
+        viewInfo.subresourceRange.layerCount = 1;
+
+        VkResult result = vkCreateImageView(m_device, &viewInfo, nullptr,
+                                            &m_swapChainImageViews[i]);
+        if (result != VK_SUCCESS) return false;
+
+        RHITextureDesc texDesc;
+        texDesc.width = m_desc.width;
+        texDesc.height = m_desc.height;
+        texDesc.format = PixelFormat::B8G8R8A8_UNORM;
+        texDesc.usage = RHITextureUsage::RenderTarget;
+        texDesc.debugName = "SwapChainImage_" + std::to_string(i);
+
+        m_backBuffers[i] = std::make_unique<VulkanTexture>(
+            texDesc, m_swapChainImages[i], VK_NULL_HANDLE,
+            m_swapChainImageViews[i], m_device, false);
+    }
+
+    return true;
+}
+
+bool VulkanSwapChain::CreateSyncObjects()
+{
+    VkSemaphoreCreateInfo semaphoreInfo = {};
+    semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+    VkFenceCreateInfo fenceInfo = {};
+    fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+
+    if (vkCreateSemaphore(m_device, &semaphoreInfo, nullptr, &m_imageAvailable) != VK_SUCCESS ||
+        vkCreateSemaphore(m_device, &semaphoreInfo, nullptr, &m_renderFinished) != VK_SUCCESS ||
+        vkCreateFence(m_device, &fenceInfo, nullptr, &m_inFlightFence) != VK_SUCCESS)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+void VulkanSwapChain::Cleanup()
+{
+    m_backBuffers.clear();
+
+    for (auto view : m_swapChainImageViews)
+    {
+        if (view != VK_NULL_HANDLE)
+            vkDestroyImageView(m_device, view, nullptr);
+    }
+    m_swapChainImageViews.clear();
+
+    if (m_imageAvailable != VK_NULL_HANDLE)
+        vkDestroySemaphore(m_device, m_imageAvailable, nullptr);
+    if (m_renderFinished != VK_NULL_HANDLE)
+        vkDestroySemaphore(m_device, m_renderFinished, nullptr);
+    if (m_inFlightFence != VK_NULL_HANDLE)
+        vkDestroyFence(m_device, m_inFlightFence, nullptr);
+
+    if (m_swapChain != VK_NULL_HANDLE)
+        vkDestroySwapchainKHR(m_device, m_swapChain, nullptr);
+}
+
+bool VulkanSwapChain::Present(bool vsync)
+{
+    VkPresentInfoKHR presentInfo = {};
+    presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+    presentInfo.waitSemaphoreCount = 1;
+    presentInfo.pWaitSemaphores = &m_renderFinished;
+    presentInfo.swapchainCount = 1;
+    presentInfo.pSwapchains = &m_swapChain;
+    presentInfo.pImageIndices = &m_currentImageIndex;
+
+    // Present queue submission would happen here
+    return true;
+}
+
+bool VulkanSwapChain::Resize(uint32_t width, uint32_t height)
+{
+    vkDeviceWaitIdle(m_device);
+    Cleanup();
+    m_desc.width = width;
+    m_desc.height = height;
+    return CreateSwapChain() && CreateImageViews() && CreateSyncObjects();
+}
+
+IRHITexture* VulkanSwapChain::GetBackBuffer()
+{
+    if (m_currentImageIndex < m_backBuffers.size())
+        return m_backBuffers[m_currentImageIndex].get();
+    return nullptr;
+}
+
+// ============================================================================
+// VULKAN COMMAND LIST
+// ============================================================================
+
+VulkanCommandList::VulkanCommandList(VkDevice device, VkCommandPool commandPool, bool isImmediate)
+    : m_device(device), m_commandPool(commandPool), m_isImmediate(isImmediate)
+{
+    VkCommandBufferAllocateInfo allocInfo = {};
+    allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    allocInfo.commandPool = commandPool;
+    allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    allocInfo.commandBufferCount = 1;
+
+    vkAllocateCommandBuffers(device, &allocInfo, &m_commandBuffer);
+}
+
+VulkanCommandList::~VulkanCommandList()
+{
+    if (m_commandBuffer != VK_NULL_HANDLE)
+    {
+        vkFreeCommandBuffers(m_device, m_commandPool, 1, &m_commandBuffer);
+    }
+}
+
+void VulkanCommandList::Begin()
+{
+    VkCommandBufferBeginInfo beginInfo = {};
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+    vkBeginCommandBuffer(m_commandBuffer, &beginInfo);
+    m_isRecording = true;
+}
+
+void VulkanCommandList::End()
+{
+    if (m_isRecording)
+    {
+        vkEndCommandBuffer(m_commandBuffer);
+        m_isRecording = false;
+    }
+}
+
+void VulkanCommandList::Reset()
+{
+    vkResetCommandBuffer(m_commandBuffer, 0);
+    m_isRecording = false;
+}
+
+void VulkanCommandList::SetRenderTargets(IRHITexture** renderTargets, uint32_t count,
+                                         IRHITexture* depthStencil)
+{
+    // Dynamic rendering (Vulkan 1.3) approach
+    std::vector<VkRenderingAttachmentInfo> colorAttachments(count);
+
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        auto* vkTex = static_cast<VulkanTexture*>(renderTargets[i]);
+        colorAttachments[i] = {};
+        colorAttachments[i].sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO;
+        colorAttachments[i].imageView = vkTex->GetVkImageView();
+        colorAttachments[i].imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        colorAttachments[i].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+        colorAttachments[i].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    }
+
+    VkRenderingInfo renderingInfo = {};
+    renderingInfo.sType = VK_STRUCTURE_TYPE_RENDERING_INFO;
+    renderingInfo.renderArea = { {0, 0}, {renderTargets[0] ?
+        static_cast<VulkanTexture*>(renderTargets[0])->GetWidth() : 0u,
+        renderTargets[0] ?
+        static_cast<VulkanTexture*>(renderTargets[0])->GetHeight() : 0u} };
+    renderingInfo.layerCount = 1;
+    renderingInfo.colorAttachmentCount = count;
+    renderingInfo.pColorAttachments = colorAttachments.data();
+
+    VkRenderingAttachmentInfo depthAttachment = {};
+    if (depthStencil)
+    {
+        auto* vkDS = static_cast<VulkanTexture*>(depthStencil);
+        depthAttachment.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO;
+        depthAttachment.imageView = vkDS->GetVkImageView();
+        depthAttachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        depthAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+        depthAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        renderingInfo.pDepthAttachment = &depthAttachment;
+    }
+
+    vkCmdBeginRendering(m_commandBuffer, &renderingInfo);
+}
+
+void VulkanCommandList::ClearRenderTarget(IRHITexture* target, const float color[4])
+{
+    if (!target) return;
+    auto* vkTex = static_cast<VulkanTexture*>(target);
+
+    VkClearColorValue clearColor;
+    memcpy(clearColor.float32, color, sizeof(float) * 4);
+
+    VkImageSubresourceRange range = {};
+    range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    range.baseMipLevel = 0;
+    range.levelCount = 1;
+    range.baseArrayLayer = 0;
+    range.layerCount = 1;
+
+    vkCmdClearColorImage(m_commandBuffer, vkTex->GetVkImage(),
+                         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearColor, 1, &range);
+}
+
+void VulkanCommandList::ClearDepthStencil(IRHITexture* target, float depth, uint8_t stencil)
+{
+    if (!target) return;
+    auto* vkTex = static_cast<VulkanTexture*>(target);
+
+    VkClearDepthStencilValue clearValue;
+    clearValue.depth = depth;
+    clearValue.stencil = stencil;
+
+    VkImageSubresourceRange range = {};
+    range.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+    range.baseMipLevel = 0;
+    range.levelCount = 1;
+    range.baseArrayLayer = 0;
+    range.layerCount = 1;
+
+    vkCmdClearDepthStencilImage(m_commandBuffer, vkTex->GetVkImage(),
+                                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearValue, 1, &range);
+}
+
+void VulkanCommandList::SetViewport(const RHIViewport& viewport)
+{
+    VkViewport vp;
+    vp.x = viewport.x;
+    vp.y = viewport.y;
+    vp.width = viewport.width;
+    vp.height = viewport.height;
+    vp.minDepth = viewport.minDepth;
+    vp.maxDepth = viewport.maxDepth;
+    vkCmdSetViewport(m_commandBuffer, 0, 1, &vp);
+}
+
+void VulkanCommandList::SetScissorRect(const RHIScissorRect& rect)
+{
+    VkRect2D scissor;
+    scissor.offset = { rect.left, rect.top };
+    scissor.extent = { static_cast<uint32_t>(rect.right - rect.left),
+                       static_cast<uint32_t>(rect.bottom - rect.top) };
+    vkCmdSetScissor(m_commandBuffer, 0, 1, &scissor);
+}
+
+void VulkanCommandList::SetPipelineState(IRHIPipelineState* pipelineState)
+{
+    if (!pipelineState) return;
+    auto* vkPSO = static_cast<VulkanPipelineState*>(pipelineState);
+    vkCmdBindPipeline(m_commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, vkPSO->GetVkPipeline());
+}
+
+void VulkanCommandList::SetPrimitiveTopology(RHIPrimitiveTopology) {}
+
+void VulkanCommandList::SetVertexBuffer(IRHIBuffer* buffer, uint32_t slot, uint32_t offset)
+{
+    if (!buffer) return;
+    auto* vkBuf = static_cast<VulkanBuffer*>(buffer);
+    VkBuffer buffers[] = { vkBuf->GetVkBuffer() };
+    VkDeviceSize offsets[] = { offset };
+    vkCmdBindVertexBuffers(m_commandBuffer, slot, 1, buffers, offsets);
+}
+
+void VulkanCommandList::SetIndexBuffer(IRHIBuffer* buffer, uint32_t offset)
+{
+    if (!buffer) return;
+    auto* vkBuf = static_cast<VulkanBuffer*>(buffer);
+    VkIndexType indexType = (vkBuf->GetStride() == 4) ?
+        VK_INDEX_TYPE_UINT32 : VK_INDEX_TYPE_UINT16;
+    vkCmdBindIndexBuffer(m_commandBuffer, vkBuf->GetVkBuffer(), offset, indexType);
+}
+
+void VulkanCommandList::SetConstantBuffer(RHIShaderStage, uint32_t, IRHIBuffer*) {}
+void VulkanCommandList::SetShaderResource(RHIShaderStage, uint32_t, IRHITexture*) {}
+void VulkanCommandList::SetSampler(RHIShaderStage, uint32_t, IRHISampler*) {}
+
+void VulkanCommandList::Draw(uint32_t vertexCount, uint32_t startVertex)
+{
+    vkCmdDraw(m_commandBuffer, vertexCount, 1, startVertex, 0);
+}
+
+void VulkanCommandList::DrawIndexed(uint32_t indexCount, uint32_t startIndex, int32_t baseVertex)
+{
+    vkCmdDrawIndexed(m_commandBuffer, indexCount, 1, startIndex, baseVertex, 0);
+}
+
+void VulkanCommandList::DrawInstanced(uint32_t vertexCount, uint32_t instanceCount,
+                                      uint32_t startVertex, uint32_t startInstance)
+{
+    vkCmdDraw(m_commandBuffer, vertexCount, instanceCount, startVertex, startInstance);
+}
+
+void VulkanCommandList::DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
+                                             uint32_t startIndex, int32_t baseVertex,
+                                             uint32_t startInstance)
+{
+    vkCmdDrawIndexed(m_commandBuffer, indexCount, instanceCount, startIndex,
+                     baseVertex, startInstance);
+}
+
+void VulkanCommandList::Dispatch(uint32_t x, uint32_t y, uint32_t z)
+{
+    vkCmdDispatch(m_commandBuffer, x, y, z);
+}
+
+void VulkanCommandList::BeginEvent(const char*) {}
+void VulkanCommandList::EndEvent() {}
+void VulkanCommandList::SetMarker(const char*) {}
+
+void VulkanCommandList::TransitionImageLayout(VkImage image, VkImageLayout oldLayout,
+                                              VkImageLayout newLayout,
+                                              VkImageAspectFlags aspectMask)
+{
+    VkImageMemoryBarrier barrier = {};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.oldLayout = oldLayout;
+    barrier.newLayout = newLayout;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.image = image;
+    barrier.subresourceRange.aspectMask = aspectMask;
+    barrier.subresourceRange.baseMipLevel = 0;
+    barrier.subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
+    barrier.subresourceRange.baseArrayLayer = 0;
+    barrier.subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
+
+    VkPipelineStageFlags srcStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    VkPipelineStageFlags dstStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+    vkCmdPipelineBarrier(m_commandBuffer, srcStage, dstStage, 0,
+                         0, nullptr, 0, nullptr, 1, &barrier);
+}
+
+// ============================================================================
+// VULKAN DEVICE
+// ============================================================================
+
+VulkanDevice::VulkanDevice()
+{
+    m_capabilities.backend = GraphicsBackend::Vulkan;
+}
+
+VulkanDevice::~VulkanDevice()
+{
+    Shutdown();
+}
+
+bool VulkanDevice::Initialize(const RHIDeviceDesc& desc)
+{
+    m_validationEnabled = desc.enableDebugLayer;
+
+    if (!CreateInstance(desc)) return false;
+    if (!SelectPhysicalDevice()) return false;
+    if (!CreateLogicalDevice()) return false;
+    if (!CreateCommandPool()) return false;
+
+    QueryCapabilities();
+
+    // Create immediate command list
+    m_immediateCommandList = std::make_unique<VulkanCommandList>(
+        m_device, m_commandPool, true);
+
+    // Create pipeline cache
+    VkPipelineCacheCreateInfo cacheInfo = {};
+    cacheInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
+    vkCreatePipelineCache(m_device, &cacheInfo, nullptr, &m_pipelineCache);
+
+    // Create descriptor pool
+    VkDescriptorPoolSize poolSizes[] = {
+        { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1000 },
+        { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1000 },
+        { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 100 },
+        { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 100 }
+    };
+
+    VkDescriptorPoolCreateInfo poolInfo = {};
+    poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    poolInfo.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+    poolInfo.poolSizeCount = 4;
+    poolInfo.pPoolSizes = poolSizes;
+    poolInfo.maxSets = 2000;
+
+    vkCreateDescriptorPool(m_device, &poolInfo, nullptr, &m_descriptorPool);
+
+    return true;
+}
+
+bool VulkanDevice::CreateInstance(const RHIDeviceDesc& desc)
+{
+    VkApplicationInfo appInfo = {};
+    appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    appInfo.pApplicationName = desc.applicationName.c_str();
+    appInfo.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
+    appInfo.pEngineName = "SparkEngine";
+    appInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+    appInfo.apiVersion = VK_API_VERSION_1_3;
+
+    std::vector<const char*> extensions = {
+        VK_KHR_SURFACE_EXTENSION_NAME,
+#ifdef _WIN32
+        VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
+#elif defined(__linux__)
+        VK_KHR_XCB_SURFACE_EXTENSION_NAME,
+#endif
+    };
+
+    std::vector<const char*> layers;
+    if (m_validationEnabled)
+    {
+        layers.push_back("VK_LAYER_KHRONOS_validation");
+        extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    }
+
+    VkInstanceCreateInfo createInfo = {};
+    createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    createInfo.pApplicationInfo = &appInfo;
+    createInfo.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
+    createInfo.ppEnabledExtensionNames = extensions.data();
+    createInfo.enabledLayerCount = static_cast<uint32_t>(layers.size());
+    createInfo.ppEnabledLayerNames = layers.data();
+
+    VkResult result = vkCreateInstance(&createInfo, nullptr, &m_instance);
+    if (result != VK_SUCCESS) return false;
+
+    // Set up debug messenger
+    if (m_validationEnabled)
+    {
+        VkDebugUtilsMessengerCreateInfoEXT debugInfo = {};
+        debugInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+        debugInfo.messageSeverity =
+            VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+            VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+        debugInfo.messageType =
+            VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
+            VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+            VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+        debugInfo.pfnUserCallback = VulkanDebugCallback;
+
+        auto createDebugFn = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(
+            vkGetInstanceProcAddr(m_instance, "vkCreateDebugUtilsMessengerEXT"));
+        if (createDebugFn)
+        {
+            createDebugFn(m_instance, &debugInfo, nullptr, &m_debugMessenger);
+        }
+    }
+
+    return true;
+}
+
+bool VulkanDevice::SelectPhysicalDevice()
+{
+    uint32_t deviceCount = 0;
+    vkEnumeratePhysicalDevices(m_instance, &deviceCount, nullptr);
+    if (deviceCount == 0) return false;
+
+    std::vector<VkPhysicalDevice> devices(deviceCount);
+    vkEnumeratePhysicalDevices(m_instance, &deviceCount, devices.data());
+
+    // Pick the best device (prefer discrete GPU)
+    for (const auto& device : devices)
+    {
+        VkPhysicalDeviceProperties properties;
+        vkGetPhysicalDeviceProperties(device, &properties);
+
+        auto queueFamilies = FindQueueFamilies(device);
+        bool extensionsSupported = CheckDeviceExtensionSupport(device);
+
+        if (queueFamilies.graphicsFamily.has_value() && extensionsSupported)
+        {
+            m_physicalDevice = device;
+            m_queueFamilies = queueFamilies;
+
+            if (properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+                break;
+        }
+    }
+
+    return m_physicalDevice != VK_NULL_HANDLE;
+}
+
+bool VulkanDevice::CreateLogicalDevice()
+{
+    std::set<uint32_t> uniqueQueueFamilies = {
+        m_queueFamilies.graphicsFamily.value()
+    };
+    if (m_queueFamilies.presentFamily.has_value())
+        uniqueQueueFamilies.insert(m_queueFamilies.presentFamily.value());
+
+    std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
+    float queuePriority = 1.0f;
+
+    for (uint32_t queueFamily : uniqueQueueFamilies)
+    {
+        VkDeviceQueueCreateInfo queueInfo = {};
+        queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+        queueInfo.queueFamilyIndex = queueFamily;
+        queueInfo.queueCount = 1;
+        queueInfo.pQueuePriorities = &queuePriority;
+        queueCreateInfos.push_back(queueInfo);
+    }
+
+    // Enable features
+    VkPhysicalDeviceFeatures deviceFeatures = {};
+    deviceFeatures.samplerAnisotropy = VK_TRUE;
+    deviceFeatures.fillModeNonSolid = VK_TRUE;
+    deviceFeatures.multiViewport = VK_TRUE;
+    deviceFeatures.geometryShader = VK_TRUE;
+    deviceFeatures.tessellationShader = VK_TRUE;
+    deviceFeatures.multiDrawIndirect = VK_TRUE;
+
+    // Vulkan 1.3 features
+    VkPhysicalDeviceVulkan13Features vulkan13Features = {};
+    vulkan13Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
+    vulkan13Features.dynamicRendering = VK_TRUE;
+    vulkan13Features.synchronization2 = VK_TRUE;
+
+    VkPhysicalDeviceVulkan12Features vulkan12Features = {};
+    vulkan12Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
+    vulkan12Features.pNext = &vulkan13Features;
+    vulkan12Features.descriptorIndexing = VK_TRUE;
+    vulkan12Features.timelineSemaphore = VK_TRUE;
+    vulkan12Features.bufferDeviceAddress = VK_TRUE;
+
+    VkDeviceCreateInfo createInfo = {};
+    createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    createInfo.pNext = &vulkan12Features;
+    createInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size());
+    createInfo.pQueueCreateInfos = queueCreateInfos.data();
+    createInfo.pEnabledFeatures = &deviceFeatures;
+    createInfo.enabledExtensionCount = static_cast<uint32_t>(m_deviceExtensions.size());
+    createInfo.ppEnabledExtensionNames = m_deviceExtensions.data();
+
+    VkResult result = vkCreateDevice(m_physicalDevice, &createInfo, nullptr, &m_device);
+    if (result != VK_SUCCESS) return false;
+
+    vkGetDeviceQueue(m_device, m_queueFamilies.graphicsFamily.value(), 0, &m_graphicsQueue);
+    if (m_queueFamilies.presentFamily.has_value())
+        vkGetDeviceQueue(m_device, m_queueFamilies.presentFamily.value(), 0, &m_presentQueue);
+
+    return true;
+}
+
+bool VulkanDevice::CreateCommandPool()
+{
+    VkCommandPoolCreateInfo poolInfo = {};
+    poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    poolInfo.queueFamilyIndex = m_queueFamilies.graphicsFamily.value();
+
+    return vkCreateCommandPool(m_device, &poolInfo, nullptr, &m_commandPool) == VK_SUCCESS;
+}
+
+QueueFamilyIndices VulkanDevice::FindQueueFamilies(VkPhysicalDevice device) const
+{
+    QueueFamilyIndices indices;
+
+    uint32_t queueFamilyCount = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
+
+    std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
+    vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
+
+    for (uint32_t i = 0; i < queueFamilyCount; ++i)
+    {
+        if (queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)
+        {
+            indices.graphicsFamily = i;
+            indices.presentFamily = i; // Assume same for now
+        }
+        if (queueFamilies[i].queueFlags & VK_QUEUE_COMPUTE_BIT)
+            indices.computeFamily = i;
+        if (queueFamilies[i].queueFlags & VK_QUEUE_TRANSFER_BIT)
+            indices.transferFamily = i;
+    }
+
+    return indices;
+}
+
+bool VulkanDevice::CheckDeviceExtensionSupport(VkPhysicalDevice device) const
+{
+    uint32_t extensionCount;
+    vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, nullptr);
+
+    std::vector<VkExtensionProperties> available(extensionCount);
+    vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, available.data());
+
+    std::set<std::string> required(m_deviceExtensions.begin(), m_deviceExtensions.end());
+    for (const auto& ext : available)
+        required.erase(ext.extensionName);
+
+    return required.empty();
+}
+
+void VulkanDevice::QueryCapabilities()
+{
+    VkPhysicalDeviceProperties properties;
+    vkGetPhysicalDeviceProperties(m_physicalDevice, &properties);
+
+    m_capabilities.deviceName = properties.deviceName;
+    m_capabilities.apiVersion = "Vulkan " +
+        std::to_string(VK_VERSION_MAJOR(properties.apiVersion)) + "." +
+        std::to_string(VK_VERSION_MINOR(properties.apiVersion)) + "." +
+        std::to_string(VK_VERSION_PATCH(properties.apiVersion));
+
+    m_capabilities.maxTextureSize = properties.limits.maxImageDimension2D;
+    m_capabilities.maxRenderTargets = properties.limits.maxColorAttachments;
+    m_capabilities.maxSamplers = properties.limits.maxPerStageDescriptorSamplers;
+    m_capabilities.maxAnisotropy = properties.limits.maxSamplerAnisotropy;
+
+    VkPhysicalDeviceMemoryProperties memProperties;
+    vkGetPhysicalDeviceMemoryProperties(m_physicalDevice, &memProperties);
+
+    m_capabilities.dedicatedVideoMemory = 0;
+    for (uint32_t i = 0; i < memProperties.memoryHeapCount; ++i)
+    {
+        if (memProperties.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
+            m_capabilities.dedicatedVideoMemory += memProperties.memoryHeaps[i].size;
+    }
+
+    VkPhysicalDeviceFeatures features;
+    vkGetPhysicalDeviceFeatures(m_physicalDevice, &features);
+
+    m_capabilities.tessellationSupport = features.tessellationShader;
+    m_capabilities.geometryShaderSupport = features.geometryShader;
+    m_capabilities.computeShaderSupport = true;
+    m_capabilities.multiDrawIndirectSupport = features.multiDrawIndirect;
+}
+
+void VulkanDevice::Shutdown()
+{
+    if (m_device != VK_NULL_HANDLE)
+        vkDeviceWaitIdle(m_device);
+
+    m_immediateCommandList.reset();
+
+    if (m_pipelineCache != VK_NULL_HANDLE)
+        vkDestroyPipelineCache(m_device, m_pipelineCache, nullptr);
+    if (m_descriptorPool != VK_NULL_HANDLE)
+        vkDestroyDescriptorPool(m_device, m_descriptorPool, nullptr);
+    if (m_commandPool != VK_NULL_HANDLE)
+        vkDestroyCommandPool(m_device, m_commandPool, nullptr);
+    if (m_device != VK_NULL_HANDLE)
+        vkDestroyDevice(m_device, nullptr);
+    if (m_debugMessenger != VK_NULL_HANDLE)
+    {
+        auto destroyFn = reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(
+            vkGetInstanceProcAddr(m_instance, "vkDestroyDebugUtilsMessengerEXT"));
+        if (destroyFn) destroyFn(m_instance, m_debugMessenger, nullptr);
+    }
+    if (m_instance != VK_NULL_HANDLE)
+        vkDestroyInstance(m_instance, nullptr);
+
+    m_pipelineCache = VK_NULL_HANDLE;
+    m_descriptorPool = VK_NULL_HANDLE;
+    m_commandPool = VK_NULL_HANDLE;
+    m_device = VK_NULL_HANDLE;
+    m_debugMessenger = VK_NULL_HANDLE;
+    m_instance = VK_NULL_HANDLE;
+}
+
+std::unique_ptr<IRHISwapChain> VulkanDevice::CreateSwapChain(const RHISwapChainDesc& desc)
+{
+    VkSurfaceKHR surface = VK_NULL_HANDLE;
+
+#ifdef _WIN32
+    VkWin32SurfaceCreateInfoKHR surfaceInfo = {};
+    surfaceInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
+    surfaceInfo.hwnd = static_cast<HWND>(desc.windowHandle);
+    surfaceInfo.hinstance = GetModuleHandle(nullptr);
+    vkCreateWin32SurfaceKHR(m_instance, &surfaceInfo, nullptr, &surface);
+#endif
+
+    return std::make_unique<VulkanSwapChain>(
+        m_device, m_physicalDevice, surface, desc, m_queueFamilies);
+}
+
+IRHIBuffer* VulkanDevice::CreateBuffer(const RHIBufferDesc& desc)
+{
+    VkBufferCreateInfo bufferInfo = {};
+    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufferInfo.size = desc.size;
+    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    if (desc.usage & RHIBufferUsage::Vertex) bufferInfo.usage |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+    if (desc.usage & RHIBufferUsage::Index) bufferInfo.usage |= VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
+    if (desc.usage & RHIBufferUsage::Constant) bufferInfo.usage |= VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+    if (desc.usage & RHIBufferUsage::Storage) bufferInfo.usage |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+    if (desc.usage & RHIBufferUsage::CopySrc) bufferInfo.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    if (desc.usage & RHIBufferUsage::CopyDst) bufferInfo.usage |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+
+    VkBuffer buffer;
+    if (vkCreateBuffer(m_device, &bufferInfo, nullptr, &buffer) != VK_SUCCESS)
+        return nullptr;
+
+    VkMemoryRequirements memRequirements;
+    vkGetBufferMemoryRequirements(m_device, buffer, &memRequirements);
+
+    VkMemoryPropertyFlags memProperties = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+    if (desc.access == RHIBufferAccess::Dynamic || desc.access == RHIBufferAccess::Staging)
+    {
+        memProperties = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    }
+
+    VkMemoryAllocateInfo allocInfo = {};
+    allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    allocInfo.allocationSize = memRequirements.size;
+    allocInfo.memoryTypeIndex = FindMemoryType(memRequirements.memoryTypeBits, memProperties);
+
+    VkDeviceMemory memory;
+    if (vkAllocateMemory(m_device, &allocInfo, nullptr, &memory) != VK_SUCCESS)
+    {
+        vkDestroyBuffer(m_device, buffer, nullptr);
+        return nullptr;
+    }
+
+    vkBindBufferMemory(m_device, buffer, memory, 0);
+
+    // Upload initial data
+    if (desc.initialData)
+    {
+        void* mapped;
+        vkMapMemory(m_device, memory, 0, desc.size, 0, &mapped);
+        memcpy(mapped, desc.initialData, desc.size);
+        vkUnmapMemory(m_device, memory);
+    }
+
+    return new VulkanBuffer(desc, buffer, memory, m_device);
+}
+
+IRHITexture* VulkanDevice::CreateTexture(const RHITextureDesc& desc)
+{
+    VkImageCreateInfo imageInfo = {};
+    imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageInfo.format = ConvertFormat(desc.format);
+    imageInfo.extent = { desc.width, desc.height, desc.depth };
+    imageInfo.mipLevels = desc.mipLevels;
+    imageInfo.arrayLayers = desc.arraySize;
+    imageInfo.samples = static_cast<VkSampleCountFlagBits>(desc.sampleCount);
+    imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+    imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    if (desc.usage & RHITextureUsage::ShaderResource) imageInfo.usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
+    if (desc.usage & RHITextureUsage::RenderTarget) imageInfo.usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    if (desc.usage & RHITextureUsage::DepthStencil) imageInfo.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+    if (desc.usage & RHITextureUsage::UnorderedAccess) imageInfo.usage |= VK_IMAGE_USAGE_STORAGE_BIT;
+    imageInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+
+    VkImage image;
+    if (vkCreateImage(m_device, &imageInfo, nullptr, &image) != VK_SUCCESS)
+        return nullptr;
+
+    VkMemoryRequirements memReqs;
+    vkGetImageMemoryRequirements(m_device, image, &memReqs);
+
+    VkMemoryAllocateInfo allocInfo = {};
+    allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    allocInfo.allocationSize = memReqs.size;
+    allocInfo.memoryTypeIndex = FindMemoryType(memReqs.memoryTypeBits,
+                                               VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+    VkDeviceMemory memory;
+    if (vkAllocateMemory(m_device, &allocInfo, nullptr, &memory) != VK_SUCCESS)
+    {
+        vkDestroyImage(m_device, image, nullptr);
+        return nullptr;
+    }
+
+    vkBindImageMemory(m_device, image, memory, 0);
+
+    // Create image view
+    VkImageViewCreateInfo viewInfo = {};
+    viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    viewInfo.image = image;
+    viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    viewInfo.format = ConvertFormat(desc.format);
+    viewInfo.subresourceRange.baseMipLevel = 0;
+    viewInfo.subresourceRange.levelCount = desc.mipLevels;
+    viewInfo.subresourceRange.baseArrayLayer = 0;
+    viewInfo.subresourceRange.layerCount = desc.arraySize;
+
+    if (desc.usage & RHITextureUsage::DepthStencil)
+        viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    else
+        viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+
+    VkImageView imageView;
+    if (vkCreateImageView(m_device, &viewInfo, nullptr, &imageView) != VK_SUCCESS)
+    {
+        vkDestroyImage(m_device, image, nullptr);
+        vkFreeMemory(m_device, memory, nullptr);
+        return nullptr;
+    }
+
+    return new VulkanTexture(desc, image, memory, imageView, m_device);
+}
+
+IRHIShader* VulkanDevice::CreateShader(const RHIShaderDesc& desc)
+{
+    std::vector<uint8_t> spirvCode;
+
+    if (desc.language == ShaderLanguage::SPIRV && desc.bytecode && desc.bytecodeSize > 0)
+    {
+        spirvCode.resize(desc.bytecodeSize);
+        memcpy(spirvCode.data(), desc.bytecode, desc.bytecodeSize);
+    }
+    else
+    {
+        // GLSL to SPIR-V compilation would happen here via glslang/shaderc
+        // For now, expect pre-compiled SPIR-V
+        return nullptr;
+    }
+
+    VkShaderModuleCreateInfo createInfo = {};
+    createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    createInfo.codeSize = spirvCode.size();
+    createInfo.pCode = reinterpret_cast<const uint32_t*>(spirvCode.data());
+
+    VkShaderModule module;
+    if (vkCreateShaderModule(m_device, &createInfo, nullptr, &module) != VK_SUCCESS)
+        return nullptr;
+
+    return new VulkanShader(desc, module, m_device, std::move(spirvCode));
+}
+
+IRHISampler* VulkanDevice::CreateSampler(const RHISamplerDesc& desc)
+{
+    VkSamplerCreateInfo samplerInfo = {};
+    samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    samplerInfo.magFilter = ConvertFilter(desc.magFilter);
+    samplerInfo.minFilter = ConvertFilter(desc.minFilter);
+    samplerInfo.mipmapMode = (desc.mipFilter == RHIFilterMode::Linear) ?
+        VK_SAMPLER_MIPMAP_MODE_LINEAR : VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    samplerInfo.addressModeU = ConvertAddressMode(desc.addressU);
+    samplerInfo.addressModeV = ConvertAddressMode(desc.addressV);
+    samplerInfo.addressModeW = ConvertAddressMode(desc.addressW);
+    samplerInfo.mipLodBias = desc.mipLodBias;
+    samplerInfo.anisotropyEnable = (desc.maxAnisotropy > 1) ? VK_TRUE : VK_FALSE;
+    samplerInfo.maxAnisotropy = static_cast<float>(desc.maxAnisotropy);
+    samplerInfo.compareEnable = (desc.compareOp != RHICompareOp::Never) ? VK_TRUE : VK_FALSE;
+    samplerInfo.compareOp = ConvertCompareOp(desc.compareOp);
+    samplerInfo.minLod = desc.minLod;
+    samplerInfo.maxLod = desc.maxLod;
+    memcpy(&samplerInfo.borderColor, desc.borderColor, sizeof(float) * 4); // Simplified
+
+    VkSampler sampler;
+    if (vkCreateSampler(m_device, &samplerInfo, nullptr, &sampler) != VK_SUCCESS)
+        return nullptr;
+
+    return new VulkanSampler(desc, sampler, m_device);
+}
+
+IRHIPipelineState* VulkanDevice::CreatePipelineState(const RHIPipelineStateDesc& desc,
+                                                      IRHIShader* vertexShader,
+                                                      IRHIShader* pixelShader)
+{
+    auto* vkVS = static_cast<VulkanShader*>(vertexShader);
+    auto* vkPS = static_cast<VulkanShader*>(pixelShader);
+
+    // Shader stages
+    VkPipelineShaderStageCreateInfo shaderStages[2] = {};
+    shaderStages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    shaderStages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
+    shaderStages[0].module = vkVS->GetVkModule();
+    shaderStages[0].pName = vkVS->GetEntryPoint().c_str();
+
+    shaderStages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    shaderStages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    shaderStages[1].module = vkPS->GetVkModule();
+    shaderStages[1].pName = vkPS->GetEntryPoint().c_str();
+
+    // Vertex input
+    std::vector<VkVertexInputBindingDescription> bindings;
+    std::vector<VkVertexInputAttributeDescription> attributes;
+
+    uint32_t currentOffset = 0;
+    for (size_t i = 0; i < desc.inputLayout.elements.size(); ++i)
+    {
+        const auto& elem = desc.inputLayout.elements[i];
+        VkVertexInputAttributeDescription attr = {};
+        attr.location = static_cast<uint32_t>(i);
+        attr.binding = elem.inputSlot;
+        attr.format = ConvertVertexFormat(elem.format);
+        attr.offset = elem.byteOffset;
+        attributes.push_back(attr);
+    }
+
+    if (!attributes.empty())
+    {
+        VkVertexInputBindingDescription binding = {};
+        binding.binding = 0;
+        binding.stride = desc.inputLayout.elements.back().byteOffset + 8; // Approximate
+        binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+        bindings.push_back(binding);
+    }
+
+    VkPipelineVertexInputStateCreateInfo vertexInputInfo = {};
+    vertexInputInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+    vertexInputInfo.vertexBindingDescriptionCount = static_cast<uint32_t>(bindings.size());
+    vertexInputInfo.pVertexBindingDescriptions = bindings.data();
+    vertexInputInfo.vertexAttributeDescriptionCount = static_cast<uint32_t>(attributes.size());
+    vertexInputInfo.pVertexAttributeDescriptions = attributes.data();
+
+    // Input assembly
+    VkPipelineInputAssemblyStateCreateInfo inputAssembly = {};
+    inputAssembly.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    inputAssembly.topology = ConvertTopology(desc.topology);
+    inputAssembly.primitiveRestartEnable = VK_FALSE;
+
+    // Dynamic state
+    VkDynamicState dynamicStates[] = {
+        VK_DYNAMIC_STATE_VIEWPORT,
+        VK_DYNAMIC_STATE_SCISSOR
+    };
+
+    VkPipelineDynamicStateCreateInfo dynamicState = {};
+    dynamicState.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dynamicState.dynamicStateCount = 2;
+    dynamicState.pDynamicStates = dynamicStates;
+
+    VkPipelineViewportStateCreateInfo viewportState = {};
+    viewportState.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    viewportState.viewportCount = 1;
+    viewportState.scissorCount = 1;
+
+    // Rasterizer
+    VkPipelineRasterizationStateCreateInfo rasterizer = {};
+    rasterizer.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    rasterizer.depthClampEnable = VK_FALSE;
+    rasterizer.rasterizerDiscardEnable = VK_FALSE;
+    rasterizer.polygonMode = (desc.rasterizer.fillMode == RHIFillMode::Wireframe) ?
+        VK_POLYGON_MODE_LINE : VK_POLYGON_MODE_FILL;
+    rasterizer.cullMode = (desc.rasterizer.cullMode == RHICullMode::None) ? VK_CULL_MODE_NONE :
+        (desc.rasterizer.cullMode == RHICullMode::Front) ? VK_CULL_MODE_FRONT_BIT : VK_CULL_MODE_BACK_BIT;
+    rasterizer.frontFace = desc.rasterizer.frontCounterClockwise ?
+        VK_FRONT_FACE_COUNTER_CLOCKWISE : VK_FRONT_FACE_CLOCKWISE;
+    rasterizer.depthBiasEnable = (desc.rasterizer.depthBias != 0) ? VK_TRUE : VK_FALSE;
+    rasterizer.lineWidth = 1.0f;
+
+    // Multisampling
+    VkPipelineMultisampleStateCreateInfo multisampling = {};
+    multisampling.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    multisampling.sampleShadingEnable = VK_FALSE;
+    multisampling.rasterizationSamples = static_cast<VkSampleCountFlagBits>(desc.sampleCount);
+
+    // Depth stencil
+    VkPipelineDepthStencilStateCreateInfo depthStencil = {};
+    depthStencil.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+    depthStencil.depthTestEnable = desc.depthStencil.depthEnable ? VK_TRUE : VK_FALSE;
+    depthStencil.depthWriteEnable = desc.depthStencil.depthWrite ? VK_TRUE : VK_FALSE;
+    depthStencil.depthCompareOp = ConvertCompareOp(desc.depthStencil.depthFunc);
+    depthStencil.stencilTestEnable = desc.depthStencil.stencilEnable ? VK_TRUE : VK_FALSE;
+
+    // Color blending
+    std::vector<VkPipelineColorBlendAttachmentState> colorBlendAttachments(desc.numRenderTargets);
+    for (uint32_t i = 0; i < desc.numRenderTargets; ++i)
+    {
+        colorBlendAttachments[i].blendEnable = desc.blend.renderTargets[i].blendEnable ? VK_TRUE : VK_FALSE;
+        colorBlendAttachments[i].srcColorBlendFactor = ConvertBlendFactor(desc.blend.renderTargets[i].srcBlend);
+        colorBlendAttachments[i].dstColorBlendFactor = ConvertBlendFactor(desc.blend.renderTargets[i].dstBlend);
+        colorBlendAttachments[i].colorBlendOp = ConvertBlendOp(desc.blend.renderTargets[i].blendOp);
+        colorBlendAttachments[i].srcAlphaBlendFactor = ConvertBlendFactor(desc.blend.renderTargets[i].srcBlendAlpha);
+        colorBlendAttachments[i].dstAlphaBlendFactor = ConvertBlendFactor(desc.blend.renderTargets[i].dstBlendAlpha);
+        colorBlendAttachments[i].alphaBlendOp = ConvertBlendOp(desc.blend.renderTargets[i].blendOpAlpha);
+        colorBlendAttachments[i].colorWriteMask = desc.blend.renderTargets[i].writeMask;
+    }
+
+    VkPipelineColorBlendStateCreateInfo colorBlending = {};
+    colorBlending.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    colorBlending.attachmentCount = static_cast<uint32_t>(colorBlendAttachments.size());
+    colorBlending.pAttachments = colorBlendAttachments.data();
+
+    // Pipeline layout
+    VkPipelineLayoutCreateInfo pipelineLayoutInfo = {};
+    pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+
+    VkPipelineLayout pipelineLayout;
+    if (vkCreatePipelineLayout(m_device, &pipelineLayoutInfo, nullptr, &pipelineLayout) != VK_SUCCESS)
+        return nullptr;
+
+    // Dynamic rendering format info (Vulkan 1.3)
+    std::vector<VkFormat> colorFormats;
+    for (uint32_t i = 0; i < desc.numRenderTargets; ++i)
+        colorFormats.push_back(ConvertFormat(desc.renderTargetFormats[i]));
+
+    VkPipelineRenderingCreateInfo renderingInfo = {};
+    renderingInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO;
+    renderingInfo.colorAttachmentCount = static_cast<uint32_t>(colorFormats.size());
+    renderingInfo.pColorAttachmentFormats = colorFormats.data();
+    renderingInfo.depthAttachmentFormat = ConvertFormat(desc.depthStencilFormat);
+
+    // Create pipeline
+    VkGraphicsPipelineCreateInfo pipelineInfo = {};
+    pipelineInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    pipelineInfo.pNext = &renderingInfo;
+    pipelineInfo.stageCount = 2;
+    pipelineInfo.pStages = shaderStages;
+    pipelineInfo.pVertexInputState = &vertexInputInfo;
+    pipelineInfo.pInputAssemblyState = &inputAssembly;
+    pipelineInfo.pViewportState = &viewportState;
+    pipelineInfo.pRasterizationState = &rasterizer;
+    pipelineInfo.pMultisampleState = &multisampling;
+    pipelineInfo.pDepthStencilState = &depthStencil;
+    pipelineInfo.pColorBlendState = &colorBlending;
+    pipelineInfo.pDynamicState = &dynamicState;
+    pipelineInfo.layout = pipelineLayout;
+    pipelineInfo.renderPass = VK_NULL_HANDLE; // Using dynamic rendering
+
+    VkPipeline pipeline;
+    if (vkCreateGraphicsPipelines(m_device, m_pipelineCache, 1, &pipelineInfo,
+                                  nullptr, &pipeline) != VK_SUCCESS)
+    {
+        vkDestroyPipelineLayout(m_device, pipelineLayout, nullptr);
+        return nullptr;
+    }
+
+    return new VulkanPipelineState(desc, pipeline, pipelineLayout, m_device);
+}
+
+void VulkanDevice::DestroyBuffer(IRHIBuffer* buffer) { delete buffer; }
+void VulkanDevice::DestroyTexture(IRHITexture* texture) { delete texture; }
+void VulkanDevice::DestroyShader(IRHIShader* shader) { delete shader; }
+void VulkanDevice::DestroySampler(IRHISampler* sampler) { delete sampler; }
+void VulkanDevice::DestroyPipelineState(IRHIPipelineState* state) { delete state; }
+
+void* VulkanDevice::MapBuffer(IRHIBuffer* buffer)
+{
+    auto* vkBuf = static_cast<VulkanBuffer*>(buffer);
+    void* mapped;
+    vkMapMemory(m_device, vkBuf->GetVkMemory(), 0, vkBuf->GetSize(), 0, &mapped);
+    vkBuf->SetMappedPtr(mapped);
+    return mapped;
+}
+
+void VulkanDevice::UnmapBuffer(IRHIBuffer* buffer)
+{
+    auto* vkBuf = static_cast<VulkanBuffer*>(buffer);
+    vkUnmapMemory(m_device, vkBuf->GetVkMemory());
+    vkBuf->SetMappedPtr(nullptr);
+}
+
+void VulkanDevice::UpdateBuffer(IRHIBuffer* buffer, const void* data, size_t size, size_t offset)
+{
+    void* mapped = MapBuffer(buffer);
+    if (mapped)
+    {
+        memcpy(static_cast<uint8_t*>(mapped) + offset, data, size);
+        UnmapBuffer(buffer);
+    }
+}
+
+void VulkanDevice::UpdateTexture(IRHITexture*, const void*, uint32_t, uint32_t)
+{
+    // Staging buffer copy would be implemented here
+}
+
+IRHICommandList* VulkanDevice::GetImmediateCommandList()
+{
+    return m_immediateCommandList.get();
+}
+
+IRHICommandList* VulkanDevice::CreateDeferredCommandList()
+{
+    return new VulkanCommandList(m_device, m_commandPool, false);
+}
+
+void VulkanDevice::ExecuteCommandList(IRHICommandList* commandList)
+{
+    auto* vkCmd = static_cast<VulkanCommandList*>(commandList);
+
+    VkSubmitInfo submitInfo = {};
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submitInfo.commandBufferCount = 1;
+    VkCommandBuffer cmd = vkCmd->GetVkCommandBuffer();
+    submitInfo.pCommandBuffers = &cmd;
+
+    vkQueueSubmit(m_graphicsQueue, 1, &submitInfo, VK_NULL_HANDLE);
+}
+
+void VulkanDevice::DestroyCommandList(IRHICommandList* commandList) { delete commandList; }
+
+void VulkanDevice::BeginFrame() { ResetStatistics(); }
+void VulkanDevice::EndFrame() {}
+void VulkanDevice::WaitForIdle()
+{
+    if (m_device != VK_NULL_HANDLE)
+        vkDeviceWaitIdle(m_device);
+}
+
+void VulkanDevice::ResetStatistics() { m_statistics = {}; }
+
+std::string VulkanDevice::GetDeviceInfo() const
+{
+    std::string info = "=== Vulkan Device Info ===\n";
+    info += "Device: " + m_capabilities.deviceName + "\n";
+    info += "API: " + m_capabilities.apiVersion + "\n";
+    info += "VRAM: " + std::to_string(m_capabilities.dedicatedVideoMemory / (1024 * 1024)) + " MB\n";
+    info += "Max Texture Size: " + std::to_string(m_capabilities.maxTextureSize) + "\n";
+    info += "Max Color Attachments: " + std::to_string(m_capabilities.maxRenderTargets) + "\n";
+    info += "Tessellation: " + std::string(m_capabilities.tessellationSupport ? "Yes" : "No") + "\n";
+    info += "Geometry Shaders: " + std::string(m_capabilities.geometryShaderSupport ? "Yes" : "No") + "\n";
+    return info;
+}
+
+uint32_t VulkanDevice::FindMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties) const
+{
+    VkPhysicalDeviceMemoryProperties memProperties;
+    vkGetPhysicalDeviceMemoryProperties(m_physicalDevice, &memProperties);
+
+    for (uint32_t i = 0; i < memProperties.memoryTypeCount; ++i)
+    {
+        if ((typeFilter & (1 << i)) &&
+            (memProperties.memoryTypes[i].propertyFlags & properties) == properties)
+        {
+            return i;
+        }
+    }
+    return 0;
+}
+
+// ============================================================================
+// FORMAT CONVERSION HELPERS
+// ============================================================================
+
+VkFormat VulkanDevice::ConvertFormat(PixelFormat format) const
+{
+    switch (format)
+    {
+    case PixelFormat::R8_UNORM:              return VK_FORMAT_R8_UNORM;
+    case PixelFormat::R8G8_UNORM:            return VK_FORMAT_R8G8_UNORM;
+    case PixelFormat::R8G8B8A8_UNORM:        return VK_FORMAT_R8G8B8A8_UNORM;
+    case PixelFormat::R8G8B8A8_UNORM_SRGB:   return VK_FORMAT_R8G8B8A8_SRGB;
+    case PixelFormat::B8G8R8A8_UNORM:        return VK_FORMAT_B8G8R8A8_UNORM;
+    case PixelFormat::R10G10B10A2_UNORM:     return VK_FORMAT_A2B10G10R10_UNORM_PACK32;
+    case PixelFormat::R11G11B10_FLOAT:       return VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+    case PixelFormat::R16_FLOAT:             return VK_FORMAT_R16_SFLOAT;
+    case PixelFormat::R16G16_FLOAT:          return VK_FORMAT_R16G16_SFLOAT;
+    case PixelFormat::R16G16B16A16_FLOAT:    return VK_FORMAT_R16G16B16A16_SFLOAT;
+    case PixelFormat::R32_FLOAT:             return VK_FORMAT_R32_SFLOAT;
+    case PixelFormat::R32G32_FLOAT:          return VK_FORMAT_R32G32_SFLOAT;
+    case PixelFormat::R32G32B32_FLOAT:       return VK_FORMAT_R32G32B32_SFLOAT;
+    case PixelFormat::R32G32B32A32_FLOAT:    return VK_FORMAT_R32G32B32A32_SFLOAT;
+    case PixelFormat::BC1_UNORM:             return VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
+    case PixelFormat::BC3_UNORM:             return VK_FORMAT_BC3_UNORM_BLOCK;
+    case PixelFormat::BC5_UNORM:             return VK_FORMAT_BC5_UNORM_BLOCK;
+    case PixelFormat::BC7_UNORM:             return VK_FORMAT_BC7_UNORM_BLOCK;
+    case PixelFormat::D16_UNORM:             return VK_FORMAT_D16_UNORM;
+    case PixelFormat::D24_UNORM_S8_UINT:     return VK_FORMAT_D24_UNORM_S8_UINT;
+    case PixelFormat::D32_FLOAT:             return VK_FORMAT_D32_SFLOAT;
+    default:                                 return VK_FORMAT_UNDEFINED;
+    }
+}
+
+VkFilter VulkanDevice::ConvertFilter(RHIFilterMode mode) const
+{
+    return (mode == RHIFilterMode::Nearest) ? VK_FILTER_NEAREST : VK_FILTER_LINEAR;
+}
+
+VkSamplerAddressMode VulkanDevice::ConvertAddressMode(RHIAddressMode mode) const
+{
+    switch (mode)
+    {
+    case RHIAddressMode::Wrap:    return VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    case RHIAddressMode::Clamp:   return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    case RHIAddressMode::Mirror:  return VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
+    case RHIAddressMode::Border:  return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+    default:                      return VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    }
+}
+
+VkCompareOp VulkanDevice::ConvertCompareOp(RHICompareOp op) const
+{
+    switch (op)
+    {
+    case RHICompareOp::Never:        return VK_COMPARE_OP_NEVER;
+    case RHICompareOp::Less:         return VK_COMPARE_OP_LESS;
+    case RHICompareOp::Equal:        return VK_COMPARE_OP_EQUAL;
+    case RHICompareOp::LessEqual:    return VK_COMPARE_OP_LESS_OR_EQUAL;
+    case RHICompareOp::Greater:      return VK_COMPARE_OP_GREATER;
+    case RHICompareOp::NotEqual:     return VK_COMPARE_OP_NOT_EQUAL;
+    case RHICompareOp::GreaterEqual: return VK_COMPARE_OP_GREATER_OR_EQUAL;
+    case RHICompareOp::Always:       return VK_COMPARE_OP_ALWAYS;
+    default:                         return VK_COMPARE_OP_LESS;
+    }
+}
+
+VkStencilOp VulkanDevice::ConvertStencilOp(RHIStencilOp op) const
+{
+    switch (op)
+    {
+    case RHIStencilOp::Keep:     return VK_STENCIL_OP_KEEP;
+    case RHIStencilOp::Zero:     return VK_STENCIL_OP_ZERO;
+    case RHIStencilOp::Replace:  return VK_STENCIL_OP_REPLACE;
+    case RHIStencilOp::IncrSat:  return VK_STENCIL_OP_INCREMENT_AND_CLAMP;
+    case RHIStencilOp::DecrSat:  return VK_STENCIL_OP_DECREMENT_AND_CLAMP;
+    case RHIStencilOp::Invert:   return VK_STENCIL_OP_INVERT;
+    case RHIStencilOp::IncrWrap: return VK_STENCIL_OP_INCREMENT_AND_WRAP;
+    case RHIStencilOp::DecrWrap: return VK_STENCIL_OP_DECREMENT_AND_WRAP;
+    default:                     return VK_STENCIL_OP_KEEP;
+    }
+}
+
+VkBlendFactor VulkanDevice::ConvertBlendFactor(RHIBlendFactor factor) const
+{
+    switch (factor)
+    {
+    case RHIBlendFactor::Zero:        return VK_BLEND_FACTOR_ZERO;
+    case RHIBlendFactor::One:         return VK_BLEND_FACTOR_ONE;
+    case RHIBlendFactor::SrcColor:    return VK_BLEND_FACTOR_SRC_COLOR;
+    case RHIBlendFactor::InvSrcColor: return VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR;
+    case RHIBlendFactor::SrcAlpha:    return VK_BLEND_FACTOR_SRC_ALPHA;
+    case RHIBlendFactor::InvSrcAlpha: return VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    case RHIBlendFactor::DstAlpha:    return VK_BLEND_FACTOR_DST_ALPHA;
+    case RHIBlendFactor::InvDstAlpha: return VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA;
+    case RHIBlendFactor::DstColor:    return VK_BLEND_FACTOR_DST_COLOR;
+    case RHIBlendFactor::InvDstColor: return VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR;
+    default:                          return VK_BLEND_FACTOR_ZERO;
+    }
+}
+
+VkBlendOp VulkanDevice::ConvertBlendOp(RHIBlendOp op) const
+{
+    switch (op)
+    {
+    case RHIBlendOp::Add:         return VK_BLEND_OP_ADD;
+    case RHIBlendOp::Subtract:    return VK_BLEND_OP_SUBTRACT;
+    case RHIBlendOp::RevSubtract: return VK_BLEND_OP_REVERSE_SUBTRACT;
+    case RHIBlendOp::Min:         return VK_BLEND_OP_MIN;
+    case RHIBlendOp::Max:         return VK_BLEND_OP_MAX;
+    default:                      return VK_BLEND_OP_ADD;
+    }
+}
+
+VkPrimitiveTopology VulkanDevice::ConvertTopology(RHIPrimitiveTopology topology) const
+{
+    switch (topology)
+    {
+    case RHIPrimitiveTopology::PointList:      return VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
+    case RHIPrimitiveTopology::LineList:        return VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
+    case RHIPrimitiveTopology::LineStrip:       return VK_PRIMITIVE_TOPOLOGY_LINE_STRIP;
+    case RHIPrimitiveTopology::TriangleList:    return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    case RHIPrimitiveTopology::TriangleStrip:   return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
+    case RHIPrimitiveTopology::PatchList:       return VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
+    default:                                    return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    }
+}
+
+VkFormat VulkanDevice::ConvertVertexFormat(RHIVertexFormat format) const
+{
+    switch (format)
+    {
+    case RHIVertexFormat::Float1:   return VK_FORMAT_R32_SFLOAT;
+    case RHIVertexFormat::Float2:   return VK_FORMAT_R32G32_SFLOAT;
+    case RHIVertexFormat::Float3:   return VK_FORMAT_R32G32B32_SFLOAT;
+    case RHIVertexFormat::Float4:   return VK_FORMAT_R32G32B32A32_SFLOAT;
+    case RHIVertexFormat::Int1:     return VK_FORMAT_R32_SINT;
+    case RHIVertexFormat::Int2:     return VK_FORMAT_R32G32_SINT;
+    case RHIVertexFormat::Int4:     return VK_FORMAT_R32G32B32A32_SINT;
+    case RHIVertexFormat::UInt1:    return VK_FORMAT_R32_UINT;
+    case RHIVertexFormat::UNorm8x4: return VK_FORMAT_R8G8B8A8_UNORM;
+    default:                        return VK_FORMAT_R32G32B32_SFLOAT;
+    }
+}
+
+}}} // namespace Spark::RHI::Vulkan
+
+#endif // SPARK_VULKAN_SUPPORT

--- a/Spark Engine/Source/Graphics/RHI/Vulkan/VulkanDevice.h
+++ b/Spark Engine/Source/Graphics/RHI/Vulkan/VulkanDevice.h
@@ -1,0 +1,416 @@
+/**
+ * @file VulkanDevice.h
+ * @brief Vulkan implementation of the RHI device interface
+ * @author Spark Engine Team
+ * @date 2025
+ *
+ * Full Vulkan 1.3 backend for the RHI abstraction layer.
+ * Supports modern Vulkan features including dynamic rendering,
+ * timeline semaphores, and descriptor indexing.
+ */
+
+#pragma once
+
+#include "../RHIDevice.h"
+#include "../RHIResources.h"
+
+// Vulkan availability is checked at build time
+#ifdef SPARK_VULKAN_SUPPORT
+
+// Platform detection for Vulkan surface creation
+#ifdef _WIN32
+#define VK_USE_PLATFORM_WIN32_KHR
+#elif defined(__linux__)
+#define VK_USE_PLATFORM_XCB_KHR
+#elif defined(__APPLE__)
+#define VK_USE_PLATFORM_METAL_EXT
+#endif
+
+#include <vulkan/vulkan.h>
+#include <vector>
+#include <unordered_map>
+#include <optional>
+#include <functional>
+
+namespace Spark { namespace RHI { namespace Vulkan {
+
+// ============================================================================
+// VULKAN QUEUE FAMILIES
+// ============================================================================
+
+struct QueueFamilyIndices
+{
+    std::optional<uint32_t> graphicsFamily;
+    std::optional<uint32_t> presentFamily;
+    std::optional<uint32_t> computeFamily;
+    std::optional<uint32_t> transferFamily;
+
+    bool IsComplete() const
+    {
+        return graphicsFamily.has_value() && presentFamily.has_value();
+    }
+};
+
+// ============================================================================
+// VULKAN RESOURCE IMPLEMENTATIONS
+// ============================================================================
+
+class VulkanBuffer : public IRHIBuffer
+{
+public:
+    VulkanBuffer(const RHIBufferDesc& desc, VkBuffer buffer, VkDeviceMemory memory,
+                 VkDevice device);
+    ~VulkanBuffer() override;
+
+    const std::string& GetDebugName() const override { return m_desc.debugName; }
+    void SetDebugName(const std::string& name) override { m_desc.debugName = name; }
+    bool IsValid() const override { return m_buffer != VK_NULL_HANDLE; }
+
+    const RHIBufferDesc& GetDesc() const override { return m_desc; }
+    uint64_t GetSize() const override { return m_desc.size; }
+    uint32_t GetStride() const override { return m_desc.stride; }
+    void* GetNativeHandle() const override { return reinterpret_cast<void*>(m_buffer); }
+
+    VkBuffer GetVkBuffer() const { return m_buffer; }
+    VkDeviceMemory GetVkMemory() const { return m_memory; }
+    void* GetMappedPtr() const { return m_mappedPtr; }
+    void SetMappedPtr(void* ptr) { m_mappedPtr = ptr; }
+
+private:
+    RHIBufferDesc m_desc;
+    VkBuffer m_buffer;
+    VkDeviceMemory m_memory;
+    VkDevice m_deviceRef;
+    void* m_mappedPtr = nullptr;
+};
+
+class VulkanTexture : public IRHITexture
+{
+public:
+    VulkanTexture(const RHITextureDesc& desc, VkImage image, VkDeviceMemory memory,
+                  VkImageView imageView, VkDevice device, bool ownsImage = true);
+    ~VulkanTexture() override;
+
+    const std::string& GetDebugName() const override { return m_desc.debugName; }
+    void SetDebugName(const std::string& name) override { m_desc.debugName = name; }
+    bool IsValid() const override { return m_image != VK_NULL_HANDLE; }
+
+    const RHITextureDesc& GetDesc() const override { return m_desc; }
+    uint32_t GetWidth() const override { return m_desc.width; }
+    uint32_t GetHeight() const override { return m_desc.height; }
+    uint32_t GetDepth() const override { return m_desc.depth; }
+    uint32_t GetMipLevels() const override { return m_desc.mipLevels; }
+    PixelFormat GetFormat() const override { return m_desc.format; }
+    void* GetNativeHandle() const override { return reinterpret_cast<void*>(m_image); }
+    void* GetShaderResourceView() const override { return reinterpret_cast<void*>(m_imageView); }
+    void* GetRenderTargetView() const override { return reinterpret_cast<void*>(m_imageView); }
+    void* GetDepthStencilView() const override { return reinterpret_cast<void*>(m_imageView); }
+
+    VkImage GetVkImage() const { return m_image; }
+    VkImageView GetVkImageView() const { return m_imageView; }
+    VkImageLayout GetCurrentLayout() const { return m_currentLayout; }
+    void SetCurrentLayout(VkImageLayout layout) { m_currentLayout = layout; }
+
+private:
+    RHITextureDesc m_desc;
+    VkImage m_image;
+    VkDeviceMemory m_memory;
+    VkImageView m_imageView;
+    VkDevice m_deviceRef;
+    VkImageLayout m_currentLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    bool m_ownsImage;
+};
+
+class VulkanShader : public IRHIShader
+{
+public:
+    VulkanShader(const RHIShaderDesc& desc, VkShaderModule module, VkDevice device,
+                 std::vector<uint8_t> spirvCode);
+    ~VulkanShader() override;
+
+    const std::string& GetDebugName() const override { return m_desc.debugName; }
+    void SetDebugName(const std::string& name) override { m_desc.debugName = name; }
+    bool IsValid() const override { return m_module != VK_NULL_HANDLE; }
+
+    RHIShaderStage GetStage() const override { return m_desc.stage; }
+    const std::string& GetEntryPoint() const override { return m_desc.entryPoint; }
+    void* GetNativeHandle() const override { return reinterpret_cast<void*>(m_module); }
+    const void* GetBytecode() const override { return m_spirvCode.data(); }
+    size_t GetBytecodeSize() const override { return m_spirvCode.size(); }
+
+    VkShaderModule GetVkModule() const { return m_module; }
+
+private:
+    RHIShaderDesc m_desc;
+    VkShaderModule m_module;
+    VkDevice m_deviceRef;
+    std::vector<uint8_t> m_spirvCode;
+};
+
+class VulkanSampler : public IRHISampler
+{
+public:
+    VulkanSampler(const RHISamplerDesc& desc, VkSampler sampler, VkDevice device);
+    ~VulkanSampler() override;
+
+    const std::string& GetDebugName() const override { return m_debugName; }
+    void SetDebugName(const std::string& name) override { m_debugName = name; }
+    bool IsValid() const override { return m_sampler != VK_NULL_HANDLE; }
+
+    const RHISamplerDesc& GetDesc() const override { return m_desc; }
+    void* GetNativeHandle() const override { return reinterpret_cast<void*>(m_sampler); }
+
+    VkSampler GetVkSampler() const { return m_sampler; }
+
+private:
+    RHISamplerDesc m_desc;
+    VkSampler m_sampler;
+    VkDevice m_deviceRef;
+    std::string m_debugName;
+};
+
+class VulkanPipelineState : public IRHIPipelineState
+{
+public:
+    VulkanPipelineState(const RHIPipelineStateDesc& desc, VkPipeline pipeline,
+                        VkPipelineLayout layout, VkDevice device);
+    ~VulkanPipelineState() override;
+
+    const std::string& GetDebugName() const override { return m_desc.debugName; }
+    void SetDebugName(const std::string& name) override { m_desc.debugName = name; }
+    bool IsValid() const override { return m_pipeline != VK_NULL_HANDLE; }
+
+    const RHIPipelineStateDesc& GetDesc() const override { return m_desc; }
+    void* GetNativeHandle() const override { return reinterpret_cast<void*>(m_pipeline); }
+
+    VkPipeline GetVkPipeline() const { return m_pipeline; }
+    VkPipelineLayout GetVkLayout() const { return m_layout; }
+
+private:
+    RHIPipelineStateDesc m_desc;
+    VkPipeline m_pipeline;
+    VkPipelineLayout m_layout;
+    VkDevice m_deviceRef;
+};
+
+// ============================================================================
+// VULKAN SWAP CHAIN
+// ============================================================================
+
+class VulkanSwapChain : public IRHISwapChain
+{
+public:
+    VulkanSwapChain(VkDevice device, VkPhysicalDevice physDevice,
+                    VkSurfaceKHR surface, const RHISwapChainDesc& desc,
+                    const QueueFamilyIndices& queueFamilies);
+    ~VulkanSwapChain() override;
+
+    bool Present(bool vsync) override;
+    bool Resize(uint32_t width, uint32_t height) override;
+    IRHITexture* GetBackBuffer() override;
+    PixelFormat GetFormat() const override { return m_desc.format; }
+    uint32_t GetWidth() const override { return m_desc.width; }
+    uint32_t GetHeight() const override { return m_desc.height; }
+    uint32_t GetCurrentBufferIndex() const override { return m_currentImageIndex; }
+
+    VkSwapchainKHR GetVkSwapChain() const { return m_swapChain; }
+    VkSemaphore GetImageAvailableSemaphore() const { return m_imageAvailable; }
+    VkSemaphore GetRenderFinishedSemaphore() const { return m_renderFinished; }
+
+private:
+    bool CreateSwapChain();
+    bool CreateImageViews();
+    bool CreateSyncObjects();
+    void Cleanup();
+
+    RHISwapChainDesc m_desc;
+    VkDevice m_device;
+    VkPhysicalDevice m_physDevice;
+    VkSurfaceKHR m_surface;
+    VkSwapchainKHR m_swapChain = VK_NULL_HANDLE;
+    QueueFamilyIndices m_queueFamilies;
+
+    std::vector<VkImage> m_swapChainImages;
+    std::vector<VkImageView> m_swapChainImageViews;
+    std::vector<std::unique_ptr<VulkanTexture>> m_backBuffers;
+    uint32_t m_currentImageIndex = 0;
+
+    VkSemaphore m_imageAvailable = VK_NULL_HANDLE;
+    VkSemaphore m_renderFinished = VK_NULL_HANDLE;
+    VkFence m_inFlightFence = VK_NULL_HANDLE;
+};
+
+// ============================================================================
+// VULKAN COMMAND LIST
+// ============================================================================
+
+class VulkanCommandList : public IRHICommandList
+{
+public:
+    VulkanCommandList(VkDevice device, VkCommandPool commandPool, bool isImmediate);
+    ~VulkanCommandList() override;
+
+    void Begin() override;
+    void End() override;
+    void Reset() override;
+
+    void SetRenderTargets(IRHITexture** renderTargets, uint32_t count,
+                          IRHITexture* depthStencil) override;
+    void ClearRenderTarget(IRHITexture* target, const float color[4]) override;
+    void ClearDepthStencil(IRHITexture* target, float depth, uint8_t stencil) override;
+
+    void SetViewport(const RHIViewport& viewport) override;
+    void SetScissorRect(const RHIScissorRect& rect) override;
+
+    void SetPipelineState(IRHIPipelineState* pipelineState) override;
+    void SetPrimitiveTopology(RHIPrimitiveTopology topology) override;
+
+    void SetVertexBuffer(IRHIBuffer* buffer, uint32_t slot, uint32_t offset) override;
+    void SetIndexBuffer(IRHIBuffer* buffer, uint32_t offset) override;
+    void SetConstantBuffer(RHIShaderStage stage, uint32_t slot, IRHIBuffer* buffer) override;
+    void SetShaderResource(RHIShaderStage stage, uint32_t slot, IRHITexture* texture) override;
+    void SetSampler(RHIShaderStage stage, uint32_t slot, IRHISampler* sampler) override;
+
+    void Draw(uint32_t vertexCount, uint32_t startVertex) override;
+    void DrawIndexed(uint32_t indexCount, uint32_t startIndex, int32_t baseVertex) override;
+    void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount,
+                       uint32_t startVertex, uint32_t startInstance) override;
+    void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
+                              uint32_t startIndex, int32_t baseVertex,
+                              uint32_t startInstance) override;
+
+    void Dispatch(uint32_t x, uint32_t y, uint32_t z) override;
+
+    void BeginEvent(const char* name) override;
+    void EndEvent() override;
+    void SetMarker(const char* name) override;
+
+    // Image layout transitions
+    void TransitionImageLayout(VkImage image, VkImageLayout oldLayout,
+                               VkImageLayout newLayout,
+                               VkImageAspectFlags aspectMask = VK_IMAGE_ASPECT_COLOR_BIT);
+
+    VkCommandBuffer GetVkCommandBuffer() const { return m_commandBuffer; }
+
+private:
+    VkDevice m_device;
+    VkCommandPool m_commandPool;
+    VkCommandBuffer m_commandBuffer = VK_NULL_HANDLE;
+    bool m_isImmediate;
+    bool m_isRecording = false;
+
+    // Current render pass state
+    VkRenderPass m_activeRenderPass = VK_NULL_HANDLE;
+    VkFramebuffer m_activeFramebuffer = VK_NULL_HANDLE;
+};
+
+// ============================================================================
+// VULKAN DEVICE
+// ============================================================================
+
+class VulkanDevice : public IRHIDevice
+{
+public:
+    VulkanDevice();
+    ~VulkanDevice() override;
+
+    bool Initialize(const RHIDeviceDesc& desc) override;
+    void Shutdown() override;
+
+    std::unique_ptr<IRHISwapChain> CreateSwapChain(const RHISwapChainDesc& desc) override;
+
+    IRHIBuffer* CreateBuffer(const RHIBufferDesc& desc) override;
+    IRHITexture* CreateTexture(const RHITextureDesc& desc) override;
+    IRHIShader* CreateShader(const RHIShaderDesc& desc) override;
+    IRHISampler* CreateSampler(const RHISamplerDesc& desc) override;
+    IRHIPipelineState* CreatePipelineState(const RHIPipelineStateDesc& desc,
+                                           IRHIShader* vertexShader,
+                                           IRHIShader* pixelShader) override;
+
+    void DestroyBuffer(IRHIBuffer* buffer) override;
+    void DestroyTexture(IRHITexture* texture) override;
+    void DestroyShader(IRHIShader* shader) override;
+    void DestroySampler(IRHISampler* sampler) override;
+    void DestroyPipelineState(IRHIPipelineState* state) override;
+
+    void* MapBuffer(IRHIBuffer* buffer) override;
+    void UnmapBuffer(IRHIBuffer* buffer) override;
+    void UpdateBuffer(IRHIBuffer* buffer, const void* data, size_t size, size_t offset) override;
+    void UpdateTexture(IRHITexture* texture, const void* data,
+                       uint32_t mipLevel, uint32_t arraySlice) override;
+
+    IRHICommandList* GetImmediateCommandList() override;
+    IRHICommandList* CreateDeferredCommandList() override;
+    void ExecuteCommandList(IRHICommandList* commandList) override;
+    void DestroyCommandList(IRHICommandList* commandList) override;
+
+    void BeginFrame() override;
+    void EndFrame() override;
+    void WaitForIdle() override;
+
+    GraphicsBackend GetBackendType() const override { return GraphicsBackend::Vulkan; }
+    const RHIDeviceCapabilities& GetCapabilities() const override { return m_capabilities; }
+    const RHIStatistics& GetStatistics() const override { return m_statistics; }
+    void ResetStatistics() override;
+    std::string GetDeviceInfo() const override;
+
+    // Vulkan-specific accessors
+    VkDevice GetVkDevice() const { return m_device; }
+    VkPhysicalDevice GetVkPhysicalDevice() const { return m_physicalDevice; }
+    VkInstance GetVkInstance() const { return m_instance; }
+    VkQueue GetGraphicsQueue() const { return m_graphicsQueue; }
+    VkQueue GetPresentQueue() const { return m_presentQueue; }
+    VkCommandPool GetCommandPool() const { return m_commandPool; }
+    const QueueFamilyIndices& GetQueueFamilies() const { return m_queueFamilies; }
+
+    // Memory helpers
+    uint32_t FindMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties) const;
+
+private:
+    bool CreateInstance(const RHIDeviceDesc& desc);
+    bool SelectPhysicalDevice();
+    bool CreateLogicalDevice();
+    bool CreateCommandPool();
+    QueueFamilyIndices FindQueueFamilies(VkPhysicalDevice device) const;
+    bool CheckDeviceExtensionSupport(VkPhysicalDevice device) const;
+    void QueryCapabilities();
+
+    // Format conversion
+    VkFormat ConvertFormat(PixelFormat format) const;
+    VkFilter ConvertFilter(RHIFilterMode mode) const;
+    VkSamplerAddressMode ConvertAddressMode(RHIAddressMode mode) const;
+    VkCompareOp ConvertCompareOp(RHICompareOp op) const;
+    VkStencilOp ConvertStencilOp(RHIStencilOp op) const;
+    VkBlendFactor ConvertBlendFactor(RHIBlendFactor factor) const;
+    VkBlendOp ConvertBlendOp(RHIBlendOp op) const;
+    VkPrimitiveTopology ConvertTopology(RHIPrimitiveTopology topology) const;
+    VkFormat ConvertVertexFormat(RHIVertexFormat format) const;
+
+    VkInstance m_instance = VK_NULL_HANDLE;
+    VkDebugUtilsMessengerEXT m_debugMessenger = VK_NULL_HANDLE;
+    VkPhysicalDevice m_physicalDevice = VK_NULL_HANDLE;
+    VkDevice m_device = VK_NULL_HANDLE;
+    VkQueue m_graphicsQueue = VK_NULL_HANDLE;
+    VkQueue m_presentQueue = VK_NULL_HANDLE;
+    VkQueue m_computeQueue = VK_NULL_HANDLE;
+    VkQueue m_transferQueue = VK_NULL_HANDLE;
+    VkCommandPool m_commandPool = VK_NULL_HANDLE;
+
+    QueueFamilyIndices m_queueFamilies;
+
+    std::unique_ptr<VulkanCommandList> m_immediateCommandList;
+    VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;
+    VkPipelineCache m_pipelineCache = VK_NULL_HANDLE;
+
+    RHIDeviceCapabilities m_capabilities;
+    RHIStatistics m_statistics;
+    bool m_validationEnabled = false;
+
+    const std::vector<const char*> m_deviceExtensions = {
+        VK_KHR_SWAPCHAIN_EXTENSION_NAME
+    };
+};
+
+}}} // namespace Spark::RHI::Vulkan
+
+#endif // SPARK_VULKAN_SUPPORT


### PR DESCRIPTION
Implement a comprehensive Rendering Hardware Interface (RHI) that abstracts graphics API backends, enabling the engine to run on D3D11, Vulkan, and OpenGL.

RHI Core:
- Platform-agnostic types, enums, and descriptors (RHITypes.h)
- Abstract resource interfaces for buffers, textures, shaders, samplers (RHIResources.h)
- Abstract device, swap chain, and command list interfaces (RHIDevice.h)
- Backend factory with runtime API detection and selection (RHIFactory)
- High-level RHI bridge with shader cache and convenience methods (RHIBridge)
- Master include header (RHI.h)

D3D11 Backend:
- Full D3D11 device wrapping existing DirectX 11 functionality through RHI
- Buffer, texture, shader, sampler, pipeline state implementations
- Swap chain, command list, format conversion helpers

Vulkan Backend:
- Vulkan 1.3 device with instance/physical device/logical device creation
- Queue family detection, memory type selection
- VkBuffer, VkImage, VkShaderModule, VkSampler, VkPipeline wrappers
- Swap chain with synchronization, command buffer management
- Image layout transitions, debug messenger support

OpenGL Backend:
- OpenGL 4.6 Core Profile device using DSA (Direct State Access)
- GLBuffer, GLTexture, GLShader (program linking), GLSampler, GLPipelineState
- VAO-based input layout, FBO-based render targets
- Platform-specific context creation (WGL/GLX)

GLSL Shaders (cross-platform equivalents of all HLSL shaders):
- BasicVS/BasicPS: PBR vertex/fragment with full UBO layout
- PBRSurface: Cook-Torrance BRDF with metallic-roughness workflow
- SSAO: 16-sample screen-space ambient occlusion
- BloomExtract: Luminance-based bright pass with soft knee
- GaussianBlur: Separable 9-tap Gaussian (horizontal/vertical variants)
- Water: Animated Fresnel reflection/refraction
- Phong: Blinn-Phong lighting model
- Rim: Fresnel-based rim/edge lighting
- EnvReflection: Cubemap reflections with roughness LOD
- PostProcess: ACES/Reinhard tonemapping, FXAA, vignette, chromatic aberration, grain
- FullscreenQuad: Procedural fullscreen triangle (no VBO needed)
- DebugVisualize: Depth, normal, UV, wireframe, overdraw visualization
- Utils: Shared noise, color space, shadow, math utilities

Shader Compilation Pipeline:
- compile_shaders.sh (Linux/macOS) and compile_shaders.bat (Windows)
- GLSL -> SPIR-V compilation via glslangValidator
- Optional SPIR-V optimization, validation mode, multi-variant compilation

CMake Build System:
- Vulkan SDK auto-detection (find_package + VULKAN_SDK env fallback)
- OpenGL + GLAD loader detection and linking
- SPARK_VULKAN_SUPPORT / SPARK_OPENGL_SUPPORT compile definitions
- GLSL and SPIR-V shader copy to output directory
- Backend availability status in configuration summary