### PR TITLE
Fix MSVC build errors: virtual Fire method and VOID macro conflict

### DIFF
--- a/Spark Engine/Source/Enums/GameSystemEnums.h
+++ b/Spark Engine/Source/Enums/GameSystemEnums.h
@@ -366,7 +366,7 @@ enum class DamageZoneType {
     ACID = 1,                ///< Corrosive damage over time
     ELECTRIC = 2,            ///< Periodic shock damage
     RADIATION = 3,           ///< Slow constant damage
-    VOID = 4                 ///< Out-of-bounds instant kill
+    VOID_ZONE = 4            ///< Out-of-bounds instant kill
 };
 
 /**

--- a/Spark Engine/Source/Game/GameMechanics.cpp
+++ b/Spark Engine/Source/Game/GameMechanics.cpp
@@ -77,7 +77,7 @@ void DamageZoneSystem::Update(float deltaTime, Player* player)
                 player->TakeDamage(damage * 0.5f); // Slow constant damage
                 break;
 
-            case DamageZoneType::VOID:
+            case DamageZoneType::VOID_ZONE:
                 player->TakeDamage(99999.0f); // Instant kill
                 break;
             }
@@ -188,7 +188,7 @@ int DamageZoneSystem::CreateVoidZone(const std::string& name, const XMFLOAT3& ce
 {
     DamageZone zone;
     zone.name = name;
-    zone.type = DamageZoneType::VOID;
+    zone.type = DamageZoneType::VOID_ZONE;
     zone.center = center;
     zone.halfExtents = halfExtents;
     zone.instantKill = true;

--- a/Spark Engine/Source/Projectiles/Projectile.h
+++ b/Spark Engine/Source/Projectiles/Projectile.h
@@ -90,7 +90,7 @@ public:
      * @param direction Normalized direction vector
      * @param speed Initial speed magnitude
      */
-    void Fire(const DirectX::XMFLOAT3& startPosition,
+    virtual void Fire(const DirectX::XMFLOAT3& startPosition,
         const DirectX::XMFLOAT3& direction,
         float speed);
 


### PR DESCRIPTION
- Add 'virtual' to Projectile::Fire() so Grenade::Fire() and Rocket::Fire() can use 'override' (fixes C3668)
- Rename DamageZoneType::VOID to VOID_ZONE to avoid conflict with Windows VOID macro from minwindef.h (fixes C2144/C2062/C2143)

https://claude.ai/code/session_014DmCR3FErJGqPUkKPf78Go