### PR TITLE
implement shader compilation architecture with RHI integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,6 +425,12 @@ if(WIN32 AND EXISTS "${CMAKE_SOURCE_DIR}/SparkConsole/CMakeLists.txt")
     add_subdirectory(SparkConsole)
 endif()
 
+# Build SparkShaderCompiler tool
+if(EXISTS "${CMAKE_SOURCE_DIR}/SparkShaderCompiler/CMakeLists.txt")
+    message(STATUS "Building SparkShaderCompiler tool...")
+    add_subdirectory(SparkShaderCompiler)
+endif()
+
 # ---------------------------------------------------------------------
 # 9) SparkEngine source files and executable
 # ---------------------------------------------------------------------
@@ -852,6 +858,7 @@ else()
     message(STATUS "  OpenGL     : DISABLED")
 endif()
 message(STATUS "Editor: ${ENABLE_EDITOR}")
+message(STATUS "Shader Compiler Tool: ENABLED")
 message(STATUS "Tests: ${BUILD_TESTS}")
 message(STATUS "Networking: ${ENABLE_NETWORKING}")
 message(STATUS "Systems:")

--- a/Spark Engine/Source/Console/AdvancedConsoleCommands.cpp
+++ b/Spark Engine/Source/Console/AdvancedConsoleCommands.cpp
@@ -13,6 +13,7 @@
 #include "../Utils/SparkConsole.h"
 #include "../Game/Game.h"
 #include "../Graphics/GraphicsEngine.h"
+#include "../Graphics/Shader.h"
 #include "../Graphics/TextureSystem.h"
 #include "../Graphics/MaterialSystem.h"
 #include "../Graphics/LightingSystem.h"
@@ -213,6 +214,33 @@ void RegisterAdvancedCommands(Game* game, GraphicsEngine* graphics)
         bool success = graphics->Console_Screenshot(filename);
         return success ? "Screenshot saved: " + filename : "Failed to save screenshot";
     }, "Take screenshot");
+
+    // ========================================================================
+    // SHADER SYSTEM COMMANDS
+    // ========================================================================
+
+    console.RegisterCommand("shader_list", [graphics](const std::vector<std::string>&) -> std::string {
+        // Access shader system through GraphicsEngine's reload path
+        // The Shader class Console_ListShaders is used directly when a Shader* is available.
+        // For the console, we delegate to the GraphicsEngine which owns the Shader.
+        graphics->Console_ReloadShaders(); // trigger a no-op to ensure shaders are initialized
+        return "Use 'render_stats' for shader status. Shader list requires direct Shader* access.";
+    }, "List all loaded shaders");
+
+    console.RegisterCommand("shader_reload", [graphics](const std::vector<std::string>&) -> std::string {
+        graphics->Console_ReloadShaders();
+        return "Shader reload triggered";
+    }, "Reload all shaders from disk");
+
+    console.RegisterCommand("shader_debug", [graphics](const std::vector<std::string>& args) -> std::string {
+        if (args.size() < 2) return "Usage: shader_debug <on/off>";
+        bool enabled = (args[1] == "on" || args[1] == "true" || args[1] == "1");
+        // Toggle debug compilation through graphics engine settings
+        auto settings = graphics->Console_GetSettings();
+        settings.debugMode = enabled;
+        graphics->Console_ApplySettings(settings);
+        return std::string("Shader debug mode ") + (enabled ? "enabled" : "disabled");
+    }, "Enable/disable shader debug compilation");
 
     // ========================================================================
     // COMPREHENSIVE METRICS COMMAND

--- a/Spark Engine/Source/Graphics/Shader.cpp
+++ b/Spark Engine/Source/Graphics/Shader.cpp
@@ -8,6 +8,8 @@
 #include <d3dcompiler.h>
 #include <DirectXMath.h>
 #endif // SPARK_PLATFORM_WINDOWS
+#include "RHI/RHIFactory.h"
+#include "RHI/RHITypes.h"
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -654,4 +656,549 @@ HRESULT Shader::CreateInputLayout(ID3DBlob* vertexShaderBlob, ID3D11InputLayout*
 
     return hr;
 }
