### PR TITLE
Fix compilation errors and formatting violations

### DIFF
--- a/SparkEngine/Source/Core/framework.h
+++ b/SparkEngine/Source/Core/framework.h
@@ -19,7 +19,7 @@
 #include "targetver.h"
 //#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <windowsx.h>  // For GET_X_LPARAM and GET_Y_LPARAM macros
+#include <windowsx.h> // For GET_X_LPARAM and GET_Y_LPARAM macros
 #include <stdlib.h>
 #include <malloc.h>
 #include <memory.h>
@@ -35,6 +35,8 @@
 #pragma comment(lib, "d3dcompiler.lib")
 #pragma comment(lib, "dxgi.lib")
 
+using namespace DirectX;
+
 #endif // SPARK_PLATFORM_WINDOWS
 
 // STL includes (cross-platform)
@@ -47,4 +49,3 @@
 #include <queue>
 #include <cstdlib>
 #include <cstring>
-

--- a/SparkEngine/Source/Utils/ChromeTracing.h
+++ b/SparkEngine/Source/Utils/ChromeTracing.h
@@ -35,168 +35,177 @@
 #include <thread>
 #include <cstdint>
 
-namespace Spark {
+namespace Spark
+{
 
-class ChromeTracing {
-public:
-    static ChromeTracing& GetInstance() {
-        static ChromeTracing instance;
-        return instance;
-    }
+    class ChromeTracing
+    {
+      public:
+        static ChromeTracing& GetInstance()
+        {
+            static ChromeTracing instance;
+            return instance;
+        }
 
-    void Start() {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_events.clear();
-        m_events.reserve(100000);
-        m_active = true;
-        m_startTime = Clock::now();
-    }
-
-    void Stop() {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_active = false;
-    }
-
-    bool IsActive() const { return m_active; }
-
-    /// Record the beginning of a duration event
-    void BeginEvent(const char* name, const char* category = "default") {
-        if (!m_active) return;
-        TraceEvent ev;
-        ev.name = name;
-        ev.category = category;
-        ev.phase = 'B'; // Begin
-        ev.timestamp = GetTimestampUs();
-        ev.threadId = GetThreadId();
+        void Start()
         {
             std::lock_guard<std::mutex> lock(m_mutex);
-            m_events.push_back(ev);
+            m_events.clear();
+            m_events.reserve(100000);
+            m_active = true;
+            m_startTime = Clock::now();
         }
-    }
 
-    /// Record the end of a duration event
-    void EndEvent(const char* name, const char* category = "default") {
-        if (!m_active) return;
-        TraceEvent ev;
-        ev.name = name;
-        ev.category = category;
-        ev.phase = 'E'; // End
-        ev.timestamp = GetTimestampUs();
-        ev.threadId = GetThreadId();
+        void Stop()
         {
             std::lock_guard<std::mutex> lock(m_mutex);
-            m_events.push_back(ev);
+            m_active = false;
         }
-    }
 
-    /// Record an instant event
-    void InstantEvent(const char* name, const char* category = "default") {
-        if (!m_active) return;
-        TraceEvent ev;
-        ev.name = name;
-        ev.category = category;
-        ev.phase = 'i'; // Instant
-        ev.timestamp = GetTimestampUs();
-        ev.threadId = GetThreadId();
+        bool IsActive() const { return m_active; }
+
+        /// Record the beginning of a duration event
+        void BeginEvent(const char* name, const char* category = "default")
+        {
+            if (!m_active)
+                return;
+            TraceEvent ev;
+            ev.name = name;
+            ev.category = category;
+            ev.phase = 'B'; // Begin
+            ev.timestamp = GetTimestampUs();
+            ev.threadId = GetThreadId();
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                m_events.push_back(ev);
+            }
+        }
+
+        /// Record the end of a duration event
+        void EndEvent(const char* name, const char* category = "default")
+        {
+            if (!m_active)
+                return;
+            TraceEvent ev;
+            ev.name = name;
+            ev.category = category;
+            ev.phase = 'E'; // End
+            ev.timestamp = GetTimestampUs();
+            ev.threadId = GetThreadId();
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                m_events.push_back(ev);
+            }
+        }
+
+        /// Record an instant event
+        void InstantEvent(const char* name, const char* category = "default")
+        {
+            if (!m_active)
+                return;
+            TraceEvent ev;
+            ev.name = name;
+            ev.category = category;
+            ev.phase = 'i'; // Instant
+            ev.timestamp = GetTimestampUs();
+            ev.threadId = GetThreadId();
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                m_events.push_back(ev);
+            }
+        }
+
+        /// Save all recorded events to a JSON file
+        bool SaveToFile(const std::string& filepath)
         {
             std::lock_guard<std::mutex> lock(m_mutex);
-            m_events.push_back(ev);
+            std::ofstream file(filepath);
+            if (!file.is_open())
+                return false;
+
+            file << "{\"traceEvents\":[\n";
+            for (size_t i = 0; i < m_events.size(); ++i)
+            {
+                const auto& ev = m_events[i];
+                file << "  {\"name\":\"" << ev.name << "\",\"cat\":\"" << ev.category << "\",\"ph\":\"" << ev.phase
+                     << "\",\"ts\":" << ev.timestamp << ",\"pid\":1" << ",\"tid\":" << ev.threadId << "}";
+                if (i + 1 < m_events.size())
+                    file << ",";
+                file << "\n";
+            }
+            file << "]}\n";
+
+            return file.good();
         }
-    }
 
-    /// Save all recorded events to a JSON file
-    bool SaveToFile(const std::string& filepath) {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        std::ofstream file(filepath);
-        if (!file.is_open()) return false;
-
-        file << "{\"traceEvents\":[\n";
-        for (size_t i = 0; i < m_events.size(); ++i) {
-            const auto& ev = m_events[i];
-            file << "  {\"name\":\"" << ev.name
-                 << "\",\"cat\":\"" << ev.category
-                 << "\",\"ph\":\"" << ev.phase
-                 << "\",\"ts\":" << ev.timestamp
-                 << ",\"pid\":1"
-                 << ",\"tid\":" << ev.threadId
-                 << "}";
-            if (i + 1 < m_events.size()) file << ",";
-            file << "\n";
+        /// Get the number of recorded events
+        size_t EventCount() const
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            return m_events.size();
         }
-        file << "]}\n";
 
-        return file.good();
-    }
+        /// Clear all recorded events
+        void Clear()
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_events.clear();
+        }
 
