### PR TITLE
Add binary publishing with tag-based releases and manual triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,13 +35,26 @@ jobs:
       if: matrix.config == 'Release'
       run: ctest --test-dir build -C ${{ matrix.config }} --output-on-failure
 
+    - name: Package build output
+      if: matrix.config == 'Release'
+      shell: pwsh
+      run: |
+        $outDir = "dist/SparkEngine-Windows-${{ matrix.config }}"
+        New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+        if (Test-Path "build/bin/${{ matrix.config }}") {
+          Copy-Item "build/bin/${{ matrix.config }}/*" $outDir -Recurse -Force
+        } elseif (Test-Path "build/bin") {
+          Copy-Item "build/bin/*" $outDir -Recurse -Force
+        }
+        Compress-Archive -Path $outDir -DestinationPath "SparkEngine-Windows-${{ matrix.config }}.zip"
+
     - name: Upload Build Artifacts
       if: matrix.config == 'Release'
       uses: actions/upload-artifact@v4
       with:
         name: SparkEngine-Windows-VS2022-${{ matrix.config }}
-        path: build/bin/${{ matrix.config }}/
-        retention-days: 7
+        path: SparkEngine-Windows-${{ matrix.config }}.zip
+        retention-days: 14
 
   # ===========================================================================
   # Windows Build (MSVC VS 2022 generator + v144 toolset for VS 2026)
@@ -97,7 +110,7 @@ jobs:
       with:
         name: SparkEngine-Windows-VS2026-${{ matrix.config }}
         path: build/bin/${{ matrix.config }}/
-        retention-days: 7
+        retention-days: 14
 
   # ===========================================================================
   # Linux Build - GCC
@@ -139,13 +152,21 @@ jobs:
         ctest --output-on-failure || true
         ./bin/SparkTests
 
