### PR TITLE
Fix shutdown segfault and complete CrashHandler stub API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1099,3 +1099,101 @@ message(STATUS "  Mesh LOD       : ${ENABLE_MESH_LOD}")
 message(STATUS "  DXR RayTracing : ${ENABLE_DXR}")
 message(STATUS "  SDL2 Input     : ${ENABLE_SDL2}")
 message(STATUS "  Headless Mode  : ${SPARK_HEADLESS_SUPPORT}")
+
+# ---------------------------------------------------------------------
+# 19) Third-party dependency status and missing module warnings
+# ---------------------------------------------------------------------
+message(STATUS "")
+message(STATUS "=== THIRD-PARTY DEPENDENCY STATUS ===")
+
+set(_SPARK_MISSING_DEPS "")
+set(_SPARK_MISSING_COUNT 0)
+
+# Bullet Physics
+if(BULLET_FOUND)
+    message(STATUS "  [OK]      Bullet Physics  — rigid body physics, collision, raycasting")
+else()
+    list(APPEND _SPARK_MISSING_DEPS "bullet3")
+    math(EXPR _SPARK_MISSING_COUNT "${_SPARK_MISSING_COUNT} + 1")
+    message(STATUS "  [MISSING] Bullet Physics  — PhysicsSystem disabled, no rigid body simulation")
+endif()
+
+# miniz
+if(MINIZ_FOUND)
+    message(STATUS "  [OK]      miniz           — crash dump compression, save file compression")
+else()
+    list(APPEND _SPARK_MISSING_DEPS "miniz")
+    math(EXPR _SPARK_MISSING_COUNT "${_SPARK_MISSING_COUNT} + 1")
+    message(STATUS "  [MISSING] miniz           — CrashHandler disabled (using stub), no save compression")
+endif()
+
+# EnTT
+if(EXISTS "${CMAKE_SOURCE_DIR}/ThirdParty/ECS/entt/single_include/entt/entt.hpp")
+    message(STATUS "  [OK]      EnTT            — entity component system")
+else()
+    list(APPEND _SPARK_MISSING_DEPS "entt")
+    math(EXPR _SPARK_MISSING_COUNT "${_SPARK_MISSING_COUNT} + 1")
+    message(STATUS "  [STUB]    EnTT            — using minimal stub, ECS features limited")
+endif()
+
+# Dear ImGui
+if(EXISTS "${CMAKE_SOURCE_DIR}/ThirdParty/UI/imgui/imgui.cpp")
+    message(STATUS "  [OK]      Dear ImGui      — editor UI, debug overlays")
+else()
+    list(APPEND _SPARK_MISSING_DEPS "imgui")
+    math(EXPR _SPARK_MISSING_COUNT "${_SPARK_MISSING_COUNT} + 1")
+    message(STATUS "  [MISSING] Dear ImGui      — editor and debug UI unavailable")
+endif()
+
+# AngelScript
+if(EXISTS "${CMAKE_SOURCE_DIR}/ThirdParty/Scripting/angelscript-mirror/angelscript/include")
+    message(STATUS "  [OK]      AngelScript     — hot-reload scripting")
+else()
+    list(APPEND _SPARK_MISSING_DEPS "angelscript")
+    math(EXPR _SPARK_MISSING_COUNT "${_SPARK_MISSING_COUNT} + 1")
+    message(STATUS "  [MISSING] AngelScript     — scripting system unavailable")
+endif()
+
+# curl
+if(EXISTS "${CMAKE_SOURCE_DIR}/ThirdParty/Networking/curl/CMakeLists.txt")
+    message(STATUS "  [OK]      curl            — HTTP client (networking)")
+else()
+    list(APPEND _SPARK_MISSING_DEPS "curl")
+    math(EXPR _SPARK_MISSING_COUNT "${_SPARK_MISSING_COUNT} + 1")
+    message(STATUS "  [MISSING] curl            — HTTP networking unavailable")
+endif()
+
+# TinyObjLoader
+if(TINYOBJ_FOUND)
+    message(STATUS "  [OK]      TinyObjLoader   — OBJ model loading")
+else()
+    message(STATUS "  [MISSING] TinyObjLoader   — OBJ model loading unavailable")
+endif()
+
+# SDL2 (Linux)
+if(ENABLE_SDL2)
+    if(SDL2_FOUND OR SDL2_PKG_FOUND)
+        message(STATUS "  [OK]      SDL2            — cross-platform windowing and input")
+    else()
+        list(APPEND _SPARK_MISSING_DEPS "SDL2")
+        math(EXPR _SPARK_MISSING_COUNT "${_SPARK_MISSING_COUNT} + 1")
+        message(STATUS "  [MISSING] SDL2            — no windowed mode on Linux (install libsdl2-dev)")
+    endif()
+endif()
+
+# Print warnings if dependencies are missing
+if(_SPARK_MISSING_COUNT GREATER 0)
+    message(STATUS "")
+    message(WARNING
+        "${_SPARK_MISSING_COUNT} third-party dependency(ies) not found: ${_SPARK_MISSING_DEPS}\n"
+        "  The engine will build but with DEGRADED functionality.\n"
+        "  To fix: initialize git submodules and install system packages:\n"
+        "    git submodule update --init --recursive\n"
+        "    # Linux: sudo apt install libsdl2-dev    (for SDL2)\n"
+        "  See README.md 'Dependencies' section for details."
+    )
+else()
+    message(STATUS "")
+    message(STATUS "All third-party dependencies found. Full engine functionality available.")
+endif()
+message(STATUS "")