-    /// Get the number of recorded events
-    size_t EventCount() const {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        return m_events.size();
-    }
+      private:
+        ChromeTracing() = default;
+        ChromeTracing(const ChromeTracing&) = delete;
+        ChromeTracing& operator=(const ChromeTracing&) = delete;
 
-    /// Clear all recorded events
-    void Clear() {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_events.clear();
-    }
+        using Clock = std::chrono::high_resolution_clock;
 
-private:
-    ChromeTracing() = default;
-    ChromeTracing(const ChromeTracing&) = delete;
-    ChromeTracing& operator=(const ChromeTracing&) = delete;
+        struct TraceEvent
+        {
+            const char* name = "";
+            const char* category = "";
+            char phase = 'B';
+            int64_t timestamp = 0; // microseconds
+            uint64_t threadId = 0;
+        };
 
-    using Clock = std::chrono::high_resolution_clock;
+        int64_t GetTimestampUs() const
+        {
+            auto now = Clock::now();
+            return std::chrono::duration_cast<std::chrono::microseconds>(now - m_startTime).count();
+        }
 
-    struct TraceEvent {
-        const char* name = "";
-        const char* category = "";
-        char phase = 'B';
-        int64_t timestamp = 0; // microseconds
-        uint64_t threadId = 0;
+        static uint64_t GetThreadId()
+        {
+            return static_cast<uint64_t>(std::hash<std::thread::id>{}(std::this_thread::get_id()));
+        }
+
+        mutable std::mutex m_mutex;
+        std::vector<TraceEvent> m_events;
+        Clock::time_point m_startTime;
+        bool m_active = false;
     };
 
-    int64_t GetTimestampUs() const {
-        auto now = Clock::now();
-        return std::chrono::duration_cast<std::chrono::microseconds>(
-            now - m_startTime).count();
-    }
-
-    static uint64_t GetThreadId() {
-        return static_cast<uint64_t>(
-            std::hash<std::thread::id>{}(std::this_thread::get_id()));
-    }
-
-    mutable std::mutex m_mutex;
-    std::vector<TraceEvent> m_events;
-    Clock::time_point m_startTime;
-    bool m_active = false;
-};
-
-/// RAII scope guard for chrome tracing
-class ScopedTraceEvent {
-public:
-    ScopedTraceEvent(const char* name, const char* category = "default")
-        : m_name(name), m_category(category)
+    /// RAII scope guard for chrome tracing
+    class ScopedTraceEvent
     {
-        ChromeTracing::GetInstance().BeginEvent(name, category);
-    }
-    ~ScopedTraceEvent() {
-        ChromeTracing::GetInstance().EndEvent(m_name, m_category);
-    }
-    ScopedTraceEvent(const ScopedTraceEvent&) = delete;
-    ScopedTraceEvent& operator=(const ScopedTraceEvent&) = delete;
+      public:
+        ScopedTraceEvent(const char* name, const char* category = "default") : m_name(name), m_category(category)
+        {
+            ChromeTracing::GetInstance().BeginEvent(name, category);
+        }
+        ~ScopedTraceEvent() { ChromeTracing::GetInstance().EndEvent(m_name, m_category); }
+        ScopedTraceEvent(const ScopedTraceEvent&) = delete;
+        ScopedTraceEvent& operator=(const ScopedTraceEvent&) = delete;
 
-private:
-    const char* m_name;
-    const char* m_category;
-};
+      private:
+        const char* m_name;
+        const char* m_category;
+    };
 
 } // namespace Spark
 
 // Convenience macros
 #define SPARK_TRACE_CONCAT_INNER(a, b) a##b
 #define SPARK_TRACE_CONCAT(a, b) SPARK_TRACE_CONCAT_INNER(a, b)
-#define SPARK_TRACE_SCOPE(name) \
-    ::Spark::ScopedTraceEvent SPARK_TRACE_CONCAT(_traceScope_, __LINE__)(name)
-#define SPARK_TRACE_SCOPE_CAT(name, cat) \
-    ::Spark::ScopedTraceEvent SPARK_TRACE_CONCAT(_traceScope_, __LINE__)(name, cat)
+#define SPARK_TRACE_SCOPE(name) ::Spark::ScopedTraceEvent SPARK_TRACE_CONCAT(_traceScope_, __LINE__)(name)
+#define SPARK_TRACE_SCOPE_CAT(name, cat) ::Spark::ScopedTraceEvent SPARK_TRACE_CONCAT(_traceScope_, __LINE__)(name, cat)


### PR DESCRIPTION
Add `using namespace DirectX;` to framework.h on Windows to match the non-Windows stub in Platform.h, resolving unqualified XMFLOAT3/XMMATRIX type errors in MathUtils.h and GraphicsEngine.h.

Run clang-format on ChromeTracing.h to fix Allman brace style violations.

https://claude.ai/code/session_01HPuX5xBwggCN9v7Wf6pXKB