### PR TITLE
Fix Linux build dependencies and RHI backend detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+*.sh text eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ chmod +x generate.sh
 ### Requirements
 
 - **Compiler**: MSVC v143 (Visual Studio 2022), GCC 11+, or Clang 14+ with C++20 support
-- **Build System**: CMake 3.16+
+- **Build System**: CMake 3.16+, Ninja (recommended on Linux)
+- **Linux packages**: `build-essential`, `ninja-build`, `cmake` (e.g. `sudo apt install build-essential ninja-build cmake`)
 - **Graphics**: DirectX 11 capable GPU (Windows), Vulkan SDK (optional), OpenGL 4.5 (optional)
 - **Platform**: Windows 10+ (primary), Linux (experimental)
 

--- a/SparkEngine/Source/Graphics/RHI/RHIFactory.cpp
+++ b/SparkEngine/Source/Graphics/RHI/RHIFactory.cpp
@@ -58,7 +58,10 @@ namespace Spark
             auto backends = DetectAvailableBackends();
 
             if (backends.empty())
-                return GraphicsBackend::Auto;
+            {
+                std::cerr << "[RHI] No graphics backends available on this platform." << std::endl;
+                return GraphicsBackend::None;
+            }
 
                 // Priority: D3D11 on Windows, Vulkan on Linux, OpenGL as fallback
 #ifdef _WIN32
@@ -78,6 +81,12 @@ namespace Spark
         {
             if (backend == GraphicsBackend::Auto)
                 backend = GetRecommendedBackend();
+
+            if (backend == GraphicsBackend::None)
+            {
+                std::cerr << "[RHI] No graphics backend available. Engine will run without rendering." << std::endl;
+                return nullptr;
+            }
 
             std::unique_ptr<IRHIDevice> device;
 
@@ -126,6 +135,8 @@ namespace Spark
                 return "Metal";
             case GraphicsBackend::Auto:
                 return "Auto";
+            case GraphicsBackend::None:
+                return "None";
             default:
                 return "Unknown";
             }

--- a/SparkEngine/Source/Graphics/RHI/RHITypes.h
+++ b/SparkEngine/Source/Graphics/RHI/RHITypes.h
@@ -32,7 +32,8 @@ namespace Spark
             Vulkan,
             OpenGL,
             Metal,
-            Auto // Auto-detect best available
+            Auto, // Auto-detect best available
+            None  // No backend available
         };
 
         // ============================================================================

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # build.sh  â”€ simple cross-platform build helper
 set -e
 
 CFG=Debug
-GENERATOR="Unix Makefiles"
+GENERATOR="Ninja"
 ENABLE_EDITOR=ON
 ENABLE_CONSOLE=ON
 ENABLE_AS=ON

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -11,6 +11,13 @@ This guide covers everything you need to clone, build, and run SparkEngine from 
 | **Graphics** | DirectX 11 capable GPU (Windows). Vulkan SDK optional. OpenGL 4.5 optional. |
 | **Platform** | Windows 10+ (primary), Linux x64 (experimental) |
 | **Git** | For cloning with submodules |
+| **Linux packages** | `build-essential`, `ninja-build`, `cmake` |
+
+**Linux (Debian/Ubuntu):**
+
+```bash
+sudo apt install build-essential ninja-build cmake
+```
 
 ## Clone the Repository
 


### PR DESCRIPTION
- Strip UTF-8 BOM from build.sh that prevented execution on Linux
- Default build.sh CMake generator to Ninja (was Unix Makefiles)
- Add *.sh eol=lf rule to .gitattributes to prevent BOM/CRLF issues
- Document Linux prerequisites (build-essential, ninja-build, cmake) in README.md and wiki/Getting-Started.md
- Fix RHI GetRecommendedBackend() returning Auto when no backends are compiled in, causing confusing "Backend 'Auto' is not available" error. Now returns None with a clear diagnostic message.

https://claude.ai/code/session_01DJUjMxRjSS2ihDHhemup7c