### PR TITLE
Merge stability fixes from claude/stability-assessment-release-0KC2L

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -40,5 +40,8 @@ trim_trailing_whitespace = false
 indent_style = space
 indent_size = 4
 
+[*.sh]
+end_of_line = lf
+
 [Makefile]
 indent_style = tab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release Builds
 
 on:
   push:
-    branches: [ master, main, Working ]
     tags: [ 'v*' ]
   workflow_dispatch:
     inputs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-```gitignore
 # ─────────────────────────────────────────────────────────────────────────────
 #                         SparkEngine .gitignore
 #          Merged GitHub VisualStudio.gitignore + custom rules
@@ -464,6 +463,3 @@ localdev.sh
 !tools/SparkBuild.exe
 
 # End of SparkEngine .gitignore
-```
-
-[1] https://github.com/github/gitignore/blob/master/VisualStudio.gitignorebuild_test/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # Set CMake policies for modern behavior
 cmake_policy(SET CMP0091 NEW)  # Enable MSVC_RUNTIME_LIBRARY support
 
-# Set consistent runtime library for all targets using modern CMake (CMP0091)
-if(MSVC)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-    # Note: With CMP0091 NEW, CMAKE_MSVC_RUNTIME_LIBRARY handles /MD and /MDd
-    # automatically. Do NOT manually add /MD or /MDd flags as they conflict.
-endif()
+# Note: CMAKE_MSVC_RUNTIME_LIBRARY is set after project() below,
+# because the MSVC variable is not defined until the compiler is identified.
 
 # MSVC toolset selection:
 #   v143 = Visual Studio 2022
@@ -50,6 +46,12 @@ if(WIN32 AND NOT CMAKE_GENERATOR_PLATFORM)
 endif()
 
 project(SparkEngine LANGUAGES CXX C)
+
+# Set consistent runtime library for all targets using modern CMake (CMP0091)
+# Must be after project() so that the MSVC variable is defined.
+if(MSVC)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+endif()
 
 # ---------------------------------------------------------------------
 # 2.5) Compiler identification and version reporting
@@ -418,8 +420,8 @@ endif()
 # ---------------------------------------------------------------------
 # 8) Build SparkConsole FIRST to ensure it's available for SparkEngine
 # ---------------------------------------------------------------------
-if(WIN32 AND EXISTS "${CMAKE_SOURCE_DIR}/SparkConsole/CMakeLists.txt")
-    message(STATUS "Building SparkConsole first...")
+if(EXISTS "${CMAKE_SOURCE_DIR}/SparkConsole/CMakeLists.txt")
+    message(STATUS "Building SparkConsole...")
     add_subdirectory(SparkConsole)
 endif()
 
@@ -447,7 +449,7 @@ file(GLOB_RECURSE SPARK_ENGINE_SOURCES
     "SparkEngine/Source/*.h"
     "SparkEngine/Source/*.hpp"
 )
-list(FILTER SPARK_ENGINE_SOURCES EXCLUDE REGEX ".*[Tt]est.*")
+list(FILTER SPARK_ENGINE_SOURCES EXCLUDE REGEX ".*/[Tt]est[^a-z].*|.*/[Tt]ests/.*")
 list(FILTER SPARK_ENGINE_SOURCES EXCLUDE REGEX ".*[Ee]xample.*")
 
 # Separate entry point from library sources
@@ -636,7 +638,11 @@ else()
         Threads::Threads
         ${CMAKE_DL_LIBS}
     )
-    target_compile_definitions(SparkEngineLib PUBLIC SPARK_PLATFORM_LINUX)
+    if(APPLE)
+        target_compile_definitions(SparkEngineLib PUBLIC SPARK_PLATFORM_MACOS)
+    else()
+        target_compile_definitions(SparkEngineLib PUBLIC SPARK_PLATFORM_LINUX)
+    endif()
 
     # X11 for windowing and OpenGL context (GLX)
     find_package(X11 QUIET)
@@ -692,7 +698,7 @@ if(ENABLE_LUA)
         "ThirdParty/sol2/single/include"
     )
         if(EXISTS "${CMAKE_SOURCE_DIR}/${PATH}")
-            if(PATH MATCHES "sol2")
+            if(PATH MATCHES "sol2" AND NOT TARGET sol2)
                 add_library(sol2 INTERFACE)
                 target_include_directories(sol2 INTERFACE "${CMAKE_SOURCE_DIR}/${PATH}")
                 target_link_libraries(SparkEngineLib PUBLIC sol2)
@@ -885,6 +891,7 @@ endif()
 # 16) Test suite
 # ---------------------------------------------------------------------
 if(BUILD_TESTS AND EXISTS "${CMAKE_SOURCE_DIR}/Tests/CMakeLists.txt")
+    enable_testing()
     message(STATUS "Adding test suite...")
     add_subdirectory(Tests)
 endif()

--- a/Shaders/GLSL/GaussianBlur.glsl
+++ b/Shaders/GLSL/GaussianBlur.glsl
@@ -20,7 +20,7 @@ layout(binding = 0) uniform sampler2D u_InputTexture;
 
 // 9-tap Gaussian weights (sigma ~1.8)
 const float weights[5] = float[5](
-    0.204164, 0.304005, 0.193783, 0.0727, 0.0155
+    0.227027, 0.194595, 0.121622, 0.054054, 0.016216
 );
 
 void main()

--- a/Shaders/GLSL/Water.glsl
+++ b/Shaders/GLSL/Water.glsl
@@ -38,7 +38,7 @@ void main()
 
     // Scrolling UV for normal map distortion
     vec2 scrollUV = inTexCoord + vec2(u_Time * u_WaveSpeed.x, u_Time * u_WaveSpeed.y);
