### PR TITLE
Add project creation and management system

### DIFF
--- a/SparkEditor/Source/Core/EditorApplication.cpp
+++ b/SparkEditor/Source/Core/EditorApplication.cpp
@@ -457,6 +457,13 @@ bool EditorApplication::OnShutdownRequested()
     return true;
 }
 
+void EditorApplication::SetWindowTitle(const std::string& title) {
+    if (m_hwnd) {
+        std::wstring wTitle(title.begin(), title.end());
+        SetWindowTextW(m_hwnd, wTitle.c_str());
+    }
+}
+
 LRESULT CALLBACK EditorApplication::WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     // Forward messages to ImGui

--- a/SparkEditor/Source/Core/EditorApplication.h
+++ b/SparkEditor/Source/Core/EditorApplication.h
@@ -65,6 +65,7 @@ public:
     PerformanceMetrics GetPerformanceMetrics() const;
     void OnWindowResize(int width, int height);
     bool OnShutdownRequested();
+    void SetWindowTitle(const std::string& title);
 
     static LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 

--- a/SparkEditor/Source/Core/EditorUI.cpp
+++ b/SparkEditor/Source/Core/EditorUI.cpp
@@ -18,6 +18,7 @@
 #include "../Panels/GameViewPanel.h"
 #include "../Panels/WeaponEditorPanel.h"
 #include "../Panels/FPSToolsPanel.h"
+#include "../Panels/ProjectBrowserPanel.h"
 #include "../Profiler/PerformanceProfiler.h"
 #include "EditorCrashHandler.h"
 #include "EditorApplication.h"
@@ -64,10 +65,45 @@ bool EditorUI::Initialize(const EditorConfig& config) {
             console.LogWarning("Crash handler initialization failed");
         }
         
+        // Initialize project manager
+        console.LogInfo("Initializing project manager...");
+        m_projectManager = std::make_unique<ProjectManager>();
+        if (m_projectManager->Initialize()) {
+            console.LogSuccess("Project manager initialized");
+        } else {
+            console.LogWarning("Project manager initialization failed");
+        }
+
+        // Create project browser panel
+        m_projectBrowserPanel = std::make_shared<ProjectBrowserPanel>(m_projectManager.get());
+        m_projectBrowserPanel->Initialize();
+
         // Create panels
         console.LogInfo("Creating editor panels...");
         CreatePanels();
         console.LogSuccess("Panels created successfully");
+
+        // Wire up project callbacks to update other panels
+        m_projectManager->SetOnProjectOpened([this](const ProjectInfo& project) {
+            // Update asset browser path
+            auto it = m_panels.find("AssetBrowser");
+            if (it != m_panels.end()) {
+                auto* assetBrowser = dynamic_cast<AssetBrowserPanel*>(it->second.get());
+                if (assetBrowser) {
+                    assetBrowser->SetProjectPath(m_projectManager->GetProjectAssetsPath());
+                }
+            }
+            ShowNotification("Project opened: " + project.name, "success");
+        });
+
+        m_projectManager->SetOnProjectClosed([this](const ProjectInfo& project) {
+            ShowNotification("Project closed: " + project.name, "info");
+        });
+
+        // Show project browser on startup if no project is loaded
+        if (!m_projectManager->HasOpenProject()) {
+            m_projectBrowserPanel->ShowBrowser();
+        }
 
         // Apply the Spark Professional theme
         console.LogInfo("Applying Spark Professional theme...");
