### PR TITLE
Add comprehensive SparkEngine wiki (29 pages)

### DIFF
--- a/wiki/AI-and-Navigation.md
+++ b/wiki/AI-and-Navigation.md
@@ -1,0 +1,172 @@
+# AI and Navigation
+
+SparkEngine provides a complete AI framework with behavior trees, NavMesh pathfinding, a perception system, and steering behaviors.
+
+**Source:** `SparkEngine/Source/Engine/AI/`
+
+## Behavior Trees
+
+The behavior tree framework in `BehaviorTree.h` enables complex NPC decision-making through a tree of reusable nodes.
+
+### Node Status
+
+Every node returns one of three statuses after being ticked:
+
+```cpp
+enum class NodeStatus {
+    Running,   // Still working (ticked again next frame)
+    Success,   // Completed successfully
+    Failure    // Could not complete
+};
+```
+
+### Node Types
+
+| Type | Subclasses | Description |
+|------|-----------|-------------|
+| **Composite** | `SequenceNode`, `SelectorNode`, `ParallelNode` | Multiple children, evaluated by policy |
+| **Decorator** | `InverterNode`, `RepeaterNode` | Single child, modifies result or timing |
+| **Leaf (Action)** | `ActionNode`, `WaitNode` | Performs actual work |
+| **Leaf (Condition)** | `ConditionNode` | Tests state, returns Success or Failure |
+
+### Composite Nodes
+
+- **SequenceNode** — Runs children left-to-right. Fails if any child fails. Succeeds when all children succeed.
+- **SelectorNode** — Runs children left-to-right. Succeeds if any child succeeds. Fails when all children fail.
+- **ParallelNode** — Runs all children simultaneously. Configurable success/failure policies.
+
+### Decorator Nodes
+
+- **InverterNode** — Inverts child result (Success ↔ Failure)
+- **RepeaterNode** — Repeats child a specified number of times
+
+### Blackboard
+
+The `Blackboard` is a typed key-value store shared by all nodes in a tree, acting as the agent's working memory:
+
+```cpp
+Blackboard bb;
+bb.Set("enemyVisible", true);
+bb.Set("targetPosition", XMFLOAT3{10, 0, 5});
+
+bool visible = bb.Get<bool>("enemyVisible", false);  // default if not found
+```
+
+### Building a Behavior Tree
+
+```cpp
+// Guard behavior: attack if enemy seen, otherwise patrol
+auto root = std::make_unique<SelectorNode>("Root");
+
+// Branch 1: attack sequence
+auto combatSeq = std::make_unique<SequenceNode>("CombatSeq");
+combatSeq->AddChild(std::make_unique<ConditionNode>("EnemyVisible",
+    [](const Blackboard& bb) { return bb.Get<bool>("enemyVisible", false); }));
+combatSeq->AddChild(std::make_unique<ActionNode>("Attack",
+    [](float dt, Blackboard& bb) -> NodeStatus {
+        // Attack logic here
+        return NodeStatus::Success;
+    }));
+root->AddChild(std::move(combatSeq));
+
+// Branch 2: patrol fallback
+root->AddChild(std::make_unique<ActionNode>("Patrol", patrolFunction));
+
+// Create and tick the tree
+auto tree = std::make_unique<BehaviorTree>("GuardBehavior");
+tree->SetRoot(std::move(root));
+
+// Each AI update:
+tree->Tick(deltaTime);
+```
+
+## NavMesh Pathfinding
+
+`NavMesh` provides A* pathfinding on navigation meshes stored in binary `.snav` format.
+
+```cpp
+NavMesh navmesh;
+navmesh.LoadFromFile("Assets/NavMeshes/Level01.snav");
+
+// Find a path
+std::vector<XMFLOAT3> path;
+if (navmesh.FindPath(startPos, endPos, path)) {
+    // Follow path waypoints
+    for (const auto& waypoint : path) {
+        // Move toward waypoint
+    }
+}
+```
+
+## Perception System
+
+`PerceptionSystem` gives NPCs awareness of their environment through configurable senses:
+
+### Vision
+
+```cpp
+PerceptionConfig config;
+config.visionRange = 30.0f;    // Maximum sight distance
+config.visionAngle = 90.0f;    // Field of view (degrees)
+config.visionHeight = 2.0f;    // Eye height
+```
+
+### Hearing
+
+```cpp
+config.hearingRange = 15.0f;   // Maximum hearing distance
+config.hearingThreshold = 0.1f; // Minimum sound level to detect
+```
+
+### Memory
+
+The perception system maintains memory of previously detected entities, with configurable memory duration.
+
+## Steering Behaviors
+
+`SteeringBehaviors` provides movement algorithms for NPC locomotion:
+
+| Behavior | Description |
+|----------|-------------|
+| **Seek** | Move directly toward a target position |
+| **Flee** | Move directly away from a target position |
+| **Pursue** | Predict target's future position and intercept |
+| **Evade** | Predict target's future position and avoid |
+| **Wander** | Random wandering with configurable parameters |
+| **Flocking** | Group behavior (separation, alignment, cohesion) |
+
+```cpp
+SteeringBehaviors steering;
+
+// Calculate steering force
+XMFLOAT3 force = steering.Seek(currentPos, targetPos, currentVelocity, maxSpeed);
+
+// Combine multiple behaviors
+XMFLOAT3 combined = steering.Seek(...) * 1.0f
+                   + steering.Separation(...) * 1.5f
+                   + steering.Alignment(...) * 1.0f;
+```
+
+## ECS Integration
+
+Use `AIComponent` on entities:
+
+```cpp
+auto& ai = world.AddComponent<AIComponent>(entity);
+ai.behaviorTreeName = "GuardBehavior";
+ai.detectionRadius  = 20.0f;
+ai.attackRange      = 5.0f;
+ai.moveSpeed        = 3.0f;
+ai.state            = AIState::Idle;
+```
+
+The `AISystem` ticks behavior trees and updates steering for all entities with `AIComponent` each frame.
+
+## Node Ownership
+
+All node classes use value-semantic ownership via `std::unique_ptr`. There are no raw-pointer ownership relationships in the behavior tree API.
+
+## See Also
+
+- [[Entity Component System]] — AIComponent
+- [[Gameplay Systems]] — NPC and combat systems

--- a/wiki/Animation.md
+++ b/wiki/Animation.md
@@ -1,0 +1,130 @@
+# Animation
+
+SparkEngine provides a full skeletal animation system with bone hierarchies, state machines, multi-layer blending, inverse kinematics, and root motion support.
+
+**Source:** `SparkEngine/Source/Engine/Animation/AnimationSystem.h`
+
+## Overview
+
+The animation system supports:
+- Skeletal animation with bone hierarchies
+- Keyframe animation clips
+- Animation state machines with cross-fading
+- Multi-layer blending (override, additive, layered with per-bone masks)
+- Inverse kinematics (two-bone, look-at, FABRIK)
+- Root motion extraction
+- FBX and glTF import via Assimp
+
+## Skeletal Animation
+
+### Bone Hierarchies
+
+Skeletons are imported from FBX/glTF files via the asset pipeline. Each bone has:
+- Name
+- Parent index (-1 for root)
+- Bind pose transform (local and inverse bind matrix)
+
+### Animation Clips
+
+Clips contain keyframe data for bones:
+- Position keyframes (translation over time)
+- Rotation keyframes (quaternion over time)
+- Scale keyframes (scaling over time)
+
+Keyframes are interpolated (lerp for position/scale, slerp for rotation).
+
+## State Machines
+
+Animation state machines manage transitions between animation clips with configurable cross-fading:
+
+```
+  ┌───────┐   walk trigger   ┌───────┐
+  │ Idle  │ ──────────────── │ Walk  │
+  │       │ ◄─────────────── │       │
+  └───────┘   idle trigger   └───────┘
+      │                          │
+      │ jump trigger             │ run trigger
+      ▼                          ▼
+  ┌───────┐                  ┌───────┐
+  │ Jump  │                  │  Run  │
+  └───────┘                  └───────┘
+```
+
+### Transitions
+
+- **Cross-fade duration** — Time to blend between states (seconds)
+- **Transition conditions** — Trigger names, parameter thresholds
+- **Exit time** — Optional: wait for current clip to finish before transitioning
+
+## Multi-Layer Blending
+
+Multiple animation layers can be combined:
+
+| Mode | Description |
+|------|-------------|
+| **Override** | Layer completely replaces the base pose for affected bones |
+| **Additive** | Layer is added on top of the base pose |
+| **Layered** | Per-bone weight masks for selective blending |
+
+Use per-bone masks to, for example, play an upper-body attack animation while the lower body continues a walk cycle.
+
+## Inverse Kinematics
+
+Three IK solvers are available:
+
+### Two-Bone IK
+
+For limbs (arms, legs):
+```
+Shoulder ─── Elbow ─── Hand → Target
+```
+Solves for natural joint angles to reach a target position.
+
+### Look-At IK
+
+Rotates a bone (typically the head) to face a target:
+```
+Head bone → Look at target position
+```
+
+### FABRIK (Forward And Backward Reaching IK)
+
+Iterative multi-joint solver for chains of any length:
+```
+Root ─── Joint1 ─── Joint2 ─── ... ─── End Effector → Target
+```
+Supports joint constraints and converges quickly (typically 5-10 iterations).
+
+## Root Motion
+
+Root motion extraction moves the character based on animation data rather than gameplay code:
+- Translation from the root bone drives character movement
+- Rotation from the root bone drives character facing
+- Useful for realistic walk/run cycles, combat animations
+
+## ECS Integration
+
+Use `AnimationController` on entities:
+
+```cpp
+auto& anim = world.AddComponent<AnimationController>(entity);
+anim.currentAnimation = "Idle";
+anim.playbackSpeed    = 1.0f;
+anim.isPlaying        = true;
+anim.loop             = true;
+anim.blendFactor      = 1.0f;
+```
+
+The `AnimationUpdateSystem` evaluates state machines and blends poses each frame.
+
+## Asset Import
+
+Models with animations are imported via Assimp (see [[Asset Pipeline]]):
+- **FBX** — Industry standard, supports skeletons and animations
+- **glTF** — Modern format with PBR materials and animations
+
+## See Also
+
+- [[Entity Component System]] — AnimationController component
+- [[Asset Pipeline]] — Importing animated models
+- [[SparkEditor]] — Animation timeline editor

