### PR TITLE
Fix Vulkan linker error in SparkShaderCompiler

### DIFF
--- a/SparkShaderCompiler/CMakeLists.txt
+++ b/SparkShaderCompiler/CMakeLists.txt
@@ -26,6 +26,12 @@ if(WIN32)
     )
 endif()
 
+if(SPARK_VULKAN_AVAILABLE)
+    list(APPEND RHI_SOURCES
+        "${CMAKE_SOURCE_DIR}/SparkEngine/Source/Graphics/RHI/Vulkan/VulkanDevice.cpp"
+    )
+endif()
+
 add_executable(SparkShaderCompiler
     ${COMPILER_SOURCES}
     ${RHI_SOURCES}
@@ -41,6 +47,16 @@ target_compile_features(SparkShaderCompiler PRIVATE cxx_std_17)
 # Platform-specific link libraries
 if(WIN32)
     target_link_libraries(SparkShaderCompiler PRIVATE d3dcompiler)
+endif()
+
+if(SPARK_VULKAN_AVAILABLE)
+    target_compile_definitions(SparkShaderCompiler PRIVATE SPARK_VULKAN_SUPPORT)
+    if(Vulkan_FOUND)
+        target_link_libraries(SparkShaderCompiler PRIVATE Vulkan::Vulkan)
+    else()
+        target_include_directories(SparkShaderCompiler PRIVATE "${Vulkan_INCLUDE_DIR}")
+        target_link_libraries(SparkShaderCompiler PRIVATE "${Vulkan_LIBRARY}")
+    endif()
 endif()
 
 set_target_properties(SparkShaderCompiler PROPERTIES


### PR DESCRIPTION
SparkShaderCompiler links RHIFactory.cpp which references VulkanDevice, but VulkanDevice.cpp was not included in the build. Add VulkanDevice.cpp to the compiler sources and link Vulkan libraries when available.

https://claude.ai/code/session_01JM9ki1HjKWRjpJRGTxyk9K