### PR TITLE
Fix WeaponStats build errors: use include-dir-relative paths and full…

### DIFF
--- a/Spark Engine/Source/Game/ClassSystem.h
+++ b/Spark Engine/Source/Game/ClassSystem.h
@@ -13,8 +13,8 @@
 #pragma once
 #include "../Core/Platform.h"
 
-#include "../Enums/GameSystemEnums.h"
-#include "../Projectiles/WeaponStats.h"
+#include "Enums/GameSystemEnums.h"
+#include "Projectiles/WeaponStats.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
 #endif // SPARK_PLATFORM_WINDOWS

--- a/Spark Engine/Source/Game/GameMechanics.h
+++ b/Spark Engine/Source/Game/GameMechanics.h
@@ -12,7 +12,7 @@
 #pragma once
 #include "../Core/Platform.h"
 
-#include "../Enums/GameSystemEnums.h"
+#include "Enums/GameSystemEnums.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
 #endif // SPARK_PLATFORM_WINDOWS

--- a/Spark Engine/Source/Game/GravitySystem.h
+++ b/Spark Engine/Source/Game/GravitySystem.h
@@ -12,7 +12,7 @@
 #pragma once
 #include "../Core/Platform.h"
 
-#include "../Enums/GameSystemEnums.h"
+#include "Enums/GameSystemEnums.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
 #endif // SPARK_PLATFORM_WINDOWS

--- a/Spark Engine/Source/Game/HUDSystem.h
+++ b/Spark Engine/Source/Game/HUDSystem.h
@@ -19,7 +19,7 @@
 #include <deque>
 #include <chrono>
 #include <functional>
-#include "../Enums/GameSystemEnums.h"
+#include "Enums/GameSystemEnums.h"
 
 // Forward declarations
 class Player;

--- a/Spark Engine/Source/Game/InteractiveObject.h
+++ b/Spark Engine/Source/Game/InteractiveObject.h
@@ -14,8 +14,8 @@
 #include "../Core/Platform.h"
 
 #include "GameObject.h"
-#include "../Enums/GameSystemEnums.h"
-#include "../Projectiles/WeaponStats.h"
+#include "Enums/GameSystemEnums.h"
+#include "Projectiles/WeaponStats.h"
 #include "ClassSystem.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>

--- a/Spark Engine/Source/Game/PlaneObject.h
+++ b/Spark Engine/Source/Game/PlaneObject.h
@@ -24,7 +24,7 @@
 
 #include "GameObject.h"
 #include "PlaceholderMesh.h"
-#include "../Projectiles/WeaponStats.h"
+#include "Projectiles/WeaponStats.h"
 #include "Primitives.h"
 #include "Utils/Assert.h"
 #ifdef SPARK_PLATFORM_WINDOWS

--- a/Spark Engine/Source/Game/Player.cpp
+++ b/Spark Engine/Source/Game/Player.cpp
@@ -6,7 +6,7 @@
 #include "Utils/Assert.h"
 #include "../Camera/SparkEngineCamera.h"
 #include "../Input/InputManager.h"
-#include "../Projectiles/WeaponStats.h"
+#include "Projectiles/WeaponStats.h"
 #include "../Projectiles/ProjectilePool.h"
 #include "../Utils/MathUtils.h"
 #include "../Game/Console.h"

--- a/Spark Engine/Source/Game/Player.h
+++ b/Spark Engine/Source/Game/Player.h
@@ -18,7 +18,7 @@
 #include "Utils/Assert.h"
 #include "../Camera/SparkEngineCamera.h"
 #include "../Input/InputManager.h"
-#include "../Projectiles/WeaponStats.h"    // Defines WeaponType and WeaponStats
+#include "Projectiles/WeaponStats.h"
 #include "../Projectiles/ProjectilePool.h"
 #include "../Utils/MathUtils.h"
 #ifdef SPARK_PLATFORM_WINDOWS

--- a/Spark Engine/Source/Game/VehicleSystem.h
+++ b/Spark Engine/Source/Game/VehicleSystem.h
@@ -14,8 +14,8 @@
 #include "../Core/Platform.h"
 
 #include "GameObject.h"