--- a/wiki/Architecture-Overview.md
+++ b/wiki/Architecture-Overview.md
@@ -1,0 +1,208 @@
+# Architecture Overview
+
+SparkEngine follows a modular, service-oriented architecture where the engine executable loads game logic as dynamically linked modules (DLLs on Windows, shared libraries on Linux).
+
+## High-Level Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│              SparkEngine (Main Executable)                   │
+│  • Initializes all subsystems                               │
+│  • Loads game modules dynamically (DLL/SO)                  │
+│  • Runs the main loop                                       │
+│  • Manages lifecycle (Initialize → MainLoop → Shutdown)     │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│              IEngineContext (Service Locator)                │
+│  • GetGraphics()   → GraphicsEngine*                        │
+│  • GetInput()      → InputManager*                          │
+│  • GetTimer()      → Timer*                                 │
+│  • GetEventBus()   → EventBus*                              │
+│  • GetEngineVersion() / GetSDKVersion()                     │
+└─────────────────────────────────────────────────────────────┘
+                            │
+              ┌─────────────┼─────────────┐
+              ▼             ▼             ▼
+     ┌──────────────┐ ┌──────────┐ ┌──────────────┐
+     │ SparkGame.dll│ │Module2.dll│ │ Module3.dll  │
+     │ (IModule)    │ │ (IModule) │ │  (IModule)   │
+     └──────────────┘ └──────────┘ └──────────────┘
+```
+
+## Module System
+
+Game logic is compiled as separate shared libraries that the engine loads at runtime. Each module implements the `Spark::IModule` interface:
+
+```cpp
+class IModule {
+public:
+    virtual ModuleInfo GetModuleInfo() const = 0;
+    virtual bool OnLoad(IEngineContext* context) = 0;
+    virtual void OnUnload() = 0;
+    virtual void OnUpdate(float deltaTime) = 0;
+    virtual void OnRender() {}           // optional
+    virtual void OnResize(int w, int h) {} // optional
+};
+```
+
+**Lifecycle order:**
+1. `OnLoad()` — Module receives the engine context
+2. `OnUpdate()` — Called every frame
+3. `OnRender()` — Called every frame after update
+4. `OnUnload()` — Called before the DLL is unloaded
+
+Multiple modules can be loaded simultaneously and are initialized in load-order (lower `ModuleInfo::loadOrder` values first, default is 1000).
+
+**Module discovery** (in order of priority):
+1. Command-line argument: `-game <path>`
+2. `spark.modules.json` manifest next to the executable
+3. Directory scan for `*Game*.dll` or `*Module*.dll`
+
+See [[Creating a Game Module]] for a step-by-step guide.
+
+## Service Locator Pattern
+
+The `IEngineContext` interface provides centralized access to engine subsystems:
+
+```cpp
+class IEngineContext {
+public:
+    virtual GraphicsEngine* GetGraphics() = 0;
+    virtual InputManager*   GetInput() = 0;
+    virtual Timer*          GetTimer() = 0;
+    virtual EventBus*       GetEventBus() = 0;
+    virtual uint32_t        GetEngineVersion() const = 0;
+    virtual uint32_t        GetSDKVersion() const = 0;
+};
+```
+
+Game modules store the context pointer during `OnLoad()` and use it throughout their lifetime to access engine services.
+
+## Subsystem Architecture
+
+```
+┌──────────────────┬──────────────────┬──────────────────┐
+│   RENDERING      │    PHYSICS       │      AUDIO       │
+│                  │                  │                  │
+│ GraphicsEngine   │ PhysicsSystem    │ AudioEngine      │
+│ RHI (DX11,      │ Bullet3 World    │ XAudio2 / mini   │
+│   Vulkan, GL)   │ Collision        │ 3D Spatial       │
+│ PBR Materials   │ Raycasting       │ Object Pool      │
+│ Post-Processing │                  │                  │
+├──────────────────┼──────────────────┼──────────────────┤
+│   SCRIPTING      │    INPUT & UI    │    CORE & ECS    │
+│                  │                  │                  │
+│ AngelScript VM   │ InputManager     │ EnTT ECS         │
+│ Hot Reload       │ Gamepad Support  │ SceneManager     │
+│ Engine Bindings  │ ImGui Editor     │ AssetPipeline    │
+├──────────────────┼──────────────────┼──────────────────┤
+│   GAMEPLAY       │    AI & NAV      │   NETWORKING     │
+│                  │                  │                  │
+│ PlayerController │ BehaviorTree     │ UDP Client/Srv   │
+│ WeaponSystem     │ NavMesh (A*)     │ Prediction       │
+│ VehicleSystem    │ Perception       │ Lag Compensation │
+├──────────────────┼──────────────────┼──────────────────┤
+│   PROCEDURAL     │    ANIMATION     │    UTILITIES     │
+│                  │                  │                  │
+│ Noise (Perlin+)  │ Skeletal Anim    │ CrashHandler     │
+│ Erosion / WFC    │ IK / Blending    │ Console (200+)   │
+│ Mesh Generation  │ State Machines   │ Profiler / Debug │
+└──────────────────┴──────────────────┴──────────────────┘
+```
+
+## ECS Data Flow
+
+SparkEngine uses the **EnTT** library for its Entity Component System. The data flow each frame:
+
+1. **Input** — `InputManager::Update()` captures keyboard/mouse/gamepad state
+2. **Scripts** — `AngelScriptEngine` calls `Update()` on entity scripts
+3. **AI** — `AISystem` ticks behavior trees and updates steering
+4. **Physics** — `PhysicsSystem::Update()` steps the Bullet simulation
+5. **Animation** — `AnimationSystem` evaluates state machines and blends poses
+6. **Audio** — `AudioEngine` updates 3D listener and source positions
+7. **Rendering** — `GraphicsEngine` renders the scene with all post-processing
+
+Components are pure POD structs (state only, no behavior). Systems query and mutate components each frame.
+
+## Project Structure
+
+```
+SparkEngine/
+├── SparkEngine/              # Main engine executable + core library
+│   └── Source/
+│       ├── Audio/            # XAudio2 3D audio engine
+│       ├── Camera/           # First-person camera controller
+│       ├── Console/          # Debug console integration
+│       ├── Core/             # Entry point, platform, framework
+│       ├── Engine/
+│       │   ├── AI/           # Behavior trees, NavMesh, perception, steering
+│       │   ├── Animation/    # Skeletal animation, IK, state machines
+│       │   ├── Cinematic/    # Cinematic sequencer
+│       │   ├── Coroutine/    # Coroutine scheduler
+│       │   ├── ECS/          # EnTT entity-component system
+│       │   ├── Events/       # Publish/subscribe event bus
+│       │   ├── Networking/   # UDP multiplayer, replication
+│       │   ├── Procedural/   # Noise, erosion, mesh generation, WFC
+│       │   ├── SaveSystem/   # Serialization, compression
+│       │   ├── Scripting/    # AngelScript VM, hot-reload
+│       │   └── World/        # World management, day/night
+│       ├── Game/             # Player, weapons, vehicles, HUD, terrain
+│       ├── Graphics/         # DX11 renderer, RHI, PBR, post-processing
+│       ├── Input/            # Keyboard, mouse, gamepad
+│       ├── Physics/          # Bullet Physics integration
+│       ├── SceneManager/     # Scene hierarchy, serialization
+│       └── Utils/            # Logging, profiler, crash handler, debug
+├── SparkEditor/              # ImGui-based visual editor (Windows only)
+├── SparkGame/                # Default game module (DLL)
+├── SparkConsole/             # Standalone debug console
+├── SparkShaderCompiler/      # Offline shader compilation tool
+├── SparkSDK/                 # Public SDK headers for module development
+├── Templates/                # Game module templates (EmptyProject)
+├── ThirdParty/               # Git submodules (15 libraries)
+├── Assets/                   # Models, Scenes, Scripts
+├── Shaders/                  # HLSL, GLSL, Compiled bytecode
+├── Tests/                    # 35 unit tests
+├── Tools/                    # CLI tools (spark-cli)
+├── docs/                     # Doxygen API docs, roadmap, status
+├── cmake/                    # CMake helper modules
+└── CMakeLists.txt            # Main build configuration (1000+ lines)
+```
+
+## Key Architectural Patterns
+
+| Pattern | Usage |
+|---------|-------|
+| **Service Locator** | `IEngineContext` provides centralized access to subsystems |
+| **ECS (Entity-Component-System)** | EnTT registry with POD components and system functions |
+| **Dynamic Module Loading** | Game logic in DLLs/SOs loaded at runtime |
+| **Event Bus** | Type-safe pub/sub for decoupled system communication |
+| **RHI Abstraction** | `RHIFactory` selects between D3D11, Vulkan, OpenGL backends |
+| **Object Pooling** | Audio sources and particles reuse pooled instances |
+| **Factory Pattern** | `RHIFactory` for graphics backend instantiation |
+| **Singleton** | `Profiler`, `AnimationManager`, `AudioEngine` via `GetInstance()` |
+
+## Build System
+
+CMake-based with 30+ toggleable feature flags. See [[Build System and CMake Modules]] for details.
+
+## Dependencies
+
+| Library | Purpose |
+|---------|---------|
+| EnTT | Entity Component System |
+| Bullet Physics 3 | Physics simulation |
+| Dear ImGui | Editor UI (docking branch) |
+| AngelScript | Gameplay scripting |
+| Assimp | 3D model import (FBX, glTF) |
+| GLM | Math library |
+| RapidJSON | JSON parsing |
+| spdlog | Structured logging |
+| stb | Image loading |
+| miniaudio | Cross-platform audio fallback |
+| DirectXTK | DirectX 11 toolkit |
+| ImGuizmo | 3D editor gizmos |
+| imnodes | Node graph editor |
+| miniz | Compression |
+| tinyobjloader | OBJ file loading |

--- a/wiki/Asset-Pipeline.md
+++ b/wiki/Asset-Pipeline.md
@@ -1,0 +1,141 @@
+# Asset Pipeline
+
+SparkEngine's asset pipeline handles loading, streaming, and management of game assets including 3D models, textures, audio, and scenes.
+
+**Source:** `SparkEngine/Source/Graphics/AssetPipeline.h`
+
+## Supported Formats
+
+### 3D Models
+
+| Format | Description | Library |
+|--------|-------------|---------|
+| `.obj` | Wavefront OBJ | tinyobjloader |
+| `.fbx` | Autodesk FBX (meshes, skeletons, animations) | Assimp |
+| `.gltf` / `.glb` | glTF 2.0 (PBR materials, animations) | Assimp |
+
+### Textures
+
+| Format | Description | Library |
+|--------|-------------|---------|
+| `.png` | Lossless compressed | stb_image |
+| `.jpg` | Lossy compressed | stb_image |
+| `.tga` | Targa | stb_image |
+| `.bmp` | Bitmap | stb_image |
+| `.hdr` | High Dynamic Range | stb_image |
+
+### Audio
+
+| Format | Description | Library |
+|--------|-------------|---------|
+| `.wav` | Waveform audio | XAudio2 / miniaudio |
+
+### Scenes
+
+| Format | Description |
+|--------|-------------|
+| `.scene` / `.json` | JSON scene files |
+| `.prefab` | Prefab templates |
+| `.snav` | Binary NavMesh data |
+
+### Shaders
+
+| Format | Description |
+|--------|-------------|
+| `.hlsl` | HLSL shader source |
+| `.glsl` | GLSL shader source |
+| `.cso` | Compiled DirectX bytecode |
+| `.spv` | SPIR-V bytecode |
+
+## Directory Conventions
+
+```
+Assets/
+├── Models/          # 3D model files (.obj, .fbx, .gltf)
+├── Scenes/          # Scene files (.scene, .json)
+├── Scripts/         # AngelScript files (.as)
+├── Textures/        # Texture files (.png, .jpg, .tga)
+├── Audio/           # Sound files (.wav)
+├── NavMeshes/       # Navigation mesh files (.snav)
+├── Prefabs/         # Prefab templates (.prefab)
+└── Cinematics/      # Cinematic sequences (.seq)
+
+Shaders/
+├── HLSL/            # DirectX shaders
+├── GLSL/            # OpenGL shaders
+└── Compiled/        # Pre-compiled bytecode
+```
+
+## Model Loading
+
+### OBJ Files
+
+```cpp
+// tinyobjloader for simple static meshes
+Model model;
+model.LoadOBJ("Assets/Models/crate.obj");
+```
+
+### FBX / glTF Files (via Assimp)
+
+```cpp
+AssetPipeline pipeline;
+
+// Import a model with skeletons and animations
+auto result = pipeline.ImportModel("Assets/Models/character.fbx");
+// result contains: meshes, materials, skeleton, animation clips
+```
+
+Assimp imports:
+- Mesh geometry (vertices, normals, UVs, tangents)
+- Material definitions (mapped to PBR properties)
+- Bone hierarchies and skinning data
+- Animation clips with keyframes
+
+## Texture Loading
+
+```cpp
+TextureSystem textures;
+
+// Load a texture
+auto texture = textures.LoadTexture("Assets/Textures/brick_albedo.png");
+
+// Async loading
+textures.LoadTextureAsync("Assets/Textures/large_texture.png",
+    [](Texture* tex) { /* callback when loaded */ });
+```
+
+### Texture Quality Levels
+
+| Level | Description |
+|-------|-------------|
+| Low | Quarter resolution, basic filtering |
+| Medium | Half resolution, bilinear filtering |
+| High | Full resolution, anisotropic filtering |
+| Ultra | Full resolution, max anisotropic filtering |
+
+## Asset Streaming
+
+`ENABLE_ASSET_STREAMING=ON`
+
+Assets can be streamed in the background to avoid loading hitches:
+- Texture mip-map streaming based on camera distance
+- Model LOD loading on demand
+- Background thread loading with callbacks
+
+## Hot Reloading
+
+`ENABLE_HOT_RELOAD=ON`
+
+During development, modified assets are automatically reloaded:
+- Texture files
+- Shader source files
+- AngelScript files
+- Scene files
+
+## See Also
+
+- [[Rendering and Graphics]] — Material and texture systems
+- [[Animation]] — Importing animated models
+- [[Shader Pipeline]] — Shader compilation
+- [[Scene Management]] — Scene file loading

--- a/wiki/Audio.md
+++ b/wiki/Audio.md
@@ -1,0 +1,127 @@
+# Audio
+
+SparkEngine provides a comprehensive audio system built on **XAudio2** (Windows) with **miniaudio** as a cross-platform fallback. It supports 2D and 3D spatial audio with Doppler effects, distance attenuation, and efficient source pooling.
+
+**Source:** `SparkEngine/Source/Audio/AudioEngine.h`
+
+## Initialization
+
+```cpp
+AudioEngine audio;
+audio.Initialize(32);  // max 32 simultaneous audio sources
+```
+
+## Loading Sounds
+
+```cpp
+audio.LoadSound("gunshot", "Assets/Audio/gunshot.wav");
+audio.LoadSound("music", "Assets/Audio/background.wav");
+```
+
+## Playing Sounds
+
+### 2D Audio (UI, music)
+
+```cpp
+audio.Play2D("music", 0.8f, true);  // name, volume, loop
+```
+
+### 3D Spatial Audio
+
+```cpp
+XMFLOAT3 position = {10.0f, 0.0f, 5.0f};
+XMFLOAT3 velocity = {0.0f, 0.0f, 0.0f};
+audio.Play3D("gunshot", position, velocity, 1.0f, false);
+```
+
+## Audio Source Properties
+
+```cpp
+struct AudioSource {
+    IXAudio2SourceVoice* Voice;
+    XMFLOAT3 Position;     // 3D world position
+    XMFLOAT3 Velocity;     // For Doppler effects
+    float    Volume;       // 0.0 to 1.0+
+    float    Pitch;        // 1.0 = normal
+    bool     Is3D;         // 3D positioning enabled
+    bool     IsLooping;    // Loop continuously
+    bool     IsPlaying;    // Currently playing
+};
+```
+
+## Volume Channels
+
+Three independent volume channels:
+
+| Channel | Description |
+|---------|-------------|
+| Master | Overall volume multiplier |
+| SFX | Sound effects volume |
+| Music | Background music volume |
+
+```cpp
+audio.SetMasterVolume(1.0f);
+audio.SetSFXVolume(0.7f);
+audio.SetMusicVolume(0.5f);
+```
+
+## 3D Audio Features
+
+- **Distance Attenuation** — Sound volume decreases with distance from the listener
+- **Doppler Effect** — Pitch shifts based on relative velocity between source and listener
+- **3D Positioning** — Sounds are spatialized relative to the listener position and orientation
+
+### Updating the Listener
+
+```cpp
+// Update listener position and orientation each frame
+audio.SetListenerPosition(cameraPosition);
+audio.SetListenerOrientation(cameraForward, cameraUp);
+```
+
+## Object Pooling
+
+The audio engine uses an object pool for efficient source management. Sources are allocated from the pool when `Play2D`/`Play3D` is called and returned when playback completes.
+
+## ECS Integration
+
+Use `AudioSourceComponent` on entities:
+
+```cpp
+auto& src = world.AddComponent<AudioSourceComponent>(entity);
+src.soundFile    = "gunshot";
+src.volume       = 1.0f;
+src.pitch        = 1.0f;
+src.loop         = false;
+src.is3D         = true;
+src.minDistance   = 1.0f;
+src.maxDistance   = 50.0f;
+```
+
+The `AudioUpdateSystem` automatically updates 3D source positions from entity transforms each frame.
+
+## Console Commands
+
+```
+audio_info           # Show audio system status
+audio_master <vol>   # Set master volume (0.0-1.0)
+audio_sfx <vol>      # Set SFX volume
+audio_music <vol>    # Set music volume
+audio_play <name>    # Play a sound
+audio_stop_all       # Stop all sounds
+audio_list           # List loaded sounds
+audio_sources        # Show active audio sources
+```
+
+## Platform Support
+
+| Platform | Backend | Status |
+|----------|---------|--------|
+| Windows | XAudio2 | Full support |
+| Linux | miniaudio | Fallback |
+| macOS | miniaudio | Fallback |
+
+## See Also
+
+- [[Entity Component System]] — AudioSourceComponent
+- [[Asset Pipeline]] — Loading audio assets

--- a/wiki/Build-System-and-CMake-Modules.md
+++ b/wiki/Build-System-and-CMake-Modules.md
@@ -1,0 +1,193 @@
+# Build System and CMake Modules
+
+SparkEngine uses CMake 3.16+ as its build system with 30+ toggleable feature modules, cross-platform presets, and CI/CD integration.
+
+**Source:** `CMakeLists.txt`, `cmake/`, `CMakePresets.json`
+
+## CMake Configuration
+
+### Minimum Requirements
+
+- CMake 3.16+
+- C++20 standard (enforced, no extensions)
+- CMP0091 policy for consistent MSVC runtime
+
+### Quick Configuration
+
+```bash
+# Windows (Visual Studio 2022)
+.\generate.bat -g "Visual Studio 17 2022" release
+
+# Linux (Ninja)
+./generate.sh release -g Ninja
+
+# Direct CMake
+cmake -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
+```
+
+## Feature Flags
+
+All flags can be set during CMake configuration with `-D<FLAG>=ON|OFF`:
+
+### Graphics
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `ENABLE_GRAPHICS` | ON | Graphics rendering engine |
+| `ENABLE_VULKAN` | ON | Vulkan backend |
+| `ENABLE_OPENGL` | ON | OpenGL backend |
+| `ENABLE_DXR` | OFF | DirectX Raytracing (requires D3D12) |
+| `ENABLE_POST_PROCESSING` | ON | Post-processing effects |
+| `ENABLE_LIGHTING_SYSTEM` | ON | Advanced lighting |
+| `ENABLE_MESH_LOD` | ON | Mesh level-of-detail |
+| `ENABLE_DECALS` | ON | Decal system |
+| `ENABLE_FOG_SYSTEM` | ON | Fog rendering |
+| `ENABLE_SCREEN_SPACE` | ON | SSAO, SSR effects |
+
+### Gameplay
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `ENABLE_PHYSX` | ON | Physics engine (Bullet) |
+| `ENABLE_AI` | ON | AI and navigation |
+| `ENABLE_ANIMATION` | ON | Skeletal animation |
+| `ENABLE_TERRAIN_SYSTEM` | ON | Heightmap terrain |
+| `ENABLE_WEATHER` | ON | Weather system |
+| `ENABLE_INVENTORY` | ON | Inventory system |
+| `ENABLE_QUEST_SYSTEM` | ON | Quest/objective tracking |
+| `ENABLE_DAY_NIGHT` | ON | Day/night cycle |
+| `ENABLE_SAVE_SYSTEM` | ON | Save/load system |
+| `ENABLE_PROCEDURAL` | ON | Procedural generation |
+| `ENABLE_CINEMATIC` | ON | Cinematic sequencer |
+| `ENABLE_EVENT_SYSTEM` | ON | Event bus |
+
+### Features
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `ENABLE_EDITOR` | ON (Windows) | ImGui editor |
+| `ENABLE_PROFILING` | ON | Performance profiler |
+| `ENABLE_HOT_RELOAD` | ON | Script hot-reload |
+| `ENABLE_ASSET_STREAMING` | ON | Runtime asset streaming |
+| `ENABLE_ADVANCED_INPUT` | ON | Advanced input features |
+| `ENABLE_PERF_STATS` | ON | Performance statistics overlay |
+| `ENABLE_LUA` | ON | Lua scripting support |
+| `ENABLE_COLLABORATIVE` | ON | Collaborative features |
+
+### External / Disabled by Default
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `ENABLE_NETWORKING` | OFF | Networking (CURL dependency issues) |
+| `ENABLE_SDL2` | OFF | SDL2 cross-platform input |
+| `BUILD_TESTS` | ON | Unit test suite |
+
+### MSVC Toolset
+
+```bash
+cmake -DSPARK_MSVC_TOOLSET=v144 ...  # VS 2026
+cmake -DSPARK_MSVC_TOOLSET=v143 ...  # VS 2022 (default)
+```
+
+## CMake Presets
+
+`CMakePresets.json` provides ready-made configurations:
+
+| Preset | Description |
+|--------|-------------|
+| `windows-debug` | Windows, VS 2022, Debug |
+| `windows-release` | Windows, VS 2022, Release |
+| `linux-gcc-debug` | Linux, GCC, Debug |
+| `linux-gcc-release` | Linux, GCC, Release |
+| `linux-clang-debug` | Linux, Clang, Debug |
+| `linux-clang-release` | Linux, Clang, Release |
+| `ci-linux-asan` | AddressSanitizer build |
+| `ci-linux-tsan` | ThreadSanitizer build |
+| `minimal` | Core-only, no advanced features |
+
+```bash
+cmake --preset windows-release
+cmake --build --preset windows-release
+```
+
+## Build Targets
+
+| Target | Type | Description |
+|--------|------|-------------|
+| `SparkEngineLib` | Static library | Core engine systems |
+| `SparkEngine` | Executable | Runtime host |
+| `SparkGame` | Shared library | Default game module |
+| `SparkEditor` | Executable | Visual editor (Windows) |
+| `SparkConsole` | Executable | Debug console (Windows) |
+| `SparkShaderCompiler` | Executable | Shader compilation tool |
+
+## Build Output
+
+```
+build/
+├── bin/       # Executables and DLLs
+├── lib/       # Static libraries
+├── Shaders/   # Compiled shaders
+└── Assets/    # Game assets (copied)
+```
+
+## CMake Helper Modules
+
+### SparkGameModule.cmake
+
+Provides `spark_add_game_module()` for creating game module DLLs:
+
+```cmake
+include(cmake/SparkGameModule.cmake)
+spark_add_game_module(MyGame ${GAME_SOURCES})
+```
+
+This:
+- Creates a shared library with module API exports
+- Links against SparkEngineLib
+- Handles platform-specific compilation flags
+
+### SparkEngineConfig.cmake
+
+Enables `find_package(SparkEngine)` for standalone game projects.
+
+## Build Scripts
+
+| Script | Platform | Description |
+|--------|----------|-------------|
+| `generate.bat` | Windows | CMake configuration |
+| `generate.sh` | Linux/macOS | CMake configuration |
+| `build.ps1` | Windows | PowerShell build script |
+| `build.sh` | Linux/macOS | Bash build script |
+
+## CI/CD (GitHub Actions)
+
+### build.yml
+
+Runs on every push to `main`, `develop`, and `feature/*` branches:
+- **Platforms:** Windows (VS 2022), Linux (GCC, Clang)
+- **Configurations:** Debug and Release matrix
+- **Artifacts:** Retained for 7 days
+
+### release.yml
+
+Runs on every push to `master`/`main`:
+- Creates rolling `latest` GitHub Release
+- Packages: Windows and Linux binaries (Debug + Release)
+- Formats: `.zip` (Windows), `.tar.gz` (Linux)
+- Includes exact commit hash and timestamp
+
+## Compiler Support
+
+| Compiler | Version | Platform |
+|----------|---------|----------|
+| MSVC | v143 (VS 2022) | Windows |
+| MSVC | v144 (VS 2026) | Windows (experimental) |
+| GCC | 11+ | Linux |
+| Clang | 14+ | Linux |
+| Apple Clang | C++20 capable | macOS |
+
+## See Also
+
+- [[Getting Started]] — Build quickstart
+- [[Testing]] — Running unit tests

--- a/wiki/Cinematic-Sequencer.md
+++ b/wiki/Cinematic-Sequencer.md
@@ -1,0 +1,88 @@
+# Cinematic Sequencer
+
+SparkEngine includes a timeline-based cinematic sequencer for creating in-game cutscenes and scripted events.
+
+**Source:** `SparkEngine/Source/Engine/Cinematic/Sequencer.h`
+
+`ENABLE_CINEMATIC=ON`
+
+## Overview
+
+The sequencer provides a non-linear timeline editor for:
+- Camera movements and cuts
+- Entity animations and transformations
+- Audio cue playback
+- Event triggers
+- UI transitions
+
+## Concepts
+
+### Sequence
+
+A sequence is a collection of tracks that play together over a defined time range.
+
+### Tracks
+
+Each track controls a specific aspect of the scene:
+
+| Track Type | Controls |
+|-----------|----------|
+| Camera | Camera position, rotation, FOV over time |
+| Transform | Entity position, rotation, scale over time |
+| Animation | Animation clip playback and blending |
+| Audio | Sound effect and music cue timing |
+| Event | Custom event triggers at specific times |
+
+### Keyframes
+
+Keyframes define values at specific points in time. The sequencer interpolates between keyframes:
+- **Linear** interpolation for smooth transitions
+- **Bezier** curves for eased motion
+- **Step** interpolation for instant changes
+
+## Playback Control
+
+```cpp
+Sequencer sequencer;
+
+// Load a sequence
+sequencer.Load("Assets/Cinematics/Intro.seq");
+
+// Playback controls
+sequencer.Play();
+sequencer.Pause();
+sequencer.Stop();
+sequencer.SetTime(5.0f);     // Seek to 5 seconds
+sequencer.SetSpeed(0.5f);    // Half speed playback
+
+// Check state
+bool playing = sequencer.IsPlaying();
+float currentTime = sequencer.GetCurrentTime();
+float duration = sequencer.GetDuration();
+```
+
+## Camera Cuts
+
+The sequencer can smoothly transition between camera angles or make hard cuts:
+
+- **Smooth transition** — Interpolate position and rotation over a duration
+- **Hard cut** — Instant switch to a new camera angle
+- **Dolly/crane shots** — Move along spline paths
+
+## Integration
+
+Cinematics can be triggered from:
+- Game module code (C++)
+- AngelScript scripts
+- Trigger volumes in scenes
+- Event system callbacks
+
+## Editor Support
+
+The SparkEditor includes a visual timeline editor for creating and editing cinematic sequences. See [[SparkEditor]] for details.
+
+## See Also
+
+- [[Animation]] — Animation tracks in sequences
+- [[Audio]] — Audio cue playback
+- [[SparkEditor]] — Timeline editor UI

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -1,0 +1,126 @@
+# Contributing
+
+SparkEngine welcomes contributions of all kinds. This guide covers code style, architecture conventions, and the contribution workflow.
+
+## License
+
+SparkEngine is licensed under the **MIT License**. All contributions are subject to the same license.
+
+## Getting Started
+
+1. Fork the repository on GitHub
+2. Clone your fork with submodules:
+   ```bash
+   git clone --recurse-submodules https://github.com/YOUR_USERNAME/SparkEngine.git
+   ```
+3. Create a feature branch:
+   ```bash
+   git checkout -b feature/my-feature
+   ```
+4. Make your changes
+5. Build and test:
+   ```bash
+   cmake -B build -DBUILD_TESTS=ON
+   cmake --build build
+   ctest --test-dir build --output-on-failure
+   ```
+6. Push and open a Pull Request
+
+## Code Style
+
+### Language Standard
+
+- **C++20** — All code must compile with C++20 enabled
+- No compiler-specific extensions (`CMAKE_CXX_EXTENSIONS OFF`)
+
+### Naming Conventions
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Classes / Structs | PascalCase | `PhysicsSystem`, `SceneNode` |
+| Functions / Methods | PascalCase | `CreateEntity()`, `GetTransform()` |
+| Variables | camelCase | `deltaTime`, `maxHealth` |
+| Member variables | m_ prefix | `m_registry`, `m_position` |
+| Constants | UPPER_SNAKE | `SPARK_SDK_VERSION` |
+| Enums | PascalCase | `RenderPath::Forward` |
+| Namespaces | PascalCase | `Spark::AI`, `Spark::Graphics` |
+| Files | PascalCase | `PhysicsSystem.h`, `GraphicsEngine.cpp` |
+
+### Code Organization
+
+- **Headers (.h)** — Declarations, inline implementations for templates
+- **Source (.cpp)** — Implementations
+- One class per file (with exceptions for small related types)
+- Include guards: `#pragma once`
+
+### Component Design
+
+Components must be **pure POD structs** (state only, no behavior):
+
+```cpp
+// Good: POD component
+struct HealthComponent {
+    float health = 100.0f;
+    float maxHealth = 100.0f;
+    bool isDead = false;
+};
+
+// Bad: behavior in component
+struct HealthComponent {
+    float health = 100.0f;
+    void TakeDamage(float amount) { health -= amount; }  // NO
+};
+```
+
+## Architecture Guidelines
+
+### Adding a New Subsystem
+
+1. Create a directory under `SparkEngine/Source/Engine/YourSystem/`
+2. Add a CMake toggle: `option(ENABLE_YOUR_SYSTEM "..." ON)`
+3. Guard code with `#ifdef SPARK_ENABLE_YOUR_SYSTEM`
+4. Register console commands if applicable
+5. Add unit tests in `Tests/`
+6. Document in the wiki
+
+### Adding a New Component
+
+1. Define the POD struct in `Components.h`
+2. Add a system function in `ECSystems.h` if needed
+3. Register serialization in the save system
+4. Add editor UI in SparkEditor if applicable
+
+### Module Interface
+
+If exposing functionality through the SDK:
+1. Add interface header to `SparkSDK/Include/Spark/`
+2. Use forward declarations to minimize includes
+3. Maintain backward compatibility
+
+## AI Disclosure
+
+This project makes extensive use of AI-assisted development. All AI-generated code is reviewed, tested, and validated. Contributions may also use AI tools, but all code must be reviewed and tested before submission.
+
+## Pull Request Guidelines
+
+- Keep PRs focused on a single feature or fix
+- Include tests for new functionality
+- Update wiki documentation if adding user-facing features
+- Ensure CI passes (GitHub Actions builds on Windows and Linux)
+- Reference related issues in the PR description
+
+## Reporting Issues
+
+Report bugs and request features at [GitHub Issues](https://github.com/Krilliac/SparkEngine/issues).
+
+Include:
+- Platform and compiler version
+- Steps to reproduce
+- Expected vs. actual behavior
+- Build configuration and CMake flags used
+
+## See Also
+
+- [[Architecture Overview]] — Engine design
+- [[Build System and CMake Modules]] — Build configuration
+- [[Testing]] — Adding and running tests

--- a/wiki/Creating-a-Game-Module.md
+++ b/wiki/Creating-a-Game-Module.md
@@ -1,0 +1,235 @@
+# Creating a Game Module
+
+SparkEngine uses a dynamic module system similar to Unreal Engine and Unity. Your game logic is compiled as a shared library (DLL on Windows, .so on Linux) that the engine loads at runtime.
+
+## Quick Start from Template
+
+The fastest way to start is using the `EmptyProject` template:
+
+```bash
+cp -r Templates/EmptyProject MyGame
+```
+
+This gives you:
+
+```
+MyGame/
+├── CMakeLists.txt          # Build configuration
+├── Source/
+│   ├── GameModule.h        # Module class (IModule implementation)
+│   └── GameModule.cpp      # Module factory exports
+├── spark.project.json      # Project metadata
+└── spark.modules.json      # Module manifest
+```
+
+## The IModule Interface
+
+Every game module implements `Spark::IModule` from `<Spark/SparkSDK.h>`:
+
+```cpp
+#include <Spark/SparkSDK.h>
+
+class MyGameModule : public Spark::IModule
+{
+public:
+    // Return metadata about your module
+    Spark::ModuleInfo GetModuleInfo() const override
+    {
+        Spark::ModuleInfo info{};
+        info.name       = "MyGame";
+        info.version    = "0.1.0";
+        info.sdkVersion = SPARK_SDK_VERSION;
+        info.loadOrder  = 1000;   // lower values load first
+        return info;
+    }
+
+    // Called once when the DLL is loaded
+    bool OnLoad(Spark::IEngineContext* context) override
+    {
+        m_context = context;
+        // Access engine systems:
+        // context->GetGraphics()  — rendering
+        // context->GetInput()     — input
+        // context->GetTimer()     — frame timing
+        // context->GetEventBus()  — events
+        return true;  // return false to abort loading
+    }
+
+    // Called before the DLL is unloaded
+    void OnUnload() override
+    {
+        m_context = nullptr;
+    }
+
+    // Called every frame
+    void OnUpdate(float deltaTime) override
+    {
+        // Game logic here
+    }
+
+    // Called every frame after OnUpdate (optional)
+    void OnRender() override
+    {
+        // Custom rendering here
+    }
+
+    // Called when the window is resized (optional)
+    void OnResize(int width, int height) override
+    {
+        // Handle resize
+    }
+
+private:
+    Spark::IEngineContext* m_context = nullptr;
+};
+```
+
+## Exporting the Module
+
+In exactly one `.cpp` file, use the `SPARK_IMPLEMENT_MODULE` macro to generate the required DLL exports:
+
+```cpp
+// GameModule.cpp
+#include "GameModule.h"
+
+SPARK_IMPLEMENT_MODULE(MyGameModule)
+```
+
+This generates:
+```cpp
+extern "C" SPARK_MODULE_API Spark::IModule* CreateModule();
+extern "C" SPARK_MODULE_API void DestroyModule(Spark::IModule*);
+```
+
+## CMake Setup
+
+### As Part of the SparkEngine Tree
+
+If your game module lives inside the SparkEngine source tree, use the `spark_add_game_module()` helper from `cmake/SparkGameModule.cmake`:
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(MyGame LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 20)
+
+include(${CMAKE_SOURCE_DIR}/cmake/SparkGameModule.cmake)
+
+file(GLOB_RECURSE GAME_SOURCES "Source/*.cpp" "Source/*.h")
+spark_add_game_module(MyGame ${GAME_SOURCES})
+target_include_directories(MyGame PRIVATE "Source")
+```
+
+### As a Standalone Project
+
+For standalone projects, use `find_package`:
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(MyGame LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 20)
+
+find_package(SparkEngine REQUIRED)
+
+file(GLOB_RECURSE GAME_SOURCES "Source/*.cpp" "Source/*.h")
+spark_add_game_module(MyGame ${GAME_SOURCES})
+target_include_directories(MyGame PRIVATE "Source")
+```
+
+## Configuration Files
+
+### spark.project.json
+
+Project metadata describing your game:
+
+```json
+{
+    "name": "MyGame",
+    "version": "0.1.0",
+    "engineVersion": "1.0.0",
+    "description": "My first SparkEngine game",
+    "modules": ["MyGame"],
+    "defaultScene": "Assets/Scenes/Default.scene"
+}
+```
+
+### spark.modules.json
+
+Module manifest that tells the engine which DLLs to load:
+
+```json
+{
+    "modules": [
+        {
+            "name": "MyGame",
+            "path": "MyGame.dll",
+            "loadOrder": 1000
+        }
+    ]
+}
+```
+
+Place `spark.modules.json` next to the engine executable (`build/bin/`).
+
+## Module Discovery
+
+The engine finds modules using three fallback mechanisms (in order):
+
+1. **Command-line argument**: `SparkEngine.exe -game path/to/MyGame.dll`
+2. **Manifest file**: `spark.modules.json` next to the executable
+3. **Directory scan**: Scans for `*Game*.dll` or `*Module*.dll` in the executable directory
+
+## Using Engine Services
+
+Once you have the `IEngineContext*`, access any engine subsystem:
+
+```cpp
+bool OnLoad(Spark::IEngineContext* context) override
+{
+    m_context = context;
+
+    // Get the graphics engine for rendering
+    GraphicsEngine* graphics = context->GetGraphics();
+
+    // Get the input manager for player controls
+    InputManager* input = context->GetInput();
+
+    // Get the timer for frame timing
+    Timer* timer = context->GetTimer();
+
+    // Subscribe to engine events
+    Spark::EventBus* events = context->GetEventBus();
+    events->Subscribe<Spark::CollisionEvent>([](const Spark::CollisionEvent& e) {
+        // Handle collision
+    });
+
+    return true;
+}
+```
+
+## Module Lifecycle
+
+```
+Engine Startup
+    │
+    ├── Load DLL/SO
+    ├── Call CreateModule()
+    ├── Call GetModuleInfo()      ← metadata, version check
+    ├── Call OnLoad(context)      ← initialization
+    │
+    ├── Main Loop ──────────────┐
+    │   ├── OnUpdate(deltaTime) │ ← every frame
+    │   └── OnRender()          │ ← every frame
+    │   └───────────────────────┘
+    │
+    ├── Call OnUnload()          ← cleanup
+    ├── Call DestroyModule()
+    └── Unload DLL/SO
+```
+
+Multiple modules are loaded in `loadOrder` and shut down in reverse order.
+
+## Next Steps
+
+- [[Entity Component System]] — Work with entities and components
+- [[Scripting with AngelScript]] — Add scripted gameplay logic
+- [[Scene Management]] — Load and manage scenes

--- a/wiki/Day-Night-Cycle-and-Weather.md
+++ b/wiki/Day-Night-Cycle-and-Weather.md
@@ -1,0 +1,98 @@
+# Day/Night Cycle and Weather
+
+SparkEngine includes dynamic time-of-day and weather systems that affect lighting, rendering, and gameplay.
+
+**Source:** `SparkEngine/Source/Engine/World/DayNightCycle.h`, `SparkEngine/Source/Graphics/WeatherSystem.h`
+
+## Day/Night Cycle
+
+`ENABLE_DAY_NIGHT=ON`
+
+The `DayNightCycle` system simulates a full day with dynamic lighting transitions:
+
+### Features
+
+- Configurable day length (real-time seconds per in-game day)
+- Sun position calculated from time of day
+- Sky color transitions (dawn → day → dusk → night)
+- Ambient light intensity changes
+- Moon and star visibility at night
+
+### Time of Day
+
+The system uses a 24-hour clock (0.0 = midnight, 12.0 = noon):
+
+| Time Range | Period |
+|-----------|--------|
+| 0.0 – 5.0 | Night |
+| 5.0 – 7.0 | Dawn |
+| 7.0 – 17.0 | Day |
+| 17.0 – 19.0 | Dusk |
+| 19.0 – 24.0 | Night |
+
+### Events
+
+The system publishes `TimeOfDayChangedEvent` at significant transitions:
+
+```cpp
+struct TimeOfDayChangedEvent {
+    float previousHour;
+    float currentHour;
+    int dayCount;
+};
+```
+
+## Weather System
+
+`ENABLE_WEATHER=ON`
+
+Dynamic weather with configurable types and smooth transitions:
+
+### Weather Types
+
+| Type | Visual Effects |
+|------|---------------|
+| Clear | Blue sky, full sun |
+| Cloudy | Overcast sky, reduced sunlight |
+| Rain | Particle rain, wet surfaces, reduced visibility |
+| Storm | Heavy rain, lightning, thunder audio, wind |
+| Snow | Particle snow, frost effects |
+| Fog | Dense fog, severely reduced visibility |
+
+### Transitions
+
+Weather changes smoothly between types over a configurable transition duration. The system can run on a schedule or be triggered manually.
+
+### Events
+
+```cpp
+struct WeatherChangedEvent {
+    int previousType;
+    int newType;
+    float intensity;   // 0.0 to 1.0
+};
+```
+
+### Effects on Gameplay
+
+- Reduced visibility in fog, rain, and storms
+- Wet surfaces affect physics friction
+- Wind affects projectile trajectories
+- Lightning provides brief illumination
+
+## Console Commands
+
+```
+time_set <hour>          # Set time of day (0-24)
+time_speed <multiplier>  # Set time speed (1.0 = real-time)
+time_pause               # Pause time progression
+weather_set <type>       # Set weather (clear/cloudy/rain/storm/snow/fog)
+weather_intensity <val>  # Set weather intensity (0.0-1.0)
+weather_transition <sec> # Set transition duration
+```
+
+## See Also
+
+- [[Rendering and Graphics]] — Volumetric lighting and fog
+- [[Event System]] — Weather and time-of-day events
+- [[Physics]] — Weather effects on physics

--- a/wiki/Entity-Component-System.md
+++ b/wiki/Entity-Component-System.md
@@ -1,0 +1,151 @@
+# Entity Component System
+
+SparkEngine uses the **EnTT** library for its Entity Component System (ECS). Components are pure POD structs holding state only — behavior is implemented by Systems that query and mutate components each frame.
+
+**Source:** `SparkEngine/Source/Engine/ECS/Components.h`, `SparkEngine/Source/Engine/ECS/Systems/ECSystems.h`
+
+## Core Concepts
+
+- **Entity** — A lightweight handle (`EntityID`, backed by `entt::entity`) that identifies a game object
+- **Component** — A plain data struct attached to an entity (no behavior)
+- **System** — A function that iterates entities with specific components and applies logic
+- **World** — A wrapper around the EnTT registry that manages entities and components
+
+## The World Class
+
+`World` is the central hub for all ECS operations:
+
+```cpp
+World world;
+
+// Create an entity with a name
+EntityID player = world.CreateEntity("Player");
+
+// Add components
+auto& tf = world.AddComponent<Transform>(player);
+tf.position = {0.0f, 1.0f, 0.0f};
+
+auto& hp = world.AddComponent<HealthComponent>(player);
+hp.maxHealth = 200.0f;
+hp.health    = 200.0f;
+
+// Query components
+if (world.HasComponent<Transform>(player)) {
+    auto& transform = world.GetComponent<Transform>(player);
+}
+
+// Remove a component
+world.RemoveComponent<HealthComponent>(player);
+
+// Destroy an entity
+world.DestroyEntity(player);
+```
+
+## Iterating Entities
+
+Use `GetEntitiesWith<>()` to iterate all entities matching a component set:
+
+```cpp
+// Iterate all entities with both Transform and HealthComponent
+for (auto [entity, tf, hp] : world.GetEntitiesWith<Transform, HealthComponent>().each())
+{
+    hp.health -= 1.0f * deltaTime;
+    if (hp.health <= 0.0f) {
+        // Handle death
+    }
+}
+```
+
+This is cache-friendly because EnTT stores components in Structure-of-Arrays (SoA) layout.
+
+## Component Reference
+
+### Core Components
+
+| Component | Fields | Description |
+|-----------|--------|-------------|
+| `NameComponent` | `name` (string) | Human-readable entity name |
+| `Transform` | `position`, `rotation`, `scale` (XMFLOAT3) | 3D transform |
+| `MeshRenderer` | `meshIndex`, `materialIndex`, `visible`, `castShadows`, `receiveShadows` | Mesh rendering |
+| `Camera` | `fov`, `nearPlane`, `farPlane`, `isActive` | Camera parameters |
+| `Script` | `scriptFile`, `className`, `moduleName` | AngelScript binding |
+
+### Physics Components
+
+| Component | Fields | Description |
+|-----------|--------|-------------|
+| `RigidBodyComponent` | `mass`, `type` (Static/Kinematic/Dynamic), `linearDamping`, `angularDamping`, `friction`, `restitution`, `physicsBodyHandle` | Rigid body properties |
+| `ColliderComponent` | `shapeType` (Box/Sphere/Capsule/...), `dimensions`, `offset`, `isTrigger` | Collision shape |
+
+### Audio Components
+
+| Component | Fields | Description |
+|-----------|--------|-------------|
+| `AudioSourceComponent` | `soundFile`, `volume`, `pitch`, `loop`, `is3D`, `minDistance`, `maxDistance`, `audioSourceHandle` | Audio source |
+
+### Lighting
+
+| Component | Fields | Description |
+|-----------|--------|-------------|
+| `LightComponent` | `type` (Point/Directional/Spot), `color`, `intensity`, `range`, `spotAngle`, `castShadows` | Light source |
+
+### Animation
+
+| Component | Fields | Description |
+|-----------|--------|-------------|
+| `AnimationController` | `currentAnimation`, `playbackSpeed`, `isPlaying`, `loop`, `blendFactor` | Animation state |
+
+### Particles
+
+| Component | Fields | Description |
+|-----------|--------|-------------|
+| `ParticleEmitterComponent` | `maxParticles`, `emissionRate`, `lifetime`, `startSize`, `endSize`, `startColor`, `endColor`, `velocity`, `gravity` | Particle emitter |
+
+### AI
+
+| Component | Fields | Description |
+|-----------|--------|-------------|
+| `AIComponent` | `behaviorTreeName`, `detectionRadius`, `attackRange`, `moveSpeed`, `state` | AI behavior |
+
+### Networking
+
+| Component | Fields | Description |
+|-----------|--------|-------------|
+| `NetworkIdentity` | `networkId`, `ownerId`, `isLocalPlayer`, `isServerAuthority` | Network replication |
+
+### Tags / Metadata
+
+| Component | Fields | Description |
+|-----------|--------|-------------|
+| `HealthComponent` | `health`, `maxHealth`, `isDead`, `isInvulnerable` | Health tracking |
+| `TagComponent` | `tag` (string) | Arbitrary tag |
+| `ActiveComponent` | `isActive` (bool) | Enable/disable entity |
+
+## Built-in Systems
+
+Systems in `ECSystems.h` run each frame:
+
+| System | Description |
+|--------|-------------|
+| `TransformUpdateSystem` | Updates world transforms from local transforms |
+| `PhysicsUpdateSystem` | Syncs physics body transforms with ECS transforms |
+| `AnimationUpdateSystem` | Evaluates animation state machines |
+| `AudioUpdateSystem` | Updates 3D audio source positions |
+| `NetworkUpdateSystem` | Syncs networked entity state |
+
+## Performance Tips
+
+- Prefer `GetEntitiesWith<A, B>()` views over per-entity queries in hot paths
+- Components use SoA layout for cache-friendly iteration of a single component type
+- Destroying an entity invalidates iterators — defer destruction until after the iteration loop
+- Use `ActiveComponent` to logically disable entities without destroying them
+
+## Thread Safety
+
+The EnTT registry is **not thread-safe**. All World operations must be performed from the main thread unless external synchronization is provided.
+
+## See Also
+
+- [[Scripting with AngelScript]] — Attach scripts to entities
+- [[Physics]] — Physics components in detail
+- [[Animation]] — Animation controller component

--- a/wiki/Event-System.md
+++ b/wiki/Event-System.md
@@ -1,0 +1,182 @@
+# Event System
+
+SparkEngine provides a type-safe publish/subscribe event bus for decoupled communication between engine subsystems.
+
+**Source:** `SparkEngine/Source/Engine/Events/EventSystem.h`
+
+## Overview
+
+The `EventBus` class uses C++ RTTI (`std::type_index`) to route events by type. Each event type can have multiple subscribers, invoked synchronously in registration order.
+
+## Basic Usage
+
+```cpp
+EventBus bus;
+
+// Subscribe to an event type
+auto id = bus.Subscribe<EntityDamagedEvent>([](const EntityDamagedEvent& e) {
+    std::cout << "Entity " << e.entityId << " took " << e.damage << " damage!\n";
+});
+
+// Publish an event (notifies all subscribers)
+bus.Publish(EntityDamagedEvent{ entityId, 50.0f, "Explosion" });
+
+// Unsubscribe when done
+bus.Unsubscribe<EntityDamagedEvent>(id);
+```
+
+## API Reference
+
+### Subscribe
+
+```cpp
+template<typename T>
+SubscriptionID Subscribe(std::function<void(const T&)> callback);
+```
+
+Returns a `SubscriptionID` for later unsubscription.
+
+### Unsubscribe
+
+```cpp
+template<typename T>
+bool Unsubscribe(SubscriptionID id);
+```
+
+Returns `true` if the subscription was found and removed.
+
+### Publish
+
+```cpp
+template<typename T>
+void Publish(const T& event);
+```
+
+Invokes all subscribers synchronously on the calling thread, in registration order.
+
+### Utility Methods
+
+```cpp
+template<typename T>
+void ClearSubscriptions();       // Remove all subscribers for type T
+
+void ClearAll();                 // Remove all subscribers for all types
+
+template<typename T>
+size_t GetSubscriberCount() const; // Count subscribers for type T
+```
+
+## Built-in Event Types
+
+### Gameplay Events
+
+```cpp
+struct EntityDamagedEvent {
+    uint32_t entityId;
+    float damage;
+    std::string damageSource;
+};
+
+struct EntityKilledEvent {
+    uint32_t entityId;
+    uint32_t killerId;
+    std::string cause;
+};
+
+struct ItemPickedUpEvent {
+    uint32_t entityId;
+    uint32_t itemDefId;
+    int count;
+};
+
+struct QuestCompletedEvent {
+    uint32_t entityId;
+    uint32_t questId;
+    std::string questName;
+};
+
+struct PlayerRespawnEvent {
+    uint32_t entityId;
+    float spawnX, spawnY, spawnZ;
+};
+```
+
+### World Events
+
+```cpp
+struct WeatherChangedEvent {
+    int previousType;
+    int newType;
+    float intensity;
+};
+
+struct TimeOfDayChangedEvent {
+    float previousHour;
+    float currentHour;
+    int dayCount;
+};
+```
+
+### Physics Events
+
+```cpp
+struct CollisionEvent {
+    uint32_t entityA;
+    uint32_t entityB;
+    float impactForce;
+};
+```
+
+## Custom Events
+
+Define your own event types as plain structs:
+
+```cpp
+struct PlayerScoredEvent {
+    uint32_t playerId;
+    int points;
+    std::string reason;
+};
+
+// Subscribe
+bus.Subscribe<PlayerScoredEvent>([](const PlayerScoredEvent& e) {
+    UpdateScoreboard(e.playerId, e.points);
+});
+
+// Publish
+bus.Publish(PlayerScoredEvent{ playerId, 100, "Headshot" });
+```
+
+## Accessing the Event Bus
+
+In a game module, get the event bus from the engine context:
+
+```cpp
+bool OnLoad(Spark::IEngineContext* context) override {
+    Spark::EventBus* bus = context->GetEventBus();
+
+    bus->Subscribe<Spark::CollisionEvent>([this](const Spark::CollisionEvent& e) {
+        HandleCollision(e);
+    });
+
+    return true;
+}
+```
+
+## Thread Safety
+
+- `Subscribe()` and `Unsubscribe()` are thread-safe (mutex protected)
+- `Publish()` is safe from any thread, but callbacks execute on the publishing thread
+- The subscriber list is copied before iteration, allowing callbacks to safely modify subscriptions
+
+## Design Notes
+
+- The event bus is **non-copyable** but **movable**
+- Events are passed by `const&` to subscribers
+- Subscribers are invoked synchronously — long-running callbacks will block the publisher
+- Consider keeping callbacks lightweight; defer heavy work to the next frame
+
+## See Also
+
+- [[Architecture Overview]] — How subsystems communicate
+- [[Entity Component System]] — Entity lifecycle events

--- a/wiki/Gameplay-Systems.md
+++ b/wiki/Gameplay-Systems.md
@@ -1,0 +1,126 @@
+# Gameplay Systems
+
+SparkEngine includes a comprehensive set of FPS gameplay systems built on top of the ECS architecture.
+
+**Source:** `SparkEngine/Source/Game/`
+
+## Player Controller
+
+The FPS player controller provides standard first-person movement and interaction:
+
+- **Movement** — WASD movement with configurable speed
+- **Mouse look** — Pitch/yaw camera control with sensitivity settings
+- **Jump** — Space bar with configurable jump height and gravity
+- **Crouch** — Ctrl with height adjustment
+- **Sprint** — Shift for increased movement speed
+
+## Weapon System
+
+Three projectile types are supported:
+
+| Type | Description |
+|------|-------------|
+| **Bullet** | Hitscan or fast projectile with raycast hit detection |
+| **Rocket** | Physics-driven projectile with area-of-effect damage |
+| **Grenade** | Arc-based projectile with timed detonation |
+
+Features:
+- Fire rate control
+- Recoil and spread patterns
+- Reload mechanics
+- Ammunition tracking
+- Muzzle flash and impact effects
+
+## Class System
+
+A player class system for multiplayer game modes with configurable:
+- Starting weapons and equipment
+- Health and armor values
+- Movement speed modifiers
+- Special abilities
+
+## Vehicle System
+
+Physics-driven vehicle mechanics:
+- Enter/exit vehicles
+- Steering and acceleration
+- Suspension and physics simulation
+
+## HUD System
+
+Built-in HUD elements for FPS gameplay:
+
+| Element | Description |
+|---------|-------------|
+| Crosshair | Configurable weapon crosshair |
+| Health bar | Player health display |
+| Kill feed | Recent kill notifications |
+| Minimap | Top-down area overview |
+| Compass | Directional compass |
+| Ammo counter | Current weapon ammunition |
+
+## Inventory System
+
+`ENABLE_INVENTORY=ON`
+
+Item management system:
+- Inventory slots with weight/capacity limits
+- Item stacking
+- Pickup and drop mechanics
+- Equipment slots
+
+## Quest System
+
+`ENABLE_QUEST_SYSTEM=ON`
+
+Objective tracking:
+- Quest definitions with stages
+- Objective tracking and completion
+- Quest log and notifications
+- Integration with `QuestCompletedEvent`
+
+## Game Mode Management
+
+Configurable game modes for multiplayer:
+- Deathmatch
+- Team Deathmatch
+- Objective-based modes
+- Score tracking and round management
+
+## HealthComponent
+
+Core gameplay component for damageable entities:
+
+```cpp
+auto& hp = world.AddComponent<HealthComponent>(entity);
+hp.maxHealth     = 100.0f;
+hp.health        = 100.0f;
+hp.isDead        = false;
+hp.isInvulnerable = false;
+```
+
+Damage events are published through the event bus:
+
+```cpp
+bus.Publish(EntityDamagedEvent{ entityId, damage, "Weapon" });
+```
+
+## Gravity System
+
+Configurable gravity for physics-driven gameplay:
+- Per-scene gravity settings (via `SceneMetadata`)
+- Gravity zones for localized effects
+
+## Interactive Objects
+
+Objects that respond to player interaction:
+- Doors (open/close)
+- Buttons and switches
+- Pickup items
+
+## See Also
+
+- [[Entity Component System]] — Gameplay components
+- [[Physics]] — Physics-driven gameplay
+- [[Event System]] — Gameplay events
+- [[AI and Navigation]] — NPC behavior

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,177 @@
+# Getting Started
+
+This guide covers everything you need to clone, build, and run SparkEngine from source.
+
+## Prerequisites
+
+| Requirement | Details |
+|-------------|---------|
+| **C++ Compiler** | MSVC v143 (Visual Studio 2022), GCC 11+, or Clang 14+ with C++20 support |
+| **CMake** | 3.16 or newer |
+| **Graphics** | DirectX 11 capable GPU (Windows). Vulkan SDK optional. OpenGL 4.5 optional. |
+| **Platform** | Windows 10+ (primary), Linux x64 (experimental) |
+| **Git** | For cloning with submodules |
+
+## Clone the Repository
+
+```bash
+git clone --recurse-submodules https://github.com/Krilliac/SparkEngine.git
+cd SparkEngine
+```
+
+If you already cloned without submodules:
+
+```bash
+git submodule sync
+git submodule init
+git submodule update --recursive
+```
+
+## Configure
+
+### Windows (Visual Studio 2022)
+
+```batch
+.\generate.bat -g "Visual Studio 17 2022" release
+```
+
+### Linux / macOS
+
+```bash
+chmod +x generate.sh
+./generate.sh release -g Ninja
+```
+
+### Using CMake Directly
+
+```bash
+cmake -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
+```
+
+### CMake Presets
+
+SparkEngine includes `CMakePresets.json` with ready-made configurations:
+
+| Preset | Platform | Description |
+|--------|----------|-------------|
+| `windows-debug` | Windows | VS 2022, Debug |
+| `windows-release` | Windows | VS 2022, Release |
+| `linux-gcc-debug` | Linux | GCC, Debug |
+| `linux-gcc-release` | Linux | GCC, Release |
+| `linux-clang-debug` | Linux | Clang, Debug |
+| `linux-clang-release` | Linux | Clang, Release |
+| `ci-linux-asan` | Linux | AddressSanitizer build |
+| `ci-linux-tsan` | Linux | ThreadSanitizer build |
+| `minimal` | Any | Core-only build without advanced features |
+
+```bash
+cmake --preset windows-release
+cmake --build --preset windows-release
+```
+
+## Build
+
+### Windows (PowerShell)
+
+```powershell
+.\build.ps1 -config Release -editor -angelscript
+```
+
+Options:
+- `-config Debug|Release` — Build configuration
+- `-editor` — Include the SparkEditor
+- `-console` — Include SparkConsole
+- `-angelscript` — Include AngelScript scripting
+
+### Linux / macOS
+
+```bash
+./build.sh release
+```
+
+Options:
+- `-g Ninja` — Use Ninja generator (faster)
+- `-E` — Disable editor
+- `-C` — Disable console
+
+### Using CMake Directly
+
+```bash
+cmake --build build --config Release
+```
+
+## Build Output
+
+After a successful build:
+
+```
+build/
+├── bin/
+│   ├── SparkEngine.exe      # Main engine executable
+│   ├── SparkConsole.exe     # Debug console (Windows)
+│   └── SparkGame.dll        # Default game module
+├── lib/                     # Static/shared libraries
+├── Shaders/                 # Compiled shaders
+└── Assets/                  # Game assets
+```
+
+## Run the Engine
+
+### Windows
+
+```batch
+cd build\bin
+SparkEngine.exe
+```
+
+You should see:
+1. A DirectX 11 window with a blue background
+2. SparkConsole opens automatically
+3. Console shows initialization messages
+
+### Linux
+
+```bash
+cd build/bin
+./SparkEngine
+```
+
+## Default Controls
+
+| Input | Action |
+|-------|--------|
+| W / A / S / D | Move |
+| Mouse | Look |
+| Space | Jump |
+| Ctrl | Crouch |
+| Left Click | Fire / Capture Mouse |
+| Esc | Release Mouse / Menu |
+| ` (Backtick) | Toggle Debug Console |
+
+## Verify Installation
+
+Once the engine is running, open SparkConsole and try:
+
+```
+help            # List all commands
+engine_status   # Check system initialization
+fps             # Show framerate
+graphics_info   # Display GPU information
+diag            # Run diagnostics
+```
+
+## Build Options
+
+SparkEngine has 30+ toggleable CMake modules. Pass them during configuration:
+
+```bash
+cmake -B build -DENABLE_AI=OFF -DENABLE_NETWORKING=ON ...
+```
+
+See [[Build System and CMake Modules]] for the full list of options.
+
+## Next Steps
+
+- [[Architecture Overview]] — Understand the engine's design
+- [[Creating a Game Module]] — Build your first game
+- [[Troubleshooting]] — If you run into issues

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,75 @@
+# Spark Engine
+
+**Spark Engine** is a free, open-source 3D game engine written in C++20. Designed for first-person shooters and other 3D games, it ships with DirectX 11 rendering, Bullet Physics, XAudio2 spatial audio, AngelScript hot-reload scripting, an EnTT-based ECS architecture, and an ImGui visual editor.
+
+> **Early Development** — SparkEngine is under active development. Expect rough edges.
+
+## Platform Support
+
+| Platform | Status | Compiler |
+|----------|--------|----------|
+| Windows 10+ | Primary | MSVC v143 (VS 2022), v144 (VS 2026) |
+| Linux x64 | Experimental | GCC 11+, Clang 14+ |
+| macOS | Experimental | Apple Clang with C++20 |
+
+## Feature Highlights
+
+- **Rendering** — DirectX 11 with forward, deferred, forward+, and clustered pipelines. PBR materials, cascaded shadow mapping, SSAO, SSR, volumetric lighting, bloom, HDR tone mapping, TAA/FXAA/MSAA, IBL, GPU particles, decals, fog, and quality presets. Experimental Vulkan and OpenGL backends via RHI abstraction.
+- **Physics** — Bullet Physics 3 with rigid bodies, 9 collision shape types, constraints, raycasting, overlap queries, physics materials, and debug draw.
+- **Audio** — XAudio2 3D spatial audio with Doppler effects, distance attenuation, volume channels, and object pooling. Miniaudio as cross-platform fallback.
+- **Gameplay** — ECS architecture (EnTT), FPS player controller, weapons, vehicles, inventory, quests, day/night cycle, weather, terrain with quadtree LOD.
+- **AI** — Behavior trees, NavMesh A* pathfinding, perception system, steering behaviors.
+- **Animation** — Skeletal animation, state machines, multi-layer blending, IK (two-bone, look-at, FABRIK), root motion, FBX/glTF import.
+- **Scripting** — AngelScript with hot-reload, lifecycle callbacks, and full engine API bindings.
+- **Networking** — UDP client/server, entity replication, client-side prediction, lag compensation.
+- **Editor** — ImGui-powered visual editor with scene hierarchy, inspector, gizmos, material editor, animation timeline, and 200+ debug console commands.
+
+## Downloads
+
+Pre-built binaries are published on every commit to `master`:
+
+- [Windows Release (x64)](https://github.com/Krilliac/SparkEngine/releases/latest/download/SparkEngine-Windows-Release.zip)
+- [Windows Debug (x64)](https://github.com/Krilliac/SparkEngine/releases/latest/download/SparkEngine-Windows-Debug.zip)
+- [Linux Release (x64)](https://github.com/Krilliac/SparkEngine/releases/latest/download/SparkEngine-Linux-Release.tar.gz)
+- [Linux Debug (x64)](https://github.com/Krilliac/SparkEngine/releases/latest/download/SparkEngine-Linux-Debug.tar.gz)
+
+## Wiki Navigation
+
+### Getting Started
+- [[Getting Started]] — Prerequisites, building, and running
+- [[Architecture Overview]] — Engine design and project structure
+- [[Creating a Game Module]] — Build your first game module
+
+### Engine Subsystems
+- [[Entity Component System]] — EnTT ECS, components, and systems
+- [[Rendering and Graphics]] — Graphics pipeline, materials, and post-processing
+- [[Physics]] — Bullet Physics integration
+- [[Audio]] — Spatial audio system
+- [[Input System]] — Keyboard, mouse, and gamepad
+- [[Scripting with AngelScript]] — Gameplay scripting
+- [[AI and Navigation]] — Behavior trees and pathfinding
+- [[Animation]] — Skeletal animation and IK
+- [[Networking]] — Multiplayer networking
+- [[Scene Management]] — Scenes, hierarchy, and prefabs
+- [[Event System]] — Publish/subscribe event bus
+
+### Gameplay & Tools
+- [[Gameplay Systems]] — Player, weapons, inventory, quests
+- [[Terrain and Procedural Generation]] — Terrain and procedural content
+- [[Save System]] — Save/load functionality
+- [[Day Night Cycle and Weather]] — Time-of-day and weather
+- [[Cinematic Sequencer]] — Timeline-based cinematics
+- [[SparkEditor]] — Visual editor guide
+- [[SparkConsole]] — Debug console
+- [[Shader Pipeline]] — Shader authoring and compilation
+- [[Asset Pipeline]] — Asset loading and formats
+
+### Advanced
+- [[Build System and CMake Modules]] — CMake configuration and CI/CD
+- [[Testing]] — Unit tests and test framework
+- [[Troubleshooting]] — Common issues and solutions
+- [[Contributing]] — How to contribute
+
+## License
+
+SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/SparkEngine/blob/master/LICENSE) — no royalties, no strings attached.

--- a/wiki/Input-System.md
+++ b/wiki/Input-System.md
@@ -1,0 +1,145 @@
+# Input System
+
+The `InputManager` handles keyboard, mouse, and gamepad input with frame-based state tracking, key bindings, and console integration.
+
+**Source:** `SparkEngine/Source/Input/InputManager.h`, `SparkEngine/Source/Input/GamepadInput.h`
+
+## Initialization
+
+```cpp
+InputManager input;
+input.Initialize(hwnd);  // Pass the window handle
+```
+
+## Keyboard Input
+
+```cpp
+// Check if a key is currently held down
+if (input.IsKeyDown(VK_SPACE)) {
+    // Space is held
+}
+
+// Check if a key was just pressed this frame
+if (input.WasKeyPressed('W')) {
+    // W was pressed this frame
+}
+
+// Check if a key was just released this frame
+if (input.WasKeyReleased(VK_SHIFT)) {
+    // Shift was released this frame
+}
+```
+
+## Mouse Input
+
+```cpp
+// Mouse button state (0 = Left, 1 = Right, 2 = Middle)
+if (input.IsMouseButtonDown(0)) {
+    // Left mouse button held
+}
+
+// Mouse position
+int mouseX = input.GetMouseX();
+int mouseY = input.GetMouseY();
+
+// Mouse movement delta (since last frame)
+int deltaX = input.GetMouseDeltaX();
+int deltaY = input.GetMouseDeltaY();
+```
+
+## Mouse Capture
+
+For first-person camera controls, capture the mouse to hide the cursor and track relative movement:
+
+```cpp
+input.CaptureMouse();    // Capture and hide cursor
+input.ReleaseMouse();    // Release and show cursor
+bool captured = input.IsMouseCaptured();
+```
+
+## Key Bindings
+
+Map action names to keys for configurable controls:
+
+```cpp
+// Bind actions to keys
+input.BindKey("MoveForward", 'W');
+input.BindKey("MoveBack", 'S');
+input.BindKey("MoveLeft", 'A');
+input.BindKey("MoveRight", 'D');
+input.BindKey("Jump", VK_SPACE);
+input.BindKey("Crouch", VK_CONTROL);
+input.BindKey("Fire", VK_LBUTTON);
+
+// Check bound actions
+if (input.IsActionDown("Jump")) {
+    // Jump action
+}
+```
+
+## Input Settings
+
+```cpp
+input.SetMouseSensitivity(1.0f);   // Mouse sensitivity multiplier
+input.SetMouseDeadZone(0.01f);     // Ignore tiny mouse movements
+input.SetMouseAcceleration(false); // Disable mouse acceleration
+input.SetInvertMouseY(false);      // Invert Y axis
+input.SetRawMouseInput(true);      // Use raw mouse input (bypasses OS acceleration)
+```
+
+## Gamepad Input
+
+`GamepadInput` provides controller support:
+
+```cpp
+GamepadInput gamepad;
+float leftStickX  = gamepad.GetLeftStickX();
+float leftStickY  = gamepad.GetLeftStickY();
+float rightStickX = gamepad.GetRightStickX();
+float rightStickY = gamepad.GetRightStickY();
+float leftTrigger = gamepad.GetLeftTrigger();
+bool  aButton     = gamepad.IsButtonDown(GamepadButton::A);
+```
+
+## Default FPS Controls
+
+| Input | Action |
+|-------|--------|
+| W / A / S / D | Move forward / left / back / right |
+| Mouse | Look around |
+| Space | Jump |
+| Ctrl | Crouch |
+| Left Click | Fire / Capture mouse |
+| Esc | Release mouse / Menu |
+| ` (Backtick) | Toggle debug console |
+
+## Frame Update
+
+Call `Update()` once per frame to process input state changes:
+
+```cpp
+// In game loop
+input.Update();  // Store current states, calculate deltas
+```
+
+## Thread Safety
+
+Input state access is protected by a mutex for thread-safe reads. However, `Update()` and `ProcessMessage()` should only be called from the main thread.
+
+## Console Commands
+
+```
+input_info           # Show input system status
+input_sensitivity <v> # Set mouse sensitivity
+input_deadzone <v>    # Set mouse dead zone
+input_invert_y       # Toggle Y-axis inversion
+input_raw <on|off>   # Toggle raw mouse input
+input_bindings       # List all key bindings
+input_log <on|off>   # Toggle input event logging
+input_stats          # Show input statistics
+```
+
+## See Also
+
+- [[Creating a Game Module]] — Accessing InputManager via IEngineContext
+- [[SparkConsole]] — Input debug commands

--- a/wiki/Networking.md
+++ b/wiki/Networking.md
@@ -1,0 +1,89 @@
+# Networking
+
+SparkEngine includes a UDP-based networking system for multiplayer games with entity replication, client-side prediction, and lag compensation.
+
+**Source:** `SparkEngine/Source/Engine/Networking/NetworkManager.h`
+
+> **Note:** Networking is disabled by default (`ENABLE_NETWORKING=OFF`) due to CURL dependency issues. Enable it with `-DENABLE_NETWORKING=ON` during CMake configuration.
+
+## Architecture
+
+The networking system uses a client/server model:
+
+```
+┌──────────┐     UDP      ┌──────────┐
+│  Client  │ ◄──────────► │  Server  │
+│          │              │          │
+│ Predict  │              │ Authority│
+│ Reconcile│              │ Replicate│
+└──────────┘              └──────────┘
+```
+
+- **Server** — Authoritative game state, processes inputs, replicates state
+- **Client** — Predicts locally, reconciles with server corrections
+
+## Message Channels
+
+| Channel | Description |
+|---------|-------------|
+| **Reliable** | Guaranteed delivery, ordered (game events, chat) |
+| **Unreliable** | No delivery guarantee, fastest (position updates) |
+| **Ordered** | Ordered delivery, may drop old packets |
+
+## Entity Replication
+
+Entities with `NetworkIdentity` are automatically replicated:
+
+```cpp
+auto& net = world.AddComponent<NetworkIdentity>(entity);
+net.networkId         = uniqueId;
+net.ownerId           = clientId;
+net.isLocalPlayer     = true;
+net.isServerAuthority = false;
+```
+
+The server sends authoritative state updates for replicated entities. Clients receive and apply these updates, smoothing position with interpolation.
+
+## Client-Side Prediction
+
+For responsive gameplay, clients predict the results of local input immediately without waiting for server confirmation:
+
+1. Client applies input locally
+2. Client sends input to server
+3. Server processes input and sends authoritative result
+4. Client reconciles: if server result differs from prediction, client corrects
+
+## Server Reconciliation
+
+When the server's authoritative state differs from the client's prediction:
+1. Client rewinds to the server's confirmed state
+2. Client re-applies all unconfirmed inputs
+3. Result is smoothly blended to avoid visual snapping
+
+## Lag Compensation
+
+For hit detection in fast-paced FPS gameplay:
+
+- Server maintains a **1-second history** of entity positions (hitbox rewinding)
+- When processing a shot, the server rewinds entities to where they were when the shooter fired
+- This ensures that what players see on-screen matches hit detection regardless of latency
+
+## Network Statistics
+
+The `NetworkManager` tracks real-time statistics:
+
+| Metric | Description |
+|--------|-------------|
+| Ping | Round-trip time (ms) |
+| Jitter | Ping variation (ms) |
+| Packet Loss | Percentage of lost packets |
+| Bandwidth | Bytes sent/received per second |
+
+## Serialization
+
+Network messages use built-in serialization helpers for efficient packing and unpacking of game state data.
+
+## See Also
+
+- [[Entity Component System]] — NetworkIdentity component
+- [[Gameplay Systems]] — Multiplayer game modes

--- a/wiki/Physics.md
+++ b/wiki/Physics.md
@@ -1,0 +1,177 @@
+# Physics
+
+SparkEngine integrates **Bullet Physics 3** for rigid body dynamics, collision detection, raycasting, and constraints. The `PhysicsSystem` wraps Bullet with a DirectX Math-native API.
+
+**Source:** `SparkEngine/Source/Physics/PhysicsSystem.h`
+
+## Overview
+
+| Class | Responsibility |
+|-------|---------------|
+| `PhysicsSystem` | World manager: lifecycle, simulation step, queries, callbacks |
+| `PhysicsBody` | Wrapper around `btRigidBody` with DirectX Math transform API |
+| `PhysicsConstraint` | Wrapper around `btTypedConstraint` |
+
+All `XMFLOAT3` / `XMMATRIX` types are transparently converted to and from Bullet's `btVector3` / `btTransform`.
+
+## Quick Start
+
+```cpp
+PhysicsSystem physics;
+if (FAILED(physics.Initialize())) return;
+
+// Create a dynamic box
+PhysicsBodyDesc desc;
+desc.type             = PhysicsBodyType::Dynamic;
+desc.position         = {0, 5, 0};
+desc.mass             = 10.0f;
+desc.shape.type       = CollisionShapeType::Box;
+desc.shape.dimensions = {1, 1, 1};
+auto box = physics.CreateBody(desc);
+
+// Game loop
+while (running) {
+    physics.Update(deltaTime);
+    renderTransform = box->GetTransform();
+}
+```
+
+## Body Types
+
+```cpp
+enum class PhysicsBodyType {
+    Static,      // Immovable (walls, floors)
+    Kinematic,   // Animated by game logic (platforms, doors)
+    Dynamic      // Fully physics-simulated (crates, projectiles)
+};
+```
+
+## Collision Shapes
+
+```cpp
+enum class CollisionShapeType {
+    Box,          // Axis-aligned box
+    Sphere,       // Sphere
+    Capsule,      // Capsule (character controllers)
+    Cylinder,     // Cylinder
+    Cone,         // Cone
+    Mesh,         // Triangle mesh (static geometry only)
+    ConvexHull,   // Convex hull (dynamic convex objects)
+    Heightfield,  // Heightfield terrain
+    Compound      // Multiple shapes combined
+};
+```
+
+## Constraints
+
+```cpp
+enum class ConstraintType {
+    Point2Point,  // Ball-and-socket joint
+    Hinge,        // Hinge (doors, wheels)
+    Slider,       // Linear slider
+    ConeTwist,    // Cone-twist (ragdoll limbs)
+    Fixed,        // Rigid connection
+    Generic       // 6-DOF generic constraint
+};
+```
+
+## Raycasting
+
+```cpp
+// Single-hit raycast
+RaycastHit hit;
+if (physics.Raycast(origin, direction, maxDistance, hit)) {
+    // hit.point, hit.normal, hit.distance, hit.body
+}
+
+// Multi-hit raycast
+std::vector<RaycastHit> hits;
+physics.RaycastAll(origin, direction, maxDistance, hits);
+```
+
+## Overlap Queries
+
+```cpp
+// Find all bodies within a sphere
+std::vector<PhysicsBody*> bodies;
+physics.SphereOverlap(center, radius, bodies);
+
+// Find all bodies within a box
+physics.BoxOverlap(center, halfExtents, bodies);
+```
+
+## Physics Materials
+
+Named material presets with friction and restitution:
+
+```cpp
+PhysicsMaterial mat;
+mat.friction    = 0.5f;
+mat.restitution = 0.3f;
+mat.linearDamping  = 0.1f;
+mat.angularDamping = 0.1f;
+
+physics.RegisterMaterial("Metal", mat);
+```
+
+## Collision Callbacks
+
+```cpp
+// Collision enter/exit callbacks
+physics.SetCollisionCallback([](PhysicsBody* a, PhysicsBody* b, const ContactInfo& info) {
+    // Handle collision
+});
+
+// Trigger enter/exit callbacks
+physics.SetTriggerCallback([](PhysicsBody* trigger, PhysicsBody* other, bool entered) {
+    // Handle trigger
+});
+```
+
+## ECS Integration
+
+Use `RigidBodyComponent` and `ColliderComponent` on entities:
+
+```cpp
+auto& rb = world.AddComponent<RigidBodyComponent>(entity);
+rb.mass = 10.0f;
+rb.type = RigidBodyComponent::Type::Dynamic;
+rb.friction = 0.5f;
+rb.restitution = 0.3f;
+
+auto& col = world.AddComponent<ColliderComponent>(entity);
+col.shapeType  = CollisionShapeType::Box;
+col.dimensions = {1.0f, 1.0f, 1.0f};
+col.isTrigger  = false;
+```
+
+The `PhysicsUpdateSystem` syncs physics body transforms with ECS `Transform` components each frame.
+
+## Debug Drawing
+
+Enable the Bullet debug draw overlay to visualize collision shapes, constraints, and contact points:
+
+```
+physics_debug on       # Enable debug draw
+physics_debug off      # Disable debug draw
+```
+
+## Console Commands
+
+```
+physics_info           # Show physics world statistics
+physics_gravity <x y z> # Set gravity vector
+physics_debug <on|off> # Toggle debug visualization
+physics_pause          # Pause physics simulation
+physics_step           # Single-step physics
+physics_material <name> # Show material properties
+```
+
+## Thread Safety
+
+PhysicsSystem is **not thread-safe**. Call all public methods from the main game thread. The physics simulation runs on the calling thread inside `Update()`.
+
+## See Also
+
+- [[Entity Component System]] — RigidBody and Collider components
+- [[Rendering and Graphics]] — Debug draw overlay

--- a/wiki/Rendering-and-Graphics.md
+++ b/wiki/Rendering-and-Graphics.md
@@ -1,0 +1,187 @@
+# Rendering and Graphics
+
+SparkEngine's rendering system is built on DirectX 11 with experimental Vulkan and OpenGL backends through a Render Hardware Interface (RHI) abstraction layer.
+
+**Source:** `SparkEngine/Source/Graphics/`
+
+## Render Pipelines
+
+Four render paths are available via the `RenderPath` enum:
+
+| Pipeline | Description |
+|----------|-------------|
+| `Forward` | Traditional forward rendering — simple, good for transparent objects |
+| `Deferred` | G-buffer based deferred rendering — efficient with many lights |
+| `ForwardPlus` | Tiled forward rendering — combines benefits of forward and deferred |
+| `Clustered` | Clustered rendering — 3D light culling for complex scenes |
+
+## Quality Presets
+
+```cpp
+enum class QualityPreset { Low, Medium, High, Ultra, Custom };
+```
+
+Each preset configures shadow resolution, MSAA level, texture quality, post-processing effects, and draw distances.
+
+## PBR Material System
+
+The `MaterialSystem` implements a physically-based metallic/roughness workflow with 18+ texture slots:
+
+| Texture Slot | Description |
+|-------------|-------------|
+| Albedo | Base color |
+| Normal | Normal mapping |
+| Metallic | Metalness (0 = dielectric, 1 = metal) |
+| Roughness | Surface roughness |
+| Occlusion | Ambient occlusion |
+| Emissive | Self-illumination |
+| Height | Parallax/displacement mapping |
+| Subsurface | Subsurface scattering |
+| Clearcoat | Clear coat layer |
+| Anisotropy | Anisotropic reflections |
+| Transmission | Light transmission |
+| Sheen | Fabric-like sheen |
+
+**Blend modes:** Opaque, AlphaTest, Transparent, Additive, Multiply, Screen
+
+## Anti-Aliasing
+
+| Method | Enum | Description |
+|--------|------|-------------|
+| None | `MSAALevel::None` | No anti-aliasing |
+| MSAA 2x | `MSAALevel::MSAA2x` | 2x multi-sample |
+| MSAA 4x | `MSAALevel::MSAA4x` | 4x multi-sample |
+| MSAA 8x | `MSAALevel::MSAA8x` | 8x multi-sample |
+| FXAA | — | Fast approximate anti-aliasing (post-process) |
+| TAA | `TAASettings` | Temporal anti-aliasing with jittered projection |
+
+## Post-Processing Pipeline
+
+The `PostProcessingPipeline` provides a composable chain of effects:
+
+### Screen-Space Effects
+- **SSAO** — Screen-space ambient occlusion (configurable radius, intensity, sample count, bias)
+- **SSR** — Screen-space reflections (ray marching with configurable max distance and steps)
+
+### Bloom and Tone Mapping
+- **Bloom** — Multi-pass bloom with soft knee threshold and configurable iterations
+- **HDR Tone Mapping** — Reinhard, ACES, Uncharted 2, AgX, FilmicALU operators
+
+### Color Grading
+- Temperature and tint adjustment
+- Saturation control
+- Lift/gamma/gain curves
+
+### Atmospheric Effects
+- **Volumetric Lighting** — Light shafts with configurable density and samples
+- **Fog** — Distance and height-based fog system (`FogSystem`)
+- **Weather** — Weather rendering effects (`WeatherSystem`)
+
+### Camera Effects
+- Motion blur
+- Depth of field
+- Vignette
+- Chromatic aberration
+- Film grain
+- Lens distortion
+- Lens flare
+
+## SSAO Settings
+
+```cpp
+struct SSAOSettings {
+    bool  enabled     = false;
+    float radius      = 0.5f;
+    float intensity   = 1.0f;
+    int   sampleCount = 16;
+    float bias        = 0.025f;
+    bool  blur        = true;
+};
+```
+
+## SSR Settings
+
+```cpp
+struct SSRSettings {
+    bool  enabled     = false;
+    float maxDistance  = 100.0f;
+    int   maxSteps    = 32;
+    float thickness   = 0.5f;
+    float fadeStart   = 80.0f;
+    float fadeEnd     = 100.0f;
+};
+```
+
+## Shadow Mapping
+
+- **PCF** — Percentage-closer filtering
+- **VSM** — Variance shadow maps
+- **CSM** — Cascaded shadow maps (up to 3 cascades)
+- **PCSS** — Percentage-closer soft shadows
+
+## RHI Abstraction Layer
+
+The Render Hardware Interface provides backend-agnostic graphics:
+
+| File | Description |
+|------|-------------|
+| `RHI.h` | Master include |
+| `RHIFactory.h` | Backend factory (creates D3D11, Vulkan, or OpenGL device) |
+| `RHIDevice.h` | Abstract device interface |
+| `RHITypes.h` | Unified type definitions |
+| `RHIResources.h` | Abstract resource interfaces |
+| `RHIBridge.h` | High-level integration bridge |
+
+**Backend implementations:**
+- `D3D11Device.h` — DirectX 11 (primary, fully featured)
+- `VulkanDevice.h` — Vulkan (experimental)
+- `OpenGLDevice.h` — OpenGL (experimental)
+- `DXRSupport.h` — DirectX Raytracing (optional, requires D3D12)
+
+## Texture System
+
+`TextureSystem` manages texture loading and streaming:
+
+- Multiple formats (R8G8B8A8, BC compression, HDR, depth)
+- Async streaming with background loading
+- Quality levels (Low/Medium/High/Ultra)
+- Dynamic texture creation
+- Hot-reloading during development
+
+## Mesh and LOD
+
+- `MeshLOD` — Automatic LOD generation with distance-based switching
+- `FrustumCulling` — Camera frustum-based visibility culling
+- `DecalSystem` — Projected decals (bullet holes, blood, scorch marks)
+
+## GPU Particle System
+
+`ParticleSystem` provides GPU-accelerated particles controlled via `ParticleEmitterComponent`.
+
+## Lighting
+
+- `LightManager` — Manages all light sources
+- `LightingSystem` — Deferred lighting pass, light culling, shadow updates
+- **IBL** — Image-Based Lighting with environment maps
+
+## Console Commands
+
+The graphics engine registers 200+ debug commands. Common ones:
+
+```
+graphics_info          # GPU and adapter information
+render_path <path>     # Switch render pipeline (forward/deferred/forward+/clustered)
+quality <preset>       # Set quality preset (low/medium/high/ultra)
+wireframe              # Toggle wireframe rendering
+ssao <on|off>          # Toggle SSAO
+ssr <on|off>           # Toggle SSR
+bloom <on|off>         # Toggle bloom
+msaa <1|2|4|8>         # Set MSAA level
+vsync <on|off>         # Toggle vertical sync
+```
+
+## See Also
+
+- [[Shader Pipeline]] — Shader authoring and compilation
+- [[Asset Pipeline]] — Model and texture loading
+- [[SparkEditor]] — Material editor and visual tools

--- a/wiki/Save-System.md
+++ b/wiki/Save-System.md
@@ -1,0 +1,93 @@
+# Save System
+
+SparkEngine provides an ECS-aware save/load system with JSON serialization and miniz compression.
+
+**Source:** `SparkEngine/Source/Engine/SaveSystem/SaveSystem.h`
+
+`ENABLE_SAVE_SYSTEM=ON`
+
+## Features
+
+- ECS-aware serialization of all entity components
+- JSON format with miniz compression
+- Multiple save slots
+- Quicksave / quickload
+- Rotating autosaves
+- Per-component serializer registry
+- Metadata tracking (scene name, player class, playtime)
+
+## Saving
+
+```cpp
+SaveSystem saveSystem;
+
+// Save to a named slot
+saveSystem.Save("slot1", world, sceneManager);
+
+// Quicksave
+saveSystem.QuickSave(world, sceneManager);
+```
+
+## Loading
+
+```cpp
+// Load from a named slot
+saveSystem.Load("slot1", world, sceneManager);
+
+// Quickload
+saveSystem.QuickLoad(world, sceneManager);
+```
+
+## Save File Format
+
+Save files use JSON compressed with miniz:
+
+```json
+{
+    "metadata": {
+        "saveName": "slot1",
+        "sceneName": "Level01",
+        "playerClass": "Soldier",
+        "playtime": 3600.0,
+        "timestamp": "2025-01-15T14:30:00Z"
+    },
+    "entities": [
+        {
+            "id": 1,
+            "components": {
+                "Transform": { "position": [0, 1, 0], "rotation": [0, 0, 0], "scale": [1, 1, 1] },
+                "HealthComponent": { "health": 80.0, "maxHealth": 100.0 }
+            }
+        }
+    ]
+}
+```
+
+## Autosave
+
+Rotating autosaves with configurable:
+- Autosave interval (minutes)
+- Maximum number of autosave slots
+- Oldest autosave is overwritten when limit is reached
+
+## Per-Component Serializers
+
+Components are serialized through a registry of serializer functions. The system automatically handles all built-in component types. Custom components can register their own serializers.
+
+## Save Slots
+
+```cpp
+// List available saves
+auto saves = saveSystem.ListSaves();
+for (const auto& save : saves) {
+    // save.name, save.sceneName, save.timestamp, save.playtime
+}
+
+// Delete a save
+saveSystem.DeleteSave("slot1");
+```
+
+## See Also
+
+- [[Entity Component System]] — Components that are serialized
+- [[Scene Management]] — Scene state persistence

--- a/wiki/Scene-Management.md
+++ b/wiki/Scene-Management.md
@@ -1,0 +1,155 @@
+# Scene Management
+
+The `SceneManager` handles loading, saving, and manipulating scenes at runtime. Scenes are stored as JSON files with a hierarchical node structure.
+
+**Source:** `SparkEngine/Source/SceneManager/SceneManager.h`
+
+## Scene File Format
+
+Scenes use a JSON format (`.scene` or `.json`):
+
+```json
+{
+    "metadata": {
+        "sceneName": "Level01",
+        "author": "Developer",
+        "gravity": [0, -9.81, 0]
+    },
+    "nodes": [
+        {
+            "name": "Ground",
+            "type": "plane",
+            "position": [0, 0, 0],
+            "rotation": [0, 0, 0],
+            "scale": [10, 1, 10],
+            "parentIndex": -1
+        },
+        {
+            "name": "Box",
+            "type": "cube",
+            "position": [0, 1, 0],
+            "parentIndex": 0
+        }
+    ]
+}
+```
+
+## Node Types
+
+| Type | Description |
+|------|-------------|
+| `"cube"` | Unit cube mesh with optional material |
+| `"sphere"` | Unit sphere mesh with optional material |
+| `"plane"` | Flat plane mesh (XZ-aligned) |
+| `"model"` | External mesh loaded from `modelPath` |
+| `"light"` | Light source (point, directional, spot) |
+| `"trigger"` | Invisible trigger volume |
+
+## Loading Scenes
+
+### Synchronous Loading
+
+```cpp
+SceneManager sceneMgr(&graphicsEngine, &inputManager);
+
+if (!sceneMgr.LoadScene(L"Assets/Scenes/Level01.scene")) {
+    LOG_ERROR("Failed to load scene");
+}
+```
+
+### Asynchronous Loading
+
+Load scenes on a background thread to avoid hitches during transitions:
+
+```cpp
+sceneMgr.LoadSceneAsync(L"Assets/Scenes/Level02.scene",
+    [](bool success, const std::string& sceneName) {
+        if (success) {
+            LOG("Loaded: " + sceneName);
+        }
+    });
+```
+
+## Hierarchy
+
+Nodes form a parent-child hierarchy using integer indices:
+- `parentIndex == -1` denotes a root node
+- Each node maintains `childIndices` for efficient tree traversal
+
+```cpp
+// Get all root nodes
+for (int root : sceneMgr.GetRootNodes()) {
+    const SceneNode* node = sceneMgr.GetNode(root);
+    LOG("Root: " + node->name);
+}
+
+// Navigate children
+const SceneNode* parent = sceneMgr.GetNode(0);
+for (int childIdx : parent->childIndices) {
+    const SceneNode* child = sceneMgr.GetNode(childIdx);
+}
+```
+
+## Scene Operations
+
+```cpp
+// Add a new node
+SceneNode node;
+node.name = "NewCube";
+node.type = "cube";
+node.position = {5, 0, 0};
+int index = sceneMgr.AddNode(node);
+
+// Remove a node
+sceneMgr.RemoveNode(index);
+
+// Save the current scene
+sceneMgr.SaveScene(L"Assets/Scenes/Modified.scene");
+```
+
+## Prefab System
+
+Save and load reusable prefab templates:
+
+```cpp
+// Save a node subtree as a prefab
+sceneMgr.SavePrefab(nodeIndex, L"Assets/Prefabs/Enemy.prefab");
+
+// Instantiate a prefab into the scene
+int newNodeIndex = sceneMgr.LoadPrefab(L"Assets/Prefabs/Enemy.prefab");
+```
+
+## Dirty State Tracking
+
+The scene manager tracks unsaved changes:
+
+```cpp
+sceneMgr.MarkDirty();          // Mark scene as modified
+bool unsaved = sceneMgr.IsDirty();  // Check for unsaved changes
+```
+
+The editor uses this to prompt "Save changes?" before closing or loading a new scene.
+
+## Undo/Redo
+
+Scene history supports undo/redo for editor operations.
+
+## Legacy Format
+
+A legacy binary format is supported via `LoadCustom()` for older scene files.
+
+## Console Commands
+
+```
+scene_info          # Show current scene info
+scene_list          # List all nodes in hierarchy
+scene_load <path>   # Load a scene file
+scene_save <path>   # Save current scene
+scene_clear         # Clear the scene
+```
+
+## See Also
+
+- [[Entity Component System]] — ECS entities created from scene nodes
+- [[SparkEditor]] — Visual scene hierarchy editor
+- [[Asset Pipeline]] — Model and asset loading

--- a/wiki/Scripting-with-AngelScript.md
+++ b/wiki/Scripting-with-AngelScript.md
@@ -1,0 +1,148 @@
+# Scripting with AngelScript
+
+SparkEngine integrates **AngelScript** as its gameplay scripting language, supporting hot-reload, entity binding, and full engine API access.
+
+**Source:** `SparkEngine/Source/Engine/Scripting/AngelScriptEngine.h`
+
+## Overview
+
+AngelScript is a statically-typed scripting language with C/C++-like syntax. Scripts are attached to ECS entities and driven through lifecycle callbacks, similar to Unity's MonoBehaviour pattern.
+
+## Writing a Script
+
+Create an `.as` file in `Assets/Scripts/`:
+
+```cpp
+// Assets/Scripts/EnemyAI.as
+
+class EnemyBehavior
+{
+    float health = 100.0f;
+    float moveSpeed = 5.0f;
+
+    void Start()
+    {
+        print("Enemy spawned!");
+    }
+
+    void Update(float dt)
+    {
+        // Game logic runs every frame
+        if (getKeyDown("F")) {
+            health -= 10.0f;
+            print("Enemy hit! Health: " + health);
+        }
+    }
+
+    void OnCollision(uint entityId)
+    {
+        print("Collided with entity: " + entityId);
+    }
+}
+```
+
+## Lifecycle Callbacks
+
+| Callback | Signature | When Called |
+|----------|-----------|------------|
+| `Start` | `void Start()` | Once, when the script is first attached |
+| `Update` | `void Update(float dt)` | Every frame, with delta time in seconds |
+| `OnCollision` | `void OnCollision(uint entityId)` | When the entity collides with another |
+
+## Engine API (Available in Scripts)
+
+### Output
+
+```cpp
+void print(const string& msg)    // Output to debug console
+```
+
+### Entity Management
+
+```cpp
+uint createEntity(const string& name)    // Create a new entity
+Transform@ getTransform(uint entityId)   // Get entity's transform
+```
+
+### Input
+
+```cpp
+bool getKeyDown(const string& key)   // Key just pressed this frame
+bool getKey(const string& key)       // Key currently held
+```
+
+### Math Types
+
+- `XMFLOAT3` — 3D vector
+- `XMMATRIX` — 4x4 matrix
+
+## Using Scripts from C++
+
+### Compile and Attach
+
+```cpp
+AngelScriptEngine& scriptEngine = AngelScriptEngine::GetInstance();
+scriptEngine.Initialize();
+
+// Compile a script file
+scriptEngine.CompileScriptFile("Assets/Scripts/EnemyAI.as");
+
+// Attach a script class to an entity
+scriptEngine.AttachScript(enemyEntity, "EnemyBehavior", "EnemyAI");
+
+// Call lifecycle methods
+scriptEngine.CallStart(enemyEntity);         // Called once
+scriptEngine.CallUpdate(enemyEntity, dt);    // Called every frame
+```
+
+### Compile from String
+
+```cpp
+scriptEngine.CompileScriptString("InlineModule",
+    "class Test { void Start() { print(\"Hello!\"); } }");
+```
+
+### Detach Scripts
+
+```cpp
+scriptEngine.DetachScript(enemyEntity);
+```
+
+## ECS Integration
+
+Use the `Script` component to bind scripts to entities:
+
+```cpp
+auto& script = world.AddComponent<Script>(entity);
+script.scriptFile = "EnemyAI";
+script.className  = "EnemyBehavior";
+script.moduleName = "EnemyAI";
+```
+
+## Hot Reload
+
+AngelScript supports hot-reloading during development. When enabled (`ENABLE_HOT_RELOAD=ON`), modifying a `.as` file triggers recompilation and re-attachment without restarting the engine.
+
+## Error Handling
+
+Compilation and runtime errors are captured:
+
+```cpp
+if (!scriptEngine.CompileScriptFile("Assets/Scripts/Broken.as")) {
+    std::string error = scriptEngine.GetLastError();
+    LOG_ERROR("Script error: " + error);
+}
+```
+
+## Module Isolation
+
+Each script file is compiled into a separate AngelScript module, providing namespace isolation between scripts.
+
+## Thread Safety
+
+Script contexts are **not thread-safe**. All script calls must happen on the main game loop thread.
+
+## See Also
+
+- [[Entity Component System]] — Script component
+- [[Creating a Game Module]] — Module lifecycle

--- a/wiki/Shader-Pipeline.md
+++ b/wiki/Shader-Pipeline.md
@@ -1,0 +1,124 @@
+# Shader Pipeline
+
+SparkEngine supports HLSL and GLSL shader authoring with cross-compilation through the RHI pipeline. The `SparkShaderCompiler` tool handles offline compilation.
+
+**Source:** `SparkEngine/Source/Graphics/Shader.h`, `SparkShaderCompiler/src/`
+
+## Shader Languages
+
+| Language | Backend | File Extension |
+|----------|---------|---------------|
+| HLSL | DirectX 11 | `.hlsl` |
+| GLSL | OpenGL | `.glsl` |
+| SPIR-V | Vulkan (cross-compiled from HLSL) | `.spv` |
+
+## Directory Structure
+
+```
+Shaders/
+├── HLSL/           # DirectX shader source files
+├── GLSL/           # OpenGL shader source files
+└── Compiled/       # Pre-compiled DirectX bytecode (.cso)
+```
+
+## Shader Stages
+
+| Stage | Description |
+|-------|-------------|
+| `vertex` | Vertex shader — transforms vertices |
+| `pixel` | Pixel/fragment shader — computes pixel color |
+| `geometry` | Geometry shader — processes primitives |
+| `hull` | Hull shader — tessellation control |
+| `domain` | Domain shader — tessellation evaluation |
+| `compute` | Compute shader — general-purpose GPU compute |
+
+## Constant Buffers
+
+Shaders use two standard constant buffers defined in `Shader.h`:
+
+### Per-Frame Constants (b0)
+
+Updated once per frame:
+- View matrix
+- Projection matrix
+- Camera position
+- Light data
+- Time
+
+### Per-Object Constants (b1)
+
+Updated for each rendered object:
+- World matrix
+- Material properties
+- Object-specific parameters
+
+## SparkShaderCompiler
+
+The standalone offline shader compilation tool:
+
+### Basic Usage
+
+```bash
+# Compile HLSL to DirectX 11 bytecode
+SparkShaderCompiler BasicVS.hlsl -stage vertex -backend d3d11 -o BasicVS.cso
+
+# Cross-compile HLSL to SPIR-V for Vulkan
+SparkShaderCompiler PBR.hlsl -stage pixel -backend vulkan -o PBR.spv
+
+# Compile GLSL for OpenGL
+SparkShaderCompiler Water.glsl -stage vertex -backend opengl -o Water.glsl.spv
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `-stage <type>` | Shader stage (vertex/pixel/geometry/hull/domain/compute) |
+| `-backend <type>` | Target backend (d3d11/vulkan/opengl/auto) |
+| `-entry <name>` | Entry point function name |
+| `-o <path>` | Output file path |
+| `-D <define>` | Preprocessor define |
+| `-I <path>` | Include search path |
+| `-O` | Enable optimization |
+| `-Od` | Disable optimization (debug) |
+| `-Zi` | Include debug information |
+| `-validate` | Validate without writing output |
+| `-reflect` | Print shader reflection data |
+| `-v` | Verbose output |
+
+### Batch Compilation
+
+Use the provided scripts to compile all shaders:
+
+```bash
+# Windows
+.\Shaders\compile_shaders.bat
+
+# Linux
+./Shaders/compile_shaders.sh
+```
+
+## Embedded Shaders
+
+The engine supports embedded shaders compiled directly into the executable, eliminating external file dependencies for core shaders.
+
+## RHI Cross-Compilation
+
+The RHI layer handles shader format differences between backends:
+
+```
+HLSL Source
+    │
+    ├─── D3D11: Direct compilation → .cso bytecode
+    ├─── Vulkan: HLSL → SPIR-V cross-compilation → .spv
+    └─── OpenGL: HLSL → GLSL transpilation → .glsl
+```
+
+## Hot Reloading
+
+During development, shader modifications can be detected and recompiled at runtime (when `ENABLE_HOT_RELOAD=ON`).
+
+## See Also
+
+- [[Rendering and Graphics]] — Shader usage in the pipeline
+- [[Asset Pipeline]] — Shader asset management

--- a/wiki/SparkConsole.md
+++ b/wiki/SparkConsole.md
@@ -1,0 +1,175 @@
+# SparkConsole
+
+SparkConsole is a standalone debug console application that communicates with the SparkEngine runtime via named pipes, providing real-time engine inspection with 200+ commands.
+
+**Source:** `SparkConsole/src/`
+
+## Overview
+
+SparkConsole runs as a separate process alongside SparkEngine:
+
+```
+┌──────────────┐   Named Pipes   ┌──────────────┐
+│ SparkEngine  │ ◄─────────────► │ SparkConsole │
+│ (game)       │                 │ (debug)      │
+└──────────────┘                 └──────────────┘
+```
+
+When SparkEngine starts, it automatically launches SparkConsole and establishes a named pipe connection.
+
+## Running SparkConsole
+
+### Automatic
+
+SparkConsole opens automatically when SparkEngine starts.
+
+### Standalone
+
+```batch
+cd build\bin
+SparkConsole.exe
+```
+
+In standalone mode, SparkConsole provides local diagnostics but cannot control the engine.
+
+## Command Categories
+
+### Engine Commands
+
+```
+help              # List all available commands
+engine_status     # Show engine system initialization status
+status            # Quick engine status
+diag              # Run full diagnostics
+fps               # Show current framerate
+quit              # Shut down the engine
+```
+
+### Graphics Commands
+
+```
+graphics_info              # GPU and adapter information
+render_path <path>         # Set render pipeline (forward/deferred/forward+/clustered)
+quality <preset>           # Set quality (low/medium/high/ultra)
+wireframe                  # Toggle wireframe rendering
+ssao <on|off>              # Toggle SSAO
+ssr <on|off>               # Toggle SSR
+bloom <on|off>             # Toggle bloom
+msaa <1|2|4|8>             # Set MSAA level
+vsync <on|off>             # Toggle vertical sync
+resolution <w> <h>         # Set resolution
+fullscreen                 # Toggle fullscreen
+```
+
+### Physics Commands
+
+```
+physics_info               # Physics world statistics
+physics_gravity <x y z>    # Set gravity
+physics_debug <on|off>     # Toggle debug draw
+physics_pause              # Pause simulation
+physics_step               # Single-step physics
+physics_material <name>    # Show material properties
+```
+
+### Audio Commands
+
+```
+audio_info                 # Audio system status
+audio_master <vol>         # Set master volume (0.0-1.0)
+audio_sfx <vol>            # Set SFX volume
+audio_music <vol>          # Set music volume
+audio_play <name>          # Play a sound
+audio_stop_all             # Stop all sounds
+audio_list                 # List loaded sounds
+audio_sources              # Show active sources
+```
+
+### Input Commands
+
+```
+input_info                 # Input system status
+input_sensitivity <val>    # Set mouse sensitivity
+input_deadzone <val>       # Set dead zone
+input_invert_y             # Toggle Y inversion
+input_bindings             # List key bindings
+input_log <on|off>         # Toggle input logging
+input_stats                # Input statistics
+```
+
+### Scene Commands
+
+```
+scene_info                 # Current scene info
+scene_list                 # List all nodes
+scene_load <path>          # Load a scene
+scene_save <path>          # Save scene
+scene_clear                # Clear scene
+```
+
+### Profiling Commands
+
+```
+profile_start              # Start profiling
+profile_stop               # Stop profiling
+profile_report             # Print profiling report
+profile_gpu                # GPU timing data
+memory_info                # Memory usage report
+frame_time                 # Frame time breakdown
+```
+
+### Networking Commands
+
+```
+net_info                   # Network status
+net_stats                  # Ping, jitter, packet loss
+net_connect <host> <port>  # Connect to server
+net_disconnect             # Disconnect
+```
+
+### Scripting Commands
+
+```
+script_reload              # Hot-reload all scripts
+script_run <file>          # Execute a script file
+script_list                # List loaded scripts
+```
+
+### Time and Weather Commands
+
+```
+time_set <hour>            # Set time of day
+time_speed <mult>          # Set time speed
+weather_set <type>         # Set weather
+weather_intensity <val>    # Set intensity
+```
+
+## Extending with Custom Commands
+
+Engine subsystems register their own console commands during initialization. The console system supports:
+- Command name and description
+- Argument parsing
+- Tab completion
+- Command history
+
+## Platform Support
+
+SparkConsole currently requires Windows (named pipe communication). On Linux, console output goes to `stdout`.
+
+## Troubleshooting
+
+### "Standalone mode" message
+
+SparkEngine failed to launch or crashed during startup. Check:
+- Both executables exist in `build/bin/`
+- Run with a debugger attached for error details
+
+### Commands not responding
+
+- Run `engine_status` to check system initialization
+- Verify the engine's main loop is running (CPU usage should be active)
+
+## See Also
+
+- [[Getting Started]] — Running SparkConsole
+- [[Troubleshooting]] — Common console issues

--- a/wiki/SparkEditor.md
+++ b/wiki/SparkEditor.md
@@ -1,0 +1,120 @@
+# SparkEditor
+
+The SparkEditor is an ImGui-based visual editor for creating and editing game content. It provides a dockable workspace with multiple panels for scene editing, material authoring, animation, and debugging.
+
+**Source:** `SparkEditor/Source/`
+
+> **Note:** SparkEditor is Windows-only (requires Win32 + DirectX 11 ImGui backends). It is automatically disabled on non-Windows platforms.
+
+`ENABLE_EDITOR=ON` (Windows only)
+
+## Editor Panels
+
+The editor includes 22+ subsystem panels:
+
+### Scene Hierarchy
+
+- Tree view of all scene nodes with parent-child relationships
+- Drag-and-drop to reparent nodes
+- Right-click context menu for add/delete/duplicate
+- Search and filter nodes by name or type
+
+### Inspector
+
+- Property editor for the selected node/entity
+- Transform editing (position, rotation, scale)
+- Component editing with type-appropriate widgets
+- Material assignment and configuration
+
+### Game Viewport
+
+- Real-time 3D preview of the scene
+- Play/pause/stop game simulation
+- Camera controls (orbit, pan, fly-through)
+- Grid and axis overlays
+
+### Gizmos (ImGuizmo)
+
+- Translate, rotate, and scale gizmos
+- World-space and local-space modes
+- Snap to grid functionality
+
+### Asset Browser
+
+- File-system view of project assets
+- Drag-and-drop assets into the scene
+- Thumbnail previews for textures and models
+
+### Material Editor
+
+- PBR material authoring
+- Texture slot assignment
+- Real-time preview sphere
+- Blend mode and shader selection
+
+### Animation Timeline
+
+- Keyframe editing on a timeline
+- State machine visualization
+- Blend tree configuration
+- Animation clip preview
+
+### Terrain Editor
+
+- Heightmap painting (raise/lower/smooth/flatten)
+- Texture splatting brush
+- Object placement brush
+- Terrain configuration (size, resolution, LOD)
+
+### Weapon Editor
+
+- Weapon property configuration
+- Projectile type selection
+- Fire rate, damage, spread tuning
+
+### Node Graph (imnodes)
+
+- Visual scripting nodes
+- Material graph editor
+- Connection-based data flow
+
+### Profiler Panel
+
+- CPU and GPU timing breakdown
+- Per-system performance graphs
+- Memory usage tracking
+- Frame time history
+
+### Additional Panels
+
+- Console output window
+- Log viewer
+- Build and deployment settings
+- Version control integration
+- Level streaming configuration
+
+## Docking and Layout
+
+The editor uses ImGui's docking branch for a fully customizable workspace:
+- Drag panels to dock at any edge
+- Create floating windows
+- Save and load layout configurations
+- Multiple theme options
+
+## Building with the Editor
+
+```powershell
+# Windows PowerShell
+.\build.ps1 -config Release -editor
+
+# Or via CMake
+cmake -B build -DENABLE_EDITOR=ON
+cmake --build build --config Release
+```
+
+## See Also
+
+- [[Scene Management]] — Scene hierarchy and serialization
+- [[Rendering and Graphics]] — Material system
+- [[Animation]] — Animation state machines
+- [[Cinematic Sequencer]] — Timeline editor

--- a/wiki/Terrain-and-Procedural-Generation.md
+++ b/wiki/Terrain-and-Procedural-Generation.md
@@ -1,0 +1,95 @@
+# Terrain and Procedural Generation
+
+SparkEngine includes heightmap terrain rendering and a procedural generation toolkit for creating game content at runtime.
+
+**Source:** `SparkEngine/Source/Game/` (terrain), `SparkEngine/Source/Engine/Procedural/ProceduralGeneration.h`
+
+## Heightmap Terrain
+
+`ENABLE_TERRAIN_SYSTEM=ON`
+
+The terrain system renders large outdoor environments using heightmaps:
+
+- **Quadtree LOD** — Automatic level-of-detail based on camera distance
+- **Texture Splatting** — Multi-texture blending based on height, slope, or paint masks
+- **Heightfield Collision** — Bullet Physics `Heightfield` shape for terrain collisions
+- **Chunk-based** — Terrain is divided into chunks for efficient culling and streaming
+
+## Noise Functions
+
+The procedural generation system provides multiple noise algorithms:
+
+| Function | Description |
+|----------|-------------|
+| **Perlin** | Classic gradient noise, smooth and continuous |
+| **Simplex** | Faster alternative to Perlin with fewer artifacts |
+| **Worley** | Cell/Voronoi noise for organic patterns |
+| **FBM** | Fractal Brownian Motion — layered octaves for natural detail |
+| **Ridged Multifractal** | Ridge-like noise for mountain ranges |
+| **Domain Warping** | Distorts input coordinates for flowing, organic shapes |
+
+## Erosion Simulation
+
+Noise-generated terrain can be refined with erosion:
+
+### Thermal Erosion
+
+Simulates material sliding downhill when slope exceeds a threshold:
+- Talus angle parameter
+- Iteration count
+- Material transport rate
+
+### Hydraulic Erosion
+
+Simulates water-based erosion with sediment transport:
+- Rain amount and evaporation rate
+- Sediment capacity
+- Erosion and deposition rates
+- Droplet lifetime and inertia
+
+## Procedural Mesh Generation
+
+Generate primitive meshes at runtime:
+
+| Shape | Description |
+|-------|-------------|
+| Plane | Flat grid with configurable subdivisions |
+| Box | Cube with per-face normals |
+| Sphere | UV sphere or icosphere |
+| Cylinder | Cylinder with configurable segments |
+| Cone | Cone with base cap |
+| Torus | Donut shape with configurable radii |
+| Terrain | Heightmap-based terrain mesh |
+| Rock | Randomized rock shapes using noise displacement |
+| Tree | Simple L-system or billboard tree geometry |
+
+## Rule-Based Object Placement
+
+Scatter objects across terrain using configurable rules:
+- Height range constraints
+- Slope angle constraints
+- Density and spacing parameters
+- Random rotation and scale variation
+- Exclusion zones
+
+## Wave Function Collapse (WFC)
+
+Procedural room and dungeon layout generation using the WFC algorithm:
+
+- Define tile types with adjacency rules
+- Generate valid layouts that satisfy all constraints
+- Configurable grid size and tile sets
+- Useful for dungeon crawlers, roguelikes, and level generation
+
+## CMake Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `ENABLE_TERRAIN_SYSTEM` | ON | Heightmap terrain rendering |
+| `ENABLE_PROCEDURAL` | ON | Procedural generation toolkit |
+
+## See Also
+
+- [[Physics]] — Heightfield collision shapes
+- [[Rendering and Graphics]] — Terrain rendering and LOD
+- [[Scene Management]] — Procedurally generated scenes

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -1,0 +1,123 @@
+# Testing
+
+SparkEngine includes 35 unit tests using a lightweight internal test framework with CTest integration.
+
+**Source:** `Tests/TestFramework.h`, `Tests/`
+
+## Test Framework
+
+The engine uses its own lightweight test framework (no external test library dependencies):
+
+### Test Macros
+
+```cpp
+#include "TestFramework.h"
+
+TEST(MyTestName) {
+    EXPECT_EQ(value, expected);        // Equality check
+    EXPECT_TRUE(condition);            // Boolean check
+    EXPECT_FALSE(condition);           // Negative boolean check
+    EXPECT_NEAR(a, b, tolerance);      // Floating-point comparison
+    EXPECT_NE(value, unexpected);      // Not-equal check
+}
+```
+
+## Running Tests
+
+### Build with Tests Enabled
+
+```bash
+cmake -B build -DBUILD_TESTS=ON
+cmake --build build
+```
+
+### Run All Tests
+
+```bash
+ctest --test-dir build --output-on-failure
+```
+
+### Run Specific Tests
+
+```bash
+ctest --test-dir build -R "TestPhysics"           # Run tests matching pattern
+ctest --test-dir build -R "TestECS|TestAnimation"  # Run multiple patterns
+```
+
+## Test Coverage
+
+The 35 unit tests cover all major subsystems:
+
+| Category | Tests |
+|----------|-------|
+| **Math** | Math utilities, vector operations |
+| **Core** | Object pool, ring buffer |
+| **ECS** | Entity creation, component operations, views |
+| **Physics** | Body creation, raycasting, collision |
+| **AI** | Behavior trees, NavMesh pathfinding |
+| **Animation** | State machines, blending, IK |
+| **Audio** | Audio source management |
+| **Input** | Input state tracking |
+| **Scripting** | Script compilation, lifecycle |
+| **Save System** | Serialization, compression |
+| **Events** | Event bus subscribe/publish |
+| **Weather** | Weather transitions |
+| **Inventory** | Item management |
+| **Quests** | Quest tracking |
+| **Day/Night** | Time progression |
+| **Lighting** | Light calculations |
+| **Performance** | Profiler, frame stats |
+| **Fog** | Fog calculations |
+| **Screen-Space** | SSAO, SSR parameters |
+| **Post-Processing** | Effect pipeline |
+| **Sequencer** | Cinematic timeline |
+| **Mesh LOD** | LOD switching |
+| **Console** | Command parsing |
+| **Coroutines** | Coroutine scheduling |
+| **Tweening** | Animation tweens |
+| **Temporal Effects** | TAA settings |
+| **Noise** | Procedural noise generation |
+| **Game Modes** | Game mode management |
+
+## Adding a New Test
+
+1. Create a test file in `Tests/`:
+
+```cpp
+// Tests/TestMyFeature.cpp
+#include "TestFramework.h"
+#include "MyFeature.h"
+
+TEST(MyFeature_BasicTest) {
+    MyFeature feature;
+    feature.Initialize();
+    EXPECT_TRUE(feature.IsReady());
+}
+
+TEST(MyFeature_EdgeCase) {
+    MyFeature feature;
+    EXPECT_EQ(feature.Compute(0), 0);
+    EXPECT_NEAR(feature.Compute(1.0f), 1.0f, 0.001f);
+}
+```
+
+2. The test is automatically discovered by CMake (tests are globbed in `Tests/CMakeLists.txt`).
+
+3. Build and run:
+
+```bash
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+## CI Integration
+
+Tests run automatically on every push via GitHub Actions:
+- Windows (VS 2022) — Debug and Release
+- Linux (GCC, Clang) — Debug and Release
+- Sanitizer builds (ASan, TSan) for memory and thread safety
+
+## See Also
+
+- [[Build System and CMake Modules]] — BUILD_TESTS flag
+- [[Getting Started]] — Building the project

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,184 @@
+# Troubleshooting
+
+Common issues and solutions when building and running SparkEngine.
+
+## Quick Verification
+
+### Test SparkConsole Standalone
+
+```batch
+cd build\bin
+SparkConsole.exe
+```
+
+Expected: "Spark Engine Console v1.0.0" banner. Try `diag`, `help`, `status`. Type `exit` to quit.
+
+### Test SparkEngine
+
+```batch
+cd build\bin
+SparkEngine.exe
+```
+
+Expected:
+1. DirectX 11 window appears (blue background)
+2. SparkConsole window opens automatically
+3. Console shows initialization messages:
+   ```
+   [INFO] SparkConsole system initialized
+   [INFO] External console connection established
+   [INFO] All engine systems initialized
+   ```
+4. Console commands respond: `help`, `engine_status`, `fps`, `graphics_info`
+
+## Build Issues
+
+### Submodule Errors
+
+```bash
+git submodule sync
+git submodule init
+git submodule update --recursive
+```
+
+### Runtime Library Mismatch (MSVC)
+
+SparkEngine uses `/MD` (dynamic CRT). If third-party libraries were built with `/MT`, you'll get linker errors. Clean rebuild:
+
+```batch
+rmdir /s /q build
+cmake -B build -G "Visual Studio 17 2022" -A x64
+cmake --build build --config Release
+```
+
+### CMake Version Too Old
+
+SparkEngine requires CMake 3.16+. Check your version:
+
+```bash
+cmake --version
+```
+
+### Missing C++20 Support
+
+Ensure your compiler supports C++20:
+- MSVC: Visual Studio 2022 (v143) or later
+- GCC: Version 11 or later
+- Clang: Version 14 or later
+
+## Runtime Issues
+
+### SparkEngine Crashes Immediately
+
+**Cause:** Graphics initialization failure or missing DirectX runtime.
+
+Solutions:
+- Update graphics drivers
+- Verify DirectX 11 support: run `dxdiag`
+- Check Visual Studio Output window for assertion failures
+- Try running as administrator
+
+### SparkConsole Shows "Standalone Mode"
+
+**Cause:** SparkEngine failed to launch or crashed during startup.
+
+Solutions:
+- Check Visual Studio Output window for errors
+- Verify both executables are in `build\bin\`
+- Run from Visual Studio with debugger attached
+
+### Neither Program Starts
+
+**Cause:** Missing build output or incomplete build.
+
+```batch
+cmake --build build --config Debug
+dir build\bin\*.exe
+```
+
+Both `SparkEngine.exe` and `SparkConsole.exe` must exist in `build\bin\`.
+
+### Console Connects but Commands Fail
+
+- Run `engine_status` to check system initialization
+- Verify the main engine loop is running (CPU usage should be active, not 0%)
+- Check debug output for errors
+
+## Debug Commands
+
+Once SparkConsole is connected:
+
+```
+help              # List all commands
+engine_status     # Check system status
+fps               # Show framerate
+graphics_info     # GPU information
+diag              # Full diagnostics
+```
+
+## Memory Reference
+
+Quick reference for debugging memory issues:
+
+| Command | Description |
+|---------|-------------|
+| `memory_info` | Show current memory usage |
+| `profile_report` | Performance breakdown |
+| `frame_time` | Frame time analysis |
+
+## Required Files
+
+For the engine to run correctly, these files must be present in `build/bin/`:
+
+| File | Purpose |
+|------|---------|
+| `SparkEngine.exe` | Main engine executable |
+| `SparkConsole.exe` | Debug console |
+| `SparkGame.dll` | Default game module |
+
+And these directories should be present:
+- `Shaders/` — Compiled shader bytecode
+- `Assets/` — Game assets
+
+## Platform-Specific Issues
+
+### Windows
+
+- Ensure Visual C++ Redistributable is installed
+- DirectX 11 capable GPU required
+- Named pipes require appropriate permissions
+
+### Linux
+
+- SparkEditor is not available (Windows-only)
+- SparkConsole uses stdout instead of named pipes
+- Vulkan SDK may be needed for the Vulkan backend
+- Some features may have limited support (experimental platform)
+
+## Last Resort
+
+1. Clean build:
+   ```bash
+   rm -rf build
+   cmake -B build -G "..." -DCMAKE_BUILD_TYPE=Debug
+   cmake --build build
+   ```
+
+2. Re-clone with submodules:
+   ```bash
+   git clone --recurse-submodules https://github.com/Krilliac/SparkEngine.git
+   ```
+
+3. Try the minimal preset:
+   ```bash
+   cmake --preset minimal
+   cmake --build --preset minimal
+   ```
+
+4. Check [GitHub Issues](https://github.com/Krilliac/SparkEngine/issues) for known problems.
+
+## See Also
+
+- [[Getting Started]] — Build instructions
+- [[Build System and CMake Modules]] — Build configuration
+- [[SparkConsole]] — Debug console usage

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,37 @@
+# SparkEngine Wiki
+
+### Getting Started
+- [[Home]]
+- [[Getting Started]]
+- [[Architecture Overview]]
+- [[Creating a Game Module]]
+
+### Engine Subsystems
+- [[Entity Component System]]
+- [[Rendering and Graphics]]
+- [[Physics]]
+- [[Audio]]
+- [[Input System]]
+- [[Scripting with AngelScript]]
+- [[AI and Navigation]]
+- [[Animation]]
+- [[Networking]]
+- [[Scene Management]]
+- [[Event System]]
+
+### Gameplay & Tools
+- [[Gameplay Systems]]
+- [[Terrain and Procedural Generation]]
+- [[Save System]]
+- [[Day Night Cycle and Weather]]
+- [[Cinematic Sequencer]]
+- [[SparkEditor]]
+- [[SparkConsole]]
+- [[Shader Pipeline]]
+- [[Asset Pipeline]]
+
+### Advanced
+- [[Build System and CMake Modules]]
+- [[Testing]]
+- [[Troubleshooting]]
+- [[Contributing]]


### PR DESCRIPTION
Create a full-fledged wiki covering all engine subsystems, organized into four tiers: orientation (Home, Getting Started, Architecture, Game Module), subsystem references (ECS, Graphics, Physics, Audio, Input, Scripting, AI, Animation, Networking, Scene, Events), gameplay and tools (Gameplay, Terrain, Save, Day/Night, Cinematic, Editor, Console, Shaders, Assets), and advanced topics (Build System, Testing, Troubleshooting, Contributing, Sidebar navigation).

All API examples and code snippets are sourced from actual engine headers for accuracy.

https://claude.ai/code/session_01Ps2Fm7wua2EDXvwyDq38sX