### PR TITLE
Add SparkTemplates link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,10 @@ cd docs
 
 Requires `doxygen` and `graphviz`.
 
+## Templates
+
+Check out **[SparkTemplates](https://github.com/Krilliac/SparkTemplates)** for ready-made project templates and starter kits built on Spark Engine. These templates give you a pre-configured starting point so you can jump straight into building your game without setting everything up from scratch.
+
 ## License
 
 MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Link to the SparkTemplates repository so users can find ready-made project templates and starter kits for the engine.

https://claude.ai/code/session_01Tf7ti3f5x7Xtg8txBhzisd