### PR TITLE
Add VS 2026 (v144) and multi-compiler support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ on:
 
 jobs:
   # ===========================================================================
-  # Windows Build (MSVC + DirectX 11)
+  # Windows Build (MSVC VS 2022, v143 toolset + DirectX 11)
   # ===========================================================================
-  build-windows:
+  build-windows-vs2022:
     runs-on: windows-latest
     strategy:
       matrix:
@@ -25,8 +25,8 @@ jobs:
     - name: Setup MSVC
       uses: microsoft/setup-msbuild@v2
 
-    - name: Configure CMake
-      run: cmake -B build -G "Visual Studio 17 2022" -A x64 -DBUILD_TESTS=ON
+    - name: Configure CMake (VS 2022 / v143)
+      run: cmake -B build -G "Visual Studio 17 2022" -A x64 -DSPARK_MSVC_TOOLSET=v143 -DBUILD_TESTS=ON
 
     - name: Build
       run: cmake --build build --config ${{ matrix.config }} --parallel
@@ -39,19 +39,56 @@ jobs:
       if: matrix.config == 'Release'
       uses: actions/upload-artifact@v7
       with:
-        name: SparkEngine-Windows-${{ matrix.config }}
+        name: SparkEngine-Windows-VS2022-${{ matrix.config }}
         path: build/bin/${{ matrix.config }}/
         retention-days: 7
 
   # ===========================================================================
-  # Linux Build (GCC)
+  # Windows Build (MSVC VS 2026, v144 toolset + DirectX 11)
+  # Marked continue-on-error until VS 2026 runner images are broadly available.
   # ===========================================================================
-  build-linux:
+  build-windows-vs2026:
+    runs-on: windows-latest
+    continue-on-error: true   # Experimental: VS 2026 may not yet be on all runners
+    strategy:
+      matrix:
+        config: [Debug, Release]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+
+    - name: Setup MSVC
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Configure CMake (VS 2026 / v144)
+      run: cmake -B build -G "Visual Studio 19 2026" -A x64 -DSPARK_MSVC_TOOLSET=v144 -DBUILD_TESTS=ON
+
+    - name: Build
+      run: cmake --build build --config ${{ matrix.config }} --parallel
+
+    - name: Run Tests
+      if: matrix.config == 'Release'
+      run: ctest --test-dir build --config ${{ matrix.config }} --output-on-failure
+
+    - name: Upload Build Artifacts
+      if: matrix.config == 'Release'
+      uses: actions/upload-artifact@v7
+      with:
+        name: SparkEngine-Windows-VS2026-${{ matrix.config }}
+        path: build/bin/${{ matrix.config }}/
+        retention-days: 7
+
+  # ===========================================================================
+  # Linux Build - GCC
+  # ===========================================================================
+  build-linux-gcc:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
         config: [Debug, Release]
-        compiler: [gcc]
 
     steps:
     - name: Checkout repository
@@ -88,6 +125,54 @@ jobs:
       if: matrix.config == 'Release'
       uses: actions/upload-artifact@v7
       with:
-        name: SparkEngine-Linux-${{ matrix.config }}
+        name: SparkEngine-Linux-GCC-${{ matrix.config }}
+        path: build/bin/
+        retention-days: 7
+
+  # ===========================================================================
+  # Linux Build - Clang (LLVM)
+  # ===========================================================================
+  build-linux-clang:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        config: [Debug, Release]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang cmake libgl-dev libvulkan-dev
+
+    - name: Configure CMake
+      run: |
+        cmake -B build \
+          -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
+          -DBUILD_TESTS=ON \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_CXX_COMPILER=clang++
+
+    - name: Build Engine
+      run: cmake --build build --parallel $(nproc) --target SparkEngine
+
+    - name: Build Tests
+      run: cmake --build build --parallel $(nproc) --target SparkTests
+
+    - name: Run Tests
+      run: |
+        cd build
+        ctest --output-on-failure || true
+        ./bin/SparkTests
+
+    - name: Upload Build Artifacts
+      if: matrix.config == 'Release'
+      uses: actions/upload-artifact@v7
+      with:
+        name: SparkEngine-Linux-Clang-${{ matrix.config }}
         path: build/bin/
         retention-days: 7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,13 @@ if(MSVC)
     # automatically. Do NOT manually add /MD or /MDd flags as they conflict.
 endif()
 
+# MSVC toolset selection:
+#   v143 = Visual Studio 2022
+#   v144 = Visual Studio 2026
+# Override at configure time: cmake -DSPARK_MSVC_TOOLSET=v144 ...
+set(SPARK_MSVC_TOOLSET "" CACHE STRING
+    "MSVC toolset version (e.g. v143 for VS 2022, v144 for VS 2026). Empty = auto-detect.")
+
 # ---------------------------------------------------------------------
 # 1) Disable all third-party tests/examples globally
 # ---------------------------------------------------------------------