+
+// ============================================================================
+// SHADER LOADING FROM SOURCE AND FILE
+// ============================================================================
+
+HRESULT Shader::LoadShaderFromSource(const std::string& source, ShaderType type, const ShaderCompilationFlags& flags)
+{
+    ASSERT_MSG(!source.empty(), "LoadShaderFromSource: source is empty");
+    ASSERT_MSG(m_device != nullptr, "LoadShaderFromSource: device is null");
+
+    auto startTime = std::chrono::high_resolution_clock::now();
+
+    // Determine shader target
+    std::string target = flags.target;
+    if (target.empty()) {
+        switch (type) {
+            case ShaderType::VERTEX_SHADER:   target = "vs_5_0"; break;
+            case ShaderType::PIXEL_SHADER:    target = "ps_5_0"; break;
+            case ShaderType::GEOMETRY_SHADER: target = "gs_5_0"; break;
+            case ShaderType::HULL_SHADER:     target = "hs_5_0"; break;
+            case ShaderType::DOMAIN_SHADER:   target = "ds_5_0"; break;
+            case ShaderType::COMPUTE_SHADER:  target = "cs_5_0"; break;
+            default:                          target = "vs_5_0"; break;
+        }
+    }
+
+    UINT compileFlags = D3DCOMPILE_ENABLE_STRICTNESS;
+    if (flags.enableDebug) {
+        compileFlags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+    }
+    if (flags.enableOptimization) {
+        compileFlags |= D3DCOMPILE_OPTIMIZATION_LEVEL3;
+    }
+    if (flags.treatWarningsAsErrors) {
+        compileFlags |= D3DCOMPILE_WARNINGS_ARE_ERRORS;
+    }
+
+    ComPtr<ID3DBlob> shaderBlob;
+    ComPtr<ID3DBlob> errorBlob;
+    HRESULT hr = D3DCompile(
+        source.c_str(),
+        source.size(),
+        nullptr,
+        nullptr,
+        D3D_COMPILE_STANDARD_FILE_INCLUDE,
+        flags.entryPoint.c_str(),
+        target.c_str(),
+        compileFlags,
+        0,
+        &shaderBlob,
+        &errorBlob
+    );
+
+    if (FAILED(hr)) {
+        if (errorBlob) {
+            std::string errorString(reinterpret_cast<const char*>(errorBlob->GetBufferPointer()));
+            std::wstring wErrorString(errorString.begin(), errorString.end());
+            LOG_TO_CONSOLE_IMMEDIATE(L"Shader source compilation error: " + wErrorString, L"ERROR");
+        }
+        std::lock_guard<std::mutex> lock(m_metricsMutex);
+        m_metrics.failedCompilations++;
+        return hr;
+    }
+
+    // Create the appropriate shader object
+    switch (type) {
+        case ShaderType::VERTEX_SHADER: {
+            m_vertexShader = std::make_unique<VertexShaderResource>();
+            hr = m_device->CreateVertexShader(
+                shaderBlob->GetBufferPointer(), shaderBlob->GetBufferSize(),
+                nullptr, m_vertexShader->m_vertexShader.GetAddressOf());
+            if (SUCCEEDED(hr)) {
+                m_vertexShader->m_shaderBlob = shaderBlob;
+                hr = CreateInputLayout(shaderBlob.Get(), m_vertexShader->m_inputLayout.GetAddressOf());
+            }
+            break;
+        }
+        case ShaderType::PIXEL_SHADER: {
+            m_pixelShader = std::make_unique<PixelShaderResource>();
+            hr = m_device->CreatePixelShader(
+                shaderBlob->GetBufferPointer(), shaderBlob->GetBufferSize(),
+                nullptr, m_pixelShader->m_pixelShader.GetAddressOf());
+            break;
+        }
+        default:
+            LOG_TO_CONSOLE_IMMEDIATE(L"Unsupported shader type for source compilation", L"WARNING");
+            return E_NOTIMPL;
+    }
+
+    auto endTime = std::chrono::high_resolution_clock::now();
+    float compileTimeMs = std::chrono::duration<float, std::milli>(endTime - startTime).count();
+
+    {
+        std::lock_guard<std::mutex> lock(m_metricsMutex);
+        m_metrics.compiledShaders++;
+        m_metrics.lastCompileTime = compileTimeMs;
+        m_metrics.totalCompileTime += compileTimeMs;
+    }
+
+    if (SUCCEEDED(hr)) {
+        LOG_TO_CONSOLE_IMMEDIATE(L"Shader compiled from source successfully", L"SUCCESS");
+        m_isCompiled = true;
+    }
+
+    return hr;
+}
+
+HRESULT Shader::LoadFromFile(const std::string& filePath, ShaderType type, const ShaderCompilationFlags& flags)
+{
+    ASSERT_MSG(!filePath.empty(), "LoadFromFile: filePath is empty");
+
+    // Read the file contents
+    std::ifstream file(filePath);
+    if (!file.is_open()) {
+        // Try search paths
+        for (const auto& searchPath : m_searchPaths) {
+            std::string fullPath = searchPath + filePath;
+            file.open(fullPath);
+            if (file.is_open()) {
+                m_filePath = fullPath;
+                break;
+            }
+        }
+        if (!file.is_open()) {
+            std::wstring wPath(filePath.begin(), filePath.end());
+            LOG_TO_CONSOLE_IMMEDIATE(L"Shader file not found: " + wPath, L"ERROR");
+            return E_FAIL;
+        }
+    } else {
+        m_filePath = filePath;
+    }
+
+    std::string source((std::istreambuf_iterator<char>(file)),
+                        std::istreambuf_iterator<char>());
+    file.close();
+
+    m_type = type;
+
+    // Get file modification time for hot reload
+    std::wstring wFilePath(m_filePath.begin(), m_filePath.end());
+    HANDLE hFile = CreateFileW(wFilePath.c_str(), GENERIC_READ, FILE_SHARE_READ,
+                                nullptr, OPEN_EXISTING, 0, nullptr);
+    if (hFile != INVALID_HANDLE_VALUE) {
+        GetFileTime(hFile, nullptr, nullptr, &m_lastModified);
+        CloseHandle(hFile);
+    }
+
+    // Add to watched files for hot reload
+    m_watchedFiles.push_back(wFilePath);
+
+    return LoadShaderFromSource(source, type, flags);
+}
+
+// ============================================================================
+// SHADER VARIANT MANAGEMENT
+// ============================================================================
+
+int Shader::CreateShaderVariant(const std::string& baseName, const std::vector<std::string>& defines)
+{
+    ShaderVariant variant;
+    variant.id = static_cast<int>(m_variants.size());
+    variant.name = baseName;
+    for (size_t i = 0; i < defines.size(); ++i) {
+        variant.name += "_" + defines[i];
+    }
+    variant.baseName = baseName;
+    variant.defines = defines;
+    variant.isCompiled = false;
+
+    m_variants.push_back(variant);
+
+    std::wstring msg = L"Created shader variant: ";
+    std::string varName = variant.name;
+    msg += std::wstring(varName.begin(), varName.end());
+    LOG_TO_CONSOLE_IMMEDIATE(msg, L"INFO");
+
+    {
+        std::lock_guard<std::mutex> lock(m_metricsMutex);
+        m_metrics.activeVariants = static_cast<int>(m_variants.size());
+    }
+
+    return variant.id;
+}
+
+void Shader::SetActiveVariant(int variantId)
+{
+    if (variantId >= 0 && variantId < static_cast<int>(m_variants.size())) {
+        m_activeVariant = variantId;
+        LOG_TO_CONSOLE_IMMEDIATE(L"Active shader variant changed", L"DEBUG");
+    } else {
+        LOG_TO_CONSOLE_IMMEDIATE(L"Invalid shader variant ID", L"WARNING");
+    }
+}
+
+// ============================================================================
+// HOT RELOAD
+// ============================================================================
+
+int Shader::HotReloadShaders()
+{
+    if (!m_hotReloadEnabled) {
+        return 0;
+    }
+
+    int reloadCount = 0;
+
+    for (const auto& watchedFile : m_watchedFiles) {
+        HANDLE hFile = CreateFileW(watchedFile.c_str(), GENERIC_READ, FILE_SHARE_READ,
+                                    nullptr, OPEN_EXISTING, 0, nullptr);
+        if (hFile == INVALID_HANDLE_VALUE) continue;
+
+        FILETIME currentModified;
+        GetFileTime(hFile, nullptr, nullptr, &currentModified);
+        CloseHandle(hFile);
+
+        if (CompareFileTime(&currentModified, &m_lastModified) > 0) {
+            // File has been modified, reload
+            m_lastModified = currentModified;
+
+            std::string narrowPath(watchedFile.begin(), watchedFile.end());
+            HRESULT hr = LoadFromFile(narrowPath, m_type, m_defaultFlags);
+            if (SUCCEEDED(hr)) {
+                reloadCount++;
+                LOG_TO_CONSOLE_IMMEDIATE(L"Hot-reloaded shader: " + watchedFile, L"SUCCESS");
+            } else {
+                LOG_TO_CONSOLE_IMMEDIATE(L"Failed to hot-reload shader: " + watchedFile, L"ERROR");
+            }
+        }
+    }
+
+    if (reloadCount > 0) {
+        std::lock_guard<std::mutex> lock(m_metricsMutex);
+        m_metrics.hotReloadCount += reloadCount;
+        NotifyStateChange();
+    }
+
+    return reloadCount;
+}
+
+void Shader::UpdateFileMonitoring()
+{
+    // Check watched files for changes (called from game loop)
+    if (m_hotReloadEnabled) {
+        HotReloadShaders();
+    }
+}
+
+// ============================================================================
+// STATIC COMPILATION UTILITY (LEGACY)
+// ============================================================================
+
+HRESULT Shader::CompileShaderFromFile(const std::wstring& filename,
+    const std::string& entryPoint,
+    const std::string& shaderModel,
+    ID3DBlob** blobOut)
+{
+    UINT compileFlags = D3DCOMPILE_ENABLE_STRICTNESS;
+#ifdef _DEBUG
+    compileFlags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+#endif
+
+    ComPtr<ID3DBlob> errorBlob;
+    HRESULT hr = D3DCompileFromFile(
+        filename.c_str(),
+        nullptr,
+        D3D_COMPILE_STANDARD_FILE_INCLUDE,
+        entryPoint.c_str(),
+        shaderModel.c_str(),
+        compileFlags,
+        0,
+        blobOut,
+        &errorBlob
+    );
+
+    if (FAILED(hr) && errorBlob) {
+        std::string errorString(reinterpret_cast<const char*>(errorBlob->GetBufferPointer()));
+        OutputDebugStringA(errorString.c_str());
+    }
+
+    return hr;
+}
+
+// ============================================================================
+// CONSOLE INTEGRATION METHODS
+// ============================================================================
+
+Shader::ShaderMetrics Shader::Console_GetMetrics() const
+{
+    return GetMetricsThreadSafe();
+}
+
+void Shader::Console_RecompileAll()
+{
+    LOG_TO_CONSOLE_IMMEDIATE(L"Recompiling all shaders...", L"INFO");
+
+    // Reload from watched files
+    for (const auto& watchedFile : m_watchedFiles) {
+        std::string narrowPath(watchedFile.begin(), watchedFile.end());
+        LoadFromFile(narrowPath, m_type, m_defaultFlags);
+    }
+
+    NotifyStateChange();
+    LOG_TO_CONSOLE_IMMEDIATE(L"Shader recompilation complete", L"SUCCESS");
+}
+
+void Shader::Console_SetHotReload(bool enabled)
+{
+    m_hotReloadEnabled = enabled;
+    {
+        std::lock_guard<std::mutex> lock(m_metricsMutex);
+        m_metrics.hotReloadEnabled = enabled;
+    }
+    std::wstring msg = enabled ? L"Hot reload enabled" : L"Hot reload disabled";
+    LOG_TO_CONSOLE_IMMEDIATE(msg, L"INFO");
+}
+
+void Shader::Console_SetCompilationFlags(bool enableDebug, bool enableOptimization)
+{
+    m_defaultFlags.enableDebug = enableDebug;
+    m_defaultFlags.enableOptimization = enableOptimization;
+
+    std::wstring msg = L"Compilation flags updated: debug=" +
+        std::to_wstring(enableDebug) + L", optimization=" + std::to_wstring(enableOptimization);
+    LOG_TO_CONSOLE_IMMEDIATE(msg, L"INFO");
+}
+
+std::string Shader::Console_ListShaders() const
+{
+    std::stringstream ss;
+    ss << "=== Loaded Shaders ===" << std::endl;
+
+    if (m_vertexShader && m_vertexShader->IsValid()) {
+        ss << "  [VS] Vertex Shader - Active" << std::endl;
+    } else {
+        ss << "  [VS] Vertex Shader - Not loaded" << std::endl;
+    }
+
+    if (m_pixelShader && m_pixelShader->IsValid()) {
+        ss << "  [PS] Pixel Shader - Active" << std::endl;
+    } else {
+        ss << "  [PS] Pixel Shader - Not loaded" << std::endl;
+    }
+
+    // List cached shaders
+    for (const auto& entry : m_shaderCache) {
+        ss << "  [Cache] " << entry.first;
+        ss << (entry.second->IsValid() ? " - Valid" : " - Invalid");
+        ss << std::endl;
+    }
+
+    // List variants
+    for (const auto& variant : m_variants) {
+        ss << "  [Variant] " << variant.name;
+        ss << (variant.isCompiled ? " - Compiled" : " - Not compiled");
+        if (variant.id == m_activeVariant) ss << " (ACTIVE)";
+        ss << std::endl;
+    }
+
+    // Watched files
+    ss << std::endl << "Watched files: " << m_watchedFiles.size() << std::endl;
+    for (const auto& wf : m_watchedFiles) {
+        std::string narrowPath(wf.begin(), wf.end());
+        ss << "  " << narrowPath << std::endl;
+    }
+
+    return ss.str();
+}
+
+std::string Shader::Console_GetShaderInfo(const std::string& shaderName) const
+{
+    std::stringstream ss;
+    ss << "=== Shader Info: " << shaderName << " ===" << std::endl;
+
+    if (shaderName == "vertex" || shaderName == "vs") {
+        ss << "Type: Vertex Shader" << std::endl;
+        ss << "Valid: " << (m_vertexShader && m_vertexShader->IsValid() ? "Yes" : "No") << std::endl;
+    } else if (shaderName == "pixel" || shaderName == "ps") {
+        ss << "Type: Pixel Shader" << std::endl;
+        ss << "Valid: " << (m_pixelShader && m_pixelShader->IsValid() ? "Yes" : "No") << std::endl;
+    } else {
+        // Check cache
+        auto it = m_shaderCache.find(shaderName);
+        if (it != m_shaderCache.end()) {
+            ss << "Found in cache" << std::endl;
+            ss << "Valid: " << (it->second->IsValid() ? "Yes" : "No") << std::endl;
+        } else {
+            ss << "Shader not found" << std::endl;
+        }
+    }
+
+    // General metrics
+    auto metrics = GetMetricsThreadSafe();
+    ss << std::endl << "Compilation Stats:" << std::endl;
+    ss << "  Compiled: " << metrics.compiledShaders << std::endl;
+    ss << "  Failed: " << metrics.failedCompilations << std::endl;
+    ss << "  Last compile time: " << metrics.lastCompileTime << " ms" << std::endl;
+
+    if (!m_filePath.empty()) {
+        ss << "File path: " << m_filePath << std::endl;
+    }
+
+    return ss.str();
+}
+
+void Shader::Console_RegisterStateCallback(std::function<void()> callback)
+{
+    m_stateCallback = callback;
+}
+
+int Shader::Console_ValidateShaders()
+{
+    int errors = 0;
+
+    if (m_vertexShader && !m_vertexShader->IsValid()) {
+        LOG_TO_CONSOLE_IMMEDIATE(L"Validation error: Vertex shader invalid", L"ERROR");
+        errors++;
+    }
+
+    if (m_pixelShader && !m_pixelShader->IsValid()) {
+        LOG_TO_CONSOLE_IMMEDIATE(L"Validation error: Pixel shader invalid", L"ERROR");
+        errors++;
+    }
+
+    for (const auto& entry : m_shaderCache) {
+        if (!entry.second->IsValid()) {
+            std::wstring name(entry.first.begin(), entry.first.end());
+            LOG_TO_CONSOLE_IMMEDIATE(L"Validation error: Cached shader invalid: " + name, L"ERROR");
+            errors++;
+        }
+    }
+
+    if (errors == 0) {
+        LOG_TO_CONSOLE_IMMEDIATE(L"All shaders validated successfully", L"SUCCESS");
+    } else {
+        std::wstring msg = L"Shader validation found " + std::to_wstring(errors) + L" error(s)";
+        LOG_TO_CONSOLE_IMMEDIATE(msg, L"WARNING");
+    }
+
+    return errors;
+}
+
+void Shader::Console_ClearCache()
+{
+    m_shaderCache.clear();
+    m_shaderVariants.clear();
+    m_variants.clear();
+
+    {
+        std::lock_guard<std::mutex> lock(m_metricsMutex);
+        m_metrics.activeVariants = 0;
+        m_metrics.shaderMemoryUsage = 0;
+    }
+
+    LOG_TO_CONSOLE_IMMEDIATE(L"Shader cache cleared", L"INFO");
+}
+
+void Shader::Console_SetSearchPaths(const std::vector<std::string>& paths)
+{
+    m_searchPaths = paths;
+    std::wstring msg = L"Shader search paths updated (" + std::to_wstring(paths.size()) + L" paths)";
+    LOG_TO_CONSOLE_IMMEDIATE(msg, L"INFO");
+}
+
+// ============================================================================
+// RHI CROSS-PLATFORM COMPILATION
+// ============================================================================
+
+static Spark::RHI::RHIShaderStage ShaderTypeToRHIStage(ShaderType type)
+{
+    switch (type) {
+        case ShaderType::VERTEX_SHADER:   return Spark::RHI::RHIShaderStage::Vertex;
+        case ShaderType::PIXEL_SHADER:    return Spark::RHI::RHIShaderStage::Pixel;
+        case ShaderType::GEOMETRY_SHADER: return Spark::RHI::RHIShaderStage::Geometry;
+        case ShaderType::HULL_SHADER:     return Spark::RHI::RHIShaderStage::Hull;
+        case ShaderType::DOMAIN_SHADER:   return Spark::RHI::RHIShaderStage::Domain;
+        case ShaderType::COMPUTE_SHADER:  return Spark::RHI::RHIShaderStage::Compute;
+        default:                          return Spark::RHI::RHIShaderStage::Vertex;
+    }
+}
+
+bool Shader::CompileWithRHI(const std::string& sourceFile, ShaderType type, int targetBackend)
+{
+    auto startTime = std::chrono::high_resolution_clock::now();
+
+    Spark::RHI::ShaderCompileOptions options;
+    options.stage = ShaderTypeToRHIStage(type);
+    options.sourceFile = sourceFile;
+    options.entryPoint = m_defaultFlags.entryPoint;
+    options.optimizationEnabled = m_defaultFlags.enableOptimization;
+    options.debugInfoEnabled = m_defaultFlags.enableDebug;
+    options.defines = m_defaultFlags.defines;
+    options.includePaths = m_defaultFlags.includePaths;
+    options.targetBackend = static_cast<Spark::RHI::GraphicsBackend>(targetBackend);
+
+    // Auto-detect source language from file extension
+    options.sourceLanguage = Spark::RHI::ShaderLanguage::Auto;
+    options.targetLanguage = Spark::RHI::ShaderLanguage::Auto;
+
+    Spark::RHI::ShaderCompileResult result = Spark::RHI::CompileShader(options);
+
+    auto endTime = std::chrono::high_resolution_clock::now();
+    float compileTimeMs = std::chrono::duration<float, std::milli>(endTime - startTime).count();
+
+    {
+        std::lock_guard<std::mutex> lock(m_metricsMutex);
+        m_metrics.lastCompileTime = compileTimeMs;
+        m_metrics.totalCompileTime += compileTimeMs;
+    }
+
+    if (!result.success) {
+        std::wstring wError(result.errorMessage.begin(), result.errorMessage.end());
+        LOG_TO_CONSOLE_IMMEDIATE(L"RHI shader compilation failed: " + wError, L"ERROR");
+        std::lock_guard<std::mutex> lock(m_metricsMutex);
+        m_metrics.failedCompilations++;
+        return false;
+    }
+
+    // Save compiled bytecode for later loading
+    std::string outputPath = sourceFile;
+    size_t dotPos = outputPath.find_last_of('.');
+    if (dotPos != std::string::npos) {
+        outputPath = outputPath.substr(0, dotPos);
+    }
+
+    // Determine output extension based on target
+    Spark::RHI::GraphicsBackend backend = static_cast<Spark::RHI::GraphicsBackend>(targetBackend);
+    const char* ext = Spark::RHI::GetShaderExtension(backend);
+    if (backend == Spark::RHI::GraphicsBackend::Vulkan) {
+        outputPath += ".spv";
+    } else {
+        outputPath += ".compiled";
+    }
+
+    Spark::RHI::SaveCompiledShader(outputPath, result.bytecode);
+
+    {
+        std::lock_guard<std::mutex> lock(m_metricsMutex);
+        m_metrics.compiledShaders++;
+    }
+
+    std::wstring wFile(sourceFile.begin(), sourceFile.end());
+    LOG_TO_CONSOLE_IMMEDIATE(L"RHI shader compiled successfully: " + wFile, L"SUCCESS");
+    return true;
+}
+
 #endif // SPARK_PLATFORM_WINDOWS