--- a/SparkEngine/Source/Core/SparkEngine.cpp
+++ b/SparkEngine/Source/Core/SparkEngine.cpp
@@ -59,8 +59,10 @@ static void LogMissingModuleWarnings()
     int missingCount = 0;
 
 #ifndef SPARK_BULLET_PHYSICS_AVAILABLE
-    console.LogWarning("[MISSING MODULE] Bullet Physics — rigid body simulation, collision detection, and raycasting are DISABLED.");
-    console.LogWarning("                 Physics-dependent features (gravity, projectiles, triggers) will not function.");
+    console.LogWarning(
+        "[MISSING MODULE] Bullet Physics — rigid body simulation, collision detection, and raycasting are DISABLED.");
+    console.LogWarning(
+        "                 Physics-dependent features (gravity, projectiles, triggers) will not function.");
     ++missingCount;
 #endif
 
@@ -1158,8 +1160,10 @@ static void LogMissingModuleWarnings()
     int missingCount = 0;
 
 #ifndef SPARK_BULLET_PHYSICS_AVAILABLE
-    console.LogWarning("[MISSING MODULE] Bullet Physics — rigid body simulation, collision detection, and raycasting are DISABLED.");
-    console.LogWarning("                 Physics-dependent features (gravity, projectiles, triggers) will not function.");
+    console.LogWarning(
+        "[MISSING MODULE] Bullet Physics — rigid body simulation, collision detection, and raycasting are DISABLED.");
+    console.LogWarning(
+        "                 Physics-dependent features (gravity, projectiles, triggers) will not function.");
     ++missingCount;
 #endif
 

--- a/SparkEngine/Source/Core/SparkEngine.cpp
+++ b/SparkEngine/Source/Core/SparkEngine.cpp
@@ -51,6 +51,45 @@
 #include "Graphics/GraphicsConsoleCommands.h"
 
 // -----------------------------------------------------------------------------
