### PR TITLE
feat: add SparkBuild GUI tool as submodule at v1.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,3 +43,6 @@
 [submodule "ThirdParty/Scripting/angelscript-mirror"]
 	path = ThirdParty/Scripting/angelscript-mirror
 	url = https://github.com/codecat/angelscript-mirror.git
+[submodule "SparkBuild"]
+	path = SparkBuild
+	url = https://github.com/Krilliac/SparkBuild.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,6 +431,12 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/SparkShaderCompiler/CMakeLists.txt")
     add_subdirectory(SparkShaderCompiler)
 endif()
 
+# Build SparkBuild GUI tool (Windows only)
+if(WIN32 AND EXISTS "${CMAKE_SOURCE_DIR}/SparkBuild/CMakeLists.txt")
+    message(STATUS "Building SparkBuild GUI tool...")
+    add_subdirectory(SparkBuild)
+endif()
+
 # ---------------------------------------------------------------------
 # 9) SparkEngine source files and executable
 # ---------------------------------------------------------------------
@@ -859,6 +865,11 @@ else()
 endif()
 message(STATUS "Editor: ${ENABLE_EDITOR}")
 message(STATUS "Shader Compiler Tool: ENABLED")
+if(WIN32 AND EXISTS "${CMAKE_SOURCE_DIR}/SparkBuild/CMakeLists.txt")
+    message(STATUS "SparkBuild GUI: ENABLED")
+else()
+    message(STATUS "SparkBuild GUI: DISABLED (Windows only)")
+endif()
 message(STATUS "Tests: ${BUILD_TESTS}")
 message(STATUS "Networking: ${ENABLE_NETWORKING}")
 message(STATUS "Systems:")


### PR DESCRIPTION
Add the SparkBuild CMake GUI builder as a git submodule pinned to the v1.0.0 release tag. SparkBuild provides a native Win32 GUI for configuring and building SparkEngine with zero external dependencies.

- Add SparkBuild submodule at repo root (pinned to v1.0.0)
- Integrate into CMakeLists.txt via add_subdirectory (Windows only)
- Add SparkBuild status to build summary output