### PR TITLE
Convert wiki [[links]] to standard markdown links for in-repo browsing

### DIFF
--- a/wiki/AI-and-Navigation.md
+++ b/wiki/AI-and-Navigation.md
@@ -149,7 +149,7 @@ XMFLOAT3 combined = steering.Seek(...) * 1.0f
 
 ## ECS Integration
 
-Use `AIComponent` on entities (see [[Entity Component System]]):
+Use `AIComponent` on entities (see [Entity Component System](Entity-Component-System)):
 
 ```cpp
 auto& ai = world.AddComponent<AIComponent>(entity);
@@ -170,10 +170,10 @@ All node classes use value-semantic ownership via `std::unique_ptr`. There are n
 
 ## See Also
 
-- [[Entity Component System]] — AIComponent
-- [[Gameplay Systems]] — NPC and combat systems
-- [[Animation]] — NPC animation state machines
-- [[Physics]] — Steering and collision avoidance
-- [[Event System]] — AI-related event publishing
-- [[Terrain and Procedural Generation]] — NavMesh generation on terrain
-- [[Scripting with AngelScript]] — Scripting AI behaviors
+- [Entity Component System](Entity-Component-System) — AIComponent
+- [Gameplay Systems](Gameplay-Systems) — NPC and combat systems
+- [Animation](Animation) — NPC animation state machines
+- [Physics](Physics) — Steering and collision avoidance
+- [Event System](Event-System) — AI-related event publishing
+- [Terrain and Procedural Generation](Terrain-and-Procedural-Generation) — NavMesh generation on terrain
+- [Scripting with AngelScript](Scripting-with-AngelScript) — Scripting AI behaviors

--- a/wiki/Animation.md
+++ b/wiki/Animation.md
@@ -104,7 +104,7 @@ Root motion extraction moves the character based on animation data rather than g
 
 ## ECS Integration
 
-Use `AnimationController` on entities (see [[Entity Component System]]):
+Use `AnimationController` on entities (see [Entity Component System](Entity-Component-System)):
 
 ```cpp
 auto& anim = world.AddComponent<AnimationController>(entity);
@@ -119,7 +119,7 @@ The `AnimationUpdateSystem` evaluates state machines and blends poses each frame
 
 ## Asset Import
 
-Models with animations are imported via Assimp (see [[Asset Pipeline]]):
+Models with animations are imported via Assimp (see [Asset Pipeline](Asset-Pipeline)):
 - **FBX** — Industry standard, supports skeletons and animations
 - **glTF** — Modern format with PBR materials and animations
 
@@ -127,11 +127,11 @@ Models with animations are imported via Assimp (see [[Asset Pipeline]]):
 
 ## See Also
 
-- [[Entity Component System]] — AnimationController component
-- [[Asset Pipeline]] — Importing animated models
-- [[SparkEditor]] — Animation timeline editor
-- [[Rendering and Graphics]] — Skinned mesh rendering
-- [[AI and Navigation]] — NPC animation integration
-- [[Physics]] — Root motion and physics interaction
-- [[Gameplay Systems]] — Player and weapon animations
-- [[Cinematic Sequencer]] — Animation in cinematics
+- [Entity Component System](Entity-Component-System) — AnimationController component
+- [Asset Pipeline](Asset-Pipeline) — Importing animated models
+- [SparkEditor](SparkEditor) — Animation timeline editor
+- [Rendering and Graphics](Rendering-and-Graphics) — Skinned mesh rendering
+- [AI and Navigation](AI-and-Navigation) — NPC animation integration
+- [Physics](Physics) — Root motion and physics interaction
+- [Gameplay Systems](Gameplay-Systems) — Player and weapon animations
+- [Cinematic Sequencer](Cinematic-Sequencer) — Animation in cinematics

--- a/wiki/Architecture-Overview.md
+++ b/wiki/Architecture-Overview.md
@@ -60,7 +60,7 @@ Multiple modules can be loaded simultaneously and are initialized in load-order 
 2. `spark.modules.json` manifest next to the executable
 3. Directory scan for `*Game*.dll` or `*Module*.dll`
 
-See [[Creating a Game Module]] for a step-by-step guide.
+See [Creating a Game Module](Creating-a-Game-Module) for a step-by-step guide.
 
 ## Service Locator Pattern
 
@@ -114,15 +114,15 @@ Game modules store the context pointer during `OnLoad()` and use it throughout t
 
 ## ECS Data Flow
 
-SparkEngine uses the **EnTT** library for its [[Entity Component System]]. The data flow each frame:
+SparkEngine uses the **EnTT** library for its [Entity Component System](Entity-Component-System). The data flow each frame:
 
-1. **Input** — `InputManager::Update()` captures keyboard/mouse/gamepad state (see [[Input System]])
-2. **Scripts** — `AngelScriptEngine` calls `Update()` on entity scripts (see [[Scripting with AngelScript]])
-3. **AI** — `AISystem` ticks behavior trees and updates steering (see [[AI and Navigation]])
-4. **Physics** — `PhysicsSystem::Update()` steps the Bullet simulation (see [[Physics]])
-5. **Animation** — `AnimationSystem` evaluates state machines and blends poses (see [[Animation]])
-6. **Audio** — `AudioEngine` updates 3D listener and source positions (see [[Audio]])
-7. **Rendering** — `GraphicsEngine` renders the scene with all post-processing (see [[Rendering and Graphics]])
+1. **Input** — `InputManager::Update()` captures keyboard/mouse/gamepad state (see [Input System](Input-System))
+2. **Scripts** — `AngelScriptEngine` calls `Update()` on entity scripts (see [Scripting with AngelScript](Scripting-with-AngelScript))
+3. **AI** — `AISystem` ticks behavior trees and updates steering (see [AI and Navigation](AI-and-Navigation))
+4. **Physics** — `PhysicsSystem::Update()` steps the Bullet simulation (see [Physics](Physics))
+5. **Animation** — `AnimationSystem` evaluates state machines and blends poses (see [Animation](Animation))
+6. **Audio** — `AudioEngine` updates 3D listener and source positions (see [Audio](Audio))
+7. **Rendering** — `GraphicsEngine` renders the scene with all post-processing (see [Rendering and Graphics](Rendering-and-Graphics))
 
 Components are pure POD structs (state only, no behavior). Systems query and mutate components each frame.
 
@@ -132,37 +132,37 @@ Components are pure POD structs (state only, no behavior). Systems query and mut
 SparkEngine/
 ├── SparkEngine/              # Main engine executable + core library
 │   └── Source/
-│       ├── Audio/            # XAudio2 3D audio engine ([[Audio]])
+│       ├── Audio/            # XAudio2 3D audio engine ([Audio](Audio))
 │       ├── Camera/           # First-person camera controller
 │       ├── Console/          # Debug console integration
 │       ├── Core/             # Entry point, platform, framework
 │       ├── Engine/
-│       │   ├── AI/           # Behavior trees, NavMesh, perception, steering ([[AI and Navigation]])
-│       │   ├── Animation/    # Skeletal animation, IK, state machines ([[Animation]])
-│       │   ├── Cinematic/    # Cinematic sequencer ([[Cinematic Sequencer]])
+│       │   ├── AI/           # Behavior trees, NavMesh, perception, steering ([AI and Navigation](AI-and-Navigation))
+│       │   ├── Animation/    # Skeletal animation, IK, state machines ([Animation](Animation))
+│       │   ├── Cinematic/    # Cinematic sequencer ([Cinematic Sequencer](Cinematic-Sequencer))
 │       │   ├── Coroutine/    # Coroutine scheduler
-│       │   ├── ECS/          # EnTT entity-component system ([[Entity Component System]])
-│       │   ├── Events/       # Publish/subscribe event bus ([[Event System]])
-│       │   ├── Networking/   # UDP multiplayer, replication ([[Networking]])
+│       │   ├── ECS/          # EnTT entity-component system ([Entity Component System](Entity-Component-System))
+│       │   ├── Events/       # Publish/subscribe event bus ([Event System](Event-System))
+│       │   ├── Networking/   # UDP multiplayer, replication ([Networking](Networking))
 │       │   ├── Procedural/   # Noise, erosion, mesh generation, WFC
 │       │   ├── SaveSystem/   # Serialization, compression
-│       │   ├── Scripting/    # AngelScript VM, hot-reload ([[Scripting with AngelScript]])
+│       │   ├── Scripting/    # AngelScript VM, hot-reload ([Scripting with AngelScript](Scripting-with-AngelScript))
 │       │   └── World/        # World management, day/night
 │       ├── Game/             # Player, weapons, vehicles, HUD, terrain