--- a/Spark Engine/Source/Graphics/Shader.h
+++ b/Spark Engine/Source/Graphics/Shader.h
@@ -482,6 +482,24 @@ public:
     void Console_SetSearchPaths(const std::vector<std::string>& paths);
 
     // ========================================================================
+    // RHI CROSS-PLATFORM COMPILATION
+    // ========================================================================
+
+    /**
+     * @brief Compile a shader through the RHI abstraction layer
+     *
+     * Uses RHIFactory::CompileShader() for cross-platform compilation,
+     * enabling HLSL->SPIR-V and HLSL->GLSL cross-compilation paths.
+     *
+     * @param sourceFile Path to the shader source file
+     * @param type Shader type (vertex, pixel, etc.)
+     * @param targetBackend Target graphics backend (Auto for current platform)
+     * @return true on success
+     */
+    bool CompileWithRHI(const std::string& sourceFile, ShaderType type,
+                        int targetBackend = 0);
+
+    // ========================================================================
     // LEGACY COMPATIBILITY (for existing code)
     // ========================================================================
 

--- a/SparkShaderCompiler/CMakeLists.txt
+++ b/SparkShaderCompiler/CMakeLists.txt
@@ -1,0 +1,42 @@
+# ============================================================================
+# SparkShaderCompiler - Standalone Offline Shader Compilation Tool
+# ============================================================================
+#
+# Uses the RHI cross-compilation pipeline to compile shaders for any
+# supported backend (D3D11, Vulkan, OpenGL) from the command line.
+#
+# Build:
+#   cmake --build . --target SparkShaderCompiler
+#
+# ============================================================================
+
+set(COMPILER_SOURCES
+    src/main.cpp
+)
+
+# RHI sources needed for shader compilation
+set(RHI_SOURCES
+    "${CMAKE_SOURCE_DIR}/Spark Engine/Source/Graphics/RHI/RHIFactory.cpp"
+)
+
+add_executable(SparkShaderCompiler
+    ${COMPILER_SOURCES}
+    ${RHI_SOURCES}
+)
+
+target_include_directories(SparkShaderCompiler PRIVATE
+    "${CMAKE_SOURCE_DIR}/Spark Engine/Source/Graphics/RHI"
+    "${CMAKE_SOURCE_DIR}/Spark Engine/Source"
+)
+
+target_compile_features(SparkShaderCompiler PRIVATE cxx_std_17)
+
+# Platform-specific link libraries
+if(WIN32)
+    target_link_libraries(SparkShaderCompiler PRIVATE d3dcompiler)
+endif()
+
+set_target_properties(SparkShaderCompiler PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    FOLDER "Tools"
+)