+// Missing module startup warnings
+// -----------------------------------------------------------------------------
+static void LogMissingModuleWarnings()
+{
+    auto& console = Spark::SimpleConsole::GetInstance();
+    int missingCount = 0;
+
+#ifndef SPARK_BULLET_PHYSICS_AVAILABLE
+    console.LogWarning("[MISSING MODULE] Bullet Physics — rigid body simulation, collision detection, and raycasting are DISABLED.");
+    console.LogWarning("                 Physics-dependent features (gravity, projectiles, triggers) will not function.");
+    ++missingCount;
+#endif
+
+#ifndef SPARK_MINIZ_AVAILABLE
+    console.LogWarning("[MISSING MODULE] miniz — crash dump compression and save file compression are DISABLED.");
+    console.LogWarning("                 CrashHandler is using a stub. Save files will not be compressed.");
+    ++missingCount;
+#endif
+
+#ifndef SPARK_SDL2_AVAILABLE
+#ifndef SPARK_PLATFORM_WINDOWS
+    console.LogWarning("[MISSING MODULE] SDL2 — cross-platform windowing and input are DISABLED.");
+    console.LogWarning("                 Install libsdl2-dev and rebuild with -DENABLE_SDL2=ON for windowed mode.");
+    ++missingCount;
+#endif
+#endif
+
+    if (missingCount > 0)
+    {
+        console.LogWarning("------------------------------------------------------------");
+        console.LogWarning(std::to_string(missingCount) + " module(s) missing. Expect degraded functionality.");
+        console.LogWarning("Run: git submodule update --init --recursive");
+        console.LogWarning("Then rebuild to restore full engine features.");
+        console.LogWarning("See README.md 'Dependencies' section for details.");
+        console.LogWarning("------------------------------------------------------------");
+    }
+}
+
+// -----------------------------------------------------------------------------
 // Globals
 // -----------------------------------------------------------------------------
 constexpr int MAX_LOADSTRING = 100;
@@ -368,6 +407,9 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR 
     // 8. Register engine console commands
     RegisterEngineConsoleCommands();
     EngineSettings::GetInstance().RegisterConsoleCommands();
+
+    // 8b. Log warnings for missing third-party modules
+    LogMissingModuleWarnings();
 
     // 9. Message loop + tick
     HACCEL accel = LoadAccelerators(hInstance, MAKEINTRESOURCE(IDC_SparkEngine));
@@ -1107,6 +1149,43 @@ std::unique_ptr<AudioEngine> g_audioEngine;
 std::unique_ptr<PhysicsSystem> g_physicsOwned;
 #endif
 
+// -----------------------------------------------------------------------------
+// Missing module startup warnings (Linux)
+// -----------------------------------------------------------------------------
+static void LogMissingModuleWarnings()
+{
+    auto& console = Spark::SimpleConsole::GetInstance();
+    int missingCount = 0;
+
+#ifndef SPARK_BULLET_PHYSICS_AVAILABLE
+    console.LogWarning("[MISSING MODULE] Bullet Physics — rigid body simulation, collision detection, and raycasting are DISABLED.");
+    console.LogWarning("                 Physics-dependent features (gravity, projectiles, triggers) will not function.");
+    ++missingCount;
+#endif
+
+#ifndef SPARK_MINIZ_AVAILABLE
+    console.LogWarning("[MISSING MODULE] miniz — crash dump compression and save file compression are DISABLED.");
+    console.LogWarning("                 CrashHandler is using a stub. Save files will not be compressed.");
+    ++missingCount;
+#endif
+
+#ifndef SPARK_SDL2_AVAILABLE
+    console.LogWarning("[MISSING MODULE] SDL2 — cross-platform windowing and input are DISABLED.");
+    console.LogWarning("                 Install libsdl2-dev and rebuild with -DENABLE_SDL2=ON for windowed mode.");
+    ++missingCount;
+#endif
+
+    if (missingCount > 0)
+    {
+        console.LogWarning("------------------------------------------------------------");
+        console.LogWarning(std::to_string(missingCount) + " module(s) missing. Expect degraded functionality.");
+        console.LogWarning("Run: git submodule update --init --recursive");
+        console.LogWarning("Then rebuild to restore full engine features.");
+        console.LogWarning("See README.md 'Dependencies' section for details.");
+        console.LogWarning("------------------------------------------------------------");
+    }
+}
+
 static volatile bool g_shutdownRequested = false;
 
 static void SignalHandler(int)