+    - name: Package build output
+      if: matrix.config == 'Release'
+      run: |
+        mkdir -p dist/SparkEngine-Linux-GCC-${{ matrix.config }}
+        cp -r build/bin/* dist/SparkEngine-Linux-GCC-${{ matrix.config }}/
+        tar -czf SparkEngine-Linux-GCC-${{ matrix.config }}.tar.gz \
+          -C dist SparkEngine-Linux-GCC-${{ matrix.config }}
+
     - name: Upload Build Artifacts
       if: matrix.config == 'Release'
       uses: actions/upload-artifact@v4
       with:
         name: SparkEngine-Linux-GCC-${{ matrix.config }}
-        path: build/bin/
-        retention-days: 7
+        path: SparkEngine-Linux-GCC-${{ matrix.config }}.tar.gz
+        retention-days: 14
 
   # ===========================================================================
   # Linux Build - Clang (LLVM)
@@ -187,10 +208,18 @@ jobs:
         ctest --output-on-failure || true
         ./bin/SparkTests
 
+    - name: Package build output
+      if: matrix.config == 'Release'
+      run: |
+        mkdir -p dist/SparkEngine-Linux-Clang-${{ matrix.config }}
+        cp -r build/bin/* dist/SparkEngine-Linux-Clang-${{ matrix.config }}/
+        tar -czf SparkEngine-Linux-Clang-${{ matrix.config }}.tar.gz \
+          -C dist SparkEngine-Linux-Clang-${{ matrix.config }}
+
     - name: Upload Build Artifacts
       if: matrix.config == 'Release'
       uses: actions/upload-artifact@v4
       with:
         name: SparkEngine-Linux-Clang-${{ matrix.config }}
-        path: build/bin/
-        retention-days: 7
+        path: SparkEngine-Linux-Clang-${{ matrix.config }}.tar.gz
+        retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,52 @@ name: Release Builds
 on:
   push:
     branches: [ master, main ]
+    tags: [ 'v*' ]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag (e.g. v1.0.0). Leave empty for rolling "latest" release.'
+        required: false
+        type: string
 
 permissions:
   contents: write
 
 jobs:
   # ===========================================================================
+  # Compute release metadata shared by all jobs
+  # ===========================================================================
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+      is_versioned: ${{ steps.meta.outputs.is_versioned }}
+    steps:
+    - name: Compute release metadata
+      id: meta
+      run: |
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.release_tag }}" ]]; then
+          TAG="${{ inputs.release_tag }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "is_versioned=true" >> "$GITHUB_OUTPUT"
+        elif [[ "${{ github.ref_type }}" == "tag" ]]; then
+          TAG="${{ github.ref_name }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "is_versioned=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "tag=latest" >> "$GITHUB_OUTPUT"
+          echo "version=latest" >> "$GITHUB_OUTPUT"
+          echo "is_versioned=false" >> "$GITHUB_OUTPUT"
+        fi
+
+  # ===========================================================================
   # Windows Build — MSVC VS 2022, Debug + Release
   # ===========================================================================
   build-windows:
+    needs: [prepare]
     runs-on: windows-latest
     strategy:
       matrix:
@@ -49,12 +86,13 @@ jobs:
       with:
         name: SparkEngine-Windows-${{ matrix.config }}
         path: SparkEngine-Windows-${{ matrix.config }}.zip
-        retention-days: 1
+        retention-days: 7
 
   # ===========================================================================
   # Linux Build — GCC, Debug + Release
   # ===========================================================================
   build-linux:
+    needs: [prepare]
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -94,13 +132,13 @@ jobs:
       with:
         name: SparkEngine-Linux-${{ matrix.config }}
         path: SparkEngine-Linux-${{ matrix.config }}.tar.gz
-        retention-days: 1
+        retention-days: 7
 
   # ===========================================================================
-  # Publish rolling "latest" GitHub Release
+  # Publish GitHub Release (versioned or rolling "latest")
   # ===========================================================================
   release:
-    needs: [build-windows, build-linux]
+    needs: [prepare, build-windows, build-linux]
     runs-on: ubuntu-latest
 
     steps:
@@ -121,7 +159,36 @@ jobs:
         find release-assets -type f \( -name "*.zip" -o -name "*.tar.gz" \) \
           -exec cp {} . \;
 
-    - name: Create or update "latest" release
+    - name: Create versioned release
+      if: needs.prepare.outputs.is_versioned == 'true'
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ needs.prepare.outputs.tag }}
+        name: "SparkEngine ${{ needs.prepare.outputs.version }}"
+        body: |
+          ## SparkEngine ${{ needs.prepare.outputs.version }}
+
+          Built from commit [`${{ steps.sha.outputs.short }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+          Built on: ${{ github.run_started_at }}
+
+          ### Downloads
+
+          | Asset | Platform | Config |
+          |---|---|---|
+          | `SparkEngine-Windows-Release.zip` | Windows (VS 2022 x64) | Release |
+          | `SparkEngine-Windows-Debug.zip` | Windows (VS 2022 x64) | Debug |
+          | `SparkEngine-Linux-Release.tar.gz` | Linux (GCC, ubuntu-24.04) | Release |
+          | `SparkEngine-Linux-Debug.tar.gz` | Linux (GCC, ubuntu-24.04) | Debug |
+        prerelease: false
+        make_latest: true
+        files: |
+          SparkEngine-Windows-Release.zip
+          SparkEngine-Windows-Debug.zip
+          SparkEngine-Linux-Release.tar.gz
+          SparkEngine-Linux-Debug.tar.gz
+
+    - name: Create or update "latest" rolling release
+      if: needs.prepare.outputs.is_versioned == 'false'
       uses: softprops/action-gh-release@v2
       with:
         tag_name: latest


### PR DESCRIPTION
- release.yml: Add v* tag trigger for versioned releases (e.g. git tag v1.0.0)
- release.yml: Add workflow_dispatch for on-demand release publishing
- release.yml: Add prepare job to compute release metadata (tag, version)
- release.yml: Split release step into versioned vs rolling "latest" paths
- release.yml: Increase artifact retention from 1 to 7 days
- build.yml: Package CI artifacts as .zip/.tar.gz for easy download
- build.yml: Increase artifact retention from 7 to 14 days

https://claude.ai/code/session_01Fdd6Y7M4Sjr8wGTCHFSdDq