### PR TITLE
Add preflight validation for incomplete SparkEngine SDK installations

### DIFF
--- a/Templates/EmptyProject/CMakeLists.txt
+++ b/Templates/EmptyProject/CMakeLists.txt
@@ -4,6 +4,10 @@ project({{PROJECT_NAME}} LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Pre-flight validation for incomplete installations
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../cmake")
+include(SparkEnginePreflight)
+
 # Find SparkEngine (install SparkEngine first, or set SparkEngine_DIR)
 find_package(SparkEngine REQUIRED)
 

--- a/cmake/SparkEnginePreflight.cmake
+++ b/cmake/SparkEnginePreflight.cmake
@@ -1,0 +1,71 @@
+# SparkEnginePreflight.cmake
+# ---------------------------------------------------------------------------
+# Pre-flight validation for SparkEngine SDK installations.
+#
+# Include this BEFORE calling find_package(SparkEngine REQUIRED) so that
+# users get actionable diagnostics instead of a cryptic CMake "include could
+# not find requested file" error when their installation is incomplete.
+# ---------------------------------------------------------------------------
+
+# If the caller already set CMAKE_PREFIX_PATH or SparkEngine_DIR, try to
+# locate the config directory and verify that every expected file is present.
+
+function(spark_preflight_check)
+  # Collect candidate directories where SparkEngineConfig.cmake might live.
+  set(_candidates)
+
+  if(DEFINED SparkEngine_DIR AND EXISTS "${SparkEngine_DIR}")
+    list(APPEND _candidates "${SparkEngine_DIR}")
+  endif()
+
+  foreach(_prefix ${CMAKE_PREFIX_PATH})
+    foreach(_subdir
+      "lib/cmake/SparkEngine"
+      "share/cmake/SparkEngine"
+      "cmake")
+      if(EXISTS "${_prefix}/${_subdir}/SparkEngineConfig.cmake")
+        list(APPEND _candidates "${_prefix}/${_subdir}")
+      endif()
+    endforeach()
+  endforeach()
+
+  if(NOT _candidates)
+    # Nothing found — find_package will report its own "package not found"
+    # message, which is already clear enough.
+    return()
+  endif()
+
+  # Check every candidate for the required companion files.
+  set(_required_files
+    SparkEngineTargets.cmake
+    SparkGameModule.cmake
+  )
+
+  foreach(_dir ${_candidates})
+    foreach(_file ${_required_files})
+      if(NOT EXISTS "${_dir}/${_file}")
+        message(FATAL_ERROR
+          "\n"
+          "SparkEngine installation is INCOMPLETE.\n"
+          "\n"
+          "  Found config at : ${_dir}/SparkEngineConfig.cmake\n"
+          "  Missing file    : ${_dir}/${_file}\n"
+          "\n"
+          "This usually means the CMake install step was interrupted or\n"
+          "you are pointing at a build tree instead of an install prefix.\n"
+          "\n"
+          "To fix this, re-run the SparkEngine install:\n"
+          "\n"
+          "  cmake --install <build-dir> --prefix <install-prefix>\n"
+          "\n"
+          "Then configure this project with:\n"
+          "\n"
+          "  cmake -B build -DCMAKE_PREFIX_PATH=<install-prefix>\n"
+          "\n"
+        )
+      endif()
+    endforeach()
+  endforeach()
+endfunction()
+
+spark_preflight_check()

--- a/wiki/Build-System-and-CMake-Modules.md
+++ b/wiki/Build-System-and-CMake-Modules.md
@@ -147,6 +147,19 @@ This:
 - Links against SparkEngineLib
 - Handles platform-specific compilation flags
 
+### SparkEnginePreflight.cmake
+
+Validates that a SparkEngine SDK installation is complete before `find_package` runs. Include it in standalone projects to get clear error messages when `SparkEngineTargets.cmake` or `SparkGameModule.cmake` is missing (e.g. due to an interrupted install or pointing at a build tree):
+
+```cmake
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../cmake")
+include(SparkEnginePreflight)
+
+find_package(SparkEngine REQUIRED)
+```
+
+If the installation is incomplete, the preflight check emits a `FATAL_ERROR` with the exact missing file and remediation steps.
+
 ### SparkEngineConfig.cmake
 
 Enables `find_package(SparkEngine)` for standalone game projects.

--- a/wiki/Creating-a-Game-Module.md
+++ b/wiki/Creating-a-Game-Module.md
@@ -121,12 +121,16 @@ target_include_directories(MyGame PRIVATE "Source")
 
 ### As a Standalone Project
 
-For standalone projects, use `find_package`:
+For standalone projects, use `find_package`. Including the preflight check first gives clear diagnostics if the SDK installation is incomplete:
 
 ```cmake
 cmake_minimum_required(VERSION 3.16)
 project(MyGame LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
+
+# Pre-flight validation (optional but recommended)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../cmake")
+include(SparkEnginePreflight)
 
 find_package(SparkEngine REQUIRED)
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -66,6 +66,21 @@ Ensure your compiler supports C++20:
 - GCC: Version 11 or later
 - Clang: Version 14 or later
 
+### Incomplete SparkEngine Installation (Standalone Projects)
+
+**Symptom:** CMake error like `include could not find requested file: SparkEngineTargets.cmake` when configuring a standalone game project.
+
+**Cause:** `SparkEngineConfig.cmake` exists but companion files (`SparkEngineTargets.cmake`, `SparkGameModule.cmake`) are missing — typically from an interrupted install or pointing at a build tree instead of an install prefix.
+
+**Solution:** Re-run the install step and reconfigure:
+
+```bash
+cmake --install <build-dir> --prefix <install-prefix>
+cmake -B build -DCMAKE_PREFIX_PATH=<install-prefix>
+```
+
+**Tip:** Include `SparkEnginePreflight.cmake` in your project (before `find_package`) for automatic detection. See [Build System and CMake Modules](Build-System-and-CMake-Modules#sparkenginepreflight-cmake).
+
 ## Runtime Issues
 
 ### SparkEngine Crashes Immediately


### PR DESCRIPTION
Port cmake/SparkEnginePreflight.cmake from SparkTemplates PR #5. This
module validates that required companion files (SparkEngineTargets.cmake,
SparkGameModule.cmake) exist before find_package runs, giving users
actionable error messages instead of cryptic CMake failures.

- Add cmake/SparkEnginePreflight.cmake preflight check module
- Integrate preflight into Templates/EmptyProject/CMakeLists.txt
- Document the module in Build System wiki page
- Update Creating a Game Module wiki with preflight example
- Add incomplete installation troubleshooting entry

https://claude.ai/code/session_01BcCFVWk8GWQqhJdCE7kFNW