-    vec2 distortion = texture(u_NormalMap, scrollUV).rg * 2.0 - 1.0;
+    vec2 distortion = textureLod(u_NormalMap, scrollUV, 0.0).rg * 2.0 - 1.0;
 
     fragUV_Refraction = inTexCoord + distortion * u_DistortionStrength;
     fragUV_Reflection = inTexCoord - distortion * u_DistortionStrength;

--- a/Shaders/HLSL/BasicVS.hlsl
+++ b/Shaders/HLSL/BasicVS.hlsl
@@ -1,4 +1,4 @@
-cbuffer ConstantBuffer : register(b1)
+cbuffer ConstantBuffer : register(b0)
 {
     matrix World;
     matrix View;

--- a/Shaders/HLSL/DebugUtils.hlsl
+++ b/Shaders/HLSL/DebugUtils.hlsl
@@ -1,4 +1,4 @@
 Texture2D DebugTex:register(t0);SamplerState Sam:register(s0);
 struct PS_IN{float2 uv:TEXCOORD;};
-float4 PS_Checker(PS_IN i):SV_Target{float s=step(0.5,frac(i.uv.x*10))^step(0.5,frac(i.uv.y*10));return float4(s,s,s,1);}
+float4 PS_Checker(PS_IN i):SV_Target{float s=abs(step(0.5,frac(i.uv.x*10))-step(0.5,frac(i.uv.y*10)));return float4(s,s,s,1);}
 float4 PS_Gradient(PS_IN i):SV_Target{return float4(i.uv.x,i.uv.y,0,1);}

--- a/Shaders/HLSL/GaussianBlur.hlsl
+++ b/Shaders/HLSL/GaussianBlur.hlsl
@@ -1,6 +1,6 @@
 Texture2D InputTex:register(t0);SamplerState Sam:register(s0);
 cbuffer BlurCB:register(b1){float2 TexelSize;}
-static const float weights[5]={0.204164,0.304005,0.193783,0.0727,0.0155};
+static const float weights[5]={0.227027,0.194595,0.121622,0.054054,0.016216};
 float4 PS_BlurH(float2 uv:TEXCOORD):SV_Target{float4 c=InputTex.Sample(Sam,uv)*weights[0];
     for(int i=1;i<5;i++){c+=InputTex.Sample(Sam,uv+float2(TexelSize.x*i,0))*weights[i];c+=InputTex.Sample(Sam,uv-float2(TexelSize.x*i,0))*weights[i];}
     return c;

--- a/Shaders/HLSL/PBRSurface.hlsl
+++ b/Shaders/HLSL/PBRSurface.hlsl
@@ -1,3 +1,5 @@
+static const float PI = 3.14159265358979323846;
+
 cbuffer PerFrame : register(b1)
 {
     float4x4 World; float4x4 View; float4x4 Projection;

--- a/Shaders/HLSL/Water.hlsl
+++ b/Shaders/HLSL/Water.hlsl
@@ -8,7 +8,7 @@ struct VS_IN{float3 Pos:POSITION;float2 UV:TEXCOORD0;};
 struct PS_IN{float4 Pos:SV_POSITION;float2 UV_Re:TEXCOORD0;float2 UV_Ref:TEXCOORD1;float3 ViewDir:TEXCOORD2;};
 PS_IN VS_Water(VS_IN i){PS_IN o;float4 worldPos=float4(i.Pos,1);o.Pos=mul(worldPos,WorldViewProj);
  float2 scroll=i.UV+float2(Time*0.05,Time*0.07);
- float2 dn=NormalMap.Sample(SamTr,scroll).rg*2-1;
+ float2 dn=NormalMap.SampleLevel(SamTr,scroll,0).rg*2-1;
  o.UV_Re=i.UV+dn*0.02;o.UV_Ref=i.UV-dn*0.02;
  o.ViewDir=normalize(CameraPos-i.Pos);return o;}
 float4 PS_Water(PS_IN i):SV_Target{

--- a/SparkConsole/CMakeLists.txt
+++ b/SparkConsole/CMakeLists.txt
@@ -46,21 +46,27 @@ if(CONSOLE_SOURCES)
         NOMINMAX
     )
 
-    # System libraries
-    target_link_libraries(SparkConsole PRIVATE
-        kernel32 user32 gdi32
-        shell32 comdlg32 advapi32
-        winmm
-    )
+    # System libraries - platform-specific
+    if(WIN32)
+        target_link_libraries(SparkConsole PRIVATE
+            kernel32 user32 gdi32
+            shell32 comdlg32 advapi32
+            winmm
+        )
+    else()
+        find_package(Threads REQUIRED)
+        target_link_libraries(SparkConsole PRIVATE Threads::Threads)
+        target_compile_definitions(SparkConsole PRIVATE SPARK_PLATFORM_LINUX)
+    endif()
 
     # MSVC specific settings
     if(MSVC)
-        target_compile_options(SparkConsole PRIVATE 
+        target_compile_options(SparkConsole PRIVATE
             /W3 /MP
             /wd4996  # Deprecated functions
         )
         set_property(TARGET SparkConsole PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
-        
+
         # Organize source files in Visual Studio
         foreach(src ${CONSOLE_SOURCES})
             get_filename_component(dir "${src}" DIRECTORY)

--- a/SparkEngine/Source/Core/Platform.h
+++ b/SparkEngine/Source/Core/Platform.h
@@ -1146,6 +1146,24 @@ namespace DirectX
         return mat;
     }
 
+    // Plane operations (used by frustum culling)
+    inline XMVECTOR XMPlaneNormalize(XMVECTOR plane)
+    {
+        float len = sqrtf(plane.x * plane.x + plane.y * plane.y + plane.z * plane.z);
+        if (len > 1e-8f)
+        {
+            float invLen = 1.0f / len;
+            return {plane.x * invLen, plane.y * invLen, plane.z * invLen, plane.w * invLen};
+        }
+        return plane;
+    }
+
+    inline XMVECTOR XMPlaneDotCoord(XMVECTOR plane, XMVECTOR point)
+    {
+        float d = plane.x * point.x + plane.y * point.y + plane.z * point.z + plane.w;
+        return {d, d, d, d};
+    }
+
 } // namespace DirectX
 
 // ============================================================================

--- a/SparkEngine/Source/Graphics/FrustumCulling.h
+++ b/SparkEngine/Source/Graphics/FrustumCulling.h
@@ -60,9 +60,12 @@ namespace Spark::Graphics
     };
 
     /**
- * @brief Bounding sphere represented by center and radius.
+ * @brief Bounding sphere for frustum culling (center/radius).
+ *
+ * Named CullingSphere to avoid conflict with Physics/CollisionSystem.h
+ * BoundingSphere which uses different member names (Center/Radius).
  */
-    struct BoundingSphere
+    struct CullingSphere
     {
         DirectX::XMFLOAT3 center{0, 0, 0};
         float radius = 0.0f;
@@ -209,7 +212,7 @@ namespace Spark::Graphics
      * @param sphere  The bounding sphere to test.
      * @return CullResult indicating visibility.
      */
-        CullResult TestSphere(const BoundingSphere& sphere) const
+        CullResult TestSphere(const CullingSphere& sphere) const
         {
             bool allInside = true;
 
@@ -233,7 +236,7 @@ namespace Spark::Graphics
         /**
      * @brief Quick boolean test — returns true if the sphere is at least partially visible.
      */
-        bool IsVisible(const BoundingSphere& sphere) const { return TestSphere(sphere) != CullResult::Outside; }
+        bool IsVisible(const CullingSphere& sphere) const { return TestSphere(sphere) != CullResult::Outside; }
 
         /**
      * @brief Test a single point against the frustum.

--- a/SparkEngine/Source/Graphics/PostProcessing.h
+++ b/SparkEngine/Source/Graphics/PostProcessing.h
@@ -16,6 +16,13 @@
  */
 
 #pragma once
+
+// Mutual exclusion: PostProcessingSystem.h defines the canonical version
+#ifdef SPARK_POST_PROCESSING_SYSTEM_H
+#error "Do not include both PostProcessing.h and PostProcessingSystem.h in the same translation unit"
+#endif
+#define SPARK_POST_PROCESSING_H
+
 #include "../Core/Platform.h"
 
 #include "Utils/Assert.h"

--- a/SparkEngine/Source/Graphics/PostProcessingSystem.h
+++ b/SparkEngine/Source/Graphics/PostProcessingSystem.h
@@ -6,6 +6,13 @@
  */
 
 #pragma once
+
+// Mutual exclusion: PostProcessing.h defines an older version of the same class
+#ifdef SPARK_POST_PROCESSING_H
+#error "Do not include both PostProcessing.h and PostProcessingSystem.h in the same translation unit"
+#endif
+#define SPARK_POST_PROCESSING_SYSTEM_H
+
 #include "../Core/Platform.h"
 
 #include "Utils/Assert.h"

--- a/SparkEngine/Source/Graphics/RenderTarget.h
+++ b/SparkEngine/Source/Graphics/RenderTarget.h
@@ -143,6 +143,7 @@ class RenderTarget
 
     // Getters
     const RenderTargetDesc& GetDesc() const { return m_desc; }
+    RenderTargetDesc& GetDesc() { return m_desc; }
     ID3D11Texture2D* GetTexture() const { return m_texture.Get(); }
     ID3D11RenderTargetView* GetRenderTargetView() const { return m_renderTargetView.Get(); }
     ID3D11DepthStencilView* GetDepthStencilView() const { return m_depthStencilView.Get(); }

--- a/SparkEngine/Source/Input/InputManager.cpp
+++ b/SparkEngine/Source/Input/InputManager.cpp
@@ -1,11 +1,13 @@
+// InputManager.cpp — Win32 implementation
 #include "../Core/Platform.h"
 #ifdef SPARK_PLATFORM_WINDOWS
-// InputManager.cpp — Win32 implementation
 #include "InputManager.h"
 #include "Utils/Assert.h"
 #include "../Utils/SparkConsole.h"
 #include <Windows.h>
+#include <windowsx.h>  // GET_X_LPARAM, GET_Y_LPARAM
 #include <cstring>
+#include <cmath>
 #include <iostream>
 #include <sstream>
 #include <iomanip>

--- a/SparkEngine/Source/SceneManager/SceneManager.cpp
+++ b/SparkEngine/Source/SceneManager/SceneManager.cpp
@@ -120,8 +120,8 @@ bool SceneManager::SaveScene(const std::wstring& filepath) const
     bool saved = SaveJSON(filepath);
     if (saved)
     {
-        const_cast<SceneManager*>(this)->m_currentFilePath = filepath;
-        const_cast<SceneManager*>(this)->m_dirty = false;
+        m_currentFilePath = filepath;
+        m_dirty = false;
     }
     return saved;
 }
@@ -378,18 +378,33 @@ bool SceneManager::LoadJSON(const std::wstring& path)
     std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     file.close();
 
-    // Simple text parser for scene format
-    // Full format:   type name px py pz rx ry rz sx sy sz parentIndex
-    // Legacy format: type name px py pz
+    // Simple text-based scene format (not actual JSON despite the method name):
+    //   Lines starting with # are comments/metadata
+    //   Data lines: type name posX posY posZ [rotX rotY rotZ scaleX scaleY scaleZ parentIndex]
     Clear();
 
     std::istringstream ss(content);
     std::string line;
+
+    // Parse metadata from comment headers
     while (std::getline(ss, line))
     {
-        if (line.empty() || line[0] == '#' || line[0] == '/' || line[0] == '{' || line[0] == '}')
+        if (line.empty()) continue;
+        if (line[0] == '#')
+        {
+            // Parse metadata comments like "# name: MyScene"
+            if (line.find("# name:") == 0)
+                m_metadata.sceneName = line.substr(8);
+            else if (line.find("# gravity:") == 0)
+            {
+                std::istringstream gs(line.substr(11));
+                gs >> m_metadata.gravityX >> m_metadata.gravityY >> m_metadata.gravityZ;
+            }
             continue;
+        }
+        if (line[0] == '/' || line[0] == '{' || line[0] == '}') continue;
 
+        // Parse node line: type name posX posY posZ [rotX rotY rotZ scaleX scaleY scaleZ parentIndex]
         std::istringstream ls(line);
         SceneNode node;
         ls >> node.type >> node.name >> node.position.x >> node.position.y >> node.position.z;
@@ -398,6 +413,15 @@ bool SceneManager::LoadJSON(const std::wstring& path)
         ls >> node.rotation.x >> node.rotation.y >> node.rotation.z >> node.scale.x >> node.scale.y >> node.scale.z >>
             node.parentIndex;
         // If extended fields aren't present, defaults are fine (rotation=0, scale=1, parent=-1)
+
+        // Try to read optional rotation, scale, and parent fields (written by SaveJSON)
+        if (ls >> node.rotation.x >> node.rotation.y >> node.rotation.z
+               >> node.scale.x >> node.scale.y >> node.scale.z
+               >> node.parentIndex)
+        {
+            // All 12 fields parsed successfully
+        }
+        // Otherwise keep defaults (zero rotation, unit scale, no parent)
 
         if (!node.type.empty())
             AddNode(node);
@@ -450,6 +474,13 @@ void SceneManager::InstantiateNodes()
 
         std::unique_ptr<GameObject> obj;
 
+        // Determine mesh path: use modelPath if specified, otherwise construct from type
+        std::wstring meshPath;
+        if (!node.modelPath.empty())
+        {
+            meshPath = std::wstring(node.modelPath.begin(), node.modelPath.end());
+        }
+
         if (node.type == "Cube" || node.type == "cube")
             obj = std::make_unique<CubeObject>(node.scale.x);
         else if (node.type == "Plane" || node.type == "plane")
@@ -462,21 +493,48 @@ void SceneManager::InstantiateNodes()
             obj = std::make_unique<RampObject>(node.scale.x, node.scale.y);
         else if (node.type == "Wall" || node.type == "wall")
             obj = std::make_unique<WallObject>(node.scale.x, node.scale.y);
+        else if (node.type == "model" || node.type == "Model")
+        {
+            // Model type: create a cube as placeholder geometry, then load the actual mesh
+            obj = std::make_unique<CubeObject>(1.0f);
+            if (meshPath.empty())
+            {
+                // No modelPath specified, skip this model node
+                LOG_TO_CONSOLE(L"SceneManager: model node '" +
+                    std::wstring(node.name.begin(), node.name.end()) +
+                    L"' has no modelPath, using placeholder", L"WARNING");
+            }
+        }
         else
+        {
+            LOG_TO_CONSOLE(L"SceneManager: Unknown node type '" +
+                std::wstring(node.type.begin(), node.type.end()) +
+                L"', skipping", L"WARNING");
+            m_objects.push_back(nullptr);
             continue;
+        }
 
         if (obj)
         {
             HRESULT hr = obj->Initialize(m_graphics->GetDevice(), m_graphics->GetContext());
             if (SUCCEEDED(hr))
             {
-                std::wstring wtype(node.type.begin(), node.type.end());
-                LoadOrPlaceholderMesh(*obj->GetMesh(), m_graphics->GetDevice(), m_graphics->GetContext(),
-                                      L"Assets\\Models\\" + wtype + L".obj");
+                if (meshPath.empty())
+                {
+                    // Construct default mesh path from type name (lowercase)
+                    std::string lowerType = node.type;
+                    std::transform(lowerType.begin(), lowerType.end(), lowerType.begin(), ::tolower);
+                    meshPath = L"Assets\\Models\\" + std::wstring(lowerType.begin(), lowerType.end()) + L".obj";
+                }
+                LoadOrPlaceholderMesh(*obj->GetMesh(), m_graphics->GetDevice(), m_graphics->GetContext(), meshPath);
                 obj->SetPosition(node.position);
                 obj->SetRotation(node.rotation);
                 obj->SetName(node.name);
                 m_objects.push_back(std::move(obj));
+            }
+            else
+            {
+                m_objects.push_back(nullptr);
             }
         }
     }
@@ -485,6 +543,15 @@ void SceneManager::InstantiateNodes()
 // ============================================================================
 // Legacy .scene loader (preserved for backward compatibility)
 // ============================================================================
+
+// Helper: parse comma-separated floats "x,y,z" into an XMFLOAT3
+static bool ParseFloat3(const std::string& str, DirectX::XMFLOAT3& out)
+{
+    std::string s = str;
+    for (char& c : s) if (c == ',') c = ' ';
+    std::istringstream ss(s);
+    return bool(ss >> out.x >> out.y >> out.z);
+}
 
 bool SceneManager::LoadCustom(const std::wstring& path)
 {
@@ -497,91 +564,180 @@ bool SceneManager::LoadCustom(const std::wstring& path)
 
     Clear();
 
-    std::wifstream file(WideToNarrow(path));
+    std::ifstream file(WideToNarrow(path));
     if (!file.is_open())
     {
         LOG_TO_CONSOLE_IMMEDIATE(L"SceneManager: Could not open scene file: " + path, L"ERROR");
         return false;
     }
 
-    std::wstring line;
-    int lineNum = 0;
-    while (std::getline(file, line))
+    // Peek at the first non-empty, non-comment line to detect format
+    std::string content((std::istreambuf_iterator<char>(file)),
+                         std::istreambuf_iterator<char>());
+    file.close();
+
+    bool isINIFormat = (content.find("[Scene]") != std::string::npos ||
+                        content.find("[Object]") != std::string::npos);
+
+    if (isINIFormat)
     {
-        ++lineNum;
-        if (line.empty() || line[0] == L'#')
-            continue;
+        // INI-style format: [Section] headers with key=value pairs
+        std::istringstream ss(content);
+        std::string line;
+        std::string currentSection;
+        SceneNode currentNode;
+        bool hasNode = false;
 
-        std::wstringstream ss(line);
-        std::wstring type;
-        ss >> type;
-        float x = 0, y = 0, z = 0;
-        ss >> x >> y >> z;
+        auto flushNode = [&]() {
+            if (hasNode && !currentNode.type.empty())
+            {
+                if (currentNode.name.empty())
+                    currentNode.name = currentNode.type + "_" + std::to_string(m_sceneNodes.size());
+                m_sceneNodes.push_back(currentNode);
+            }
+            currentNode = SceneNode{};
+            hasNode = false;
+        };
 
-        std::unique_ptr<GameObject> obj;
+        while (std::getline(ss, line))
+        {
+            // Trim whitespace
+            while (!line.empty() && (line.back() == '\r' || line.back() == ' ')) line.pop_back();
+            if (line.empty() || line[0] == '#' || line[0] == ';') continue;
 
-        if (type == L"Cube")
-        {
-            float size;
-            ss >> size;
-            obj = std::make_unique<CubeObject>(size);
-        }
-        else if (type == L"Plane")
-        {
-            float width, depth;
-            ss >> width >> depth;
-            obj = std::make_unique<PlaneObject>(width, depth);
-        }
-        else if (type == L"Sphere")
-        {
-            float radius;
-            int slices, stacks;
-            ss >> radius >> slices >> stacks;
-            obj = std::make_unique<SphereObject>(radius, slices, stacks);
-        }
-        else if (type == L"Pyramid")
-        {
-            float size;
-            ss >> size;
-            obj = std::make_unique<PyramidObject>(size);
-        }
-        else if (type == L"Ramp")
-        {
-            float length, height;
-            ss >> length >> height;
-            obj = std::make_unique<RampObject>(length, height);
-        }
-        else if (type == L"Wall")
-        {
-            float width, height;
-            ss >> width >> height;
-            obj = std::make_unique<WallObject>(width, height);
-        }
-        else
-        {
-            LOG_TO_CONSOLE_IMMEDIATE(L"SceneManager: Unknown type on line " + std::to_wstring(lineNum) + L": " + type,
-                                     L"ERROR");
-            continue;
-        }
+            // Section header
+            if (line[0] == '[' && line.back() == ']')
+            {
+                flushNode();
+                currentSection = line.substr(1, line.size() - 2);
 
-        ASSERT(obj);
-        HRESULT hr = obj->Initialize(m_graphics->GetDevice(), m_graphics->GetContext());
-        ASSERT_MSG(SUCCEEDED(hr), "SceneManager: object Initialize failed");
-        LoadOrPlaceholderMesh(*obj->GetMesh(), m_graphics->GetDevice(), m_graphics->GetContext(),
-                              L"Assets\\Models\\" + type + L".obj");
-        obj->SetPosition({x, y, z});
-        m_objects.push_back(std::move(obj));
+                if (currentSection == "Object" || currentSection == "Terrain" || currentSection == "SpawnPoint")
+                    hasNode = true;
+                continue;
+            }
 
-        // Also track in scene hierarchy
-        SceneNode node;
-        node.type = std::string(type.begin(), type.end());
-        node.name = node.type + "_" + std::to_string(lineNum);
-        node.position = {x, y, z};
-        m_sceneNodes.push_back(node);
+            // Key=Value pair
+            auto eqPos = line.find('=');
+            if (eqPos == std::string::npos) continue;
+            std::string key = line.substr(0, eqPos);
+            std::string value = line.substr(eqPos + 1);
+
+            if (currentSection == "Scene")
+            {
+                if (key == "name") m_metadata.sceneName = value;
+                else if (key == "author") m_metadata.author = value;
+                else if (key == "gravity")
+                {
+                    XMFLOAT3 grav;
+                    if (ParseFloat3(value, grav))
+                    {
+                        m_metadata.gravityX = grav.x;
+                        m_metadata.gravityY = grav.y;
+                        m_metadata.gravityZ = grav.z;
+                    }
+                }
+            }
+            else if (hasNode)
+            {
+                if (key == "type") currentNode.type = value;
+                else if (key == "name") currentNode.name = value;
+                else if (key == "model") currentNode.modelPath = value;
+                else if (key == "position") ParseFloat3(value, currentNode.position);
+                else if (key == "rotation") ParseFloat3(value, currentNode.rotation);
+                else if (key == "scale") ParseFloat3(value, currentNode.scale);
+                else if (key == "material") currentNode.materialPath = value;
+                else currentNode.properties[key] = value;
+            }
+        }
+        flushNode();
+
+        InstantiateNodes();
+    }
+    else
+    {
+        // Legacy space-delimited format: Type X Y Z [params...]
+        std::istringstream ss(content);
+        std::string line;
+        int lineNum = 0;
+
+        while (std::getline(ss, line))
+        {
+            ++lineNum;
+            // Trim
+            while (!line.empty() && (line.back() == '\r' || line.back() == ' ')) line.pop_back();
+            if (line.empty() || line[0] == '#') continue;
+
+            std::istringstream ls(line);
+            std::string type;
+            ls >> type;
+            float x = 0, y = 0, z = 0;
+            ls >> x >> y >> z;
+
+            std::unique_ptr<GameObject> obj;
+
+            if (type == "Cube")
+            {
+                float size = 1.0f; ls >> size;
+                obj = std::make_unique<CubeObject>(size);
+            }
+            else if (type == "Plane")
+            {
+                float width = 10.0f, depth = 10.0f; ls >> width >> depth;
+                obj = std::make_unique<PlaneObject>(width, depth);
+            }
+            else if (type == "Sphere")
+            {
+                float radius = 0.5f; int slices = 16, stacks = 16;
+                ls >> radius >> slices >> stacks;
+                obj = std::make_unique<SphereObject>(radius, slices, stacks);
+            }
+            else if (type == "Pyramid")
+            {
+                float size = 1.0f; ls >> size;
+                obj = std::make_unique<PyramidObject>(size);
+            }
+            else if (type == "Ramp")
+            {
+                float length = 2.0f, height = 1.0f; ls >> length >> height;
+                obj = std::make_unique<RampObject>(length, height);
+            }
+            else if (type == "Wall")
+            {
+                float width = 1.0f, height = 2.0f; ls >> width >> height;
+                obj = std::make_unique<WallObject>(width, height);
+            }
+            else
+            {
+                std::wstring wtype(type.begin(), type.end());
+                LOG_TO_CONSOLE(L"SceneManager: Unknown type on line " + std::to_wstring(lineNum) + L": " + wtype, L"WARNING");
+                continue;
+            }
+
+            HRESULT hr = obj->Initialize(m_graphics->GetDevice(), m_graphics->GetContext());
+            if (FAILED(hr))
+            {
+                LOG_TO_CONSOLE(L"SceneManager: object Initialize failed on line " + std::to_wstring(lineNum), L"ERROR");
+                continue;
+            }
+
+            std::string lowerType = type;
+            std::transform(lowerType.begin(), lowerType.end(), lowerType.begin(), ::tolower);
+            std::wstring meshPath = L"Assets\\Models\\" + std::wstring(lowerType.begin(), lowerType.end()) + L".obj";
+            LoadOrPlaceholderMesh(*obj->GetMesh(), m_graphics->GetDevice(), m_graphics->GetContext(), meshPath);
+            obj->SetPosition({ x, y, z });
+            m_objects.push_back(std::move(obj));
+
+            // Also track in scene hierarchy
+            SceneNode node;
+            node.type = type;
+            node.name = type + "_" + std::to_string(lineNum);
+            node.position = {x, y, z};
+            m_sceneNodes.push_back(node);
+        }
     }
 
-    LOG_TO_CONSOLE_IMMEDIATE(L"SceneManager: Loaded " + std::to_wstring(m_objects.size()) + L" objects", L"SUCCESS");
-    return !m_objects.empty();
+    LOG_TO_CONSOLE_IMMEDIATE(L"SceneManager: Loaded " + std::to_wstring(m_sceneNodes.size()) + L" nodes", L"SUCCESS");
+    return !m_sceneNodes.empty();
 }
 
 // ============================================================================
@@ -640,6 +796,12 @@ bool SceneManager::Console_RenameNode(int index, const std::string& newName)
     auto* node = GetNode(index);
     if (!node)
         return false;
+
+    // Reject if another node already has this name (per documentation contract)
+    int existing = FindNode(newName);
+    if (existing >= 0 && existing != index)
+        return false;
+
     node->name = newName;
     m_dirty = true;
     return true;

--- a/SparkEngine/Source/SceneManager/SceneManager.h
+++ b/SparkEngine/Source/SceneManager/SceneManager.h
@@ -746,16 +746,18 @@ class SceneManager
      * @brief File path from which the current scene was last loaded or saved.
      *
      * Empty if the scene was created with `NewScene()` and never saved.
+     * Mutable because SaveScene (logically const) updates this as a side effect.
      */
-    std::wstring m_currentFilePath;
+    mutable std::wstring m_currentFilePath;
 
     /**
      * @brief Dirty flag indicating unsaved changes.
      *
      * Set to `true` by any method that modifies the hierarchy or metadata.
      * Cleared by `LoadScene()`, `SaveScene()`, and `NewScene()`.
+     * Mutable because SaveScene (logically const) clears this flag.
      */
-    bool m_dirty = false;
+    mutable bool m_dirty = false;
 
     /** @brief Background thread for async scene loading (joined in destructor). */
     std::thread m_asyncLoadThread;

--- a/SparkEngine/Source/Utils/CrashHandler.cpp
+++ b/SparkEngine/Source/Utils/CrashHandler.cpp
@@ -59,8 +59,10 @@ static bool g_triggerCrashOnAssert = false;
 static std::string WideToUtf8(const std::wstring& w)
 {
 #ifdef SPARK_PLATFORM_WINDOWS
+    if (w.empty()) return {};
     int len = WideCharToMultiByte(CP_UTF8, 0, w.c_str(), -1, nullptr, 0, nullptr, nullptr);
-    std::string s(len, '\0');
+    if (len <= 1) return {};  // Only null terminator
+    std::string s(len - 1, '\0');  // Exclude the null terminator from std::string length
     WideCharToMultiByte(CP_UTF8, 0, w.c_str(), -1, &s[0], len, nullptr, nullptr);
     return s;
 #else
@@ -456,7 +458,7 @@ static std::wstring ThreadStacks()
     BYTE symBuffer[sizeof(SYMBOL_INFO) + 256] = {};
 
     THREADENTRY32 te{sizeof(te)};
-    for (Thread32First(snap, &te); Thread32Next(snap, &te);)
+    for (BOOL ok = Thread32First(snap, &te); ok; ok = Thread32Next(snap, &te))
     {
         if (te.th32OwnerProcessID != pid)
             continue;
@@ -526,6 +528,7 @@ static void SaveScreenshot(const std::wstring& file)
 
     auto dev = GetD3DDevice();
     auto ctx = GetD3DContext();
+    if (!dev || !ctx) return;
     Microsoft::WRL::ComPtr<ID3D11Texture2D> cpu;
     if (FAILED(dev->CreateTexture2D(&d, nullptr, &cpu)))
         return;
@@ -563,6 +566,7 @@ static void SaveScreenshot(const std::wstring& file)
         stm->Release();
     if (wic)
         wic->Release();
+    CoUninitialize();
     ctx->Unmap(cpu.Get(), 0);
 }
 

--- a/SparkEngine/Source/Utils/CrashHandler.h
+++ b/SparkEngine/Source/Utils/CrashHandler.h
@@ -33,6 +33,7 @@
  */
 
 #pragma once
+#include "../Core/Platform.h"
 #include <string>
 
 /**
@@ -52,6 +53,8 @@ struct CrashConfig
     bool triggerCrashOnAssert = false;            ///< Whether assertion failures should generate a full crash report
     int connectTimeoutSeconds = 5;                ///< HTTP connection timeout for crash report uploads
 };
+
+#ifdef SPARK_PLATFORM_WINDOWS
 
 /**
  * @brief Install the unhandled-exception filter with the given configuration
@@ -89,3 +92,12 @@ void TriggerCrashHandler(const char* assertMsg);
  * @param shouldCrash true to generate crash reports on assert, false to only log
  */
 void SetAssertCrashBehavior(bool shouldCrash);
+
+#else // !SPARK_PLATFORM_WINDOWS
+
+// Stub implementations for non-Windows platforms
+inline void InstallCrashHandler(const CrashConfig&) {}
+inline void TriggerCrashHandler(const char*) {}
+inline void SetAssertCrashBehavior(bool) {}
+
+#endif // SPARK_PLATFORM_WINDOWS

--- a/SparkEngine/Source/Utils/SparkConsole.cpp
+++ b/SparkEngine/Source/Utils/SparkConsole.cpp
@@ -593,7 +593,11 @@ namespace Spark
             return;
         }
 
+#ifdef SPARK_PLATFORM_WINDOWS
         system("cls");
+#else
+        system("clear");
+#endif
 
         PrintLine("==========================================", Color::Cyan);
         PrintLine("    Spark Engine Development Console", Color::Cyan);

--- a/SparkGame/Source/Game/Game.cpp
+++ b/SparkGame/Source/Game/Game.cpp
@@ -78,7 +78,10 @@ HRESULT Game::Initialize(GraphicsEngine* graphics, InputManager* input)
     m_camera = std::make_unique<SparkEngineCamera>();
     ASSERT(m_camera);
 
-    float aspect = float(m_graphics->GetWindowWidth()) / float(m_graphics->GetWindowHeight());
+    UINT winHeight = m_graphics->GetWindowHeight();
+    float aspect = (winHeight > 0)
+        ? float(m_graphics->GetWindowWidth()) / float(winHeight)
+        : 16.0f / 9.0f;  // Safe fallback if window is minimized
     ASSERT_MSG(aspect > 0.0f, "Invalid aspect ratio");
 
     m_camera->Initialize(aspect);

--- a/SparkShaderCompiler/CMakeLists.txt
+++ b/SparkShaderCompiler/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(SparkShaderCompiler PRIVATE
     "${CMAKE_SOURCE_DIR}/SparkEngine/Source"
 )
 
-target_compile_features(SparkShaderCompiler PRIVATE cxx_std_17)
+target_compile_features(SparkShaderCompiler PRIVATE cxx_std_20)
 
 # Platform-specific link libraries
 if(WIN32)

--- a/ThirdParty/CMakeLists.txt
+++ b/ThirdParty/CMakeLists.txt
@@ -1,28 +1,56 @@
 ﻿# ThirdParty Dependencies CMakeLists.txt
 cmake_minimum_required(VERSION 3.16)
 
-# Set C++ standard
-set(CMAKE_CXX_STANDARD 17)
+# Match the root project C++ standard
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # EnTT - Header only
-add_library(entt INTERFACE)
-target_include_directories(entt INTERFACE ECS/entt/include)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ECS/entt/single_include")
+    add_library(entt INTERFACE)
+    target_include_directories(entt INTERFACE ECS/entt/single_include)
+    message(STATUS "ThirdParty: EnTT configured (header-only)")
+else()
+    message(STATUS "ThirdParty: EnTT not found (submodule not initialized)")
+endif()
 
-# Dear ImGui
-set(IMGUI_DIR UI/imgui)
-add_library(imgui STATIC
-    ${IMGUI_DIR}/imgui.cpp
-    ${IMGUI_DIR}/imgui_demo.cpp
-    ${IMGUI_DIR}/imgui_draw.cpp
-    ${IMGUI_DIR}/imgui_tables.cpp
-    ${IMGUI_DIR}/imgui_widgets.cpp
-    ${IMGUI_DIR}/backends/imgui_impl_dx11.cpp
-    ${IMGUI_DIR}/backends/imgui_impl_win32.cpp
-)
-target_include_directories(imgui PUBLIC ${IMGUI_DIR} ${IMGUI_DIR}/backends)
+# Dear ImGui (Windows only - requires DX11/Win32 backends)
+set(IMGUI_DIR "${CMAKE_CURRENT_SOURCE_DIR}/UI/imgui")
+if(WIN32 AND EXISTS "${IMGUI_DIR}/imgui.cpp")
+    add_library(imgui STATIC
+        ${IMGUI_DIR}/imgui.cpp
+        ${IMGUI_DIR}/imgui_demo.cpp
+        ${IMGUI_DIR}/imgui_draw.cpp
+        ${IMGUI_DIR}/imgui_tables.cpp
+        ${IMGUI_DIR}/imgui_widgets.cpp
+        ${IMGUI_DIR}/backends/imgui_impl_dx11.cpp
+        ${IMGUI_DIR}/backends/imgui_impl_win32.cpp
+    )
+    target_include_directories(imgui PUBLIC ${IMGUI_DIR} ${IMGUI_DIR}/backends)
+    if(MSVC)
+        set_property(TARGET imgui PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    endif()
+    message(STATUS "ThirdParty: Dear ImGui configured (Win32+DX11)")
+elseif(EXISTS "${IMGUI_DIR}/imgui.cpp")
+    # Non-Windows: build core ImGui without platform backends
+    add_library(imgui STATIC
+        ${IMGUI_DIR}/imgui.cpp
+        ${IMGUI_DIR}/imgui_demo.cpp
+        ${IMGUI_DIR}/imgui_draw.cpp
+        ${IMGUI_DIR}/imgui_tables.cpp
+        ${IMGUI_DIR}/imgui_widgets.cpp
+    )
+    target_include_directories(imgui PUBLIC ${IMGUI_DIR})
+    message(STATUS "ThirdParty: Dear ImGui configured (core only, no platform backend)")
+else()
+    message(STATUS "ThirdParty: Dear ImGui not found (submodule not initialized)")
+endif()
 
-# AngelScript
-add_subdirectory(Scripting/angelscript/angelscript/projects/cmake)
-
-
+# AngelScript - path matches the submodule name in .gitmodules (angelscript-mirror)
+set(ANGELSCRIPT_CMAKE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Scripting/angelscript-mirror/angelscript/projects/cmake")
+if(EXISTS "${ANGELSCRIPT_CMAKE_DIR}/CMakeLists.txt")
+    add_subdirectory("${ANGELSCRIPT_CMAKE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/angelscript")
+    message(STATUS "ThirdParty: AngelScript configured")
+else()
+    message(STATUS "ThirdParty: AngelScript not found (submodule not initialized)")
+endif()

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ while [[ $# -gt 0 ]]; do
     -E) ENABLE_EDITOR=OFF ;;
     -C) ENABLE_CONSOLE=OFF ;;
     -A) ENABLE_AS=OFF ;;
-    -g) shift; GENERATOR="$1" ;;
+    -g) if [[ $# -lt 2 ]]; then echo "Error: -g requires a generator name"; exit 1; fi; shift; GENERATOR="$1" ;;
     *) usage ;;
   esac
   shift

--- a/generate.bat
+++ b/generate.bat
@@ -1,7 +1,7 @@
 @echo off
 REM generate.bat - Standalone CMake configuration generator for SparkEngine
 
-set GEN="Visual Studio 17 2022"
+set "GEN=Visual Studio 17 2022"
 set CONFIG=Debug
 
 :parse_args
@@ -20,7 +20,7 @@ if not exist build (
 cd build
 
 echo [*] Running CMake configure for %GEN% (%CONFIG%)...
-cmake .. -G %GEN% -DCMAKE_BUILD_TYPE=%CONFIG%
+cmake .. -G "%GEN%" -DCMAKE_BUILD_TYPE=%CONFIG%
 
 cd ..
 echo [*] CMake configuration/sln generation complete.


### PR DESCRIPTION
Manually cherry-picked and resolved conflicts from 5 stability commits, adapting changes for the SparkEngine/ directory structure (renamed from 'Spark Engine/').

Build system fixes:
- Move CMAKE_MSVC_RUNTIME_LIBRARY after project() (MSVC var undefined before)
- Fix overly broad test file exclusion regex (was excluding TextProcessor.cpp etc)
- Distinguish macOS from Linux platform defines
- Guard sol2 target creation with NOT TARGET check
- Add enable_testing() to root CMakeLists.txt for ctest discovery
- Upgrade ThirdParty/SparkShaderCompiler C++ standard from 17 to 20
- Make SparkConsole cross-platform (platform-specific linking)
- Add non-Windows ImGui core-only build
- Fix AngelScript CMake path to match angelscript-mirror submodule
- Fix EnTT include path (single_include)
- Remove branch triggers from release.yml (tag-only + manual dispatch)

Shader fixes:
- Add missing PI constant to PBRSurface.hlsl
- Fix BasicVS.hlsl cbuffer register b1->b0 (conflict with BasicPS LightBuffer)
- Fix Water.hlsl/Water.glsl: use SampleLevel/textureLod in vertex shader
- Fix DebugUtils.hlsl: replace bitwise XOR on floats with abs(a-b)
- Normalize GaussianBlur weights to sum to 1.0 (HLSL + GLSL)

Critical bug fixes:
- Fix CrashHandler WideToUtf8 embedded null terminator
- Fix CrashHandler thread enumeration skipping first thread
- Fix CrashHandler null pointer dereference in SaveScreenshot
- Fix CrashHandler COM resource leak (missing CoUninitialize)
- Fix division by zero in Game.cpp when window is minimized
- Fix SceneManager LoadJSON metadata comment parsing
- Fix SceneManager ParseFloat3 initializer list error (C2664 on MSVC)
- Add duplicate name check in Console_RenameNode
- Make m_dirty mutable to eliminate const_cast UB
- Add platform-aware console clear (cls vs clear)

Cross-platform improvements:
- Add XMPlaneNormalize/XMPlaneDotCoord stubs to Platform.h
- Add non-Windows CrashHandler stubs
- Add windowsx.h include for GET_X_LPARAM
- Rename FrustumCulling BoundingSphere to CullingSphere (avoids conflict)
- Add mutual exclusion guards for PostProcessing.h/PostProcessingSystem.h
- Add non-const GetDesc() overload to RenderTarget

Config fixes:
- Remove markdown fences wrapping .gitignore
- Add .editorconfig LF override for *.sh files
- Fix build.sh -g flag missing argument guard
- Fix generate.bat variable quoting

https://claude.ai/code/session_01WTFzMC1WDzzA5uj3wn7DpF