@@ -147,6 +183,11 @@ void EditorUI::Render() {
     RenderNotifications();
     RenderModalDialogs();
 
+    // Render project browser modal (on top of everything)
+    if (m_projectBrowserPanel && m_projectBrowserPanel->IsModalActive()) {
+        m_projectBrowserPanel->Render();
+    }
+
     if (m_showDemoWindow) {
         ImGui::ShowDemoWindow(&m_showDemoWindow);
     }
@@ -198,8 +239,22 @@ void EditorUI::Shutdown() {
     m_panels.clear();
     console.LogInfo("All panels shutdown and cleared");
     
+    // Shutdown project browser
+    if (m_projectBrowserPanel) {
+        m_projectBrowserPanel->Shutdown();
+        m_projectBrowserPanel.reset();
+    }
+
+    // Shutdown project manager
+    if (m_projectManager) {
+        console.LogInfo("Shutting down project manager...");
+        m_projectManager->Shutdown();
+        m_projectManager.reset();
+        console.LogSuccess("Project manager shutdown complete");
+    }
+
     // Note: Don't shutdown crash handler here as it's managed elsewhere
-    
+
     m_isInitialized = false;
     console.LogSuccess("EditorUI shutdown complete");
 }
@@ -388,12 +443,42 @@ void EditorUI::RenderMainMenuBar() {
                 ShowNotification("Scene saved!", "success");
             }
             ImGui::Separator();
-            if (ImGui::MenuItem("New Project")) {
-                ShowNotification("New Project feature coming soon!", "info");
+            if (ImGui::MenuItem("New Project...")) {
+                ShowNewProjectDialog();
             }
-            if (ImGui::MenuItem("Open Project")) {
-                ShowNotification("Open Project feature coming soon!", "info");
+            if (ImGui::MenuItem("Open Project...")) {
+                ShowOpenProjectDialog();
             }
+            if (ImGui::MenuItem("Save Project", nullptr, false, m_projectManager && m_projectManager->HasOpenProject())) {
+                if (m_projectManager->SaveProject()) {
+                    ShowNotification("Project saved!", "success");
+                } else {
+                    ShowNotification("Failed to save project", "error");
+                }
+            }
+
+            // Recent projects submenu
+            if (m_projectManager && !m_projectManager->GetRecentProjects().empty()) {
+                if (ImGui::BeginMenu("Recent Projects")) {
+                    for (const auto& rp : m_projectManager->GetRecentProjects()) {
+                        std::string label = rp.name + "  (" + rp.path + ")";
+                        if (!rp.valid) label += "  [missing]";
+                        if (ImGui::MenuItem(label.c_str(), nullptr, false, rp.valid)) {
+                            if (m_projectManager->OpenProject(rp.path)) {
+                                ShowNotification("Opened project: " + rp.name, "success");
+                            } else {
+                                ShowNotification("Failed to open project: " + rp.name, "error");
+                            }
+                        }
+                    }
+                    ImGui::Separator();
+                    if (ImGui::MenuItem("Clear Recent Projects")) {
+                        m_projectManager->ClearRecentProjects();
+                    }
+                    ImGui::EndMenu();
+                }
+            }
+
             ImGui::Separator();
             if (ImGui::MenuItem("Import Asset")) {
                 ShowNotification("Import Asset feature coming soon!", "info");
@@ -717,6 +802,14 @@ void EditorUI::RenderStatusBar() {
         ImGui::TextColored(statusColor, ICON_FA_CIRCLE);
         ImGui::SameLine();
         ImGui::Text("Engine: %s", m_engineConnected ? "Connected" : "Disconnected");
+
+        // Project name
+        if (m_projectManager && m_projectManager->HasOpenProject()) {
+            ImGui::SameLine();
+            ImGui::Text("|");
+            ImGui::SameLine();
+            ImGui::Text("Project: %s", m_projectManager->GetCurrentProject().name.c_str());
+        }
 
         ImGui::SameLine();
         ImGui::Text("|");
@@ -1139,6 +1232,27 @@ void EditorUI::ShowModalDialog(const std::string& title,
     m_currentDialog.content = content;
     m_currentDialog.buttons = buttons;
     m_currentDialog.isOpen = true;
+}
+
+// ------------------------------------------------------------------
+// Project operations
+// ------------------------------------------------------------------
+void EditorUI::ShowNewProjectDialog() {
+    if (m_projectBrowserPanel) {
+        m_projectBrowserPanel->ShowNewProject();
+    }
+}
+
+void EditorUI::ShowOpenProjectDialog() {
+    if (m_projectBrowserPanel) {
+        m_projectBrowserPanel->ShowOpenProject();
+    }
+}
+
+void EditorUI::ShowProjectBrowser() {
+    if (m_projectBrowserPanel) {
+        m_projectBrowserPanel->ShowBrowser();
+    }
 }
 
 } // namespace SparkEditor

--- a/SparkEditor/Source/Core/EditorUI.h
+++ b/SparkEditor/Source/Core/EditorUI.h
@@ -22,11 +22,13 @@
 #include "EditorLogger.h"
 #include "EditorLayoutManager.h"
 #include "EditorCrashHandler.h"
+#include "ProjectManager.h"
 
 namespace SparkEditor {
 
 // Forward declarations
 class EditorPanel;
+class ProjectBrowserPanel;
 struct EditorConfig; // Forward declare instead of defining
 
 /**
@@ -64,6 +66,12 @@ public:
     EditorLayoutManager* GetLayoutManager() const { return m_layoutManager.get(); }
     EditorLogger* GetLogger() const { return m_logger.get(); }
     EditorCrashHandler* GetCrashHandler() const { return m_crashHandler; }
+    ProjectManager* GetProjectManager() { return m_projectManager.get(); }
+
+    // Project operations (triggered from menu bar)
+    void ShowNewProjectDialog();
+    void ShowOpenProjectDialog();
+    void ShowProjectBrowser();
 
     // Simple layout operations
     bool SaveLayout(const std::string& layoutName, const std::string& description = "");
@@ -111,6 +119,8 @@ private:
     std::unique_ptr<EditorLogger> m_logger;
     std::unique_ptr<EditorLayoutManager> m_layoutManager;
     EditorCrashHandler* m_crashHandler = nullptr;
+    std::unique_ptr<ProjectManager> m_projectManager;
+    std::shared_ptr<ProjectBrowserPanel> m_projectBrowserPanel;
 
     // Panel management
     std::unordered_map<std::string, std::shared_ptr<EditorPanel>> m_panels;

--- a/SparkEditor/Source/Core/ProjectManager.cpp
+++ b/SparkEditor/Source/Core/ProjectManager.cpp
@@ -10,55 +10,189 @@
 #include <filesystem>
 #include <fstream>
 #include <chrono>
-#include <string>
-#include <iterator>
+#include <sstream>
+#include <algorithm>
+
+#ifdef _WIN32
+#include <ShlObj.h>
+#include <Windows.h>
+#endif
+
+namespace fs = std::filesystem;
 
 namespace SparkEditor {
 
-ProjectManager::ProjectManager() = default;
+// ------------------------------------------------------------------
+// EngineVersion
+// ------------------------------------------------------------------
+std::string EngineVersion::ToString() const {
+    return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch);
+}
 
+static EngineVersion GetCurrentEngineVersion() {
+    return { EDITOR_VERSION_MAJOR, EDITOR_VERSION_MINOR, EDITOR_VERSION_PATCH };
+}
+
+static uint64_t GetCurrentTimestamp() {
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count());
+}
+
+// ------------------------------------------------------------------
+// Simple JSON helpers (write-only, no dependency)
+// ------------------------------------------------------------------
+static std::string EscapeJsonString(const std::string& s) {
+    std::string out;
+    out.reserve(s.size() + 8);
+    for (char c : s) {
+        switch (c) {
+            case '\"': out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:   out += c; break;
+        }
+    }
+    return out;
+}
+
+static std::string ExtractJsonString(const std::string& json, const std::string& key) {
+    std::string search = "\"" + key + "\"";
+    size_t pos = json.find(search);
+    if (pos == std::string::npos) return "";
+    pos = json.find(':', pos);
+    if (pos == std::string::npos) return "";
+    pos = json.find('\"', pos + 1);
+    if (pos == std::string::npos) return "";
+    size_t end = json.find('\"', pos + 1);
+    if (end == std::string::npos) return "";
+    return json.substr(pos + 1, end - pos - 1);
+}
+
+static uint64_t ExtractJsonUint64(const std::string& json, const std::string& key) {
+    std::string search = "\"" + key + "\"";
+    size_t pos = json.find(search);
+    if (pos == std::string::npos) return 0;
+    pos = json.find(':', pos);
+    if (pos == std::string::npos) return 0;
+    pos++;
+    while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t')) pos++;
+    std::string numStr;
+    while (pos < json.size() && json[pos] >= '0' && json[pos] <= '9') {
+        numStr += json[pos++];
+    }
+    if (numStr.empty()) return 0;
+    return std::stoull(numStr);
+}
+
+static std::vector<std::string> ExtractJsonStringArray(const std::string& json, const std::string& key) {
+    std::vector<std::string> result;
+    std::string search = "\"" + key + "\"";
+    size_t pos = json.find(search);
+    if (pos == std::string::npos) return result;
+    pos = json.find('[', pos);
+    if (pos == std::string::npos) return result;
+    size_t end = json.find(']', pos);
+    if (end == std::string::npos) return result;
+
+    std::string arr = json.substr(pos + 1, end - pos - 1);
+    size_t i = 0;
+    while (i < arr.size()) {
+        size_t qStart = arr.find('\"', i);
+        if (qStart == std::string::npos) break;
+        size_t qEnd = arr.find('\"', qStart + 1);
+        if (qEnd == std::string::npos) break;
+        result.push_back(arr.substr(qStart + 1, qEnd - qStart - 1));
+        i = qEnd + 1;
+    }
+    return result;
+}
+
+// ------------------------------------------------------------------
+// ProjectManager
+// ------------------------------------------------------------------
+ProjectManager::ProjectManager() = default;
 ProjectManager::~ProjectManager() = default;
 
-bool ProjectManager::Initialize()
-{
+bool ProjectManager::Initialize() {
     std::cout << "ProjectManager::Initialize()\n";
+
+    // Ensure editor data directory exists
+    std::string editorDataDir = GetEditorDataDirectory();
+    try {
+        fs::create_directories(editorDataDir);
+    } catch (const std::exception& e) {
+        std::cerr << "Warning: Could not create editor data directory: " << e.what() << "\n";
+    }
+
+    LoadRecentProjectsList();
     m_isInitialized = true;
     return true;
 }
 
-void ProjectManager::Shutdown()
-{
+void ProjectManager::Shutdown() {
     std::cout << "ProjectManager::Shutdown()\n";
-    CloseProject();
+    if (m_hasOpenProject) {
+        SaveProject();
+        CloseProject();
+    }
+    SaveRecentProjectsList();
     m_isInitialized = false;
 }
 
-bool ProjectManager::CreateProject(const std::string& projectName, const std::string& projectPath)
-{
-    std::cout << "Creating project: " << projectName << " at " << projectPath << "\n";
-    
+// ------------------------------------------------------------------
+// Project lifecycle
+// ------------------------------------------------------------------
+bool ProjectManager::CreateProject(const std::string& projectName,
+                                   const std::string& parentDirectory,
+                                   ProjectTemplate templateType,
+                                   const std::string& description) {
+    std::cout << "Creating project '" << projectName << "' in " << parentDirectory << "\n";
+
+    // Build the project root: parentDirectory/projectName
+    std::string projectRoot = (fs::path(parentDirectory) / projectName).string();
+
     try {
-        // Create project directory structure
-        if (!CreateProjectStructure(projectPath)) {
+        if (fs::exists(projectRoot) && !fs::is_empty(projectRoot)) {
+            std::cerr << "Project directory already exists and is not empty: " << projectRoot << "\n";
             return false;
         }
-        
-        // Initialize project info
+
+        if (!CreateProjectStructure(projectRoot, templateType)) {
+            return false;
+        }
+
+        // Fill project info
+        m_currentProject = ProjectInfo{};
         m_currentProject.name = projectName;
-        m_currentProject.path = projectPath;
+        m_currentProject.path = projectRoot;
         m_currentProject.version = "1.0.0";
-        m_currentProject.description = "Spark Engine Project";
-        m_currentProject.lastModified = std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
-        
-        // Save project settings
-        if (!SaveProjectSettings()) {
+        m_currentProject.description = description.empty() ? "Spark Engine Project" : description;
+        m_currentProject.engineVersion = GetCurrentEngineVersion().ToString();
+        m_currentProject.createdTime = GetCurrentTimestamp();
+        m_currentProject.lastModified = m_currentProject.createdTime;
+        m_currentProject.templateType = templateType;
+
+        // Add the default scene
+        std::string defaultSceneRelative = "Scenes/Default.sparkscene";
+        m_currentProject.scenes.push_back(defaultSceneRelative);
+        m_currentProject.defaultScene = defaultSceneRelative;
+        m_currentProject.lastOpenedScene = defaultSceneRelative;
+
+        if (!SaveProjectFile()) {
             return false;
         }
-        
+
         m_hasOpenProject = true;
-        AddToRecentProjects(projectPath);
-        
+        AddToRecentProjects(projectName, GetProjectFilePath());
+
+        if (m_onProjectOpened) {
+            m_onProjectOpened(m_currentProject);
+        }
+
+        std::cout << "Project created successfully: " << projectRoot << "\n";
         return true;
     } catch (const std::exception& e) {
         std::cerr << "Error creating project: " << e.what() << "\n";
@@ -66,159 +200,545 @@ bool ProjectManager::CreateProject(const std::string& projectName, const std::st
     }
 }
 
-bool ProjectManager::OpenProject(const std::string& projectPath)
-{
-    std::cout << "Opening project: " << projectPath << "\n";
-    
-    if (!LoadProjectSettings(projectPath)) {
+bool ProjectManager::OpenProject(const std::string& sparkprojectPath) {
+    std::cout << "Opening project: " << sparkprojectPath << "\n";
+
+    // Accept either a .sparkproject file or a directory containing one
+    std::string resolvedPath = sparkprojectPath;
+    if (fs::is_directory(sparkprojectPath)) {
+        // Search for .sparkproject file inside
+        for (auto& entry : fs::directory_iterator(sparkprojectPath)) {
+            if (entry.path().extension() == ".sparkproject") {
+                resolvedPath = entry.path().string();
+                break;
+            }
+        }
+    }
+
+    if (!fs::exists(resolvedPath)) {
+        std::cerr << "Project file not found: " << resolvedPath << "\n";
         return false;
     }
-    
+
+    if (m_hasOpenProject) {
+        SaveProject();
+        CloseProject();
+    }
+
+    if (!LoadProjectFile(resolvedPath)) {
+        return false;
+    }
+
     m_hasOpenProject = true;
-    AddToRecentProjects(projectPath);
-    
+    m_currentProject.lastModified = GetCurrentTimestamp();
+    AddToRecentProjects(m_currentProject.name, resolvedPath);
+
+    if (m_onProjectOpened) {
+        m_onProjectOpened(m_currentProject);
+    }
+
     return true;
 }
 
-bool ProjectManager::SaveProject()
-{
+bool ProjectManager::SaveProject() {
     if (!m_hasOpenProject) {
         std::cerr << "No project is currently open\n";
         return false;
     }
-    
     std::cout << "Saving project: " << m_currentProject.name << "\n";
-    return SaveProjectSettings();
+    m_currentProject.lastModified = GetCurrentTimestamp();
+    return SaveProjectFile();
 }
 
-void ProjectManager::CloseProject()
-{
+void ProjectManager::CloseProject() {
     if (m_hasOpenProject) {
         std::cout << "Closing project: " << m_currentProject.name << "\n";
+        ProjectInfo closed = m_currentProject;
         m_hasOpenProject = false;
-        m_currentProject = ProjectInfo{}; // Reset to default
+        m_currentProject = ProjectInfo{};
+        if (m_onProjectClosed) {
+            m_onProjectClosed(closed);
+        }
     }
 }
 
-void ProjectManager::AddToRecentProjects(const std::string& projectPath)
-{
-    // Remove if already exists
-    auto it = std::find(m_recentProjects.begin(), m_recentProjects.end(), projectPath);
-    if (it != m_recentProjects.end()) {
-        m_recentProjects.erase(it);
+// ------------------------------------------------------------------
+// Path helpers
+// ------------------------------------------------------------------
+std::string ProjectManager::GetProjectAssetsPath() const {
+    return (fs::path(m_currentProject.path) / "Assets").string();
+}
+std::string ProjectManager::GetProjectScenesPath() const {
+    return (fs::path(m_currentProject.path) / "Scenes").string();
+}
+std::string ProjectManager::GetProjectScriptsPath() const {
+    return (fs::path(m_currentProject.path) / "Scripts").string();
+}
+std::string ProjectManager::GetProjectConfigPath() const {
+    return (fs::path(m_currentProject.path) / "Config").string();
+}
+std::string ProjectManager::GetProjectTempPath() const {
+    return (fs::path(m_currentProject.path) / "Temp").string();
+}
+std::string ProjectManager::GetProjectFilePath() const {
+    return (fs::path(m_currentProject.path) / (m_currentProject.name + ".sparkproject")).string();
+}
+
+// ------------------------------------------------------------------
+// Recent projects
+// ------------------------------------------------------------------
+void ProjectManager::RefreshRecentProjects() {
+    for (auto& rp : m_recentProjects) {
+        rp.valid = fs::exists(rp.path);
     }
-    
-    // Add to front
-    m_recentProjects.insert(m_recentProjects.begin(), projectPath);
-    
-    // Limit to 10 recent projects
+}
+
+void ProjectManager::RemoveRecentProject(const std::string& path) {
+    m_recentProjects.erase(
+        std::remove_if(m_recentProjects.begin(), m_recentProjects.end(),
+                       [&](const RecentProject& rp) { return rp.path == path; }),
+        m_recentProjects.end());
+    SaveRecentProjectsList();
+}
+
+void ProjectManager::ClearRecentProjects() {
+    m_recentProjects.clear();
+    SaveRecentProjectsList();
+}
+
+void ProjectManager::AddToRecentProjects(const std::string& projectName,
+                                         const std::string& sparkprojectPath) {
+    // Remove existing entry with same path
+    m_recentProjects.erase(
+        std::remove_if(m_recentProjects.begin(), m_recentProjects.end(),
+                       [&](const RecentProject& rp) { return rp.path == sparkprojectPath; }),
+        m_recentProjects.end());
+
+    RecentProject rp;
+    rp.name = projectName;
+    rp.path = sparkprojectPath;
+    rp.engineVersion = GetCurrentEngineVersion().ToString();
+    rp.lastOpened = GetCurrentTimestamp();
+    rp.valid = true;
+
+    m_recentProjects.insert(m_recentProjects.begin(), rp);
+
+    // Keep max 10
     if (m_recentProjects.size() > 10) {
         m_recentProjects.resize(10);
     }
+    SaveRecentProjectsList();
 }
 
-bool ProjectManager::LoadProjectSettings(const std::string& projectPath)
-{
-    std::string settingsFile = projectPath + "/project.json";
-
-    std::ifstream file(settingsFile);
+// ------------------------------------------------------------------
+// Project file I/O (.sparkproject)
+// ------------------------------------------------------------------
+bool ProjectManager::LoadProjectFile(const std::string& sparkprojectPath) {
+    std::ifstream file(sparkprojectPath);
     if (!file.is_open()) {
-        // Fall back to defaults when no project.json exists yet
-        std::cerr << "Could not open " << settingsFile << ", using defaults\n";
-        m_currentProject.name = std::filesystem::path(projectPath).filename().string();
-        m_currentProject.path = projectPath;
-        m_currentProject.version = "1.0.0";
-        m_currentProject.description = "Loaded project";
-        return true;
+        std::cerr << "Could not open project file: " << sparkprojectPath << "\n";
+        return false;
     }
 
-    // Read the entire file
     std::string content((std::istreambuf_iterator<char>(file)),
                          std::istreambuf_iterator<char>());
     file.close();
 
-    // Simple JSON value extractor for string fields
-    auto extractValue = [&](const std::string& key) -> std::string {
-        std::string search = "\"" + key + "\"";
-        size_t pos = content.find(search);
-        if (pos == std::string::npos) return "";
-        pos = content.find(':', pos);
-        if (pos == std::string::npos) return "";
-        pos = content.find('\"', pos + 1);
-        if (pos == std::string::npos) return "";
-        size_t end = content.find('\"', pos + 1);
-        if (end == std::string::npos) return "";
-        return content.substr(pos + 1, end - pos - 1);
-    };
+    std::string name = ExtractJsonString(content, "name");
+    std::string version = ExtractJsonString(content, "version");
+    std::string description = ExtractJsonString(content, "description");
+    std::string engineVer = ExtractJsonString(content, "engineVersion");
+    std::string defaultScene = ExtractJsonString(content, "defaultScene");
+    std::string lastScene = ExtractJsonString(content, "lastOpenedScene");
+    uint64_t lastModified = ExtractJsonUint64(content, "lastModified");
+    uint64_t createdTime = ExtractJsonUint64(content, "createdTime");
+    auto scenes = ExtractJsonStringArray(content, "scenes");
 
-    std::string name = extractValue("name");
-    std::string version = extractValue("version");
-    std::string description = extractValue("description");
+    // Derive project root from the .sparkproject file location
+    std::string projectRoot = fs::path(sparkprojectPath).parent_path().string();
 
-    m_currentProject.name = name.empty()
-        ? std::filesystem::path(projectPath).filename().string()
-        : name;
-    m_currentProject.path = projectPath;
+    m_currentProject = ProjectInfo{};
+    m_currentProject.name = name.empty() ? fs::path(projectRoot).filename().string() : name;
+    m_currentProject.path = projectRoot;
     m_currentProject.version = version.empty() ? "1.0.0" : version;
-    m_currentProject.description = description.empty() ? "Loaded project" : description;
+    m_currentProject.description = description.empty() ? "Spark Engine Project" : description;
+    m_currentProject.engineVersion = engineVer.empty() ? GetCurrentEngineVersion().ToString() : engineVer;
+    m_currentProject.defaultScene = defaultScene;
+    m_currentProject.lastOpenedScene = lastScene;
+    m_currentProject.lastModified = lastModified;
+    m_currentProject.createdTime = createdTime;
+    m_currentProject.scenes = scenes;
 
-    std::cout << "Loaded project settings: " << m_currentProject.name
-              << " v" << m_currentProject.version << "\n";
-
+    std::cout << "Loaded project: " << m_currentProject.name
+              << " v" << m_currentProject.version
+              << " (engine " << m_currentProject.engineVersion << ")\n";
     return true;
 }
 
-bool ProjectManager::SaveProjectSettings()
-{
-    std::string settingsFile = m_currentProject.path + "/project.json";
-    
+bool ProjectManager::SaveProjectFile() {
+    std::string filePath = GetProjectFilePath();
+
     try {
-        std::ofstream file(settingsFile);
+        // Ensure directory exists
+        fs::create_directories(fs::path(filePath).parent_path());
+
+        std::ofstream file(filePath);
         if (!file.is_open()) {
-            std::cerr << "Failed to open project settings file for writing\n";
+            std::cerr << "Failed to open project file for writing: " << filePath << "\n";
             return false;
         }
-        
-        // Write project settings as JSON
-        m_currentProject.lastModified = std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
 
         file << "{\n";
-        file << "  \"name\": \"" << m_currentProject.name << "\",\n";
-        file << "  \"version\": \"" << m_currentProject.version << "\",\n";
-        file << "  \"description\": \"" << m_currentProject.description << "\",\n";
-        file << "  \"lastModified\": " << m_currentProject.lastModified << "\n";
+        file << "  \"projectFileVersion\": 1,\n";
+        file << "  \"name\": \"" << EscapeJsonString(m_currentProject.name) << "\",\n";
+        file << "  \"version\": \"" << EscapeJsonString(m_currentProject.version) << "\",\n";
+        file << "  \"description\": \"" << EscapeJsonString(m_currentProject.description) << "\",\n";
+        file << "  \"engineVersion\": \"" << EscapeJsonString(m_currentProject.engineVersion) << "\",\n";
+        file << "  \"defaultScene\": \"" << EscapeJsonString(m_currentProject.defaultScene) << "\",\n";
+        file << "  \"lastOpenedScene\": \"" << EscapeJsonString(m_currentProject.lastOpenedScene) << "\",\n";
+        file << "  \"createdTime\": " << m_currentProject.createdTime << ",\n";
+        file << "  \"lastModified\": " << m_currentProject.lastModified << ",\n";
+
+        // scenes array
+        file << "  \"scenes\": [\n";
+        for (size_t i = 0; i < m_currentProject.scenes.size(); ++i) {
+            file << "    \"" << EscapeJsonString(m_currentProject.scenes[i]) << "\"";
+            if (i + 1 < m_currentProject.scenes.size()) file << ",";
+            file << "\n";
+        }
+        file << "  ]\n";
         file << "}\n";
-        
+
         file.close();
+        std::cout << "Project file saved: " << filePath << "\n";
         return true;
     } catch (const std::exception& e) {
-        std::cerr << "Error saving project settings: " << e.what() << "\n";
+        std::cerr << "Error saving project file: " << e.what() << "\n";
         return false;
     }
 }
 
-bool ProjectManager::CreateProjectStructure(const std::string& projectPath)
-{
+// ------------------------------------------------------------------
+// Project structure creation
+// ------------------------------------------------------------------
+bool ProjectManager::CreateProjectStructure(const std::string& projectPath,
+                                            ProjectTemplate templateType) {
     try {
-        // Create main project directory
-        std::filesystem::create_directories(projectPath);
-        
-        // Create standard subdirectories
-        std::filesystem::create_directories(projectPath + "/Assets");
-        std::filesystem::create_directories(projectPath + "/Assets/Textures");
-        std::filesystem::create_directories(projectPath + "/Assets/Models");
-        std::filesystem::create_directories(projectPath + "/Assets/Materials");
-        std::filesystem::create_directories(projectPath + "/Assets/Shaders");
-        std::filesystem::create_directories(projectPath + "/Assets/Audio");
-        std::filesystem::create_directories(projectPath + "/Scenes");
-        std::filesystem::create_directories(projectPath + "/Scripts");
-        std::filesystem::create_directories(projectPath + "/Temp");
-        
+        fs::create_directories(projectPath);
+
+        // Core directories every project needs
+        fs::create_directories(projectPath + "/Assets");
+        fs::create_directories(projectPath + "/Assets/Textures");
+        fs::create_directories(projectPath + "/Assets/Models");
+        fs::create_directories(projectPath + "/Assets/Materials");
+        fs::create_directories(projectPath + "/Assets/Audio");
+        fs::create_directories(projectPath + "/Assets/Fonts");
+        fs::create_directories(projectPath + "/Assets/Prefabs");
+        fs::create_directories(projectPath + "/Scenes");
+        fs::create_directories(projectPath + "/Scripts");
+        fs::create_directories(projectPath + "/Config");
+        fs::create_directories(projectPath + "/Temp");
+        fs::create_directories(projectPath + "/Saved");
+        fs::create_directories(projectPath + "/Saved/Backups");
+
+        // Template-specific directories
+        if (templateType == ProjectTemplate::FirstPerson ||
+            templateType == ProjectTemplate::ThirdPerson) {
+            fs::create_directories(projectPath + "/Assets/Characters");
+            fs::create_directories(projectPath + "/Assets/Weapons");
+            fs::create_directories(projectPath + "/Assets/UI");
+        }
+
+        // Create default scene
+        CreateDefaultScene(projectPath + "/Scenes/Default.sparkscene", templateType);
+
+        // Create editor settings
+        CreateDefaultEditorSettings(projectPath + "/Config");
+
+        // Create .gitignore for the project
+        {
+            std::ofstream gitignore(projectPath + "/.gitignore");
+            if (gitignore.is_open()) {
+                gitignore << "# Spark Engine Project\n";
+                gitignore << "Temp/\n";
+                gitignore << "Saved/Backups/\n";
+                gitignore << "*.log\n";
+                gitignore << ".vs/\n";
+                gitignore << "build/\n";
+                gitignore.close();
+            }
+        }
+
         return true;
     } catch (const std::exception& e) {
         std::cerr << "Error creating project structure: " << e.what() << "\n";
         return false;
+    }
+}
+
+void ProjectManager::CreateDefaultScene(const std::string& scenePath,
+                                        ProjectTemplate templateType) {
+    std::ofstream file(scenePath);
+    if (!file.is_open()) return;
+
+    file << "{\n";
+    file << "  \"sceneVersion\": 1,\n";
+    file << "  \"name\": \"Default\",\n";
+    file << "  \"entities\": [\n";
+
+    // Every template gets a directional light
+    file << "    {\n";
+    file << "      \"name\": \"Directional Light\",\n";
+    file << "      \"components\": [\n";
+    file << "        {\n";
+    file << "          \"type\": \"Transform\",\n";
+    file << "          \"position\": [0, 10, 0],\n";
+    file << "          \"rotation\": [50, -30, 0],\n";
+    file << "          \"scale\": [1, 1, 1]\n";
+    file << "        },\n";
+    file << "        {\n";
+    file << "          \"type\": \"DirectionalLight\",\n";
+    file << "          \"color\": [1.0, 0.96, 0.84],\n";
+    file << "          \"intensity\": 1.0\n";
+    file << "        }\n";
+    file << "      ]\n";
+    file << "    }";
+
+    // Templates with a ground plane
+    if (templateType != ProjectTemplate::Empty) {
+        file << ",\n";
+        file << "    {\n";
+        file << "      \"name\": \"Ground\",\n";
+        file << "      \"components\": [\n";
+        file << "        {\n";
+        file << "          \"type\": \"Transform\",\n";
+        file << "          \"position\": [0, 0, 0],\n";
+        file << "          \"rotation\": [0, 0, 0],\n";
+        file << "          \"scale\": [50, 1, 50]\n";
+        file << "        },\n";
+        file << "        { \"type\": \"MeshRenderer\", \"mesh\": \"Plane\" }\n";
+        file << "      ]\n";
+        file << "    }";
+    }
+
+    // Camera
+    if (templateType != ProjectTemplate::Empty) {
+        file << ",\n";
+        file << "    {\n";
+        file << "      \"name\": \"Main Camera\",\n";
+        file << "      \"components\": [\n";
+        file << "        {\n";
+        file << "          \"type\": \"Transform\",\n";
+
+        switch (templateType) {
+            case ProjectTemplate::FirstPerson:
+                file << "          \"position\": [0, 1.7, 0],\n";
+                break;
+            case ProjectTemplate::ThirdPerson:
+                file << "          \"position\": [0, 5, -8],\n";
+                file << "          \"rotation\": [25, 0, 0],\n";
+                break;
+            case ProjectTemplate::TopDown:
+                file << "          \"position\": [0, 20, 0],\n";
+                file << "          \"rotation\": [90, 0, 0],\n";
+                break;
+            default:
+                file << "          \"position\": [0, 3, -8],\n";
+                file << "          \"rotation\": [15, 0, 0],\n";
+                break;
+        }
+        if (templateType == ProjectTemplate::FirstPerson ||
+            templateType == ProjectTemplate::Blank3D) {
+            // Only write scale if rotation wasn't already written above for some templates
+        }
+        file << "          \"scale\": [1, 1, 1]\n";
+        file << "        },\n";
+        file << "        { \"type\": \"Camera\", \"fov\": 60.0, \"nearClip\": 0.1, \"farClip\": 1000.0 }\n";
+        file << "      ]\n";
+        file << "    }";
+    }
+
+    // Player for FPS/TPS templates
+    if (templateType == ProjectTemplate::FirstPerson ||
+        templateType == ProjectTemplate::ThirdPerson) {
+        file << ",\n";
+        file << "    {\n";
+        file << "      \"name\": \"Player\",\n";
+        file << "      \"components\": [\n";
+        file << "        {\n";
+        file << "          \"type\": \"Transform\",\n";
+        file << "          \"position\": [0, 1, 0],\n";
+        file << "          \"rotation\": [0, 0, 0],\n";
+        file << "          \"scale\": [1, 1, 1]\n";
+        file << "        },\n";
+        file << "        { \"type\": \"CharacterController\", \"height\": 1.8, \"radius\": 0.3 }\n";
+        file << "      ]\n";
+        file << "    }";
+    }
+
+    file << "\n  ]\n";
+    file << "}\n";
+    file.close();
+}
+
+void ProjectManager::CreateDefaultEditorSettings(const std::string& configPath) {
+    std::ofstream file(configPath + "/EditorSettings.json");
+    if (!file.is_open()) return;
+
+    file << "{\n";
+    file << "  \"editor\": {\n";
+    file << "    \"theme\": \"Spark Professional\",\n";
+    file << "    \"fontSize\": 15,\n";
+    file << "    \"autoSaveInterval\": 300,\n";
+    file << "    \"showGrid\": true,\n";
+    file << "    \"gridSize\": 1.0,\n";
+    file << "    \"snapToGrid\": false\n";
+    file << "  },\n";
+    file << "  \"viewport\": {\n";
+    file << "    \"fieldOfView\": 60.0,\n";
+    file << "    \"nearClip\": 0.1,\n";
+    file << "    \"farClip\": 5000.0,\n";
+    file << "    \"moveSpeed\": 10.0,\n";
+    file << "    \"showGizmos\": true\n";
+    file << "  },\n";
+    file << "  \"build\": {\n";
+    file << "    \"targetPlatform\": \"Windows\",\n";
+    file << "    \"configuration\": \"Debug\"\n";
+    file << "  }\n";
+    file << "}\n";
+    file.close();
+}
+
+// ------------------------------------------------------------------
+// Recent projects persistence
+// ------------------------------------------------------------------
+std::string ProjectManager::GetEditorDataDirectory() {
+#ifdef _WIN32
+    char appDataPath[MAX_PATH];
+    if (SUCCEEDED(SHGetFolderPathA(nullptr, CSIDL_APPDATA, nullptr, 0, appDataPath))) {
+        return std::string(appDataPath) + "\\SparkEngine\\Editor";
+    }
+    return "./SparkEditor";
+#else
+    const char* home = getenv("HOME");
+    if (home) {
+        return std::string(home) + "/.sparkengine/editor";
+    }
+    return "./.sparkengine/editor";
+#endif
+}
+
+std::string ProjectManager::GetRecentProjectsFilePath() {
+    return (fs::path(GetEditorDataDirectory()) / "RecentProjects.json").string();
+}
+
+void ProjectManager::LoadRecentProjectsList() {
+    m_recentProjects.clear();
+    std::string filePath = GetRecentProjectsFilePath();
+
+    std::ifstream file(filePath);
+    if (!file.is_open()) return;
+
+    std::string content((std::istreambuf_iterator<char>(file)),
+                         std::istreambuf_iterator<char>());
+    file.close();
+
+    // Parse array of recent projects (simple parser)
+    // Format: { "recentProjects": [ { "name": ..., "path": ..., ... }, ... ] }
+    size_t pos = 0;
+    while (true) {
+        pos = content.find('{', pos);
+        if (pos == std::string::npos) break;
+
+        // Skip the outer object
+        if (content.find("\"recentProjects\"", 0) != std::string::npos && pos == 0) {
+            pos++;
+            continue;
+        }
+
+        size_t end = content.find('}', pos);
+        if (end == std::string::npos) break;
+
+        std::string entry = content.substr(pos, end - pos + 1);
+        std::string name = ExtractJsonString(entry, "name");
+        std::string path = ExtractJsonString(entry, "path");
+        std::string engineVer = ExtractJsonString(entry, "engineVersion");
+        uint64_t lastOpened = ExtractJsonUint64(entry, "lastOpened");
+
+        if (!path.empty()) {
+            RecentProject rp;
+            rp.name = name;
+            rp.path = path;
+            rp.engineVersion = engineVer;
+            rp.lastOpened = lastOpened;
+            rp.valid = fs::exists(path);
+            m_recentProjects.push_back(rp);
+        }
+
+        pos = end + 1;
+    }
+
+    std::cout << "Loaded " << m_recentProjects.size() << " recent projects\n";
+}
+
+void ProjectManager::SaveRecentProjectsList() {
+    std::string filePath = GetRecentProjectsFilePath();
+
+    try {
+        fs::create_directories(fs::path(filePath).parent_path());
+
+        std::ofstream file(filePath);
+        if (!file.is_open()) return;
+
+        file << "{\n";
+        file << "  \"recentProjects\": [\n";
+        for (size_t i = 0; i < m_recentProjects.size(); ++i) {
+            const auto& rp = m_recentProjects[i];
+            file << "    {\n";
+            file << "      \"name\": \"" << EscapeJsonString(rp.name) << "\",\n";
+            file << "      \"path\": \"" << EscapeJsonString(rp.path) << "\",\n";
+            file << "      \"engineVersion\": \"" << EscapeJsonString(rp.engineVersion) << "\",\n";
+            file << "      \"lastOpened\": " << rp.lastOpened << "\n";
+            file << "    }";
+            if (i + 1 < m_recentProjects.size()) file << ",";
+            file << "\n";
+        }
+        file << "  ]\n";
+        file << "}\n";
+        file.close();
+    } catch (const std::exception& e) {
+        std::cerr << "Error saving recent projects: " << e.what() << "\n";
+    }
+}
+
+// ------------------------------------------------------------------
+// Static template helpers
+// ------------------------------------------------------------------
+std::string ProjectManager::GetProjectTemplateName(ProjectTemplate t) {
+    switch (t) {
+        case ProjectTemplate::Empty:       return "Empty";
+        case ProjectTemplate::FirstPerson: return "First Person";
+        case ProjectTemplate::ThirdPerson: return "Third Person";
+        case ProjectTemplate::TopDown:     return "Top Down";
+        case ProjectTemplate::Blank3D:     return "Blank 3D";
+        default:                           return "Unknown";
+    }
+}
+
+std::string ProjectManager::GetProjectTemplateDescription(ProjectTemplate t) {
+    switch (t) {
+        case ProjectTemplate::Empty:
+            return "A completely empty project with no default scenes or assets.";
+        case ProjectTemplate::FirstPerson:
+            return "First-person template with player controller, camera, and a basic level.";
+        case ProjectTemplate::ThirdPerson:
+            return "Third-person template with follow camera and character controller.";
+        case ProjectTemplate::TopDown:
+            return "Top-down camera template suitable for strategy or adventure games.";
+        case ProjectTemplate::Blank3D:
+            return "A single empty 3D scene with default lighting and a ground plane.";
+        default:
+            return "";
     }
 }
 

--- a/SparkEditor/Source/Core/ProjectManager.h
+++ b/SparkEditor/Source/Core/ProjectManager.h
@@ -3,9 +3,9 @@
  * @brief Project management system for the Spark Engine Editor
  * @author Spark Engine Team
  * @date 2025
- * 
- * This file defines the project management system that handles project
- * creation, loading, saving, and organization within the editor.
+ *
+ * Handles project creation, loading, saving, and organization.
+ * Projects use .sparkproject files and a standardized directory structure.
  */
 
 #pragma once
@@ -13,126 +13,129 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <functional>
+#include <cstdint>
 
 namespace SparkEditor {
 
 /**
- * @brief Project information structure
+ * @brief Engine version info embedded in project files
+ */
+struct EngineVersion {
+    int major = 1;
+    int minor = 0;
+    int patch = 0;
+    std::string ToString() const;
+};
+
+/**
+ * @brief Project template types for new project creation
+ */
+enum class ProjectTemplate {
+    Empty,          ///< Bare project with no assets or scenes
+    FirstPerson,    ///< FPS template with player controller and basic level
+    ThirdPerson,    ///< Third person template
+    TopDown,        ///< Top-down camera template
+    Blank3D         ///< Single empty scene with default lighting
+};
+
+/**
+ * @brief Project information structure stored in .sparkproject files
  */
 struct ProjectInfo {
-    std::string name;               ///< Project name
-    std::string path;               ///< Project root path
-    std::string version;            ///< Project version
-    std::string description;        ///< Project description
-    std::vector<std::string> scenes; ///< Scene file paths
-    std::string lastOpenedScene;    ///< Last opened scene path
-    uint64_t lastModified = 0;      ///< Last modified timestamp
+    std::string name;                ///< Project name
+    std::string path;                ///< Project root directory
+    std::string version;             ///< Project version
+    std::string description;         ///< Project description
+    std::string engineVersion;       ///< Engine version that created this project
+    std::vector<std::string> scenes; ///< Scene file paths (relative to project root)
+    std::string lastOpenedScene;     ///< Last opened scene path
+    std::string defaultScene;        ///< Default scene loaded on play
+    uint64_t lastModified = 0;       ///< Last modified timestamp (epoch seconds)
+    uint64_t createdTime = 0;        ///< Creation timestamp (epoch seconds)
+    ProjectTemplate templateType = ProjectTemplate::Blank3D;
+};
+
+/**
+ * @brief Recent project entry for the project browser
+ */
+struct RecentProject {
+    std::string name;
+    std::string path;               ///< Full path to .sparkproject file
+    std::string engineVersion;
+    uint64_t lastOpened = 0;
+    bool valid = true;              ///< False if project directory no longer exists
 };
 
 /**
  * @brief Project management system
- * 
+ *
  * Handles project creation, loading, saving, and organization for the editor.
+ * Persists recent projects list and editor preferences across sessions.
  */
 class ProjectManager {
 public:
-    /**
-     * @brief Constructor
-     */
     ProjectManager();
-
-    /**
-     * @brief Destructor
-     */
     ~ProjectManager();
 
-    /**
-     * @brief Initialize the project manager
-     * @return true if initialization succeeded, false otherwise
-     */
     bool Initialize();
-
-    /**
-     * @brief Shutdown the project manager
-     */
     void Shutdown();
 
-    /**
-     * @brief Create a new project
-     * @param projectName Name of the new project
-     * @param projectPath Directory where to create the project
-     * @return true if project was created successfully
-     */
-    bool CreateProject(const std::string& projectName, const std::string& projectPath);
-
-    /**
-     * @brief Open an existing project
-     * @param projectPath Path to the project file
-     * @return true if project was opened successfully
-     */
-    bool OpenProject(const std::string& projectPath);
-
-    /**
-     * @brief Save current project
-     * @return true if project was saved successfully
-     */
+    // --- Project lifecycle ---
+    bool CreateProject(const std::string& projectName, const std::string& parentDirectory,
+                       ProjectTemplate templateType = ProjectTemplate::Blank3D,
+                       const std::string& description = "");
+    bool OpenProject(const std::string& sparkprojectPath);
     bool SaveProject();
-
-    /**
-     * @brief Close current project
-     */
     void CloseProject();
 
-    /**
-     * @brief Check if a project is currently open
-     * @return true if a project is open
-     */
     bool HasOpenProject() const { return m_hasOpenProject; }
-
-    /**
-     * @brief Get current project information
-     * @return Reference to current project info
-     */
     const ProjectInfo& GetCurrentProject() const { return m_currentProject; }
 
-    /**
-     * @brief Get recent projects list
-     * @return Vector of recent project paths
-     */
-    const std::vector<std::string>& GetRecentProjects() const { return m_recentProjects; }
+    // --- Recent projects ---
+    const std::vector<RecentProject>& GetRecentProjects() const { return m_recentProjects; }
+    void RefreshRecentProjects();
+    void RemoveRecentProject(const std::string& path);
+    void ClearRecentProjects();
 
-    /**
-     * @brief Add project to recent projects list
-     * @param projectPath Path to the project
-     */
-    void AddToRecentProjects(const std::string& projectPath);
+    // --- Path helpers ---
+    std::string GetProjectAssetsPath() const;
+    std::string GetProjectScenesPath() const;
+    std::string GetProjectScriptsPath() const;
+    std::string GetProjectConfigPath() const;
+    std::string GetProjectTempPath() const;
+    std::string GetProjectFilePath() const;  ///< Full path to .sparkproject file
 
-private:
-    /**
-     * @brief Load project settings from file
-     * @param projectPath Path to the project file
-     * @return true if loading succeeded
-     */
-    bool LoadProjectSettings(const std::string& projectPath);
+    // --- Callbacks ---
+    using ProjectCallback = std::function<void(const ProjectInfo&)>;
+    void SetOnProjectOpened(ProjectCallback cb) { m_onProjectOpened = std::move(cb); }
+    void SetOnProjectClosed(ProjectCallback cb) { m_onProjectClosed = std::move(cb); }
 
-    /**
-     * @brief Save project settings to file
-     * @return true if saving succeeded
-     */
-    bool SaveProjectSettings();
-
-    /**
-     * @brief Create default project structure
-     * @param projectPath Project root directory
-     * @return true if creation succeeded
-     */
-    bool CreateProjectStructure(const std::string& projectPath);
+    // --- Static helpers ---
+    static std::string GetProjectTemplateName(ProjectTemplate t);
+    static std::string GetProjectTemplateDescription(ProjectTemplate t);
+    static std::string GetEditorDataDirectory();  ///< %APPDATA%/SparkEngine/Editor
 
 private:
-    ProjectInfo m_currentProject;                   ///< Current project information
-    std::vector<std::string> m_recentProjects;     ///< Recent projects list
-    bool m_hasOpenProject = false;                  ///< Whether a project is open
-    bool m_isInitialized = false;                   ///< Initialization state
+    bool LoadProjectFile(const std::string& sparkprojectPath);
+    bool SaveProjectFile();
+    bool CreateProjectStructure(const std::string& projectPath, ProjectTemplate templateType);
+    void CreateDefaultScene(const std::string& scenePath, ProjectTemplate templateType);
+    void CreateDefaultEditorSettings(const std::string& configPath);
+
+    void LoadRecentProjectsList();
+    void SaveRecentProjectsList();
+    void AddToRecentProjects(const std::string& projectName, const std::string& sparkprojectPath);
+
+    static std::string GetRecentProjectsFilePath();
+
+    ProjectInfo m_currentProject;
+    std::vector<RecentProject> m_recentProjects;
+    bool m_hasOpenProject = false;
+    bool m_isInitialized = false;
+
+    ProjectCallback m_onProjectOpened;
+    ProjectCallback m_onProjectClosed;
 };
 
 } // namespace SparkEditor

--- a/SparkEditor/Source/Panels/ProjectBrowserPanel.cpp
+++ b/SparkEditor/Source/Panels/ProjectBrowserPanel.cpp
@@ -1,0 +1,446 @@
+/**
+ * @file ProjectBrowserPanel.cpp
+ * @brief Implementation of the project browser panel
+ * @author Spark Engine Team
+ * @date 2025
+ */
+
+#include "ProjectBrowserPanel.h"
+#include <imgui.h>
+#include <imgui_internal.h>
+#include <filesystem>
+#include <iostream>
+#include <chrono>
+#include <ctime>
+#include <cstring>
+
+#ifdef _WIN32
+#include <Windows.h>
+#include <ShlObj.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace SparkEditor {
+
+ProjectBrowserPanel::ProjectBrowserPanel(ProjectManager* projectManager)
+    : EditorPanel("Project Browser", "project_browser_panel")
+    , m_projectManager(projectManager)
+{
+    // Default new project path to user's Documents/SparkProjects
+#ifdef _WIN32
+    char docPath[MAX_PATH];
+    if (SUCCEEDED(SHGetFolderPathA(nullptr, CSIDL_PERSONAL, nullptr, 0, docPath))) {
+        std::string defaultPath = std::string(docPath) + "\\SparkProjects";
+        strncpy(m_newProjectPath, defaultPath.c_str(), sizeof(m_newProjectPath) - 1);
+    } else {
+        strncpy(m_newProjectPath, "C:\\SparkProjects", sizeof(m_newProjectPath) - 1);
+    }
+#else
+    const char* home = getenv("HOME");
+    if (home) {
+        std::string defaultPath = std::string(home) + "/SparkProjects";
+        strncpy(m_newProjectPath, defaultPath.c_str(), sizeof(m_newProjectPath) - 1);
+    }
+#endif
+}
+
+bool ProjectBrowserPanel::Initialize() {
+    m_isInitialized = true;
+    return true;
+}
+
+void ProjectBrowserPanel::Update(float /*deltaTime*/) {
+    // Nothing to update
+}
+
+void ProjectBrowserPanel::Shutdown() {
+    m_isInitialized = false;
+}
+
+void ProjectBrowserPanel::ShowNewProject() {
+    m_showModal = true;
+    m_activeTab = Tab::NewProject;
+    m_createError.clear();
+}
+
+void ProjectBrowserPanel::ShowOpenProject() {
+    m_showModal = true;
+    m_activeTab = Tab::RecentProjects;
+    m_openError.clear();
+}
+
+void ProjectBrowserPanel::ShowBrowser() {
+    m_showModal = true;
+    m_activeTab = Tab::RecentProjects;
+    m_createError.clear();
+    m_openError.clear();
+}
+
+void ProjectBrowserPanel::Render() {
+    if (m_showModal) {
+        RenderModal();
+    }
+}
+
+void ProjectBrowserPanel::RenderModal() {
+    ImGuiViewport* viewport = ImGui::GetMainViewport();
+    ImVec2 center = ImVec2(viewport->WorkPos.x + viewport->WorkSize.x * 0.5f,
+                           viewport->WorkPos.y + viewport->WorkSize.y * 0.5f);
+    ImVec2 modalSize = ImVec2(820, 560);
+
+    ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSize(modalSize, ImGuiCond_Always);
+
+    ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
+                             ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoSavedSettings;
+
+    // Dim background
+    ImGui::GetBackgroundDrawList()->AddRectFilled(
+        viewport->WorkPos,
+        ImVec2(viewport->WorkPos.x + viewport->WorkSize.x,
+               viewport->WorkPos.y + viewport->WorkSize.y),
+        IM_COL32(0, 0, 0, 140));
+
+    if (ImGui::Begin("Spark Engine - Project Browser###project_browser_modal", &m_showModal, flags)) {
+
+        // Tab bar
+        if (ImGui::BeginTabBar("ProjectBrowserTabs")) {
+            if (ImGui::BeginTabItem("Projects")) {
+                m_activeTab = Tab::RecentProjects;
+                RenderRecentProjects();
+                ImGui::EndTabItem();
+            }
+            if (ImGui::BeginTabItem("New Project")) {
+                m_activeTab = Tab::NewProject;
+                RenderNewProjectForm();
+                ImGui::EndTabItem();
+            }
+            ImGui::EndTabBar();
+        }
+    }
+    ImGui::End();
+}
+
+// ------------------------------------------------------------------
+// Recent Projects tab
+// ------------------------------------------------------------------
+void ProjectBrowserPanel::RenderRecentProjects() {
+    if (!m_projectManager) return;
+
+    const auto& recentProjects = m_projectManager->GetRecentProjects();
+
+    ImGui::Spacing();
+
+    // Open project button
+    if (ImGui::Button("Browse...", ImVec2(100, 30))) {
+        std::string path;
+        if (BrowseForFolder(path)) {
+            if (m_projectManager->OpenProject(path)) {
+                m_showModal = false;
+            } else {
+                m_openError = "Failed to open project at: " + path;
+            }
+        }
+    }
+    ImGui::SameLine();
+    ImGui::TextDisabled("Open a project by browsing to its folder or .sparkproject file");
+
+    if (!m_openError.empty()) {
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.3f, 0.3f, 1.0f));
+        ImGui::TextWrapped("%s", m_openError.c_str());
+        ImGui::PopStyleColor();
+    }
+
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    if (recentProjects.empty()) {
+        ImGui::Spacing();
+        ImGui::Spacing();
+        float windowWidth = ImGui::GetContentRegionAvail().x;
+        std::string text = "No recent projects";
+        float textWidth = ImGui::CalcTextSize(text.c_str()).x;
+        ImGui::SetCursorPosX((windowWidth - textWidth) * 0.5f);
+        ImGui::TextDisabled("%s", text.c_str());
+
+        ImGui::Spacing();
+        std::string hint = "Create a new project or open an existing one to get started.";
+        float hintWidth = ImGui::CalcTextSize(hint.c_str()).x;
+        ImGui::SetCursorPosX((windowWidth - hintWidth) * 0.5f);
+        ImGui::TextDisabled("%s", hint.c_str());
+        return;
+    }
+
+    // Recent projects header
+    ImGui::Text("Recent Projects");
+    ImGui::SameLine(ImGui::GetContentRegionAvail().x - 80);
+    if (ImGui::SmallButton("Clear All")) {
+        m_projectManager->ClearRecentProjects();
+    }
+
+    ImGui::Spacing();
+
+    // Project list
+    if (ImGui::BeginChild("RecentProjectsList", ImVec2(0, 0), ImGuiChildFlags_Border)) {
+        int removeIdx = -1;
+
+        for (size_t i = 0; i < recentProjects.size(); ++i) {
+            const auto& rp = recentProjects[i];
+
+            ImGui::PushID(static_cast<int>(i));
+
+            // Highlight invalid projects
+            if (!rp.valid) {
+                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.6f, 0.6f, 0.6f, 1.0f));
+            }
+
+            // Clickable selectable for the whole row
+            bool selected = false;
+            if (ImGui::Selectable("##project_entry", &selected,
+                                  ImGuiSelectableFlags_AllowDoubleClick,
+                                  ImVec2(0, 50))) {
+                if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
+                    if (rp.valid) {
+                        if (m_projectManager->OpenProject(rp.path)) {
+                            m_showModal = false;
+                        } else {
+                            m_openError = "Failed to open: " + rp.path;
+                        }
+                    }
+                }
+            }
+
+            // Draw content over the selectable
+            ImVec2 itemMin = ImGui::GetItemRectMin();
+            ImGui::SetCursorScreenPos(ImVec2(itemMin.x + 10, itemMin.y + 6));
+            ImGui::Text("%s", rp.name.c_str());
+
+            ImGui::SetCursorScreenPos(ImVec2(itemMin.x + 10, itemMin.y + 28));
+            ImGui::TextDisabled("%s", rp.path.c_str());
+
+            // Engine version on the right
+            std::string verText = rp.engineVersion.empty() ? "" : ("v" + rp.engineVersion);
+            if (!verText.empty()) {
+                float verWidth = ImGui::CalcTextSize(verText.c_str()).x;
+                ImGui::SetCursorScreenPos(ImVec2(itemMin.x + ImGui::GetContentRegionAvail().x - verWidth - 60, itemMin.y + 6));
+                ImGui::TextDisabled("%s", verText.c_str());
+            }
+
+            // Remove button
+            ImGui::SetCursorScreenPos(ImVec2(itemMin.x + ImGui::GetContentRegionAvail().x - 30, itemMin.y + 14));
+            if (ImGui::SmallButton("X")) {
+                removeIdx = static_cast<int>(i);
+            }
+
+            if (!rp.valid) {
+                ImGui::PopStyleColor();
+                // Show missing indicator
+                ImGui::SetCursorScreenPos(ImVec2(itemMin.x + ImGui::GetContentRegionAvail().x - 100, itemMin.y + 28));
+                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.5f, 0.2f, 1.0f));
+                ImGui::TextUnformatted("(missing)");
+                ImGui::PopStyleColor();
+            }
+
+            ImGui::PopID();
+            ImGui::Separator();
+        }
+
+        if (removeIdx >= 0) {
+            m_projectManager->RemoveRecentProject(recentProjects[removeIdx].path);
+        }
+    }
+    ImGui::EndChild();
+}
+
+// ------------------------------------------------------------------
+// New Project tab
+// ------------------------------------------------------------------
+void ProjectBrowserPanel::RenderNewProjectForm() {
+    ImGui::Spacing();
+
+    // Template selection
+    ImGui::Text("Choose a Template:");
+    ImGui::Spacing();
+
+    if (ImGui::BeginChild("TemplateSelection", ImVec2(0, 170), ImGuiChildFlags_Border)) {
+        float cardWidth = 140.0f;
+        float spacing = 10.0f;
+        float totalWidth = ImGui::GetContentRegionAvail().x;
+        int cols = std::max(1, static_cast<int>((totalWidth + spacing) / (cardWidth + spacing)));
+
+        int idx = 0;
+        ProjectTemplate templates[] = {
+            ProjectTemplate::Blank3D,
+            ProjectTemplate::FirstPerson,
+            ProjectTemplate::ThirdPerson,
+            ProjectTemplate::TopDown,
+            ProjectTemplate::Empty
+        };
+        const char* icons[] = { "[ ]", "[FP]", "[TP]", "[TD]", "[ ]" };
+
+        for (int i = 0; i < 5; ++i) {
+            if (idx > 0 && (idx % cols) != 0) {
+                ImGui::SameLine(0, spacing);
+            }
+            RenderTemplateCard(templates[i], icons[i]);
+            idx++;
+        }
+    }
+    ImGui::EndChild();
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    // Project details
+    ImGui::Text("Project Settings:");
+    ImGui::Spacing();
+
+    ImGui::SetNextItemWidth(400);
+    ImGui::InputText("Project Name", m_newProjectName, sizeof(m_newProjectName));
+
+    ImGui::SetNextItemWidth(400);
+    ImGui::InputText("Location", m_newProjectPath, sizeof(m_newProjectPath));
+    ImGui::SameLine();
+    if (ImGui::Button("Browse...##location")) {
+        std::string path;
+        if (BrowseForFolder(path)) {
+            strncpy(m_newProjectPath, path.c_str(), sizeof(m_newProjectPath) - 1);
+        }
+    }
+
+    // Show full project path preview
+    if (strlen(m_newProjectName) > 0 && strlen(m_newProjectPath) > 0) {
+        std::string fullPath = std::string(m_newProjectPath) + "/" + m_newProjectName;
+        ImGui::TextDisabled("Project will be created at: %s", fullPath.c_str());
+    }
+
+    ImGui::SetNextItemWidth(400);
+    ImGui::InputText("Description (optional)", m_newProjectDescription, sizeof(m_newProjectDescription));
+
+    ImGui::Spacing();
+
+    // Error message
+    if (!m_createError.empty()) {
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.3f, 0.3f, 1.0f));
+        ImGui::TextWrapped("%s", m_createError.c_str());
+        ImGui::PopStyleColor();
+    }
+
+    // Create button
+    ImGui::Spacing();
+    bool canCreate = strlen(m_newProjectName) > 0 && strlen(m_newProjectPath) > 0;
+    if (!canCreate) {
+        ImGui::BeginDisabled();
+    }
+
+    if (ImGui::Button("Create Project", ImVec2(160, 36))) {
+        m_createError.clear();
+
+        // Validate project name (no special filesystem characters)
+        std::string name(m_newProjectName);
+        for (char c : name) {
+            if (c == '/' || c == '\\' || c == ':' || c == '*' ||
+                c == '?' || c == '"' || c == '<' || c == '>' || c == '|') {
+                m_createError = "Project name contains invalid characters.";
+                break;
+            }
+        }
+
+        if (m_createError.empty()) {
+            if (m_projectManager->CreateProject(name, m_newProjectPath,
+                                                m_selectedTemplate,
+                                                m_newProjectDescription)) {
+                m_showModal = false;
+                std::cout << "Project created successfully!\n";
+            } else {
+                m_createError = "Failed to create project. Check that the path is writable "
+                                "and the directory doesn't already contain a project.";
+            }
+        }
+    }
+
+    if (!canCreate) {
+        ImGui::EndDisabled();
+    }
+
+    ImGui::SameLine();
+    if (ImGui::Button("Cancel", ImVec2(100, 36))) {
+        m_showModal = false;
+    }
+}
+
+void ProjectBrowserPanel::RenderTemplateCard(ProjectTemplate tmpl, const char* icon) {
+    bool isSelected = (m_selectedTemplate == tmpl);
+    std::string name = ProjectManager::GetProjectTemplateName(tmpl);
+    std::string desc = ProjectManager::GetProjectTemplateDescription(tmpl);
+
+    ImGui::PushID(static_cast<int>(tmpl));
+
+    ImVec2 cardSize(130, 130);
+
+    // Card background
+    if (isSelected) {
+        ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.2f, 0.4f, 0.7f, 0.5f));
+        ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.3f, 0.5f, 0.9f, 1.0f));
+    } else {
+        ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
+        ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.3f, 0.3f, 0.3f, 1.0f));
+    }
+
+    if (ImGui::BeginChild("##card", cardSize, ImGuiChildFlags_Border)) {
+        // Make the child window clickable
+        if (ImGui::IsWindowHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+            m_selectedTemplate = tmpl;
+        }
+
+        // Center icon
+        float iconWidth = ImGui::CalcTextSize(icon).x;
+        ImGui::SetCursorPosX((cardSize.x - iconWidth) * 0.5f);
+        ImGui::SetCursorPosY(20);
+        ImGui::Text("%s", icon);
+
+        // Center name
+        float nameWidth = ImGui::CalcTextSize(name.c_str()).x;
+        ImGui::SetCursorPosX((cardSize.x - nameWidth) * 0.5f);
+        ImGui::SetCursorPosY(60);
+        ImGui::Text("%s", name.c_str());
+
+        // Short description
+        ImGui::SetCursorPosY(85);
+        ImGui::PushTextWrapPos(cardSize.x - 5);
+        ImGui::TextDisabled("%s", desc.substr(0, 60).c_str());
+        ImGui::PopTextWrapPos();
+    }
+    ImGui::EndChild();
+
+    ImGui::PopStyleColor(2);
+    ImGui::PopID();
+}
+
+bool ProjectBrowserPanel::BrowseForFolder(std::string& outPath) {
+#ifdef _WIN32
+    BROWSEINFOA bi = {};
+    bi.lpszTitle = "Select Project Folder";
+    bi.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE;
+
+    LPITEMIDLIST pidl = SHBrowseForFolderA(&bi);
+    if (pidl) {
+        char path[MAX_PATH];
+        if (SHGetPathFromIDListA(pidl, path)) {
+            outPath = path;
+            CoTaskMemFree(pidl);
+            return true;
+        }
+        CoTaskMemFree(pidl);
+    }
+    return false;
+#else
+    // On non-Windows platforms, we'd use a different dialog or zenity
+    // For now, return false to indicate no folder was selected
+    return false;
+#endif
+}
+
+} // namespace SparkEditor