-│       ├── Graphics/         # DX11 renderer, RHI, PBR, post-processing ([[Rendering and Graphics]])
-│       ├── Input/            # Keyboard, mouse, gamepad ([[Input System]])
-│       ├── Physics/          # Bullet Physics integration ([[Physics]])
-│       ├── SceneManager/     # Scene hierarchy, serialization ([[Scene Management]])
+│       ├── Graphics/         # DX11 renderer, RHI, PBR, post-processing ([Rendering and Graphics](Rendering-and-Graphics))
+│       ├── Input/            # Keyboard, mouse, gamepad ([Input System](Input-System))
+│       ├── Physics/          # Bullet Physics integration ([Physics](Physics))
+│       ├── SceneManager/     # Scene hierarchy, serialization ([Scene Management](Scene-Management))
 │       └── Utils/            # Logging, profiler, crash handler, debug
-├── SparkEditor/              # ImGui-based visual editor (Windows only) ([[SparkEditor]])
+├── SparkEditor/              # ImGui-based visual editor (Windows only) ([SparkEditor](SparkEditor))
 ├── SparkGame/                # Default game module (DLL)
-├── SparkConsole/             # Standalone debug console ([[SparkConsole]])
-├── SparkShaderCompiler/      # Offline shader compilation tool ([[Shader Pipeline]])
+├── SparkConsole/             # Standalone debug console ([SparkConsole](SparkConsole))
+├── SparkShaderCompiler/      # Offline shader compilation tool ([Shader Pipeline](Shader-Pipeline))
 ├── SparkSDK/                 # Public SDK headers for module development
 ├── Templates/                # Game module templates (EmptyProject)
 ├── ThirdParty/               # Git submodules (15 libraries)
 ├── Assets/                   # Models, Scenes, Scripts
-├── Shaders/                  # HLSL, GLSL, Compiled bytecode ([[Shader Pipeline]])
+├── Shaders/                  # HLSL, GLSL, Compiled bytecode ([Shader Pipeline](Shader-Pipeline))
 ├── Tests/                    # 35 unit tests
 ├── Tools/                    # CLI tools (spark-cli)
 ├── docs/                     # Doxygen API docs, roadmap, status
@@ -185,7 +185,7 @@ SparkEngine/
 
 ## Build System
 
-CMake-based with 30+ toggleable feature flags. See [[Build System and CMake Modules]] for details.
+CMake-based with 30+ toggleable feature flags. See [Build System and CMake Modules](Build-System-and-CMake-Modules) for details.
 
 ## Dependencies
 