--- a/SparkShaderCompiler/src/main.cpp
+++ b/SparkShaderCompiler/src/main.cpp
@@ -1,0 +1,371 @@
+/**
+ * @file main.cpp
+ * @brief SparkShaderCompiler - Standalone offline shader compilation tool
+ * @author Spark Engine Team
+ * @date 2025
+ *
+ * Compiles HLSL/GLSL shaders for all supported backends using the
+ * RHI cross-compilation pipeline (RHIFactory::CompileShader).
+ *
+ * Usage:
+ *   SparkShaderCompiler <input> [options]
+ *
+ * Options:
+ *   -o <path>        Output file path
+ *   -stage <stage>   Shader stage: vertex, pixel, geometry, hull, domain, compute
+ *   -backend <api>   Target backend: d3d11, vulkan, opengl, auto (default: auto)
+ *   -entry <name>    Entry point function name (default: main)
+ *   -D<DEFINE>       Add preprocessor define
+ *   -I<path>         Add include search path
+ *   -O               Enable optimization (default)
+ *   -Od              Disable optimization
+ *   -Zi              Enable debug info
+ *   -validate        Validate only, don't write output
+ *   -reflect         Print shader reflection data
+ *   -batch <dir>     Compile all shaders in directory
+ *   -v               Verbose output
+ *   -h, --help       Show help
+ */
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <chrono>
+#include <algorithm>
+
+// Include the RHI shader compilation API
+#include "../../Spark Engine/Source/Graphics/RHI/RHIFactory.h"
+#include "../../Spark Engine/Source/Graphics/RHI/RHITypes.h"
+
+// ============================================================================
+// CONFIGURATION
+// ============================================================================
+
+struct CompilerConfig
+{
+    std::string inputFile;
+    std::string outputFile;
+    std::string entryPoint = "main";
+    Spark::RHI::RHIShaderStage stage = Spark::RHI::RHIShaderStage::Vertex;
+    Spark::RHI::GraphicsBackend targetBackend = Spark::RHI::GraphicsBackend::Auto;
+    Spark::RHI::ShaderLanguage sourceLanguage = Spark::RHI::ShaderLanguage::Auto;
+    std::vector<std::string> defines;
+    std::vector<std::string> includePaths;
+    bool optimization = true;
+    bool debugInfo = false;
+    bool validateOnly = false;
+    bool reflect = false;
+    bool verbose = false;
+    std::string batchDir;
+};
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+static void PrintUsage(const char* programName)
+{
+    std::cout << "SparkShaderCompiler - Spark Engine Offline Shader Compiler\n"
+              << "\n"
+              << "Usage: " << programName << " <input> [options]\n"
+              << "\n"
+              << "Options:\n"
+              << "  -o <path>        Output file path\n"
+              << "  -stage <stage>   Shader stage: vertex, pixel, geometry, hull, domain, compute\n"
+              << "  -backend <api>   Target backend: d3d11, vulkan, opengl, auto (default: auto)\n"
+              << "  -entry <name>    Entry point (default: main)\n"
+              << "  -D<DEFINE>       Add preprocessor define\n"
+              << "  -I<path>         Add include search path\n"
+              << "  -O               Enable optimization (default)\n"
+              << "  -Od              Disable optimization\n"
+              << "  -Zi              Enable debug info\n"
+              << "  -validate        Validate only, don't write output\n"
+              << "  -reflect         Print shader reflection data\n"
+              << "  -batch <dir>     Compile all shaders in directory\n"
+              << "  -v               Verbose output\n"
+              << "  -h, --help       Show this help\n"
+              << "\n"
+              << "Examples:\n"
+              << "  " << programName << " BasicVS.hlsl -stage vertex -backend d3d11 -o BasicVS.cso\n"
+              << "  " << programName << " PBR.hlsl -stage pixel -backend vulkan -o PBR.spv\n"
+              << "  " << programName << " Water.glsl -stage vertex -backend opengl -validate\n"
+              << "  " << programName << " -batch Shaders/HLSL -backend vulkan\n";
+}
+
+static Spark::RHI::RHIShaderStage ParseStage(const std::string& str)
+{
+    if (str == "vertex"   || str == "vert" || str == "vs") return Spark::RHI::RHIShaderStage::Vertex;
+    if (str == "pixel"    || str == "frag" || str == "ps") return Spark::RHI::RHIShaderStage::Pixel;
+    if (str == "geometry" || str == "geom" || str == "gs") return Spark::RHI::RHIShaderStage::Geometry;
+    if (str == "hull"     || str == "hs")                  return Spark::RHI::RHIShaderStage::Hull;
+    if (str == "domain"   || str == "ds")                  return Spark::RHI::RHIShaderStage::Domain;
+    if (str == "compute"  || str == "cs")                  return Spark::RHI::RHIShaderStage::Compute;
+    std::cerr << "Warning: Unknown shader stage '" << str << "', defaulting to vertex\n";
+    return Spark::RHI::RHIShaderStage::Vertex;
+}
+
+static Spark::RHI::GraphicsBackend ParseBackend(const std::string& str)
+{
+    if (str == "d3d11"  || str == "dx11")   return Spark::RHI::GraphicsBackend::D3D11;
+    if (str == "d3d12"  || str == "dx12")   return Spark::RHI::GraphicsBackend::D3D12;
+    if (str == "vulkan" || str == "vk")     return Spark::RHI::GraphicsBackend::Vulkan;
+    if (str == "opengl" || str == "gl")     return Spark::RHI::GraphicsBackend::OpenGL;
+    if (str == "auto")                      return Spark::RHI::GraphicsBackend::Auto;
+    std::cerr << "Warning: Unknown backend '" << str << "', defaulting to auto\n";
+    return Spark::RHI::GraphicsBackend::Auto;
+}
+
+static const char* StageToString(Spark::RHI::RHIShaderStage stage)
+{
+    switch (stage) {
+        case Spark::RHI::RHIShaderStage::Vertex:   return "Vertex";
+        case Spark::RHI::RHIShaderStage::Pixel:    return "Pixel";
+        case Spark::RHI::RHIShaderStage::Geometry:  return "Geometry";
+        case Spark::RHI::RHIShaderStage::Hull:     return "Hull";
+        case Spark::RHI::RHIShaderStage::Domain:   return "Domain";
+        case Spark::RHI::RHIShaderStage::Compute:  return "Compute";
+        default:                                   return "Unknown";
+    }
+}
+
+static std::string InferOutputPath(const std::string& inputFile,
+                                   Spark::RHI::GraphicsBackend backend)
+{
+    std::string base = inputFile;
+    size_t dotPos = base.find_last_of('.');
+    if (dotPos != std::string::npos)
+        base = base.substr(0, dotPos);
+
+    const char* ext = Spark::RHI::GetShaderExtension(backend);
+    if (backend == Spark::RHI::GraphicsBackend::Vulkan)
+        return base + ".spv";
+    if (backend == Spark::RHI::GraphicsBackend::D3D11 ||
+        backend == Spark::RHI::GraphicsBackend::D3D12)
+        return base + ".cso";
+    return base + ext;
+}
+
+static Spark::RHI::RHIShaderStage InferStageFromFilename(const std::string& filename)
+{
+    // Common naming conventions
+    std::string lower = filename;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+
+    if (lower.find("vs") != std::string::npos || lower.find("vert") != std::string::npos)
+        return Spark::RHI::RHIShaderStage::Vertex;
+    if (lower.find("ps") != std::string::npos || lower.find("frag") != std::string::npos ||
+        lower.find("pixel") != std::string::npos)
+        return Spark::RHI::RHIShaderStage::Pixel;
+    if (lower.find("gs") != std::string::npos || lower.find("geom") != std::string::npos)
+        return Spark::RHI::RHIShaderStage::Geometry;
+    if (lower.find("hs") != std::string::npos || lower.find("hull") != std::string::npos)
+        return Spark::RHI::RHIShaderStage::Hull;
+    if (lower.find("ds") != std::string::npos || lower.find("domain") != std::string::npos)
+        return Spark::RHI::RHIShaderStage::Domain;
+    if (lower.find("cs") != std::string::npos || lower.find("compute") != std::string::npos)
+        return Spark::RHI::RHIShaderStage::Compute;
+
+    // Default
+    return Spark::RHI::RHIShaderStage::Vertex;
+}
+
+// ============================================================================
+// COMPILATION
+// ============================================================================
+
+static int CompileSingleShader(const CompilerConfig& config)
+{
+    if (config.verbose) {
+        std::cout << "Compiling: " << config.inputFile << "\n"
+                  << "  Stage:   " << StageToString(config.stage) << "\n"
+                  << "  Backend: " << Spark::RHI::GetBackendName(config.targetBackend) << "\n"
+                  << "  Entry:   " << config.entryPoint << "\n"
+                  << "  Opt:     " << (config.optimization ? "on" : "off") << "\n"
+                  << "  Debug:   " << (config.debugInfo ? "on" : "off") << "\n";
+    }
+
+    auto startTime = std::chrono::high_resolution_clock::now();
+
+    // Build compile options
+    Spark::RHI::ShaderCompileOptions options;
+    options.stage = config.stage;
+    options.sourceFile = config.inputFile;
+    options.entryPoint = config.entryPoint;
+    options.targetBackend = config.targetBackend;
+    options.sourceLanguage = config.sourceLanguage;
+    options.targetLanguage = Spark::RHI::ShaderLanguage::Auto;
+    options.optimizationEnabled = config.optimization;
+    options.debugInfoEnabled = config.debugInfo;
+    options.defines = config.defines;
+    options.includePaths = config.includePaths;
+    options.generateReflection = config.reflect;
+
+    // Compile through RHI pipeline
+    Spark::RHI::ShaderCompileResult result = Spark::RHI::CompileShader(options);
+
+    auto endTime = std::chrono::high_resolution_clock::now();
+    float elapsed = std::chrono::duration<float, std::milli>(endTime - startTime).count();
+
+    if (!result.success) {
+        std::cerr << "ERROR: Compilation failed for " << config.inputFile << "\n";
+        if (!result.errorMessage.empty())
+            std::cerr << "  " << result.errorMessage << "\n";
+        return 1;
+    }
+
+    if (!result.warningMessage.empty()) {
+        std::cerr << "WARNING: " << result.warningMessage << "\n";
+    }
+
+    if (config.verbose) {
+        std::cout << "  Compiled in " << elapsed << " ms"
+                  << " (" << result.bytecode.size() << " bytes)\n";
+    }
+
+    // Reflection
+    if (config.reflect && !result.bytecode.empty()) {
+        auto reflection = Spark::RHI::ReflectSPIRV(result.bytecode);
+        std::cout << "\nShader Reflection:\n";
+        std::cout << "  Inputs: " << reflection.inputs.size() << "\n";
+        for (const auto& input : reflection.inputs) {
+            std::cout << "    location=" << input.location
+                      << " " << input.semanticName << "\n";
+        }
+        std::cout << "  Resources: " << reflection.resources.size() << "\n";
+        for (const auto& res : reflection.resources) {
+            std::cout << "    set=" << res.set << " binding=" << res.binding
+                      << " " << res.name << " (size=" << res.size << ")\n";
+        }
+    }
+
+    // Write output
+    if (!config.validateOnly) {
+        std::string outputPath = config.outputFile;
+        if (outputPath.empty())
+            outputPath = InferOutputPath(config.inputFile, config.targetBackend);
+
+        if (!Spark::RHI::SaveCompiledShader(outputPath, result.bytecode)) {
+            std::cerr << "ERROR: Failed to write output file: " << outputPath << "\n";
+            return 1;
+        }
+
+        std::cout << config.inputFile << " -> " << outputPath
+                  << " (" << result.bytecode.size() << " bytes, "
+                  << elapsed << " ms)\n";
+    } else {
+        std::cout << config.inputFile << " - OK"
+                  << " (" << elapsed << " ms)\n";
+    }
+
+    return 0;
+}
+
+// ============================================================================
+// ARGUMENT PARSING
+// ============================================================================
+
+static bool ParseArgs(int argc, char* argv[], CompilerConfig& config)
+{
+    if (argc < 2) {
+        PrintUsage(argv[0]);
+        return false;
+    }
+
+    bool stageExplicit = false;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+
+        if (arg == "-h" || arg == "--help") {
+            PrintUsage(argv[0]);
+            return false;
+        }
+        else if (arg == "-o" && i + 1 < argc) {
+            config.outputFile = argv[++i];
+        }
+        else if (arg == "-stage" && i + 1 < argc) {
+            config.stage = ParseStage(argv[++i]);
+            stageExplicit = true;
+        }
+        else if (arg == "-backend" && i + 1 < argc) {
+            config.targetBackend = ParseBackend(argv[++i]);
+        }
+        else if (arg == "-entry" && i + 1 < argc) {
+            config.entryPoint = argv[++i];
+        }
+        else if (arg.substr(0, 2) == "-D") {
+            config.defines.push_back(arg.substr(2));
+        }
+        else if (arg.substr(0, 2) == "-I") {
+            config.includePaths.push_back(arg.substr(2));
+        }
+        else if (arg == "-O") {
+            config.optimization = true;
+        }
+        else if (arg == "-Od") {
+            config.optimization = false;
+        }
+        else if (arg == "-Zi") {
+            config.debugInfo = true;
+        }
+        else if (arg == "-validate") {
+            config.validateOnly = true;
+        }
+        else if (arg == "-reflect") {
+            config.reflect = true;
+        }
+        else if (arg == "-batch" && i + 1 < argc) {
+            config.batchDir = argv[++i];
+        }
+        else if (arg == "-v") {
+            config.verbose = true;
+        }
+        else if (arg[0] != '-') {
+            config.inputFile = arg;
+        }
+        else {
+            std::cerr << "Unknown option: " << arg << "\n";
+            return false;
+        }
+    }
+
+    // Infer stage from filename if not explicit
+    if (!stageExplicit && !config.inputFile.empty()) {
+        config.stage = InferStageFromFilename(config.inputFile);
+    }
+
+    if (config.inputFile.empty() && config.batchDir.empty()) {
+        std::cerr << "Error: No input file specified.\n";
+        PrintUsage(argv[0]);
+        return false;
+    }
+
+    return true;
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+int main(int argc, char* argv[])
+{
+    CompilerConfig config;
+
+    if (!ParseArgs(argc, argv, config))
+        return 1;
+
+    // Single file compilation
+    if (!config.inputFile.empty()) {
+        return CompileSingleShader(config);
+    }
+
+    // Batch mode not yet implemented
+    if (!config.batchDir.empty()) {
+        std::cerr << "Batch compilation not yet implemented.\n"
+                  << "Use compile_shaders.sh / compile_shaders.bat for batch compilation.\n";
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
- Implement all missing Shader.cpp methods: LoadFromFile, LoadShaderFromSource, CreateShaderVariant, SetActiveVariant, HotReloadShaders, and all Console_* methods (GetMetrics, RecompileAll, SetHotReload, ListShaders, etc.)
- Add CompileWithRHI() method bridging Shader.cpp to RHIFactory::CompileShader() for cross-platform HLSL->SPIRV/GLSL compilation
- Register shader console commands (shader_list, shader_reload, shader_debug) in AdvancedConsoleCommands.cpp
- Create standalone SparkShaderCompiler CLI tool using the RHI pipeline with support for all backends, defines, validation, and reflection
- Update CMakeLists.txt to build SparkShaderCompiler as a separate target