@@ -28,13 +35,57 @@ set(BUILD_DOCS OFF CACHE BOOL "Disable docs" FORCE)
 # ---------------------------------------------------------------------
 # Platform-specific generator settings (only if not already set)
 if(WIN32 AND NOT CMAKE_GENERATOR_TOOLSET)
-    set(CMAKE_GENERATOR_TOOLSET "v143")
+    if(NOT SPARK_MSVC_TOOLSET STREQUAL "")
+        set(CMAKE_GENERATOR_TOOLSET "${SPARK_MSVC_TOOLSET}")
+    else()
+        # Default to v143 (VS 2022). Use -DSPARK_MSVC_TOOLSET=v144 for VS 2026.
+        set(CMAKE_GENERATOR_TOOLSET "v143")
+    endif()
 endif()
 if(WIN32 AND NOT CMAKE_GENERATOR_PLATFORM)
     set(CMAKE_GENERATOR_PLATFORM "x64")
 endif()
 
 project(SparkEngine LANGUAGES CXX C)
+
+# ---------------------------------------------------------------------
+# 2.5) Compiler identification and version reporting
+# ---------------------------------------------------------------------
+if(MSVC)
+    # Map _MSC_VER ranges to Visual Studio release years
+    if(MSVC_VERSION GREATER_EQUAL 1950)
+        set(SPARK_VS_YEAR "2026+")
+        set(SPARK_VS_TOOLSET "v144+")
+    elseif(MSVC_VERSION GREATER_EQUAL 1940)
+        set(SPARK_VS_YEAR "2026")
+        set(SPARK_VS_TOOLSET "v144")
+    elseif(MSVC_VERSION GREATER_EQUAL 1930)
+        set(SPARK_VS_YEAR "2022")
+        set(SPARK_VS_TOOLSET "v143")
+    elseif(MSVC_VERSION GREATER_EQUAL 1920)
+        set(SPARK_VS_YEAR "2019")
+        set(SPARK_VS_TOOLSET "v142")
+    elseif(MSVC_VERSION GREATER_EQUAL 1910)
+        set(SPARK_VS_YEAR "2017")
+        set(SPARK_VS_TOOLSET "v141")
+    else()
+        set(SPARK_VS_YEAR "2015 or older")
+        set(SPARK_VS_TOOLSET "v14x")
+    endif()
+    message(STATUS "Compiler : MSVC Visual Studio ${SPARK_VS_YEAR} (${SPARK_VS_TOOLSET}, _MSC_VER=${MSVC_VERSION})")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    message(STATUS "Compiler : Apple Clang ${CMAKE_CXX_COMPILER_VERSION}")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+    message(STATUS "Compiler : Intel oneAPI DPC++/C++ (ICPX) ${CMAKE_CXX_COMPILER_VERSION}")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+    message(STATUS "Compiler : Intel C++ Classic (ICC) ${CMAKE_CXX_COMPILER_VERSION}")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(STATUS "Compiler : LLVM Clang ${CMAKE_CXX_COMPILER_VERSION}")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    message(STATUS "Compiler : GCC ${CMAKE_CXX_COMPILER_VERSION}")
+else()
+    message(STATUS "Compiler : ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+endif()
 
 # ---------------------------------------------------------------------
 # 3) Custom build options
@@ -111,7 +162,30 @@ if(MSVC)
         /wd26495 # Uninitialized member variable warnings (for TinyObjLoader)
     )
     add_compile_definitions(WIN32_LEAN_AND_MEAN NOMINMAX _CRT_SECURE_NO_WARNINGS)
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+
+    # Conformance improvements available in VS 2017+ - enforce __cplusplus macro and
+    # disable non-conforming extensions so code is portable across compilers.
+    if(MSVC_VERSION GREATER_EQUAL 1910)
+        add_compile_options(/Zc:__cplusplus /permissive-)
+    endif()
+
+    # VS 2026 (v144, _MSC_VER >= 1940): enable additional C++23 readiness flags
+    if(MSVC_VERSION GREATER_EQUAL 1940)
+        add_compile_options(
+            /Zc:preprocessor   # Standard-conforming preprocessor (fully enabled in v144)
+            /wd5045            # Spectre mitigation informational warning
+        )
+        add_compile_definitions(SPARK_COMPILER_VS2026)
+    # VS 2022 (v143, _MSC_VER 1930-1939)
+    elseif(MSVC_VERSION GREATER_EQUAL 1930)
+        add_compile_options(/Zc:preprocessor)
+        add_compile_definitions(SPARK_COMPILER_VS2022)
+    # VS 2019 (v142, _MSC_VER 1920-1929)
+    elseif(MSVC_VERSION GREATER_EQUAL 1920)
+        add_compile_definitions(SPARK_COMPILER_VS2019)
+    endif()
+
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang|IntelLLVM")
     add_compile_options(
         -Wall -Wextra
         -Wno-unused-parameter
@@ -122,18 +196,26 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         -Wno-reorder
         -Wno-ignored-qualifiers
     )
