### PR TITLE
Add Working branch to CI workflow triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build SparkEngine
 
 on:
   push:
-    branches: [ main, develop, 'feature/**', 'claude/**' ]
+    branches: [ main, develop, Working, 'feature/**', 'claude/**' ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, Working ]
 
 jobs:
   # ===========================================================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release Builds
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ master, main, Working ]
     tags: [ 'v*' ]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Add working branch as a temp workaround to binary publishing, to be removed at a later date.