@@ -1372,6 +1451,7 @@ int main(int argc, char* argv[])
 
         Spark::SaveSystem::GetInstance().Initialize("Saves");
         RegisterEngineConsoleCommandsLinux();
+        LogMissingModuleWarnings();
 
         constexpr auto TICK_INTERVAL = std::chrono::microseconds(16667);
         console.LogInfo("Starting headless server loop (60 Hz)...");
@@ -1536,6 +1616,9 @@ int main(int argc, char* argv[])
     // 8. Console commands
     RegisterEngineConsoleCommandsLinux();
     settings.RegisterConsoleCommands();
+
+    // 8b. Log warnings for missing third-party modules
+    LogMissingModuleWarnings();
 
     // 9. Main event loop (SDL2)
     console.LogInfo("Starting main engine loop (SDL2)...");
@@ -1726,6 +1809,7 @@ int main(int argc, char* argv[])
     auto& console = Spark::SimpleConsole::GetInstance();
     console.Initialize();
     console.LogWarning("No SDL2 - engine will exit after initialization.");
+    LogMissingModuleWarnings();
 
     if (LoadGameModulesLinux(*g_moduleManager, argc, argv))
     {

--- a/SparkEngine/Source/Utils/CrashHandlerStub.cpp
+++ b/SparkEngine/Source/Utils/CrashHandlerStub.cpp
@@ -1,16 +1,27 @@
 /**
  * @file CrashHandlerStub.cpp
- * @brief No-op fallback for TriggerCrashHandler when CrashHandler.cpp is
- *        excluded from the build (e.g. miniz not available).
+ * @brief No-op fallbacks for CrashHandler when CrashHandler.cpp is excluded
+ *        from the build (e.g. miniz not available).
  *
  * This file is only compiled when MINIZ is not found. When miniz IS available,
  * the real CrashHandler.cpp provides the full implementation.
  */
 
+#include "CrashHandler.h"
 #include <cstdio>
+
+void InstallCrashHandler(const CrashConfig& /*cfg*/)
+{
+    // No crash handler available without miniz
+}
 
 void TriggerCrashHandler(const char* assertMsg)
 {
     if (assertMsg)
         std::fprintf(stderr, "Assert (no crash handler): %s\n", assertMsg);
+}
+
+void SetAssertCrashBehavior(bool /*shouldCrash*/)
+{
+    // No-op without crash handler
 }

--- a/SparkGame/Source/Game/Game.cpp
+++ b/SparkGame/Source/Game/Game.cpp
@@ -426,6 +426,10 @@ HRESULT Game::Initialize(GraphicsEngine* graphics, InputManager* input)
 --------------------------------------------------------------*/
 void Game::Shutdown()
 {
+    if (m_isShutDown)
+        return;
+    m_isShutDown = true;
+
     LOG_TO_CONSOLE_IMMEDIATE(L"Game::Shutdown called.", L"INFO");
 
     m_gameObjects.clear();

--- a/SparkGame/Source/Game/Game.h
+++ b/SparkGame/Source/Game/Game.h
@@ -493,8 +493,8 @@ class SPARK_GAME_API Game
     // Scene objects
     std::vector<std::unique_ptr<GameObject>> m_gameObjects; ///< All game objects in the scene
 
-    bool m_isPaused{false};    ///< Current pause state of the game
-    bool m_isShutDown{false};  ///< Guards against double-shutdown
+    bool m_isPaused{false};   ///< Current pause state of the game
+    bool m_isShutDown{false}; ///< Guards against double-shutdown
 
     // Console integration state
     float m_timeScale{1.0f};           ///< Global time scale multiplier for console control

--- a/SparkGame/Source/Game/Game.h
+++ b/SparkGame/Source/Game/Game.h
@@ -493,7 +493,8 @@ class SPARK_GAME_API Game
     // Scene objects
     std::vector<std::unique_ptr<GameObject>> m_gameObjects; ///< All game objects in the scene
 
-    bool m_isPaused{false}; ///< Current pause state of the game
+    bool m_isPaused{false};    ///< Current pause state of the game
+    bool m_isShutDown{false};  ///< Guards against double-shutdown
 
     // Console integration state
     float m_timeScale{1.0f};           ///< Global time scale multiplier for console control

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
   Configure & build SparkEngine from PowerShell.
 .PARAMETER Config
@@ -22,6 +22,50 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+
+# -----------------------------------------------------------------
+# Check and initialize git submodules
+# -----------------------------------------------------------------
+Write-Host ""
+Write-Host "=== Checking git submodules ===" -ForegroundColor Cyan
+
+$submodules = @(
+    @{ Path = "ThirdParty\Utils\miniz";                        Name = "miniz";          Desc = "Compression (crash dumps, save files)" },
+    @{ Path = "ThirdParty\Physics\bullet3";                    Name = "Bullet Physics"; Desc = "Rigid body physics, collision, raycasting" },
+    @{ Path = "ThirdParty\UI\imgui";                           Name = "Dear ImGui";     Desc = "Editor UI, debug overlays" },
+    @{ Path = "ThirdParty\ECS\entt";                           Name = "EnTT";           Desc = "Entity component system" },
+    @{ Path = "ThirdParty\Scripting\angelscript-mirror";       Name = "AngelScript";    Desc = "Hot-reload scripting" },
+    @{ Path = "ThirdParty\Networking\curl";                    Name = "curl";           Desc = "HTTP networking (optional)" }
+)
+
+$missingSubmodules = 0
+foreach ($sub in $submodules) {
+    $fullPath = Join-Path $PSScriptRoot $sub.Path
+    if ((Test-Path $fullPath) -and ((Get-ChildItem $fullPath -Force | Measure-Object).Count -eq 0)) {
+        Write-Host "  [MISSING] $($sub.Name) ($($sub.Path)) - $($sub.Desc)" -ForegroundColor Yellow
+        $missingSubmodules++
+    } elseif (-not (Test-Path $fullPath)) {
+        Write-Host "  [MISSING] $($sub.Name) ($($sub.Path)) - $($sub.Desc)" -ForegroundColor Yellow
+        $missingSubmodules++
+    } else {
+        Write-Host "  [OK]      $($sub.Name)" -ForegroundColor Green
+    }
+}
+
+if ($missingSubmodules -gt 0) {
+    Write-Host ""
+    Write-Host "WARNING: $missingSubmodules submodule(s) not initialized." -ForegroundColor Yellow
+    Write-Host "  The engine will build but with DEGRADED functionality." -ForegroundColor Yellow
+    Write-Host "  Initializing submodules now..." -ForegroundColor Yellow
+    Write-Host ""
+    git submodule update --init --recursive
+    Write-Host ""
+    Write-Host "Submodules initialized successfully." -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "=== Building SparkEngine ($config) ===" -ForegroundColor Cyan
+Write-Host ""
 
 $buildDir = "build"
 if (!(Test-Path $buildDir)) { New-Item $buildDir -ItemType Directory | Out-Null }

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# build.sh  â”€ simple cross-platform build helper
+# build.sh  — simple cross-platform build helper
 set -e
 
 CFG=Debug
@@ -26,6 +26,104 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
+
+# -----------------------------------------------------------------
+# Check and initialize git submodules
+# -----------------------------------------------------------------
+echo ""
+echo "=== Checking git submodules ==="
+
+SUBMODULES=(
+  "ThirdParty/Utils/miniz|miniz|Compression (crash dumps, save files)"
+  "ThirdParty/Physics/bullet3|Bullet Physics|Rigid body physics, collision, raycasting"
+  "ThirdParty/UI/imgui|Dear ImGui|Editor UI, debug overlays"
+  "ThirdParty/ECS/entt|EnTT|Entity component system"
+  "ThirdParty/Scripting/angelscript-mirror|AngelScript|Hot-reload scripting"
+  "ThirdParty/Networking/curl|curl|HTTP networking (optional)"
+)
+
+missing_submodules=0
+for entry in "${SUBMODULES[@]}"; do
+  IFS='|' read -r path name desc <<< "$entry"
+  # A submodule directory exists but is empty (not initialized) when it has no files
+  if [ -d "$path" ] && [ -z "$(ls -A "$path" 2>/dev/null)" ]; then
+    echo "  [MISSING] $name ($path) — $desc"
+    missing_submodules=$((missing_submodules + 1))
+  elif [ ! -d "$path" ]; then
+    echo "  [MISSING] $name ($path) — $desc"
+    missing_submodules=$((missing_submodules + 1))
+  else
+    echo "  [OK]      $name"
+  fi
+done
+
+if [ "$missing_submodules" -gt 0 ]; then
+  echo ""
+  echo "WARNING: $missing_submodules submodule(s) not initialized."
+  echo "  The engine will build but with DEGRADED functionality."
+  echo "  Initializing submodules now..."
+  echo ""
+  git submodule update --init --recursive
+  echo ""
+  echo "Submodules initialized successfully."
+fi
+
+# -----------------------------------------------------------------
+# Check system dependencies (Linux)
+# -----------------------------------------------------------------
+echo ""
+echo "=== Checking system dependencies ==="
+
+missing_deps=0
+
+# SDL2
+if pkg-config --exists sdl2 2>/dev/null; then
+  echo "  [OK]      SDL2 ($(pkg-config --modversion sdl2))"
+elif [ -f /usr/include/SDL2/SDL.h ] || [ -f /usr/local/include/SDL2/SDL.h ]; then
+  echo "  [OK]      SDL2 (headers found)"
+else
+  echo "  [MISSING] SDL2 — Install with: sudo apt install libsdl2-dev"
+  echo "            Without SDL2, Linux builds will run in headless/fallback mode only."
+  missing_deps=$((missing_deps + 1))
+fi
+
+# Vulkan SDK (optional)
+if pkg-config --exists vulkan 2>/dev/null || [ -n "${VULKAN_SDK:-}" ]; then
+  echo "  [OK]      Vulkan SDK"
+else
+  echo "  [INFO]    Vulkan SDK not found (optional — Vulkan backend will be disabled)"
+fi
+
+# CMake
+if command -v cmake &>/dev/null; then
+  echo "  [OK]      CMake ($(cmake --version | head -1 | sed 's/cmake version //'))"
+else
+  echo "  [MISSING] CMake — Install with: sudo apt install cmake"
+  missing_deps=$((missing_deps + 1))
+fi
+
+# Build tool
+if [ "$GENERATOR" = "Ninja" ]; then
+  if command -v ninja &>/dev/null; then
+    echo "  [OK]      Ninja ($(ninja --version))"
+  else
+    echo "  [MISSING] Ninja — Install with: sudo apt install ninja-build"
+    echo "            Or use -g 'Unix Makefiles' to build with make instead."
+    missing_deps=$((missing_deps + 1))
+  fi
+fi
+
+if [ "$missing_deps" -gt 0 ]; then
+  echo ""
+  echo "WARNING: $missing_deps system dependency(ies) missing."
+  echo "  Install the missing packages above for full functionality."
+  echo "  Quick install (Ubuntu/Debian): sudo apt install build-essential ninja-build cmake libsdl2-dev"
+  echo ""
+fi
+
+echo ""
+echo "=== Configuring and building SparkEngine ($CFG) ==="
+echo ""
 
 mkdir -p build && cd build
 cmake .. -G "${GENERATOR}" \


### PR DESCRIPTION
- Add m_isShutDown guard to Game::Shutdown() to prevent double-free when
  the destructor calls Shutdown() after it was already called by the
  module unload sequence.
- Add InstallCrashHandler() and SetAssertCrashBehavior() stubs so the
  game module can load when miniz/CrashHandler.cpp is excluded.

https://claude.ai/code/session_016FTwkQrNkUzSzNbrT3NLjz