-    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         add_compile_options(
             -Wno-class-memaccess
             -Wno-stringop-truncation
         )
     endif()
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Clang (LLVM), Apple Clang, and Intel LLVM (ICPX) share Clang-compatible flags
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|IntelLLVM")
         add_compile_options(
             -Wno-unused-private-field
             -Wno-unused-lambda-capture
-            -Wno-microsoft-include
         )
+        # -Wno-microsoft-include only relevant on Windows with LLVM/Clang
+        if(WIN32)
+            add_compile_options(-Wno-microsoft-include)
+        endif()
+    endif()
+    # Intel LLVM (ICPX) extra suppressions
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+        add_compile_options(-Wno-tautological-constant-compare)
     endif()
 endif()
 
@@ -747,7 +829,11 @@ endif()
 # 17) Build summary
 # ---------------------------------------------------------------------
 message(STATUS "=== SPARKENGINE CONFIGURED SUCCESSFULLY ===")
-message(STATUS "Platform: ${CMAKE_SYSTEM_NAME} (${CMAKE_CXX_COMPILER_ID})")
+if(MSVC)
+    message(STATUS "Platform: ${CMAKE_SYSTEM_NAME} (MSVC VS ${SPARK_VS_YEAR} / ${SPARK_VS_TOOLSET})")
+else()
+    message(STATUS "Platform: ${CMAKE_SYSTEM_NAME} (${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION})")
+endif()
 message(STATUS "Output: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 message(STATUS "Graphics Backends:")
 if(WIN32)

--- a/Spark Engine/Source/Core/Platform.h
+++ b/Spark Engine/Source/Core/Platform.h
@@ -13,6 +13,73 @@
 #pragma once
 
 // ============================================================================
+// Compiler Detection
+// Defines SPARK_COMPILER_* macros before any platform-specific includes.
+// ============================================================================
+
+// --- MSVC (Visual Studio) ---
+#if defined(_MSC_VER)
+#  define SPARK_COMPILER_MSVC 1
+#  define SPARK_COMPILER_VERSION _MSC_VER
+   // Visual Studio release year mapping (_MSC_VER ranges):
+   //   VS 2017 (v141) : 1910-1916
+   //   VS 2019 (v142) : 1920-1929
+   //   VS 2022 (v143) : 1930-1939
+   //   VS 2026 (v144) : 1940+
+#  if _MSC_VER >= 1950
+#    define SPARK_COMPILER_MSVC_2026_PLUS 1
+#  elif _MSC_VER >= 1940
+#    define SPARK_COMPILER_MSVC_2026 1
+#  elif _MSC_VER >= 1930
+#    define SPARK_COMPILER_MSVC_2022 1
+#  elif _MSC_VER >= 1920
+#    define SPARK_COMPILER_MSVC_2019 1
+#  elif _MSC_VER >= 1910
+#    define SPARK_COMPILER_MSVC_2017 1
+#  endif
+
+// --- Apple Clang (must be checked before generic Clang) ---
+#elif defined(__clang__) && defined(__apple_build_version__)
+#  define SPARK_COMPILER_APPLE_CLANG 1
+#  define SPARK_COMPILER_CLANG 1
+#  define SPARK_COMPILER_VERSION \
+       (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+
+// --- Intel oneAPI DPC++/C++ (ICPX) - Clang-compatible ---
+#elif defined(__INTEL_LLVM_COMPILER)
+#  define SPARK_COMPILER_INTEL_LLVM 1
+#  define SPARK_COMPILER_CLANG 1   // ICPX is Clang-compatible
+#  define SPARK_COMPILER_VERSION __INTEL_LLVM_COMPILER
+
+// --- Intel Classic C++ Compiler (ICC) ---
+#elif defined(__INTEL_COMPILER)
+#  define SPARK_COMPILER_INTEL_CLASSIC 1
+#  define SPARK_COMPILER_VERSION __INTEL_COMPILER
+
+// --- Generic LLVM Clang ---
+#elif defined(__clang__)
+#  define SPARK_COMPILER_CLANG 1
+#  define SPARK_COMPILER_VERSION \
+       (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+
+// --- GCC ---
+#elif defined(__GNUC__)
+#  define SPARK_COMPILER_GCC 1
+#  define SPARK_COMPILER_VERSION \
+       (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
+#else
+#  define SPARK_COMPILER_UNKNOWN 1
+#  define SPARK_COMPILER_VERSION 0
+#endif
+
+// Convenience: true if any Clang-family compiler (Clang, Apple Clang, Intel LLVM)
+#if defined(SPARK_COMPILER_CLANG) || defined(SPARK_COMPILER_APPLE_CLANG) || \
+    defined(SPARK_COMPILER_INTEL_LLVM)
+#  define SPARK_COMPILER_CLANG_FAMILY 1
+#endif
+
+// ============================================================================
 // Platform Detection
 // ============================================================================
 

--- a/Spark Engine/Source/Utils/Assert.h
+++ b/Spark Engine/Source/Utils/Assert.h
@@ -6,9 +6,17 @@
 #include <ctime>
 #include <string>
 
-#ifdef _MSC_VER
+// DEBUG_BREAK: trigger a debugger breakpoint.
+//   - MSVC (all versions, including VS 2026): uses the intrinsic __debugbreak().
+//   - Modern Clang/GCC (incl. Apple Clang, Intel LLVM, GCC 12+): uses the
+//     portable __builtin_debugtrap() when available via __has_builtin.
+//   - Fallback: raise(SIGTRAP) on POSIX systems.
+#if defined(_MSC_VER)
 #  include <intrin.h>
 #  define DEBUG_BREAK() __debugbreak()
+#elif defined(__has_builtin) && __has_builtin(__builtin_debugtrap)
+   // Clang 3.8+, Apple Clang, Intel LLVM (ICPX), GCC 12+
+#  define DEBUG_BREAK() __builtin_debugtrap()
 #else
 #  include <signal.h>
 #  define DEBUG_BREAK() raise(SIGTRAP)

--- a/SparkEditor/Source/BuildSystem/BuildDeploymentSystem.h
+++ b/SparkEditor/Source/BuildSystem/BuildDeploymentSystem.h
@@ -285,6 +285,14 @@ struct BuildSystemConfig {
     std::string buildCacheDirectory = "Temp/BuildCache/"; ///< Build cache directory
     
     // Toolchain settings
+    // Supported compiler identifiers:
+    //   "msvc"        - MSVC (auto-detect installed VS version)
+    //   "vs2022"      - Visual Studio 2022 (v143, _MSC_VER 1930-1939)
+    //   "vs2026"      - Visual Studio 2026 (v144, _MSC_VER 1940+)
+    //   "gcc"         - GCC (Linux/macOS)
+    //   "clang"       - LLVM Clang
+    //   "apple-clang" - Apple Clang (macOS)
+    //   "icpx"        - Intel oneAPI DPC++/C++ Compiler (ICPX/IntelLLVM)
     std::string defaultCompiler = "msvc";       ///< Default compiler
     std::string buildToolPath;                  ///< Build tool path
     std::string sdkPath;                        ///< SDK path


### PR DESCRIPTION
- CMakeLists.txt: add SPARK_MSVC_TOOLSET cache option (v143/v144); detect MSVC version post-project() and emit VS year/toolset in status messages; extend compiler flags to cover AppleClang, IntelLLVM (ICPX), and per-VS-version conformance flags (/Zc:__cplusplus, /permissive-, /Zc:preprocessor); add SPARK_COMPILER_VS2026/VS2022/VS2019 definitions.
- Platform.h: new SPARK_COMPILER_* detection macros covering MSVC (with VS 2017/2019/2022/2026 sub-macros), Apple Clang, Intel LLVM (ICPX), Intel Classic (ICC), LLVM Clang, and GCC; includes SPARK_COMPILER_CLANG_FAMILY convenience macro.
- Assert.h: modernise DEBUG_BREAK() – use __builtin_debugtrap() via __has_builtin when available (Clang 3.8+, Apple Clang, ICPX, GCC 12+) instead of the POSIX raise(SIGTRAP) fallback, while keeping MSVC __debugbreak() and the legacy POSIX path unchanged.
- build.yml: rename Windows job to build-windows-vs2022; add build-windows-vs2026 job (VS 19 2026, v144, continue-on-error); rename Linux GCC job to build-linux-gcc; add new build-linux-clang job.
- BuildDeploymentSystem.h: document supported compiler identifier strings (msvc, vs2022, vs2026, gcc, clang, apple-clang, icpx) on defaultCompiler.