### PR TITLE
Add Linux and macOS SparkBuild binaries to weekly update workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,11 @@
 * text=auto
 *.sh text eol=lf
 
+# SparkBuild pre-built binaries — treat as binary
+tools/SparkBuild.exe binary
+tools/SparkBuild-linux binary
+tools/SparkBuild-macos binary
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/.github/workflows/update-sparkbuild.yml
+++ b/.github/workflows/update-sparkbuild.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to download (default: v1.0.0)"
+        description: "Release tag to download (default: latest)"
         required: false
-        default: "v1.0.0"
+        default: "latest"
 
 permissions:
   contents: write
@@ -25,7 +25,7 @@ jobs:
       - name: Determine tag
         id: tag
         run: |
-          TAG="${{ github.event.inputs.tag || 'v1.0.0' }}"
+          TAG="${{ github.event.inputs.tag || 'latest' }}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Fetch latest SparkBuild release info
@@ -33,64 +33,116 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Get the latest release from SparkBuild
-          LATEST=$(curl -sL \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            https://api.github.com/repos/Krilliac/SparkBuild/releases/latest)
+          TAG="${{ steps.tag.outputs.tag }}"
 
-          LATEST_TAG=$(echo "$LATEST" | jq -r '.tag_name')
+          if [ "$TAG" = "latest" ]; then
+            RELEASE=$(curl -sL \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              https://api.github.com/repos/Krilliac/SparkBuild/releases/latest)
+          else
+            RELEASE=$(curl -sL \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/Krilliac/SparkBuild/releases/tags/$TAG")
+          fi
+
+          LATEST_TAG=$(echo "$RELEASE" | jq -r '.tag_name')
           echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
 
-          # Find the SparkBuild.exe asset download URL
-          DOWNLOAD_URL=$(echo "$LATEST" | jq -r '.assets[] | select(.name == "SparkBuild.exe") | .browser_download_url')
-          echo "download_url=$DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
+          # Extract download URLs for each platform binary
+          WIN_URL=$(echo "$RELEASE" | jq -r '.assets[] | select(.name == "SparkBuild.exe") | .browser_download_url')
+          LINUX_URL=$(echo "$RELEASE" | jq -r '.assets[] | select(.name == "SparkBuild-linux") | .browser_download_url')
+          MACOS_URL=$(echo "$RELEASE" | jq -r '.assets[] | select(.name == "SparkBuild-macos") | .browser_download_url')
+
+          echo "win_url=$WIN_URL" >> "$GITHUB_OUTPUT"
+          echo "linux_url=$LINUX_URL" >> "$GITHUB_OUTPUT"
+          echo "macos_url=$MACOS_URL" >> "$GITHUB_OUTPUT"
 
           echo "[*] Latest SparkBuild release: $LATEST_TAG"
-          echo "    Download URL: $DOWNLOAD_URL"
+          echo "    Windows URL: $WIN_URL"
+          echo "    Linux URL:   $LINUX_URL"
+          echo "    macOS URL:   $MACOS_URL"
 
-      - name: Check current binary
+      - name: Compute current checksums
         id: check
         run: |
-          if [ -f tools/SparkBuild.exe ]; then
-            CURRENT_SHA=$(sha256sum tools/SparkBuild.exe | awk '{print $1}')
-          else
-            CURRENT_SHA="none"
-          fi
-          echo "current_sha=$CURRENT_SHA" >> "$GITHUB_OUTPUT"
+          for file in SparkBuild.exe SparkBuild-linux SparkBuild-macos; do
+            key=$(echo "$file" | tr '.-' '_')
+            if [ -f "tools/$file" ]; then
+              SHA=$(sha256sum "tools/$file" | awk '{print $1}')
+            else
+              SHA="none"
+            fi
+            echo "${key}_sha=$SHA" >> "$GITHUB_OUTPUT"
+          done
 
-      - name: Download SparkBuild binary
+      - name: Download SparkBuild binaries
         env:
-          DOWNLOAD_URL: ${{ steps.release.outputs.download_url }}
+          WIN_URL: ${{ steps.release.outputs.win_url }}
+          LINUX_URL: ${{ steps.release.outputs.linux_url }}
+          MACOS_URL: ${{ steps.release.outputs.macos_url }}
         run: |
-          echo "[*] Downloading SparkBuild.exe ..."
-          curl -L -o tools/SparkBuild.exe "$DOWNLOAD_URL"
-          echo "[+] Downloaded to tools/SparkBuild.exe"
+          download() {
+            local url="$1" dest="$2" label="$3"
+            if [ -n "$url" ] && [ "$url" != "null" ]; then
+              echo "[*] Downloading $label ..."
+              curl -L -o "$dest" "$url"
+              echo "[+] Downloaded to $dest"
+            else
+              echo "[~] No $label asset found in this release, skipping."
+            fi
+          }
 
-      - name: Check if binary changed
+          download "$WIN_URL"   "tools/SparkBuild.exe"   "SparkBuild.exe (Windows)"
+          download "$LINUX_URL" "tools/SparkBuild-linux"  "SparkBuild-linux (Linux)"
+          download "$MACOS_URL" "tools/SparkBuild-macos"  "SparkBuild-macos (macOS)"
+
+          # Ensure Linux/macOS binaries are executable
+          [ -f tools/SparkBuild-linux ] && chmod +x tools/SparkBuild-linux
+          [ -f tools/SparkBuild-macos ] && chmod +x tools/SparkBuild-macos
+
+      - name: Check if any binary changed
         id: diff
         run: |
-          NEW_SHA=$(sha256sum tools/SparkBuild.exe | awk '{print $1}')
-          if [ "$NEW_SHA" = "${{ steps.check.outputs.current_sha }}" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "[=] SparkBuild.exe is already up to date."
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "[+] SparkBuild.exe has been updated (sha256: $NEW_SHA)."
-          fi
+          changed=false
+
+          check_changed() {
+            local file="$1" old_sha="$2"
+            if [ -f "tools/$file" ]; then
+              NEW_SHA=$(sha256sum "tools/$file" | awk '{print $1}')
+              if [ "$NEW_SHA" != "$old_sha" ]; then
+                echo "[+] $file has been updated (sha256: $NEW_SHA)."
+                changed=true
+              else
+                echo "[=] $file is already up to date."
+              fi
+            fi
+          }
+
+          check_changed "SparkBuild.exe"   "${{ steps.check.outputs.SparkBuild_exe_sha }}"
+          check_changed "SparkBuild-linux"  "${{ steps.check.outputs.SparkBuild_linux_sha }}"
+          check_changed "SparkBuild-macos"  "${{ steps.check.outputs.SparkBuild_macos_sha }}"
+
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: "chore: update SparkBuild.exe to ${{ steps.release.outputs.latest_tag }}"
+          commit-message: "chore: update SparkBuild binaries to ${{ steps.release.outputs.latest_tag }}"
           branch: chore/update-sparkbuild
-          title: "chore: update SparkBuild.exe to ${{ steps.release.outputs.latest_tag }}"
+          title: "chore: update SparkBuild binaries to ${{ steps.release.outputs.latest_tag }}"
           body: |
-            Automated weekly update of `tools/SparkBuild.exe` from [Krilliac/SparkBuild](https://github.com/Krilliac/SparkBuild).
+            Automated weekly update of SparkBuild binaries from [Krilliac/SparkBuild](https://github.com/Krilliac/SparkBuild).
 
             **Release:** ${{ steps.release.outputs.latest_tag }}
-            **Source:** ${{ steps.release.outputs.download_url }}
+
+            | Binary | Platform | Status |
+            |--------|----------|--------|
+            | `tools/SparkBuild.exe` | Windows | ${{ steps.release.outputs.win_url && '✅ Updated' || '⏭️ Not available' }} |
+            | `tools/SparkBuild-linux` | Linux | ${{ steps.release.outputs.linux_url && '✅ Updated' || '⏭️ Not available' }} |
+            | `tools/SparkBuild-macos` | macOS | ${{ steps.release.outputs.macos_url && '✅ Updated' || '⏭️ Not available' }} |
 
             ---
             *This PR was created automatically by the [update-sparkbuild](.github/workflows/update-sparkbuild.yml) workflow.*

--- a/.gitignore
+++ b/.gitignore
@@ -460,7 +460,9 @@ localdev.ps1
 localdev.bat
 localdev.sh
 
-# SparkBuild pre-built tool (allow binary from release)
+# SparkBuild pre-built tools (allow binaries from release)
 !tools/SparkBuild.exe
+!tools/SparkBuild-linux
+!tools/SparkBuild-macos
 
 # End of SparkEngine .gitignore

--- a/tools/update-sparkbuild.ps1
+++ b/tools/update-sparkbuild.ps1
@@ -1,6 +1,8 @@
-# update-sparkbuild.ps1 -- Download the latest SparkBuild.exe from GitHub Releases
+# update-sparkbuild.ps1 -- Download SparkBuild binaries from GitHub Releases
 #
-# Usage:  .\tools\update-sparkbuild.ps1            (fetches "latest" pre-release)
+# Downloads Windows, Linux, and macOS binaries.
+#
+# Usage:  .\tools\update-sparkbuild.ps1            (fetches "latest" release)
 #         .\tools\update-sparkbuild.ps1 v1.0.0     (fetches a specific version)
 
 param(
@@ -8,22 +10,32 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$repo  = "Krilliac/SparkBuild"
-$dest  = Join-Path $PSScriptRoot "SparkBuild.exe"
+$repo = "Krilliac/SparkBuild"
 
-if ($Tag -eq "latest") {
-    $url = "https://github.com/$repo/releases/download/latest/SparkBuild.exe"
-} else {
-    $url = "https://github.com/$repo/releases/download/$Tag/SparkBuild.exe"
+# Map of asset name -> local filename
+$binaries = @(
+    @{ Asset = "SparkBuild.exe";   Local = "SparkBuild.exe"   }
+    @{ Asset = "SparkBuild-linux"; Local = "SparkBuild-linux" }
+    @{ Asset = "SparkBuild-macos"; Local = "SparkBuild-macos" }
+)
+
+Write-Host "[*] Fetching SparkBuild binaries ($Tag) from $repo ..."
+Write-Host ""
+
+foreach ($bin in $binaries) {
+    $asset = $bin.Asset
+    $dest  = Join-Path $PSScriptRoot $bin.Local
+    $url   = "https://github.com/$repo/releases/download/$Tag/$asset"
+
+    Write-Host ("    {0,-20} -> {1}" -f $asset, $dest)
+
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
+        Write-Host "    [+] OK"
+    } catch {
+        Write-Host "    [~] Not available (skipped)"
+    }
 }
 
-Write-Host "[*] Downloading SparkBuild.exe ($Tag) ..."
-Write-Host "    $url"
-
-try {
-    Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
-    Write-Host "[+] Updated: $dest"
-} catch {
-    Write-Error "[-] Download failed: $_"
-    exit 1
-}
+Write-Host ""
+Write-Host "[*] Done."

--- a/tools/update-sparkbuild.sh
+++ b/tools/update-sparkbuild.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# update-sparkbuild.sh -- Download the latest SparkBuild.exe from GitHub Releases
+# update-sparkbuild.sh -- Download SparkBuild binaries from GitHub Releases
 #
-# Usage:  ./tools/update-sparkbuild.sh              (fetches "latest" pre-release)
+# Downloads Windows, Linux, and macOS binaries.
+#
+# Usage:  ./tools/update-sparkbuild.sh              (fetches "latest" release)
 #         ./tools/update-sparkbuild.sh v1.0.0       (fetches a specific version)
 
 set -e
@@ -9,20 +11,48 @@ set -e
 TAG="${1:-latest}"
 REPO="Krilliac/SparkBuild"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-DEST="$SCRIPT_DIR/SparkBuild.exe"
 
-URL="https://github.com/$REPO/releases/download/$TAG/SparkBuild.exe"
+# Map of asset name -> local filename
+declare -A BINARIES=(
+    ["SparkBuild.exe"]="SparkBuild.exe"
+    ["SparkBuild-linux"]="SparkBuild-linux"
+    ["SparkBuild-macos"]="SparkBuild-macos"
+)
 
-echo "[*] Downloading SparkBuild.exe ($TAG) ..."
-echo "    $URL"
+download() {
+    local url="$1" dest="$2"
+    if command -v curl &>/dev/null; then
+        curl -fL -o "$dest" "$url"
+    elif command -v wget &>/dev/null; then
+        wget -O "$dest" "$url"
+    else
+        echo "[-] Neither curl nor wget found." >&2
+        return 1
+    fi
+}
 
-if command -v curl &>/dev/null; then
-    curl -L -o "$DEST" "$URL"
-elif command -v wget &>/dev/null; then
-    wget -O "$DEST" "$URL"
-else
-    echo "[-] Neither curl nor wget found." >&2
-    exit 1
-fi
+echo "[*] Fetching SparkBuild binaries ($TAG) from $REPO ..."
+echo
 
-echo "[+] Updated: $DEST"
+for asset in "${!BINARIES[@]}"; do
+    LOCAL="${BINARIES[$asset]}"
+    DEST="$SCRIPT_DIR/$LOCAL"
+    URL="https://github.com/$REPO/releases/download/$TAG/$asset"
+
+    printf "    %-20s -> %s\n" "$asset" "$DEST"
+
+    if download "$URL" "$DEST" 2>/dev/null; then
+        # Make Linux/macOS binaries executable
+        case "$LOCAL" in
+            SparkBuild-linux|SparkBuild-macos)
+                chmod +x "$DEST"
+                ;;
+        esac
+        echo "    [+] OK"
+    else
+        echo "    [~] Not available (skipped)"
+    fi
+done
+
+echo
+echo "[*] Done."


### PR DESCRIPTION
Extend the update-sparkbuild workflow, shell script, and PowerShell script
to download SparkBuild-linux and SparkBuild-macos alongside SparkBuild.exe.
Each platform binary is checksummed independently and missing assets are
gracefully skipped. Also update .gitignore and .gitattributes to track
the new binaries.

https://claude.ai/code/session_01XeLwxH7oCeKpdk4ZmbZ8ob