--- a/SparkEditor/Source/Panels/ProjectBrowserPanel.h
+++ b/SparkEditor/Source/Panels/ProjectBrowserPanel.h
@@ -1,0 +1,75 @@
+/**
+ * @file ProjectBrowserPanel.h
+ * @brief Project browser panel for creating and opening projects
+ * @author Spark Engine Team
+ * @date 2025
+ *
+ * Provides a startup hub similar to Unity Hub / Unreal Project Browser.
+ * Users can create new projects from templates, open existing projects,
+ * or pick from their recent projects list.
+ */
+
+#pragma once
+
+#include "../Core/EditorPanel.h"
+#include "../Core/ProjectManager.h"
+#include <string>
+#include <functional>
+
+namespace SparkEditor {
+
+/**
+ * @brief Project browser panel for creating/opening projects
+ *
+ * Displayed as a modal window on startup (when no project is loaded),
+ * or via File > New Project / Open Project. Provides:
+ * - Recent projects list
+ * - New project wizard with template selection
+ * - Browse for existing project
+ */
+class ProjectBrowserPanel : public EditorPanel {
+public:
+    ProjectBrowserPanel(ProjectManager* projectManager);
+    ~ProjectBrowserPanel() override = default;
+
+    bool Initialize() override;
+    void Update(float deltaTime) override;
+    void Render() override;
+    void Shutdown() override;
+
+    /// Show the panel in "New Project" mode
+    void ShowNewProject();
+    /// Show the panel in "Open Project" mode
+    void ShowOpenProject();
+    /// Show the full browser (recent projects + new/open buttons)
+    void ShowBrowser();
+
+    /// Returns true while the browser wants to be shown as a modal overlay
+    bool IsModalActive() const { return m_showModal; }
+    void SetModalActive(bool active) { m_showModal = active; }
+
+private:
+    enum class Tab { RecentProjects, NewProject };
+
+    void RenderModal();
+    void RenderRecentProjects();
+    void RenderNewProjectForm();
+    void RenderTemplateCard(ProjectTemplate tmpl, const char* icon);
+    bool BrowseForFolder(std::string& outPath);
+
+    ProjectManager* m_projectManager = nullptr;
+    bool m_showModal = false;
+    Tab m_activeTab = Tab::RecentProjects;
+
+    // New project form state
+    char m_newProjectName[256] = "MyProject";
+    char m_newProjectPath[512] = "";
+    char m_newProjectDescription[512] = "";
+    ProjectTemplate m_selectedTemplate = ProjectTemplate::Blank3D;
+    std::string m_createError;
+
+    // Open project state
+    std::string m_openError;
+};
+
+} // namespace SparkEditor


### PR DESCRIPTION
Implement a project system similar to other game engines (Unity, Unreal, Godot) that allows game-specific code, assets, and scenes to be created in their own project directories outside the engine source tree.

Key changes:
- Enhanced ProjectManager with .sparkproject file format, project templates (Empty, First Person, Third Person, Top Down, Blank 3D), and standardized directory structure generation (Assets/, Scenes/, Scripts/, Config/, etc.)
- New ProjectBrowserPanel that shows on editor startup as a modal hub for creating new projects or opening recent ones, with template selection cards
- Integrated project lifecycle into EditorUI menu bar (File > New Project, Open Project, Save Project, Recent Projects submenu)
- Recent projects list persisted to %APPDATA%/SparkEngine/Editor
- Project-aware asset browser that updates its root path when a project opens
- Project name shown in editor status bar
- Default scene generation per template with appropriate entities
- EditorSettings.json and .gitignore generated for new projects

This lays the groundwork for moving game-specific code out of the engine.

https://claude.ai/code/session_01Ab7P8yj8x6YCZdLiyRmKPE