### PR TITLE
Switch imgui submodule to docking branch to fix MSVC build errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,7 @@
 [submodule "ThirdParty/UI/imgui"]
 	path = ThirdParty/UI/imgui
 	url = https://github.com/ocornut/imgui.git
+	branch = docking
 [submodule "ThirdParty/Networking/curl"]
 	path = ThirdParty/Networking/curl
 	url = https://github.com/curl/curl.git


### PR DESCRIPTION
The EditorUI code uses ImGui's DockBuilder API (DockBuilderSplitNode, DockBuilderDockWindow, DockBuilderFinish, etc.) and ImGuiWindowFlags_NoDocking, which are only available on imgui's docking branch. The submodule was pointing to the master branch which lacks these APIs, causing C2039/C3861/C2065 errors.