### PR TITLE
Fix recursive ScriptValue type definition causing C2065 compile error

### DIFF
--- a/SparkEditor/Source/VisualScripting/VisualScriptingSystem.h
+++ b/SparkEditor/Source/VisualScripting/VisualScriptingSystem.h
@@ -47,6 +47,11 @@ enum class ScriptVariableType {
 };
 
 /**
+ * @brief Forward declaration for recursive script value array
+ */
+struct ScriptValueArray;
+
+/**
  * @brief Script variable value container
  */
 using ScriptValue = std::variant<
@@ -58,8 +63,15 @@ using ScriptValue = std::variant<
     XMFLOAT3,
     XMFLOAT4,
     ObjectID,
-    std::vector<ScriptValue>
+    std::shared_ptr<ScriptValueArray>
 >;
+
+/**
+ * @brief Wrapper for recursive script value arrays
+ */
+struct ScriptValueArray {
+    std::vector<ScriptValue> values;
+};
 
 /**
  * @brief Visual script node categories


### PR DESCRIPTION
ScriptValue was defined as a std::variant containing std::vector<ScriptValue>, but the type alias isn't complete at that point, causing 'undeclared identifier' errors on MSVC. Fix by introducing a forward-declared ScriptValueArray wrapper struct and using std::shared_ptr<ScriptValueArray> in the variant instead.