### PR TITLE
Add game module and templates documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,9 +362,32 @@ cd docs
 
 Requires `doxygen` and `graphviz`.
 
-## Templates
+## Templates & Game Modules
 
-Check out **[SparkTemplates](https://github.com/Krilliac/SparkTemplates)** for ready-made project templates and starter kits built on Spark Engine. These templates give you a pre-configured starting point so you can jump straight into building your game without setting everything up from scratch.
+SparkEngine supports **game modules** — shared libraries (`.dll` on Windows, `.so` on Linux) that the engine loads at startup. This lets you build your game independently from the engine using only the installed SDK.
+
+### Quick Start (Game Module)
+
+```bash
+# 1. Install SparkEngine to a local prefix
+cmake --install build --prefix ~/SparkEngine-install
+
+# 2. Copy the empty template and build it
+cp -r Templates/EmptyProject MyGame && cd MyGame
+# Replace {{PROJECT_NAME}} placeholders with your project name
+cmake -B build -DCMAKE_PREFIX_PATH=~/SparkEngine-install
+cmake --build build --config Release
+
+# 3. Run your module through the engine
+# Windows:  SparkEngine.exe -game MyGame.dll
+# Linux:    ./SparkEngine -game libMyGame.so
+```
+
+> **Important:** You must use the **install prefix** (the path passed to `--prefix`) as `CMAKE_PREFIX_PATH`, not the build directory. The build tree does not contain the CMake config files that `find_package(SparkEngine)` needs.
+
+See **[Templates/README.md](Templates/README.md)** for full documentation on prerequisites, project structure, and creating new projects.
+
+For additional templates covering physics, AI, networking, procedural generation, and more, check out **[SparkTemplates](https://github.com/Krilliac/SparkTemplates)**.
 
 ## License
 

--- a/Templates/EmptyProject/README.md
+++ b/Templates/EmptyProject/README.md
@@ -1,0 +1,62 @@
+# EmptyProject — Spark Engine Template
+
+A minimal game module template for SparkEngine. Provides a blank `Spark::IModule` implementation with the correct project structure, CMake configuration, and DLL exports — ready for you to add your game logic.
+
+## Prerequisites
+
+This template requires a **built and installed** SparkEngine SDK. See the [Templates README](../README.md) for full installation instructions.
+
+> **Short version:** You need to run `cmake --install build --prefix <install-path>` on SparkEngine so that `find_package(SparkEngine)` can locate the SDK.
+
+## Setup
+
+1. Copy this directory and rename it to your project name:
+   ```bash
+   cp -r Templates/EmptyProject MyGame
+   cd MyGame
+   ```
+
+2. Replace all `{{PROJECT_NAME}}` placeholders with your project name in:
+   - `CMakeLists.txt`
+   - `Source/GameModule.h`
+   - `Source/GameModule.cpp`
+   - `spark.project.json`
+   - `spark.modules.json`
+
+## Build
+
+```bash
+cmake -B build -DCMAKE_PREFIX_PATH=<path-to-SparkEngine-install-prefix>
+cmake --build build --config Release
+```
+
+> **Warning:** Do not pass the SparkEngine build directory or its `bin/` subdirectory as `CMAKE_PREFIX_PATH`. This will fail because the build tree does not contain the installed config files. Always use the **install prefix** (the path you passed to `--prefix`).
+
+## Run
+
+The template compiles into a shared library (game module), not a standalone executable. Launch it through the SparkEngine executable:
+
+```bash
+# Windows
+SparkEngine.exe -game MyGame.dll
+
+# Linux
+./SparkEngine -game libMyGame.so
+```
+
+## What's Included
+
+| File | Purpose |
+|------|---------|
+| `CMakeLists.txt` | Standalone CMake project — calls `find_package(SparkEngine)` and `spark_add_game_module()` |
+| `Source/GameModule.h` | Your `IModule` subclass with lifecycle stubs (`OnLoad`, `OnUnload`, `OnUpdate`, `OnRender`) |
+| `Source/GameModule.cpp` | DLL exports via `SPARK_IMPLEMENT_MODULE()` |
+| `spark.project.json` | Project metadata (name, version, engine version, default scene) |
+| `spark.modules.json` | Module loading config (DLL path and load order) |
+
+## Next Steps
+
+- Implement your game logic in `GameModule::OnUpdate()` and `GameModule::OnRender()`
+- Use the `Spark::IEngineContext*` provided in `OnLoad()` to access engine subsystems
+- Add assets under an `Assets/` directory — they will be copied to the output automatically
+- See the **[SparkTemplates](https://github.com/Krilliac/SparkTemplates)** repository for more advanced examples (physics, AI, networking, etc.)

--- a/Templates/README.md
+++ b/Templates/README.md
@@ -1,0 +1,106 @@
+# Spark Engine — Game Module Templates
+
+This directory contains project templates for building **game modules** that run on SparkEngine. Each template is a standalone CMake project that compiles into a shared library loaded by the engine at runtime.
+
+## Templates
+
+| Name | Description |
+|------|-------------|
+| **EmptyProject** | Minimal scaffolding — a blank `IModule` implementation ready for your game logic |
+
+> For additional templates (physics, AI, networking, procedural generation, and more), see the **[SparkTemplates](https://github.com/Krilliac/SparkTemplates)** repository.
+
+## Prerequisites
+
+These templates require a **built and installed** copy of SparkEngine on your system. "Installed" means you have run CMake's install step — pointing at the raw build tree will not work because the exported CMake config files (`SparkEngineConfig.cmake`, `SparkGameModule.cmake`, etc.) are only generated during installation.
+
+### Installing SparkEngine
+
+```bash
+# 1. Clone and build SparkEngine (if you haven't already)
+git clone --recurse-submodules https://github.com/Krilliac/SparkEngine.git
+cd SparkEngine
+cmake -B build
+cmake --build build --config Release
+
+# 2. Install to a local prefix (e.g. ~/SparkEngine-install)
+cmake --install build --prefix ~/SparkEngine-install
+```
+
+After this, `~/SparkEngine-install` will contain the engine executable, headers, libraries, and — critically — the CMake package config files that `find_package(SparkEngine)` needs.
+
+> **Common mistake:** Passing the build directory or the `bin/` subdirectory as `CMAKE_PREFIX_PATH`. This will fail because the build tree does not contain the installed config files. Always point at the **install prefix** (the path you passed to `--prefix`).
+
+## Building a Template
+
+Each template is a standalone CMake project:
+
+```bash
+cd Templates/EmptyProject
+cmake -B build -DCMAKE_PREFIX_PATH=<path-to-SparkEngine-install-prefix>
+cmake --build build --config Release
+```
+
+Replace `<path-to-SparkEngine-install-prefix>` with the actual install prefix you used (e.g. `~/SparkEngine-install`).
+
+> **Warning:** Do not pass the SparkEngine build directory or its `bin/` subdirectory as the prefix path. Only the install prefix contains the required CMake config files.
+
+## How Templates Relate to the Engine
+
+Each template compiles into a **game module** — a shared library (`.dll` on Windows, `.so` on Linux) — not a standalone executable. The SparkEngine executable loads the game module at startup:
+
+```bash
+# Windows
+SparkEngine.exe -game MyGame.dll
+
+# Linux
+./SparkEngine -game libMyGame.so
+```
+
+Because templates are separate shared libraries, they are built independently from the engine. You do not need the engine source tree at build time — only the installed SDK (headers + CMake config). However, a game module cannot be hot-swapped while the engine is running; you must restart the engine to pick up a rebuilt module. (AngelScript scripts *can* be hot-reloaded at runtime, but compiled C++ modules cannot.)
+
+## Template Structure
+
+Each template follows this layout:
+
+```
+TemplateName/
+├── CMakeLists.txt          # Standalone CMake project using find_package(SparkEngine)
+├── Source/
+│   ├── GameModule.h        # IModule implementation (your game logic entry point)
+│   └── GameModule.cpp      # DLL exports via SPARK_IMPLEMENT_MODULE()
+├── spark.project.json      # Project metadata (name, version, default scene)
+└── spark.modules.json      # Module loading configuration (DLL path, load order)
+```
+
+### Key Files
+
+- **`CMakeLists.txt`** — Calls `find_package(SparkEngine REQUIRED)` and uses the `spark_add_game_module()` helper to create the shared library with correct definitions and linkage.
+- **`GameModule.h`** — Your module class inheriting from `Spark::IModule`. Implement the lifecycle methods: `OnLoad()`, `OnUnload()`, `OnUpdate()`, `OnRender()`.
+- **`GameModule.cpp`** — Uses `SPARK_IMPLEMENT_MODULE(YourModuleClass)` to generate the `CreateModule()` / `DestroyModule()` DLL exports the engine requires.
+
+## Creating a New Project from a Template
+
+1. Copy the `EmptyProject` directory and rename it:
+   ```bash
+   cp -r Templates/EmptyProject MyGame
+   cd MyGame
+   ```
+
+2. Replace all `{{PROJECT_NAME}}` placeholders with your project name in `CMakeLists.txt`, `Source/GameModule.h`, `Source/GameModule.cpp`, `spark.project.json`, and `spark.modules.json`.
+
+3. Build and run:
+   ```bash
+   cmake -B build -DCMAKE_PREFIX_PATH=<path-to-SparkEngine-install-prefix>
+   cmake --build build --config Release
+
+   # Windows
+   SparkEngine.exe -game MyGame.dll
+
+   # Linux
+   ./SparkEngine -game libMyGame.so
+   ```
+
+## License
+
+MIT License. See [LICENSE](../LICENSE) for details.


### PR DESCRIPTION
Document the game module system (prerequisites, install workflow,
build instructions, and how modules relate to the engine) mirroring
the documentation style from SparkTemplates. Adds Templates/README.md,
Templates/EmptyProject/README.md, and expands the main README's
Templates section with a quick-start guide.

https://claude.ai/code/session_01F3YZV3gDDMChBMMAArzTvv