@@ -211,20 +211,20 @@ CMake-based with 30+ toggleable feature flags. See [[Build System and CMake Modu
 
 ## See Also
 
-- [[Entity Component System]] — ECS architecture using EnTT
-- [[Rendering and Graphics]] — Render pipelines, PBR materials, post-processing
-- [[Physics]] — Bullet Physics integration
-- [[Audio]] — XAudio2 / miniaudio audio engine
-- [[AI and Navigation]] — Behavior trees, NavMesh, perception
-- [[Animation]] — Skeletal animation, IK, state machines
-- [[Networking]] — UDP multiplayer and replication
-- [[Input System]] — Keyboard, mouse, and gamepad input
-- [[Scripting with AngelScript]] — AngelScript VM and hot-reload
-- [[Event System]] — Publish/subscribe event bus
-- [[Scene Management]] — Scene hierarchy and serialization
-- [[Asset Pipeline]] — Model and texture loading
-- [[Shader Pipeline]] — Shader authoring and compilation
-- [[SparkEditor]] — ImGui-based visual editor
-- [[SparkConsole]] — Standalone debug console
-- [[Creating a Game Module]] — Building game modules
-- [[Getting Started]] — Build and run the engine
+- [Entity Component System](Entity-Component-System) — ECS architecture using EnTT
+- [Rendering and Graphics](Rendering-and-Graphics) — Render pipelines, PBR materials, post-processing
+- [Physics](Physics) — Bullet Physics integration
+- [Audio](Audio) — XAudio2 / miniaudio audio engine
+- [AI and Navigation](AI-and-Navigation) — Behavior trees, NavMesh, perception
+- [Animation](Animation) — Skeletal animation, IK, state machines
+- [Networking](Networking) — UDP multiplayer and replication
+- [Input System](Input-System) — Keyboard, mouse, and gamepad input
+- [Scripting with AngelScript](Scripting-with-AngelScript) — AngelScript VM and hot-reload
+- [Event System](Event-System) — Publish/subscribe event bus
+- [Scene Management](Scene-Management) — Scene hierarchy and serialization
+- [Asset Pipeline](Asset-Pipeline) — Model and texture loading
+- [Shader Pipeline](Shader-Pipeline) — Shader authoring and compilation
+- [SparkEditor](SparkEditor) — ImGui-based visual editor
+- [SparkConsole](SparkConsole) — Standalone debug console
+- [Creating a Game Module](Creating-a-Game-Module) — Building game modules
+- [Getting Started](Getting-Started) — Build and run the engine

--- a/wiki/Asset-Pipeline.md
+++ b/wiki/Asset-Pipeline.md
@@ -1,6 +1,6 @@
 # Asset Pipeline
 
-SparkEngine's asset pipeline handles loading, streaming, and management of game assets including 3D models, textures, [[Audio|audio]], and [[Scene Management|scenes]].
+SparkEngine's asset pipeline handles loading, streaming, and management of game assets including 3D models, textures, [audio](Audio), and [scenes](Scene-Management).
 
 **Source:** `SparkEngine/Source/Graphics/AssetPipeline.h`
 
@@ -129,18 +129,18 @@ Assets can be streamed in the background to avoid loading hitches:
 
 During development, modified assets are automatically reloaded:
 - Texture files
-- [[Shader Pipeline|Shader source files]]
-- [[Scripting with AngelScript|AngelScript files]]
+- [Shader source files](Shader-Pipeline)
+- [AngelScript files](Scripting-with-AngelScript)
 - Scene files
 
 ---
 
 ## See Also
 
-- [[Rendering and Graphics]] — Material and texture systems
-- [[Animation]] — Importing animated models
-- [[Shader Pipeline]] — Shader compilation
-- [[Scene Management]] — Scene file loading
-- [[Audio]] — Audio asset formats and loading
-- [[Terrain and Procedural Generation]] — Terrain asset streaming
-- [[Entity Component System]] — Component-based asset references
+- [Rendering and Graphics](Rendering-and-Graphics) — Material and texture systems
+- [Animation](Animation) — Importing animated models
+- [Shader Pipeline](Shader-Pipeline) — Shader compilation
+- [Scene Management](Scene-Management) — Scene file loading
+- [Audio](Audio) — Audio asset formats and loading
+- [Terrain and Procedural Generation](Terrain-and-Procedural-Generation) — Terrain asset streaming
+- [Entity Component System](Entity-Component-System) — Component-based asset references

--- a/wiki/Audio.md
+++ b/wiki/Audio.md
@@ -98,7 +98,7 @@ src.minDistance   = 1.0f;
 src.maxDistance   = 50.0f;
 ```
 
-The `AudioUpdateSystem` automatically updates 3D source positions from [[Entity Component System|entity]] transforms each frame.
+The `AudioUpdateSystem` automatically updates 3D source positions from [entity](Entity-Component-System) transforms each frame.
 
 ## Console Commands
 
@@ -125,8 +125,8 @@ audio_sources        # Show active audio sources
 
 ## See Also
 
-- [[Entity Component System]] — AudioSourceComponent
-- [[Asset Pipeline]] — Loading audio assets
-- [[Cinematic Sequencer]] — Audio tracks in cinematics
-- [[Event System]] — Triggering audio from game events
-- [[Day Night Cycle and Weather]] — Ambient audio for weather and time of day
+- [Entity Component System](Entity-Component-System) — AudioSourceComponent
+- [Asset Pipeline](Asset-Pipeline) — Loading audio assets
+- [Cinematic Sequencer](Cinematic-Sequencer) — Audio tracks in cinematics
+- [Event System](Event-System) — Triggering audio from game events
+- [Day Night Cycle and Weather](Day-Night-Cycle-and-Weather) — Ambient audio for weather and time of day

--- a/wiki/Build-System-and-CMake-Modules.md
+++ b/wiki/Build-System-and-CMake-Modules.md
@@ -80,7 +80,7 @@ All flags can be set during CMake configuration with `-D<FLAG>=ON|OFF`:
 |------|---------|-------------|
 | `ENABLE_NETWORKING` | OFF | Networking (CURL dependency issues) |
 | `ENABLE_SDL2` | OFF | SDL2 cross-platform input |
-| `BUILD_TESTS` | ON | Unit test suite (see [[Testing]]) |
+| `BUILD_TESTS` | ON | Unit test suite (see [Testing](Testing)) |
 
 ### MSVC Toolset
 
@@ -117,8 +117,8 @@ cmake --build --preset windows-release
 | `SparkEngineLib` | Static library | Core engine systems |
 | `SparkEngine` | Executable | Runtime host |
 | `SparkGame` | Shared library | Default game module |
-| [[SparkEditor]] | Executable | Visual editor (Windows) |
-| [[SparkConsole]] | Executable | Debug console (Windows) |
+| [SparkEditor](SparkEditor) | Executable | Visual editor (Windows) |
+| [SparkConsole](SparkConsole) | Executable | Debug console (Windows) |
 | `SparkShaderCompiler` | Executable | Shader compilation tool |
 
 ## Build Output
@@ -191,7 +191,7 @@ Runs on every push to `master`/`main`:
 
 ## See Also
 
-- [[Getting Started]] — Build quickstart
-- [[Testing]] — Running unit tests
-- [[Architecture Overview]] — Engine design and subsystems
-- [[Contributing]] — Contribution workflow and code style
+- [Getting Started](Getting-Started) — Build quickstart
+- [Testing](Testing) — Running unit tests
+- [Architecture Overview](Architecture-Overview) — Engine design and subsystems
+- [Contributing](Contributing) — Contribution workflow and code style

--- a/wiki/Cinematic-Sequencer.md
+++ b/wiki/Cinematic-Sequencer.md
@@ -11,8 +11,8 @@ SparkEngine includes a timeline-based cinematic sequencer for creating in-game c
 The sequencer provides a non-linear timeline editor for:
 - Camera movements and cuts
 - Entity animations and transformations
-- [[Audio]] cue playback
-- [[Event System|Event triggers]]
+- [Audio](Audio) cue playback
+- [Event triggers](Event-System)
 - UI transitions
 
 ## Concepts
@@ -73,21 +73,21 @@ The sequencer can smoothly transition between camera angles or make hard cuts:
 
 Cinematics can be triggered from:
 - Game module code (C++)
-- [[Scripting with AngelScript|AngelScript scripts]]
-- Trigger volumes in [[Scene Management|scenes]]
-- [[Event System]] callbacks
+- [AngelScript scripts](Scripting-with-AngelScript)
+- Trigger volumes in [scenes](Scene-Management)
+- [Event System](Event-System) callbacks
 
 ## Editor Support
 
-The SparkEditor includes a visual timeline editor for creating and editing cinematic sequences. See [[SparkEditor]] for details.
+The SparkEditor includes a visual timeline editor for creating and editing cinematic sequences. See [SparkEditor](SparkEditor) for details.
 
 ---
 
 ## See Also
 
-- [[Animation]] — Animation tracks in sequences
-- [[Audio]] — Audio cue playback
-- [[SparkEditor]] — Timeline editor UI
-- [[Event System]] — Event triggers from sequences
-- [[Scripting with AngelScript]] — Script-driven cinematics
-- [[Scene Management]] — Scene-based cinematic triggers
+- [Animation](Animation) — Animation tracks in sequences
+- [Audio](Audio) — Audio cue playback
+- [SparkEditor](SparkEditor) — Timeline editor UI
+- [Event System](Event-System) — Event triggers from sequences
+- [Scripting with AngelScript](Scripting-with-AngelScript) — Script-driven cinematics
+- [Scene Management](Scene-Management) — Scene-based cinematic triggers

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -83,7 +83,7 @@ struct HealthComponent {
 5. Add unit tests in `Tests/`
 6. Document in the wiki
 
-### Adding a New Component (see [[Entity Component System]])
+### Adding a New Component (see [Entity Component System](Entity-Component-System))
 
 1. Define the POD struct in `Components.h`
 2. Add a system function in `ECSystems.h` if needed
@@ -123,8 +123,8 @@ Include:
 
 ## See Also
 
-- [[Architecture Overview]] — Engine design
-- [[Build System and CMake Modules]] — Build configuration
-- [[Testing]] — Adding and running tests
-- [[Getting Started]] — Building and running the project
-- [[Entity Component System]] — Component architecture and ECS patterns
+- [Architecture Overview](Architecture-Overview) — Engine design
+- [Build System and CMake Modules](Build-System-and-CMake-Modules) — Build configuration
+- [Testing](Testing) — Adding and running tests
+- [Getting Started](Getting-Started) — Building and running the project
+- [Entity Component System](Entity-Component-System) — Component architecture and ECS patterns

--- a/wiki/Creating-a-Game-Module.md
+++ b/wiki/Creating-a-Game-Module.md
@@ -230,17 +230,17 @@ Multiple modules are loaded in `loadOrder` and shut down in reverse order.
 
 ## Next Steps
 
-- [[Entity Component System]] — Work with entities and components
-- [[Scripting with AngelScript]] — Add scripted gameplay logic
-- [[Scene Management]] — Load and manage scenes
+- [Entity Component System](Entity-Component-System) — Work with entities and components
+- [Scripting with AngelScript](Scripting-with-AngelScript) — Add scripted gameplay logic
+- [Scene Management](Scene-Management) — Load and manage scenes
 
 ---
 
 ## See Also
 
-- [[Architecture Overview]] — Engine architecture and module system
-- [[Entity Component System]] — Work with entities and components
-- [[Scripting with AngelScript]] — Add scripted gameplay logic
-- [[Scene Management]] — Load and manage scenes
-- [[Event System]] — Subscribe to engine events
-- [[Input System]] — Handle player input
+- [Architecture Overview](Architecture-Overview) — Engine architecture and module system
+- [Entity Component System](Entity-Component-System) — Work with entities and components
+- [Scripting with AngelScript](Scripting-with-AngelScript) — Add scripted gameplay logic
+- [Scene Management](Scene-Management) — Load and manage scenes
+- [Event System](Event-System) — Subscribe to engine events
+- [Input System](Input-System) — Handle player input

--- a/wiki/Day-Night-Cycle-and-Weather.md
+++ b/wiki/Day-Night-Cycle-and-Weather.md
@@ -1,6 +1,6 @@
 # Day/Night Cycle and Weather
 
-SparkEngine includes dynamic time-of-day and weather systems that affect lighting, [[Rendering and Graphics|rendering]], and [[Gameplay Systems|gameplay]].
+SparkEngine includes dynamic time-of-day and weather systems that affect lighting, [rendering](Rendering-and-Graphics), and [gameplay](Gameplay-Systems).
 
 **Source:** `SparkEngine/Source/Engine/World/DayNightCycle.h`, `SparkEngine/Source/Graphics/WeatherSystem.h`
 
@@ -76,7 +76,7 @@ struct WeatherChangedEvent {
 ### Effects on Gameplay
 
 - Reduced visibility in fog, rain, and storms
-- Wet surfaces affect [[Physics|physics friction]]
+- Wet surfaces affect [physics friction](Physics)
 - Wind affects projectile trajectories
 - Lightning provides brief illumination
 
@@ -95,9 +95,9 @@ weather_transition <sec> # Set transition duration
 
 ## See Also
 
-- [[Rendering and Graphics]] — Volumetric lighting and fog
-- [[Event System]] — Weather and time-of-day events
-- [[Physics]] — Weather effects on physics
-- [[Audio]] — Weather-driven audio (thunder, rain, wind)
-- [[Gameplay Systems]] — Weather impact on gameplay mechanics
-- [[Terrain and Procedural Generation]] — Terrain interaction with weather
+- [Rendering and Graphics](Rendering-and-Graphics) — Volumetric lighting and fog
+- [Event System](Event-System) — Weather and time-of-day events
+- [Physics](Physics) — Weather effects on physics
+- [Audio](Audio) — Weather-driven audio (thunder, rain, wind)
+- [Gameplay Systems](Gameplay-Systems) — Weather impact on gameplay mechanics
+- [Terrain and Procedural Generation](Terrain-and-Procedural-Generation) — Terrain interaction with weather

--- a/wiki/Entity-Component-System.md
+++ b/wiki/Entity-Component-System.md
@@ -68,16 +68,16 @@ This is cache-friendly because EnTT stores components in Structure-of-Arrays (So
 | `Transform` | `position`, `rotation`, `scale` (XMFLOAT3) | 3D transform |
 | `MeshRenderer` | `meshIndex`, `materialIndex`, `visible`, `castShadows`, `receiveShadows` | Mesh rendering |
 | `Camera` | `fov`, `nearPlane`, `farPlane`, `isActive` | Camera parameters |
-| `Script` | `scriptFile`, `className`, `moduleName` | [[Scripting with AngelScript|AngelScript]] binding |
+| `Script` | `scriptFile`, `className`, `moduleName` | [AngelScript](Scripting-with-AngelScript) binding |
 
-### [[Physics]] Components
+### [Physics](Physics) Components
 
 | Component | Fields | Description |
 |-----------|--------|-------------|
 | `RigidBodyComponent` | `mass`, `type` (Static/Kinematic/Dynamic), `linearDamping`, `angularDamping`, `friction`, `restitution`, `physicsBodyHandle` | Rigid body properties |
 | `ColliderComponent` | `shapeType` (Box/Sphere/Capsule/...), `dimensions`, `offset`, `isTrigger` | Collision shape |
 
-### [[Audio]] Components
+### [Audio](Audio) Components
 
 | Component | Fields | Description |
 |-----------|--------|-------------|
@@ -89,7 +89,7 @@ This is cache-friendly because EnTT stores components in Structure-of-Arrays (So
 |-----------|--------|-------------|
 | `LightComponent` | `type` (Point/Directional/Spot), `color`, `intensity`, `range`, `spotAngle`, `castShadows` | Light source |
 
-### [[Animation]]
+### [Animation](Animation)
 
 | Component | Fields | Description |
 |-----------|--------|-------------|
@@ -101,13 +101,13 @@ This is cache-friendly because EnTT stores components in Structure-of-Arrays (So
 |-----------|--------|-------------|
 | `ParticleEmitterComponent` | `maxParticles`, `emissionRate`, `lifetime`, `startSize`, `endSize`, `startColor`, `endColor`, `velocity`, `gravity` | Particle emitter |
 
-### [[AI and Navigation]]
+### [AI and Navigation](AI-and-Navigation)
 
 | Component | Fields | Description |
 |-----------|--------|-------------|
 | `AIComponent` | `behaviorTreeName`, `detectionRadius`, `attackRange`, `moveSpeed`, `state` | AI behavior |
 
-### [[Networking]]
+### [Networking](Networking)
 
 | Component | Fields | Description |
 |-----------|--------|-------------|
@@ -128,10 +128,10 @@ Systems in `ECSystems.h` run each frame:
 | System | Description |
 |--------|-------------|
 | `TransformUpdateSystem` | Updates world transforms from local transforms |
-| `PhysicsUpdateSystem` | Syncs [[Physics]] body transforms with ECS transforms |
-| `AnimationUpdateSystem` | Evaluates [[Animation]] state machines |
-| `AudioUpdateSystem` | Updates 3D [[Audio]] source positions |
-| `NetworkUpdateSystem` | Syncs [[Networking|networked]] entity state |
+| `PhysicsUpdateSystem` | Syncs [Physics](Physics) body transforms with ECS transforms |
+| `AnimationUpdateSystem` | Evaluates [Animation](Animation) state machines |
+| `AudioUpdateSystem` | Updates 3D [Audio](Audio) source positions |
+| `NetworkUpdateSystem` | Syncs [networked](Networking) entity state |
 
 ## Performance Tips
 
@@ -148,11 +148,11 @@ The EnTT registry is **not thread-safe**. All World operations must be performed
 
 ## See Also
 
-- [[Rendering and Graphics]] — MeshRenderer and lighting components
-- [[Audio]] — AudioSourceComponent for spatial audio
-- [[AI and Navigation]] — AIComponent for behavior trees
-- [[Event System]] — Publish/subscribe event bus
-- [[Physics]] — RigidBody and Collider components
-- [[Animation]] — Animation controller component
-- [[Scripting with AngelScript]] — Attach scripts to entities
-- [[Scene Management]] — Scene hierarchy and serialization
+- [Rendering and Graphics](Rendering-and-Graphics) — MeshRenderer and lighting components
+- [Audio](Audio) — AudioSourceComponent for spatial audio
+- [AI and Navigation](AI-and-Navigation) — AIComponent for behavior trees
+- [Event System](Event-System) — Publish/subscribe event bus
+- [Physics](Physics) — RigidBody and Collider components
+- [Animation](Animation) — Animation controller component
+- [Scripting with AngelScript](Scripting-with-AngelScript) — Attach scripts to entities
+- [Scene Management](Scene-Management) — Scene hierarchy and serialization

--- a/wiki/Event-System.md
+++ b/wiki/Event-System.md
@@ -68,7 +68,7 @@ size_t GetSubscriberCount() const; // Count subscribers for type T
 
 ## Built-in Event Types
 
-### [[Gameplay Systems|Gameplay]] Events
+### [Gameplay](Gameplay-Systems) Events
 
 ```cpp
 struct EntityDamagedEvent {
@@ -101,7 +101,7 @@ struct PlayerRespawnEvent {
 };
 ```
 
-### [[Day Night Cycle and Weather|World]] Events
+### [World](Day-Night-Cycle-and-Weather) Events
 
 ```cpp
 struct WeatherChangedEvent {
@@ -117,7 +117,7 @@ struct TimeOfDayChangedEvent {
 };
 ```
 
-### [[Physics]] Events
+### [Physics](Physics) Events
 
 ```cpp
 struct CollisionEvent {
@@ -180,10 +180,10 @@ bool OnLoad(Spark::IEngineContext* context) override {
 
 ## See Also
 
-- [[Architecture Overview]] — How subsystems communicate
-- [[Entity Component System]] — Entity lifecycle events
-- [[Day Night Cycle and Weather]] — Weather and time-of-day events
-- [[Physics]] — Collision events
-- [[Gameplay Systems]] — Gameplay events (damage, kills, quests)
-- [[Networking]] — Network event replication
-- [[Audio]] — Audio event triggers
+- [Architecture Overview](Architecture-Overview) — How subsystems communicate
+- [Entity Component System](Entity-Component-System) — Entity lifecycle events
+- [Day Night Cycle and Weather](Day-Night-Cycle-and-Weather) — Weather and time-of-day events
+- [Physics](Physics) — Collision events
+- [Gameplay Systems](Gameplay-Systems) — Gameplay events (damage, kills, quests)
+- [Networking](Networking) — Network event replication
+- [Audio](Audio) — Audio event triggers

--- a/wiki/Gameplay-Systems.md
+++ b/wiki/Gameplay-Systems.md
@@ -1,6 +1,6 @@
 # Gameplay Systems
 
-SparkEngine includes a comprehensive set of FPS gameplay systems built on top of the [[Entity Component System]] architecture.
+SparkEngine includes a comprehensive set of FPS gameplay systems built on top of the [Entity Component System](Entity-Component-System) architecture.
 
 **Source:** `SparkEngine/Source/Game/`
 
@@ -41,7 +41,7 @@ A player class system for multiplayer game modes with configurable:
 
 ## Vehicle System
 
-[[Physics]]-driven vehicle mechanics:
+[Physics](Physics)-driven vehicle mechanics:
 - Enter/exit vehicles
 - Steering and acceleration
 - Suspension and physics simulation
@@ -99,7 +99,7 @@ hp.isDead        = false;
 hp.isInvulnerable = false;
 ```
 
-Damage events are published through the [[Event System|event bus]]:
+Damage events are published through the [event bus](Event-System):
 
 ```cpp
 bus.Publish(EntityDamagedEvent{ entityId, damage, "Weapon" });
@@ -108,7 +108,7 @@ bus.Publish(EntityDamagedEvent{ entityId, damage, "Weapon" });
 ## Gravity System
 
 Configurable gravity for physics-driven gameplay:
-- Per-scene gravity settings (via `SceneMetadata`, see [[Scene Management]])
+- Per-scene gravity settings (via `SceneMetadata`, see [Scene Management](Scene-Management))
 - Gravity zones for localized effects
 
 ## Interactive Objects
@@ -122,15 +122,15 @@ Objects that respond to player interaction:
 
 ## See Also
 
-- [[Entity Component System]] — Gameplay components
-- [[Physics]] — Physics-driven gameplay
-- [[Event System]] — Gameplay events
-- [[AI and Navigation]] — NPC behavior
-- [[Networking]] — Multiplayer game modes
-- [[Scene Management]] — Scene gravity and level loading
-- [[Scripting with AngelScript]] — Scripting gameplay logic
-- [[Input System]] — Player input handling
-- [[Audio]] — Gameplay sound effects
-- [[Rendering and Graphics]] — HUD and visual effects
-- [[Animation]] — Player and weapon animations
-- [[Terrain and Procedural Generation]] — Level environments
+- [Entity Component System](Entity-Component-System) — Gameplay components
+- [Physics](Physics) — Physics-driven gameplay
+- [Event System](Event-System) — Gameplay events
+- [AI and Navigation](AI-and-Navigation) — NPC behavior
+- [Networking](Networking) — Multiplayer game modes
+- [Scene Management](Scene-Management) — Scene gravity and level loading
+- [Scripting with AngelScript](Scripting-with-AngelScript) — Scripting gameplay logic
+- [Input System](Input-System) — Player input handling
+- [Audio](Audio) — Gameplay sound effects
+- [Rendering and Graphics](Rendering-and-Graphics) — HUD and visual effects
+- [Animation](Animation) — Player and weapon animations
+- [Terrain and Procedural Generation](Terrain-and-Procedural-Generation) — Level environments

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -79,8 +79,8 @@ cmake --build --preset windows-release
 
 Options:
 - `-config Debug|Release` — Build configuration
-- `-editor` — Include the [[SparkEditor]]
-- `-console` — Include [[SparkConsole]]
+- `-editor` — Include the [SparkEditor](SparkEditor)
+- `-console` — Include [SparkConsole](SparkConsole)
 - `-angelscript` — Include AngelScript scripting
 
 ### Linux / macOS
@@ -108,7 +108,7 @@ After a successful build:
 build/
 ├── bin/
 │   ├── SparkEngine.exe      # Main engine executable
-│   ├── SparkConsole.exe     # Debug console (Windows) — see [[SparkConsole]]
+│   ├── SparkConsole.exe     # Debug console (Windows) — see [SparkConsole](SparkConsole)
 │   └── SparkGame.dll        # Default game module
 ├── lib/                     # Static/shared libraries
 ├── Shaders/                 # Compiled shaders
@@ -126,7 +126,7 @@ SparkEngine.exe
 
 You should see:
 1. A DirectX 11 window with a blue background
-2. [[SparkConsole]] opens automatically
+2. [SparkConsole](SparkConsole) opens automatically
 3. Console shows initialization messages
 
 ### Linux
@@ -150,7 +150,7 @@ cd build/bin
 
 ## Verify Installation
 
-Once the engine is running, open [[SparkConsole]] and try:
+Once the engine is running, open [SparkConsole](SparkConsole) and try:
 
 ```
 help            # List all commands
@@ -168,19 +168,19 @@ SparkEngine has 30+ toggleable CMake modules. Pass them during configuration:
 cmake -B build -DENABLE_AI=OFF -DENABLE_NETWORKING=ON ...
 ```
 
-See [[Build System and CMake Modules]] for the full list of options.
+See [Build System and CMake Modules](Build-System-and-CMake-Modules) for the full list of options.
 
 ## Next Steps
 
-- [[Architecture Overview]] — Understand the engine's design
-- [[Creating a Game Module]] — Build your first game
-- [[Troubleshooting]] — If you run into issues
+- [Architecture Overview](Architecture-Overview) — Understand the engine's design
+- [Creating a Game Module](Creating-a-Game-Module) — Build your first game
+- [Troubleshooting](Troubleshooting) — If you run into issues
 
 ---
 
 ## See Also
 
-- [[SparkConsole]] — Debug console for engine interaction
-- [[SparkEditor]] — Visual editor for scenes and materials
-- [[Architecture Overview]] — Understand the engine's design
-- [[Creating a Game Module]] — Build your first game module
+- [SparkConsole](SparkConsole) — Debug console for engine interaction
+- [SparkEditor](SparkEditor) — Visual editor for scenes and materials
+- [Architecture Overview](Architecture-Overview) — Understand the engine's design
+- [Creating a Game Module](Creating-a-Game-Module) — Build your first game module

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -36,39 +36,39 @@ Pre-built binaries are published on every commit to `master`:
 ## Wiki Navigation
 
 ### Getting Started
-- [[Getting Started]] — Prerequisites, building, and running
-- [[Architecture Overview]] — Engine design and project structure
-- [[Creating a Game Module]] — Build your first game module
+- [Getting Started](Getting-Started) — Prerequisites, building, and running
+- [Architecture Overview](Architecture-Overview) — Engine design and project structure
+- [Creating a Game Module](Creating-a-Game-Module) — Build your first game module
 
 ### Engine Subsystems
-- [[Entity Component System]] — EnTT ECS, components, and systems
-- [[Rendering and Graphics]] — Graphics pipeline, materials, and post-processing
-- [[Physics]] — Bullet Physics integration
-- [[Audio]] — Spatial audio system
-- [[Input System]] — Keyboard, mouse, and gamepad
-- [[Scripting with AngelScript]] — Gameplay scripting
-- [[AI and Navigation]] — Behavior trees and pathfinding
-- [[Animation]] — Skeletal animation and IK
-- [[Networking]] — Multiplayer networking
-- [[Scene Management]] — Scenes, hierarchy, and prefabs
-- [[Event System]] — Publish/subscribe event bus
+- [Entity Component System](Entity-Component-System) — EnTT ECS, components, and systems
+- [Rendering and Graphics](Rendering-and-Graphics) — Graphics pipeline, materials, and post-processing
+- [Physics](Physics) — Bullet Physics integration
+- [Audio](Audio) — Spatial audio system
+- [Input System](Input-System) — Keyboard, mouse, and gamepad
+- [Scripting with AngelScript](Scripting-with-AngelScript) — Gameplay scripting
+- [AI and Navigation](AI-and-Navigation) — Behavior trees and pathfinding
+- [Animation](Animation) — Skeletal animation and IK
+- [Networking](Networking) — Multiplayer networking
+- [Scene Management](Scene-Management) — Scenes, hierarchy, and prefabs
+- [Event System](Event-System) — Publish/subscribe event bus
 
 ### Gameplay & Tools
-- [[Gameplay Systems]] — Player, weapons, inventory, quests
-- [[Terrain and Procedural Generation]] — Terrain and procedural content
-- [[Save System]] — Save/load functionality
-- [[Day Night Cycle and Weather]] — Time-of-day and weather
-- [[Cinematic Sequencer]] — Timeline-based cinematics
-- [[SparkEditor]] — Visual editor guide
-- [[SparkConsole]] — Debug console
-- [[Shader Pipeline]] — Shader authoring and compilation
-- [[Asset Pipeline]] — Asset loading and formats
+- [Gameplay Systems](Gameplay-Systems) — Player, weapons, inventory, quests
+- [Terrain and Procedural Generation](Terrain-and-Procedural-Generation) — Terrain and procedural content
+- [Save System](Save-System) — Save/load functionality
+- [Day Night Cycle and Weather](Day-Night-Cycle-and-Weather) — Time-of-day and weather
+- [Cinematic Sequencer](Cinematic-Sequencer) — Timeline-based cinematics
+- [SparkEditor](SparkEditor) — Visual editor guide
+- [SparkConsole](SparkConsole) — Debug console
+- [Shader Pipeline](Shader-Pipeline) — Shader authoring and compilation
+- [Asset Pipeline](Asset-Pipeline) — Asset loading and formats
 
 ### Advanced
-- [[Build System and CMake Modules]] — CMake configuration and CI/CD
-- [[Testing]] — Unit tests and test framework
-- [[Troubleshooting]] — Common issues and solutions
-- [[Contributing]] — How to contribute
+- [Build System and CMake Modules](Build-System-and-CMake-Modules) — CMake configuration and CI/CD
+- [Testing](Testing) — Unit tests and test framework
+- [Troubleshooting](Troubleshooting) — Common issues and solutions
+- [Contributing](Contributing) — How to contribute
 
 ## License
 

--- a/wiki/Input-System.md
+++ b/wiki/Input-System.md
@@ -1,6 +1,6 @@
 # Input System
 
-The `InputManager` handles keyboard, mouse, and gamepad input with frame-based state tracking, key bindings, and [[SparkConsole]] integration.
+The `InputManager` handles keyboard, mouse, and gamepad input with frame-based state tracking, key bindings, and [SparkConsole](SparkConsole) integration.
 
 **Source:** `SparkEngine/Source/Input/InputManager.h`, `SparkEngine/Source/Input/GamepadInput.h`
 
@@ -143,8 +143,8 @@ input_stats          # Show input statistics
 
 ## See Also
 
-- [[Creating a Game Module]] — Accessing InputManager via IEngineContext
-- [[SparkConsole]] — Input debug commands
-- [[Gameplay Systems]] — Player controller and FPS controls
-- [[Scripting with AngelScript]] — Input API available in scripts
-- [[Event System]] — Input-related event publishing
+- [Creating a Game Module](Creating-a-Game-Module) — Accessing InputManager via IEngineContext
+- [SparkConsole](SparkConsole) — Input debug commands
+- [Gameplay Systems](Gameplay-Systems) — Player controller and FPS controls
+- [Scripting with AngelScript](Scripting-with-AngelScript) — Input API available in scripts
+- [Event System](Event-System) — Input-related event publishing

--- a/wiki/Networking.md
+++ b/wiki/Networking.md
@@ -32,7 +32,7 @@ The networking system uses a client/server model:
 
 ## Entity Replication
 
-Entities with `NetworkIdentity` are automatically replicated via the [[Entity Component System]]:
+Entities with `NetworkIdentity` are automatically replicated via the [Entity Component System](Entity-Component-System):
 
 ```cpp
 auto& net = world.AddComponent<NetworkIdentity>(entity);
@@ -62,7 +62,7 @@ When the server's authoritative state differs from the client's prediction:
 
 ## Lag Compensation
 
-For hit detection in fast-paced FPS [[Gameplay Systems|gameplay]]:
+For hit detection in fast-paced FPS [gameplay](Gameplay-Systems):
 
 - Server maintains a **1-second history** of entity positions (hitbox rewinding)
 - When processing a shot, the server rewinds entities to where they were when the shooter fired
@@ -87,10 +87,10 @@ Network messages use built-in serialization helpers for efficient packing and un
 
 ## See Also
 
-- [[Entity Component System]] — NetworkIdentity component
-- [[Gameplay Systems]] — Multiplayer game modes
-- [[Event System]] — Network event handling
-- [[Scene Management]] — Networked scene transitions
-- [[Physics]] — Server-authoritative physics
-- [[Animation]] — Replicated animation states
-- [[Input System]] — Client input processing and prediction
+- [Entity Component System](Entity-Component-System) — NetworkIdentity component
+- [Gameplay Systems](Gameplay-Systems) — Multiplayer game modes
+- [Event System](Event-System) — Network event handling
+- [Scene Management](Scene-Management) — Networked scene transitions
+- [Physics](Physics) — Server-authoritative physics
+- [Animation](Animation) — Replicated animation states
+- [Input System](Input-System) — Client input processing and prediction

--- a/wiki/Physics.md
+++ b/wiki/Physics.md
@@ -145,7 +145,7 @@ col.dimensions = {1.0f, 1.0f, 1.0f};
 col.isTrigger  = false;
 ```
 
-The `PhysicsUpdateSystem` syncs physics body transforms with [[Entity Component System|ECS]] `Transform` components each frame.
+The `PhysicsUpdateSystem` syncs physics body transforms with [ECS](Entity-Component-System) `Transform` components each frame.
 
 ## Debug Drawing
 
@@ -175,9 +175,9 @@ PhysicsSystem is **not thread-safe**. Call all public methods from the main game
 
 ## See Also
 
-- [[Entity Component System]] — RigidBody and Collider components
-- [[Rendering and Graphics]] — Debug draw overlay
-- [[Gameplay Systems]] — Player controller, weapons, and vehicles
-- [[Terrain and Procedural Generation]] — Heightfield collision shapes
-- [[Animation]] — Physics-driven animation and ragdolls
-- [[Day Night Cycle and Weather]] — Environmental physics interactions
+- [Entity Component System](Entity-Component-System) — RigidBody and Collider components
+- [Rendering and Graphics](Rendering-and-Graphics) — Debug draw overlay
+- [Gameplay Systems](Gameplay-Systems) — Player controller, weapons, and vehicles
+- [Terrain and Procedural Generation](Terrain-and-Procedural-Generation) — Heightfield collision shapes
+- [Animation](Animation) — Physics-driven animation and ragdolls
+- [Day Night Cycle and Weather](Day-Night-Cycle-and-Weather) — Environmental physics interactions

--- a/wiki/Rendering-and-Graphics.md
+++ b/wiki/Rendering-and-Graphics.md
@@ -156,7 +156,7 @@ The Render Hardware Interface provides backend-agnostic graphics:
 
 ## GPU Particle System
 
-`ParticleSystem` provides GPU-accelerated particles controlled via `ParticleEmitterComponent` (see [[Entity Component System]]).
+`ParticleSystem` provides GPU-accelerated particles controlled via `ParticleEmitterComponent` (see [Entity Component System](Entity-Component-System)).
 
 ## Lighting
 
@@ -184,11 +184,11 @@ vsync <on|off>         # Toggle vertical sync
 
 ## See Also
 
-- [[Entity Component System]] — MeshRenderer, LightComponent, and ParticleEmitter components
-- [[Shader Pipeline]] — Shader authoring and compilation
-- [[Asset Pipeline]] — Model and texture loading
-- [[SparkEditor]] — Material editor and visual tools
-- [[Animation]] — Skeletal animation and blending
-- [[Terrain and Procedural Generation]] — Procedural mesh and terrain rendering
-- [[Physics]] — Debug draw overlay for collision shapes
-- [[Day Night Cycle and Weather]] — Dynamic lighting and weather effects
+- [Entity Component System](Entity-Component-System) — MeshRenderer, LightComponent, and ParticleEmitter components
+- [Shader Pipeline](Shader-Pipeline) — Shader authoring and compilation
+- [Asset Pipeline](Asset-Pipeline) — Model and texture loading
+- [SparkEditor](SparkEditor) — Material editor and visual tools
+- [Animation](Animation) — Skeletal animation and blending
+- [Terrain and Procedural Generation](Terrain-and-Procedural-Generation) — Procedural mesh and terrain rendering
+- [Physics](Physics) — Debug draw overlay for collision shapes
+- [Day Night Cycle and Weather](Day-Night-Cycle-and-Weather) — Dynamic lighting and weather effects

--- a/wiki/Save-System.md
+++ b/wiki/Save-System.md
@@ -1,6 +1,6 @@
 # Save System
 
-SparkEngine provides an [[Entity Component System]]-aware save/load system with JSON serialization and miniz compression.
+SparkEngine provides an [Entity Component System](Entity-Component-System)-aware save/load system with JSON serialization and miniz compression.
 
 **Source:** `SparkEngine/Source/Engine/SaveSystem/SaveSystem.h`
 
@@ -8,13 +8,13 @@ SparkEngine provides an [[Entity Component System]]-aware save/load system with 
 
 ## Features
 
-- [[Entity Component System]]-aware serialization of all entity components
+- [Entity Component System](Entity-Component-System)-aware serialization of all entity components
 - JSON format with miniz compression
 - Multiple save slots
 - Quicksave / quickload
 - Rotating autosaves
 - Per-component serializer registry
-- Metadata tracking ([[Scene Management|scene name]], player class, playtime)
+- Metadata tracking ([scene name](Scene-Management), player class, playtime)
 
 ## Saving
 
@@ -91,8 +91,8 @@ saveSystem.DeleteSave("slot1");
 
 ## See Also
 
-- [[Entity Component System]] — Components that are serialized
-- [[Scene Management]] — Scene state persistence
-- [[Scripting with AngelScript]] — Script-driven save/load triggers
-- [[Event System]] — Save/load event callbacks
-- [[Networking]] — Multiplayer state persistence
+- [Entity Component System](Entity-Component-System) — Components that are serialized
+- [Scene Management](Scene-Management) — Scene state persistence
+- [Scripting with AngelScript](Scripting-with-AngelScript) — Script-driven save/load triggers
+- [Event System](Event-System) — Save/load event callbacks
+- [Networking](Networking) — Multiplayer state persistence

--- a/wiki/Scene-Management.md
+++ b/wiki/Scene-Management.md
@@ -128,7 +128,7 @@ sceneMgr.MarkDirty();          // Mark scene as modified
 bool unsaved = sceneMgr.IsDirty();  // Check for unsaved changes
 ```
 
-The [[SparkEditor|editor]] uses this to prompt "Save changes?" before closing or loading a new scene.
+The [editor](SparkEditor) uses this to prompt "Save changes?" before closing or loading a new scene.
 
 ## Undo/Redo
 
@@ -152,12 +152,12 @@ scene_clear         # Clear the scene
 
 ## See Also
 
-- [[Entity Component System]] — ECS entities created from scene nodes
-- [[SparkEditor]] — Visual scene hierarchy editor
-- [[Asset Pipeline]] — Model and asset loading
-- [[Rendering and Graphics]] — Scene rendering pipeline
-- [[Physics]] — Physics bodies from scene nodes
-- [[Gameplay Systems]] — Gravity and interactive objects
-- [[Save System]] — Saving and restoring scene state
-- [[Event System]] — Scene lifecycle events
-- [[Networking]] — Networked scene synchronization
+- [Entity Component System](Entity-Component-System) — ECS entities created from scene nodes
+- [SparkEditor](SparkEditor) — Visual scene hierarchy editor
+- [Asset Pipeline](Asset-Pipeline) — Model and asset loading
+- [Rendering and Graphics](Rendering-and-Graphics) — Scene rendering pipeline
+- [Physics](Physics) — Physics bodies from scene nodes
+- [Gameplay Systems](Gameplay-Systems) — Gravity and interactive objects
+- [Save System](Save-System) — Saving and restoring scene state
+- [Event System](Event-System) — Scene lifecycle events
+- [Networking](Networking) — Networked scene synchronization

--- a/wiki/Scripting-with-AngelScript.md
+++ b/wiki/Scripting-with-AngelScript.md
@@ -6,7 +6,7 @@ SparkEngine integrates **AngelScript** as its gameplay scripting language, suppo
 
 ## Overview
 
-AngelScript is a statically-typed scripting language with C/C++-like syntax. Scripts are attached to [[Entity Component System|ECS]] entities and driven through lifecycle callbacks, similar to Unity's MonoBehaviour pattern.
+AngelScript is a statically-typed scripting language with C/C++-like syntax. Scripts are attached to [ECS](Entity-Component-System) entities and driven through lifecycle callbacks, similar to Unity's MonoBehaviour pattern.
 
 ## Writing a Script
 
@@ -146,11 +146,11 @@ Script contexts are **not thread-safe**. All script calls must happen on the mai
 
 ## See Also
 
-- [[Entity Component System]] — Script component
-- [[Creating a Game Module]] — Module lifecycle
-- [[Event System]] — Publishing and subscribing to events from scripts
-- [[Physics]] — Physics API available in scripts
-- [[Input System]] — Input API available in scripts
-- [[Audio]] — Audio API available in scripts
-- [[Animation]] — Controlling animations from scripts
-- [[Scene Management]] — Scene operations from scripts
+- [Entity Component System](Entity-Component-System) — Script component
+- [Creating a Game Module](Creating-a-Game-Module) — Module lifecycle
+- [Event System](Event-System) — Publishing and subscribing to events from scripts
+- [Physics](Physics) — Physics API available in scripts
+- [Input System](Input-System) — Input API available in scripts
+- [Audio](Audio) — Audio API available in scripts
+- [Animation](Animation) — Controlling animations from scripts
+- [Scene Management](Scene-Management) — Scene operations from scripts

--- a/wiki/Shader-Pipeline.md
+++ b/wiki/Shader-Pipeline.md
@@ -1,6 +1,6 @@
 # Shader Pipeline
 
-SparkEngine supports HLSL and GLSL shader authoring with cross-compilation through the [[Rendering and Graphics|RHI pipeline]]. The `SparkShaderCompiler` tool handles offline compilation.
+SparkEngine supports HLSL and GLSL shader authoring with cross-compilation through the [RHI pipeline](Rendering-and-Graphics). The `SparkShaderCompiler` tool handles offline compilation.
 
 **Source:** `SparkEngine/Source/Graphics/Shader.h`, `SparkShaderCompiler/src/`
 
@@ -116,13 +116,13 @@ HLSL Source
 
 ## Hot Reloading
 
-During development, shader modifications can be detected and recompiled at runtime (when `ENABLE_HOT_RELOAD=ON`). See [[Asset Pipeline]] for hot-reload details.
+During development, shader modifications can be detected and recompiled at runtime (when `ENABLE_HOT_RELOAD=ON`). See [Asset Pipeline](Asset-Pipeline) for hot-reload details.
 
 ---
 
 ## See Also
 
-- [[Rendering and Graphics]] — Shader usage in the rendering pipeline
-- [[Asset Pipeline]] — Shader asset management
-- [[Build System and CMake Modules]] — Shader compilation integration
-- [[SparkEditor]] — Shader editing and preview
+- [Rendering and Graphics](Rendering-and-Graphics) — Shader usage in the rendering pipeline
+- [Asset Pipeline](Asset-Pipeline) — Shader asset management
+- [Build System and CMake Modules](Build-System-and-CMake-Modules) — Shader compilation integration
+- [SparkEditor](SparkEditor) — Shader editing and preview

--- a/wiki/SparkConsole.md
+++ b/wiki/SparkConsole.md
@@ -45,7 +45,7 @@ fps               # Show current framerate
 quit              # Shut down the engine
 ```
 
-### Graphics Commands (see [[Rendering and Graphics]])
+### Graphics Commands (see [Rendering and Graphics](Rendering-and-Graphics))
 
 ```
 graphics_info              # GPU and adapter information
@@ -61,7 +61,7 @@ resolution <w> <h>         # Set resolution
 fullscreen                 # Toggle fullscreen
 ```
 
-### Physics Commands (see [[Physics]])
+### Physics Commands (see [Physics](Physics))
 
 ```
 physics_info               # Physics world statistics
@@ -72,7 +72,7 @@ physics_step               # Single-step physics
 physics_material <name>    # Show material properties
 ```
 
-### Audio Commands (see [[Audio]])
+### Audio Commands (see [Audio](Audio))
 
 ```
 audio_info                 # Audio system status
@@ -97,7 +97,7 @@ input_log <on|off>         # Toggle input logging
 input_stats                # Input statistics
 ```
 
-### Scene Commands (see [[Scene Management]])
+### Scene Commands (see [Scene Management](Scene-Management))
 
 ```
 scene_info                 # Current scene info
@@ -135,7 +135,7 @@ script_run <file>          # Execute a script file
 script_list                # List loaded scripts
 ```
 
-### Time and Weather Commands (see [[Terrain and Procedural Generation]])
+### Time and Weather Commands (see [Terrain and Procedural Generation](Terrain-and-Procedural-Generation))
 
 ```
 time_set <hour>            # Set time of day
@@ -156,7 +156,7 @@ Engine subsystems register their own console commands during initialization. The
 
 SparkConsole currently requires Windows (named pipe communication). On Linux, console output goes to `stdout`.
 
-## [[Troubleshooting]]
+## [Troubleshooting](Troubleshooting)
 
 ### "Standalone mode" message
 
@@ -173,11 +173,11 @@ SparkEngine failed to launch or crashed during startup. Check:
 
 ## See Also
 
-- [[Getting Started]] — Running SparkConsole
-- [[Troubleshooting]] — Common console issues
-- [[Rendering and Graphics]] — Graphics commands and render paths
-- [[Physics]] — Physics simulation commands
-- [[Audio]] — Audio system commands
-- [[AI and Navigation]] — AI and pathfinding systems
-- [[Scene Management]] — Scene loading and management
-- [[Terrain and Procedural Generation]] — Weather and terrain systems
+- [Getting Started](Getting-Started) — Running SparkConsole
+- [Troubleshooting](Troubleshooting) — Common console issues
+- [Rendering and Graphics](Rendering-and-Graphics) — Graphics commands and render paths
+- [Physics](Physics) — Physics simulation commands
+- [Audio](Audio) — Audio system commands
+- [AI and Navigation](AI-and-Navigation) — AI and pathfinding systems
+- [Scene Management](Scene-Management) — Scene loading and management
+- [Terrain and Procedural Generation](Terrain-and-Procedural-Generation) — Weather and terrain systems

--- a/wiki/SparkEditor.md
+++ b/wiki/SparkEditor.md
@@ -1,6 +1,6 @@
 # SparkEditor
 
-The SparkEditor is an ImGui-based visual editor for creating and editing game content. It provides a dockable workspace with multiple panels for [[Scene Management|scene editing]], material authoring, [[Animation|animation]], and debugging.
+The SparkEditor is an ImGui-based visual editor for creating and editing game content. It provides a dockable workspace with multiple panels for [scene editing](Scene-Management), material authoring, [animation](Animation), and debugging.
 
 **Source:** `SparkEditor/Source/`
 
@@ -23,7 +23,7 @@ The editor includes 22+ subsystem panels:
 
 - Property editor for the selected node/entity
 - Transform editing (position, rotation, scale)
-- [[Entity Component System|Component]] editing with type-appropriate widgets
+- [Component](Entity-Component-System) editing with type-appropriate widgets
 - Material assignment and configuration
 
 ### Game Viewport
@@ -39,18 +39,18 @@ The editor includes 22+ subsystem panels:
 - World-space and local-space modes
 - Snap to grid functionality
 
-### Asset Browser (see [[Asset Pipeline]])
+### Asset Browser (see [Asset Pipeline](Asset-Pipeline))
 
 - File-system view of project assets
 - Drag-and-drop assets into the scene
 - Thumbnail previews for textures and models
 
-### Material Editor (see [[Shader Pipeline]])
+### Material Editor (see [Shader Pipeline](Shader-Pipeline))
 
 - PBR material authoring
 - Texture slot assignment
 - Real-time preview sphere
-- Blend mode and [[Shader Pipeline|shader]] selection
+- Blend mode and [shader](Shader-Pipeline) selection
 
 ### Animation Timeline
 
@@ -59,14 +59,14 @@ The editor includes 22+ subsystem panels:
 - Blend tree configuration
 - Animation clip preview
 
-### Terrain Editor (see [[Terrain and Procedural Generation]])
+### Terrain Editor (see [Terrain and Procedural Generation](Terrain-and-Procedural-Generation))
 
 - Heightmap painting (raise/lower/smooth/flatten)
 - Texture splatting brush
 - Object placement brush
 - Terrain configuration (size, resolution, LOD)
 
-### Weapon Editor (see [[Gameplay Systems]])
+### Weapon Editor (see [Gameplay Systems](Gameplay-Systems))
 
 - Weapon property configuration
 - Projectile type selection
@@ -116,13 +116,13 @@ cmake --build build --config Release
 
 ## See Also
 
-- [[Scene Management]] — Scene hierarchy and serialization
-- [[Rendering and Graphics]] — Material system and render pipelines
-- [[Animation]] — Animation state machines and timeline
-- [[Cinematic Sequencer]] — Timeline editor
-- [[Entity Component System]] — Component architecture
-- [[Shader Pipeline]] — Shader authoring and compilation
-- [[Asset Pipeline]] — Asset importing and management
-- [[Physics]] — Physics simulation
-- [[Terrain and Procedural Generation]] — Terrain editing and procedural tools
-- [[Gameplay Systems]] — Weapons, inventory, and game mechanics
+- [Scene Management](Scene-Management) — Scene hierarchy and serialization
+- [Rendering and Graphics](Rendering-and-Graphics) — Material system and render pipelines
+- [Animation](Animation) — Animation state machines and timeline
+- [Cinematic Sequencer](Cinematic-Sequencer) — Timeline editor
+- [Entity Component System](Entity-Component-System) — Component architecture
+- [Shader Pipeline](Shader-Pipeline) — Shader authoring and compilation
+- [Asset Pipeline](Asset-Pipeline) — Asset importing and management
+- [Physics](Physics) — Physics simulation
+- [Terrain and Procedural Generation](Terrain-and-Procedural-Generation) — Terrain editing and procedural tools
+- [Gameplay Systems](Gameplay-Systems) — Weapons, inventory, and game mechanics

--- a/wiki/Terrain-and-Procedural-Generation.md
+++ b/wiki/Terrain-and-Procedural-Generation.md
@@ -12,7 +12,7 @@ The terrain system renders large outdoor environments using heightmaps:
 
 - **Quadtree LOD** — Automatic level-of-detail based on camera distance
 - **Texture Splatting** — Multi-texture blending based on height, slope, or paint masks
-- **Heightfield Collision** — [[Physics|Bullet Physics]] `Heightfield` shape for terrain collisions
+- **Heightfield Collision** — [Bullet Physics](Physics) `Heightfield` shape for terrain collisions
 - **Chunk-based** — Terrain is divided into chunks for efficient culling and streaming
 
 ## Noise Functions
@@ -92,9 +92,9 @@ Procedural room and dungeon layout generation using the WFC algorithm:
 
 ## See Also
 
-- [[Physics]] — Heightfield collision shapes
-- [[Rendering and Graphics]] — Terrain rendering and LOD
-- [[Scene Management]] — Procedurally generated scenes
-- [[Asset Pipeline]] — Terrain asset streaming and loading
-- [[Gameplay Systems]] — Procedural content for gameplay
-- [[Event System]] — Terrain generation event hooks
+- [Physics](Physics) — Heightfield collision shapes
+- [Rendering and Graphics](Rendering-and-Graphics) — Terrain rendering and LOD
+- [Scene Management](Scene-Management) — Procedurally generated scenes
+- [Asset Pipeline](Asset-Pipeline) — Terrain asset streaming and loading
+- [Gameplay Systems](Gameplay-Systems) — Procedural content for gameplay
+- [Event System](Event-System) — Terrain generation event hooks

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -101,7 +101,7 @@ TEST(MyFeature_EdgeCase) {
 }
 ```
 
-2. The test is automatically discovered by CMake (tests are globbed in `Tests/CMakeLists.txt`). See [[Build System and CMake Modules]] for build configuration.
+2. The test is automatically discovered by CMake (tests are globbed in `Tests/CMakeLists.txt`). See [Build System and CMake Modules](Build-System-and-CMake-Modules) for build configuration.
 
 3. Build and run:
 
@@ -121,6 +121,6 @@ Tests run automatically on every push via GitHub Actions:
 
 ## See Also
 
-- [[Build System and CMake Modules]] — BUILD_TESTS flag
-- [[Getting Started]] — Building the project
-- [[Contributing]] — Contribution workflow and adding tests
+- [Build System and CMake Modules](Build-System-and-CMake-Modules) — BUILD_TESTS flag
+- [Getting Started](Getting-Started) — Building the project
+- [Contributing](Contributing) — Contribution workflow and adding tests

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -4,7 +4,7 @@ Common issues and solutions when building and running SparkEngine.
 
 ## Quick Verification
 
-### Test [[SparkConsole]] Standalone
+### Test [SparkConsole](SparkConsole) Standalone
 
 ```batch
 cd build\bin
@@ -181,7 +181,7 @@ And these directories should be present:
 
 ## See Also
 
-- [[Getting Started]] — Build instructions
-- [[Build System and CMake Modules]] — Build configuration
-- [[SparkConsole]] — Debug console usage
-- [[Rendering and Graphics]] — Graphics troubleshooting and render pipelines
+- [Getting Started](Getting-Started) — Build instructions
+- [Build System and CMake Modules](Build-System-and-CMake-Modules) — Build configuration
+- [SparkConsole](SparkConsole) — Debug console usage
+- [Rendering and Graphics](Rendering-and-Graphics) — Graphics troubleshooting and render pipelines

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,37 +1,37 @@
 # SparkEngine Wiki
 
 ### Getting Started
-- [[Home]]
-- [[Getting Started]]
-- [[Architecture Overview]]
-- [[Creating a Game Module]]
+- [Home](Home)
+- [Getting Started](Getting-Started)
+- [Architecture Overview](Architecture-Overview)
+- [Creating a Game Module](Creating-a-Game-Module)
 
 ### Engine Subsystems
-- [[Entity Component System]]
-- [[Rendering and Graphics]]
-- [[Physics]]
-- [[Audio]]
-- [[Input System]]
-- [[Scripting with AngelScript]]
-- [[AI and Navigation]]
-- [[Animation]]
-- [[Networking]]
-- [[Scene Management]]
-- [[Event System]]
+- [Entity Component System](Entity-Component-System)
+- [Rendering and Graphics](Rendering-and-Graphics)
+- [Physics](Physics)
+- [Audio](Audio)
+- [Input System](Input-System)
+- [Scripting with AngelScript](Scripting-with-AngelScript)
+- [AI and Navigation](AI-and-Navigation)
+- [Animation](Animation)
+- [Networking](Networking)
+- [Scene Management](Scene-Management)
+- [Event System](Event-System)
 
 ### Gameplay & Tools
-- [[Gameplay Systems]]
-- [[Terrain and Procedural Generation]]
-- [[Save System]]
-- [[Day Night Cycle and Weather]]
-- [[Cinematic Sequencer]]
-- [[SparkEditor]]
-- [[SparkConsole]]
-- [[Shader Pipeline]]
-- [[Asset Pipeline]]
+- [Gameplay Systems](Gameplay-Systems)
+- [Terrain and Procedural Generation](Terrain-and-Procedural-Generation)
+- [Save System](Save-System)
+- [Day Night Cycle and Weather](Day-Night-Cycle-and-Weather)
+- [Cinematic Sequencer](Cinematic-Sequencer)
+- [SparkEditor](SparkEditor)
+- [SparkConsole](SparkConsole)
+- [Shader Pipeline](Shader-Pipeline)
+- [Asset Pipeline](Asset-Pipeline)
 
 ### Advanced
-- [[Build System and CMake Modules]]
-- [[Testing]]
-- [[Troubleshooting]]
-- [[Contributing]]
+- [Build System and CMake Modules](Build-System-and-CMake-Modules)
+- [Testing](Testing)
+- [Troubleshooting](Troubleshooting)
+- [Contributing](Contributing)


### PR DESCRIPTION
The wiki pages used [[Page Name]] syntax which only works on GitHub's wiki hosting. Since these files live in the wiki/ directory of the repo, convert all links to standard markdown [Page Name](Page-Name) format so they work as clickable links when browsing the repo on GitHub.

Handles both simple [[Page Name]] and pipe [[Page|Display]] syntax across all 29 wiki pages.

https://claude.ai/code/session_01U24knDCDmFP3kBqS98bGr8