-#include "../Enums/GameSystemEnums.h"
-#include "../Projectiles/WeaponStats.h"
+#include "Enums/GameSystemEnums.h"
+#include "Projectiles/WeaponStats.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
 #endif // SPARK_PLATFORM_WINDOWS

--- a/Spark Engine/Source/Projectiles/WeaponStats.h
+++ b/Spark Engine/Source/Projectiles/WeaponStats.h
@@ -11,11 +11,8 @@
 
 #pragma once
 
-#include "../Enums/GameSystemEnums.h"
+#include "Enums/GameSystemEnums.h"
 #include "Utils/Assert.h"
-
-// Use the SparkEditor namespace for enum types
-using SparkEditor::WeaponType;
 
 /**
  * @brief Weapon statistics and configuration structure
@@ -25,7 +22,7 @@ using SparkEditor::WeaponType;
  */
 struct WeaponStats
 {
-    WeaponType Type;         ///< Weapon category/type
+    SparkEditor::WeaponType Type;         ///< Weapon category/type
     float      Damage;       ///< Base damage per shot/projectile
     float      FireRate;     ///< Rate of fire in rounds per minute
     int        MagazineSize; ///< Number of rounds per magazine/clip
@@ -37,7 +34,7 @@ struct WeaponStats
      * @brief Default constructor with safe initial values
      */
     WeaponStats()
-        : Type(WeaponType::PISTOL)
+        : Type(SparkEditor::WeaponType::PISTOL)
         , Damage(10.0f)
         , FireRate(600.0f)
         , MagazineSize(15)
@@ -58,7 +55,7 @@ struct WeaponStats
      * @param velocity Muzzle velocity
      * @param accuracy Accuracy factor (0.0-1.0)
      */
-    WeaponStats(WeaponType type, float damage, float fireRate, int magSize, 
+    WeaponStats(SparkEditor::WeaponType type, float damage, float fireRate, int magSize,
                float reloadTime, float velocity, float accuracy)
         : Type(type)
         , Damage(damage)
@@ -128,7 +125,7 @@ struct WeaponStats
  * @param type The weapon type to get defaults for
  * @return WeaponStats structure with default values for the specified type
  */
-WeaponStats GetDefaultWeaponStats(WeaponType type);
+WeaponStats GetDefaultWeaponStats(SparkEditor::WeaponType type);
 
 /**
  * @brief Create a weapon stats configuration from parameters
@@ -144,7 +141,7 @@ WeaponStats GetDefaultWeaponStats(WeaponType type);
  * @param accuracy Accuracy factor (0.0-1.0)
  * @return WeaponStats structure with specified values
  */
-WeaponStats CreateWeaponStats(WeaponType type, float damage, float fireRate, 
+WeaponStats CreateWeaponStats(SparkEditor::WeaponType type, float damage, float fireRate,
                              int magSize, float reloadTime, float velocity, float accuracy);
 
 /**
@@ -172,7 +169,7 @@ WeaponStats ApplyWeaponModifications(const WeaponStats& baseStats,
  * @param type Weapon type to convert
  * @return String name of the weapon type
  */
-const char* WeaponTypeToString(WeaponType type);
+const char* WeaponTypeToString(SparkEditor::WeaponType type);
 
 /**
  * @brief Convert string to weapon type
@@ -180,4 +177,4 @@ const char* WeaponTypeToString(WeaponType type);
  * @param str String representation of weapon type
  * @return Corresponding weapon type, or WeaponType::PISTOL if not found
  */
-WeaponType StringToWeaponType(const char* str);
+SparkEditor::WeaponType StringToWeaponType(const char* str);


### PR DESCRIPTION
…y qualified types

Replace ../Enums/GameSystemEnums.h and ../Projectiles/WeaponStats.h relative includes with include-directory-relative paths (Enums/... and Projectiles/...) to fix MSVC path resolution failures in the CI build.

In WeaponStats.h, remove the file-scope `using SparkEditor::WeaponType` declaration and use fully qualified SparkEditor::WeaponType throughout the header to prevent type resolution issues when the header is included transitively from different directory contexts.