### PR TITLE
Fix MSVC errors: TAASettings init, PostProcessingPipeline namespace, …

### DIFF
--- a/Spark Engine/Source/Graphics/GraphicsEngine.cpp
+++ b/Spark Engine/Source/Graphics/GraphicsEngine.cpp
@@ -16,6 +16,7 @@
 #include "TemporalEffects.h"
 #include "LightManager.h"
 #include "PostProcessingPipeline.h"
+using Spark::Graphics::PostProcessingPipeline;
 #include "Shader.h"
 #include "RenderTarget.h"
 #include "../Physics/PhysicsSystem.h"
@@ -96,10 +97,10 @@ GraphicsEngine::GraphicsEngine()
     m_settings.anisotropyLevel = 8;
 
     // Initialize advanced settings
-    m_taaSettings = {};
-    m_ssaoSettings = {};
-    m_ssrSettings = {};
-    m_volumetricSettings = {};
+    m_taaSettings = TAASettings();
+    m_ssaoSettings = SSAOSettings();
+    m_ssrSettings = SSRSettings();
+    m_volumetricSettings = VolumetricSettings();
 
     // Initialize statistics
     m_statistics = {};

--- a/Spark Engine/Source/Graphics/GraphicsEngine.h
+++ b/Spark Engine/Source/Graphics/GraphicsEngine.h
@@ -40,7 +40,7 @@ using namespace DirectX;
 class RenderTarget;
 class MaterialSystem;
 class LightManager;
-class PostProcessingPipeline;
+namespace Spark::Graphics { class PostProcessingPipeline; }
 class TemporalEffects;
 class TextureSystem;
 class LightingSystem;
@@ -613,7 +613,7 @@ private:
 
     // Legacy rendering subsystems
     std::unique_ptr<LightManager> m_lightManager;
-    std::unique_ptr<PostProcessingPipeline> m_postProcessing;
+    std::unique_ptr<Spark::Graphics::PostProcessingPipeline> m_postProcessing;
     std::unique_ptr<TemporalEffects> m_temporalEffects;
 
     // ========================================================================

--- a/Spark Engine/Source/Graphics/MeshLOD.cpp
+++ b/Spark Engine/Source/Graphics/MeshLOD.cpp
@@ -83,9 +83,10 @@ SimplificationResult MeshSimplifier::Simplify(
     };
 
     // Iterative edge collapse
+    float bestCost = 1e30f;
     while (result.indices.size() > targetIndexCount && result.indices.size() >= 3) {
         // Find cheapest edge
-        float bestCost = 1e30f;
+        bestCost = 1e30f;
         uint32_t bestV0 = 0, bestV1 = 0;
 
         std::set<uint64_t> processedEdges;


### PR DESCRIPTION
…bestCost scope

- Use explicit type construction (TAASettings(), etc.) instead of = {} to fix MSVC C2679 brace-init assignment error
- Fix PostProcessingPipeline forward declaration to use Spark::Graphics namespace matching its actual definition (fixes C2027)
- Move bestCost declaration outside while loop in MeshLOD.cpp so it's accessible for result.errorMetric assignment (fixes C2065)

https://claude.ai/code/session_014DmCR3FErJGqPUkKPf78Go