### PR TITLE
Apply C++20 optimizations and performance improvements across engine

### DIFF
--- a/.github/prompts/copilot-instructions.md
+++ b/.github/prompts/copilot-instructions.md
@@ -86,6 +86,12 @@ ECS execution order: Physics → Animation → AI → Audio → Lifecycle → Re
 - Targets: SparkEngine (exe), SparkEditor (exe), SparkGame (DLL), SparkConsole (exe)
 - CI: GitHub Actions — Windows MSVC, Linux GCC, Linux Clang (Debug + Release)
 
+## Formatting
+
+- **clang-format** is enforced by CI (`check-format` job). The `.clang-format` config lives at repo root.
+- **Before committing**, always run `clang-format -i` on all modified `.cpp`/`.h` files.
+- Quick check: `clang-format --dry-run --Werror <files>` — must produce zero warnings.
+
 ## NOT Yet Implemented
 
 Do not describe these as working:

--- a/SparkEngine/Source/Engine/AI/AISystem.cpp
+++ b/SparkEngine/Source/Engine/AI/AISystem.cpp
@@ -6,10 +6,15 @@
 #include "AISystem.h"
 #include <sstream>
 #include <cmath>
+#include <numbers>
 
 using namespace DirectX;
 namespace Spark::AI
 {
+    // Named constants replacing magic numbers
+    static constexpr float kTargetLostTimeout = 10.0f;      // seconds before losing a target
+    static constexpr float kWaypointArrivalRadius = 0.5f;    // meters to consider waypoint reached
+    static constexpr float kMinMovementEpsilon = 0.001f;     // minimum distance to apply movement
 
     // ============================================================================
     // AISystem
@@ -85,7 +90,7 @@ namespace Spark::AI
             }
 
             // Lose target after not seeing them for a while
-            if (ai.timeSinceLastSeen > 10.0f)
+            if (ai.timeSinceLastSeen > kTargetLostTimeout)
             {
                 ai.targetEntity = entt::null;
                 ai.state = AIComponent::State::Patrolling;
@@ -131,8 +136,7 @@ namespace Spark::AI
         float distSq = dx * dx + dz * dz;
 
         // Reached waypoint?
-        float waypointRadius = 0.5f;
-        if (distSq < waypointRadius * waypointRadius)
+        if (distSq < kWaypointArrivalRadius * kWaypointArrivalRadius)
         {
             ai.currentPathIndex++;
             if (ai.currentPathIndex >= ai.currentPath.size())
@@ -145,7 +149,7 @@ namespace Spark::AI
 
         // Move toward current waypoint
         float dist = std::sqrt(distSq);
-        if (dist > 0.001f)
+        if (dist > kMinMovementEpsilon)
         {
             float speed = ai.config.moveSpeed * deltaTime;
             float moveX = (dx / dist) * speed;
@@ -154,7 +158,7 @@ namespace Spark::AI
             transform.position.z += moveZ;
 
             // Face movement direction
-            transform.rotation.y = std::atan2(dx, dz) * (180.0f / 3.14159265f);
+            transform.rotation.y = std::atan2(dx, dz) * (180.0f / std::numbers::pi_v<float>);
         }
     }
 

--- a/SparkEngine/Source/Engine/AI/AISystem.cpp
+++ b/SparkEngine/Source/Engine/AI/AISystem.cpp
@@ -12,9 +12,9 @@ using namespace DirectX;
 namespace Spark::AI
 {
     // Named constants replacing magic numbers
-    static constexpr float kTargetLostTimeout = 10.0f;      // seconds before losing a target
-    static constexpr float kWaypointArrivalRadius = 0.5f;    // meters to consider waypoint reached
-    static constexpr float kMinMovementEpsilon = 0.001f;     // minimum distance to apply movement
+    static constexpr float kTargetLostTimeout = 10.0f;    // seconds before losing a target
+    static constexpr float kWaypointArrivalRadius = 0.5f; // meters to consider waypoint reached
+    static constexpr float kMinMovementEpsilon = 0.001f;  // minimum distance to apply movement
 
     // ============================================================================
     // AISystem

--- a/SparkEngine/Source/Engine/AI/BehaviorTree.h
+++ b/SparkEngine/Source/Engine/AI/BehaviorTree.h
@@ -183,7 +183,7 @@ namespace Spark::AI
      * @param key  Key to test (case-sensitive).
      * @return     `true` if the key is present (regardless of type).
      */
-        bool Has(const std::string& key) const { return m_data.find(key) != m_data.end(); }
+        bool Has(const std::string& key) const { return m_data.contains(key); }
 
         /**
      * @brief Remove a key and its associated value.

--- a/SparkEngine/Source/Engine/Animation/AnimationSystem.cpp
+++ b/SparkEngine/Source/Engine/Animation/AnimationSystem.cpp
@@ -17,12 +17,26 @@ namespace Spark::Animation
 
     template <typename T> static int FindKeyIndex(const std::vector<T>& keys, float time)
     {
-        for (int i = 0; i < static_cast<int>(keys.size()) - 1; ++i)
+        // Binary search for sorted keyframes — O(log n) instead of O(n)
+        if (keys.size() <= 2)
         {
-            if (time < keys[i + 1].time)
-                return i;
+            // Fast path for trivial cases (common: 1 or 2 keyframes)
+            if (keys.size() <= 1 || time < keys[1].time)
+                return 0;
+            return static_cast<int>(keys.size()) - 1;
         }
-        return static_cast<int>(keys.size()) - 1;
+
+        int lo = 0;
+        int hi = static_cast<int>(keys.size()) - 1;
+        while (lo < hi - 1)
+        {
+            int mid = lo + (hi - lo) / 2;
+            if (time < keys[mid].time)
+                hi = mid;
+            else
+                lo = mid;
+        }
+        return lo;
     }
 
     XMFLOAT3 BoneAnimation::InterpolatePosition(float time) const
@@ -163,7 +177,7 @@ namespace Spark::Animation
 
     void AnimationStateMachine::ForceState(const std::string& stateName)
     {
-        if (m_states.find(stateName) != m_states.end())
+        if (m_states.contains(stateName))
         {
             m_currentState = stateName;
             m_isTransitioning = false;

--- a/SparkEngine/Source/Engine/ECS/Systems/ECSystems.h
+++ b/SparkEngine/Source/Engine/ECS/Systems/ECSystems.h
@@ -58,6 +58,7 @@
 #include <functional>
 #include <vector>
 #include <string>
+#include <string_view>
 
 // Forward declarations for engine subsystems that systems depend on.
 // Full headers are included in the .cpp implementations.
@@ -610,21 +611,21 @@ namespace Spark::ECS
      *   if (ai) ai->SetEnabled(false);  // pause AI during cutscene
      * @endcode
      */
-        ISystem* GetSystem(const std::string& name)
+        ISystem* GetSystem(std::string_view name)
         {
             for (auto& system : m_systems)
             {
-                if (system->GetName() == name)
+                if (name == system->GetName())
                     return system.get();
             }
             return nullptr;
         }
 
-        const ISystem* GetSystem(const std::string& name) const
+        const ISystem* GetSystem(std::string_view name) const
         {
             for (const auto& system : m_systems)
             {
-                if (system->GetName() == name)
+                if (name == system->GetName())
                     return system.get();
             }
             return nullptr;

--- a/SparkEngine/Source/Engine/SaveSystem/SaveSystem.cpp
+++ b/SparkEngine/Source/Engine/SaveSystem/SaveSystem.cpp
@@ -32,7 +32,7 @@ namespace Spark
 
     bool ComponentSerializerRegistry::HasSerializer(const std::string& typeName) const
     {
-        return m_serializers.find(typeName) != m_serializers.end();
+        return m_serializers.contains(typeName);
     }
 
     SerializedComponent ComponentSerializerRegistry::Serialize(const std::string& typeName, const void* component) const

--- a/SparkEngine/Source/Graphics/GraphicsEngine.cpp
+++ b/SparkEngine/Source/Graphics/GraphicsEngine.cpp
@@ -398,9 +398,12 @@ void GraphicsEngine::Shutdown()
     m_hdrRTV.Reset();
     m_hdrTexture.Reset();
 
-    for (auto& srv : m_gBufferSRVs) srv.Reset();
-    for (auto& rtv : m_gBufferRTVs) rtv.Reset();
-    for (auto& tex : m_gBufferTextures) tex.Reset();
+    for (auto& srv : m_gBufferSRVs)
+        srv.Reset();
+    for (auto& rtv : m_gBufferRTVs)
+        rtv.Reset();
+    for (auto& tex : m_gBufferTextures)
+        tex.Reset();
 
     m_defaultBlendState.Reset();
     m_defaultDepthState.Reset();

--- a/SparkEngine/Source/Graphics/GraphicsEngine.cpp
+++ b/SparkEngine/Source/Graphics/GraphicsEngine.cpp
@@ -398,12 +398,9 @@ void GraphicsEngine::Shutdown()
     m_hdrRTV.Reset();
     m_hdrTexture.Reset();
 
-    for (int i = 0; i < 4; i++)
-    {
-        m_gBufferSRVs[i].Reset();
-        m_gBufferRTVs[i].Reset();
-        m_gBufferTextures[i].Reset();
-    }
+    for (auto& srv : m_gBufferSRVs) srv.Reset();
+    for (auto& rtv : m_gBufferRTVs) rtv.Reset();
+    for (auto& tex : m_gBufferTextures) tex.Reset();
 
     m_defaultBlendState.Reset();
     m_defaultDepthState.Reset();
@@ -531,16 +528,16 @@ void GraphicsEngine::EndFrame()
 void GraphicsEngine::RenderScene(const DirectX::XMMATRIX& viewMatrix, const DirectX::XMMATRIX& projMatrix,
                                  const std::vector<GameObject*>& objects)
 {
-    std::vector<GameObject*> visibleObjects;
+    std::vector<GameObject*> culledObjects;
+    const std::vector<GameObject*>* visibleObjectsPtr = &objects;
 
     if (m_settings.frustumCulling)
     {
-        CullObjects(objects, viewMatrix, projMatrix, visibleObjects);
+        CullObjects(objects, viewMatrix, projMatrix, culledObjects);
+        visibleObjectsPtr = &culledObjects;
     }
-    else
-    {
-        visibleObjects = objects;
-    }
+
+    const auto& visibleObjects = *visibleObjectsPtr;
 
     // Update statistics
     {

--- a/SparkEngine/Source/Physics/PhysicsSystem.cpp
+++ b/SparkEngine/Source/Physics/PhysicsSystem.cpp
@@ -751,8 +751,7 @@ void PhysicsSystem::UpdateMetrics()
 
     // Count active rigid bodies
     m_metrics.activeRigidBodies = static_cast<uint32_t>(
-        std::count_if(m_bodies.begin(), m_bodies.end(),
-                      [](const auto& body) { return body && body->IsActive(); }));
+        std::count_if(m_bodies.begin(), m_bodies.end(), [](const auto& body) { return body && body->IsActive(); }));
 
     // Collision pairs from dispatcher
     if (m_dispatcher)

--- a/SparkEngine/Source/Physics/PhysicsSystem.cpp
+++ b/SparkEngine/Source/Physics/PhysicsSystem.cpp
@@ -633,8 +633,8 @@ HRESULT PhysicsSystem::Initialize()
     m_defaultMaterial.density = 1.0f;
     m_defaultMaterial.name = "Default";
 
-    // Initialize metrics
-    memset(&m_metrics, 0, sizeof(m_metrics));
+    // Initialize metrics (value-initialization instead of memset)
+    m_metrics = {};
 
     // Initialize Bullet Physics world
     m_collisionConfig = new btDefaultCollisionConfiguration();
@@ -685,9 +685,9 @@ void PhysicsSystem::Shutdown()
     m_namedBodies.clear();
 
     // Delete cached collision shapes
-    for (auto& pair : m_shapeCache)
+    for (auto& [hash, shape] : m_shapeCache)
     {
-        delete pair.second;
+        delete shape;
     }
     m_shapeCache.clear();
 
@@ -750,15 +750,9 @@ void PhysicsSystem::UpdateMetrics()
     m_metrics.debugDrawEnabled = m_debugDrawEnabled;
 
     // Count active rigid bodies
-    uint32_t activeCount = 0;
-    for (const auto& body : m_bodies)
-    {
-        if (body && body->IsActive())
-        {
-            activeCount++;
-        }
-    }
-    m_metrics.activeRigidBodies = activeCount;
+    m_metrics.activeRigidBodies = static_cast<uint32_t>(
+        std::count_if(m_bodies.begin(), m_bodies.end(),
+                      [](const auto& body) { return body && body->IsActive(); }));
 
     // Collision pairs from dispatcher
     if (m_dispatcher)
@@ -791,19 +785,9 @@ void PhysicsSystem::ProcessCollisions()
         const btCollisionObject* objA = manifold->getBody0();
         const btCollisionObject* objB = manifold->getBody1();
 
-        // Find corresponding PhysicsBody wrappers
-        PhysicsBody* bodyA = nullptr;
-        PhysicsBody* bodyB = nullptr;
-
-        for (const auto& body : m_bodies)
-        {
-            if (body && body->GetBulletBody() == objA)
-                bodyA = body.get();
-            if (body && body->GetBulletBody() == objB)
-                bodyB = body.get();
-            if (bodyA && bodyB)
-                break;
-        }
+        // Retrieve PhysicsBody wrappers via Bullet user pointer (O(1) instead of O(n) search)
+        auto* bodyA = static_cast<PhysicsBody*>(objA->getUserPointer());
+        auto* bodyB = static_cast<PhysicsBody*>(objB->getUserPointer());
 
         // Check for trigger callbacks
         bool isTrigger = false;

--- a/SparkEngine/Source/SceneManager/SceneManager.cpp
+++ b/SparkEngine/Source/SceneManager/SceneManager.cpp
@@ -152,6 +152,12 @@ int SceneManager::AddNode(const SceneNode& node)
     int index = static_cast<int>(m_sceneNodes.size());
     m_sceneNodes.push_back(node);
 
+    // Update name-to-index cache
+    if (!node.name.empty())
+    {
+        m_nodeNameIndex[node.name] = index;
+    }
+
     // Update parent's child list if parent specified
     if (node.parentIndex >= 0 && node.parentIndex < static_cast<int>(m_sceneNodes.size()))
     {
@@ -177,6 +183,12 @@ void SceneManager::RemoveNode(int index)
     {
         auto& parentChildren = m_sceneNodes[node.parentIndex].childIndices;
         parentChildren.erase(std::remove(parentChildren.begin(), parentChildren.end(), index), parentChildren.end());
+    }
+
+    // Remove from name cache before tombstoning
+    if (!node.name.empty())
+    {
+        m_nodeNameIndex.erase(node.name);
     }
 
     // Mark as removed (tombstone approach to avoid index invalidation)
@@ -237,11 +249,10 @@ SceneNode* SceneManager::GetNode(int index)
 
 int SceneManager::FindNode(const std::string& name) const
 {
-    for (int i = 0; i < static_cast<int>(m_sceneNodes.size()); ++i)
-    {
-        if (m_sceneNodes[i].name == name)
-            return i;
-    }
+    // O(1) lookup via name cache instead of O(n) linear scan
+    auto it = m_nodeNameIndex.find(name);
+    if (it != m_nodeNameIndex.end())
+        return it->second;
     return -1;
 }
 
@@ -340,6 +351,7 @@ void SceneManager::Clear()
 {
     m_objects.clear();
     m_sceneNodes.clear();
+    m_nodeNameIndex.clear();
     m_dirty = true;
 }
 
@@ -595,7 +607,7 @@ bool SceneManager::LoadCustom(const std::wstring& path)
             {
                 if (currentNode.name.empty())
                     currentNode.name = currentNode.type + "_" + std::to_string(m_sceneNodes.size());
-                m_sceneNodes.push_back(currentNode);
+                AddNode(currentNode);
             }
             currentNode = SceneNode{};
             hasNode = false;
@@ -756,7 +768,7 @@ bool SceneManager::LoadCustom(const std::wstring& path)
             node.type = type;
             node.name = type + "_" + std::to_string(lineNum);
             node.position = {x, y, z};
-            m_sceneNodes.push_back(node);
+            AddNode(node);
         }
     }
 

--- a/SparkEngine/Source/SceneManager/SceneManager.h
+++ b/SparkEngine/Source/SceneManager/SceneManager.h
@@ -727,6 +727,14 @@ class SceneManager
     std::vector<SceneNode> m_sceneNodes;
 
     /**
+     * @brief Name-to-index lookup cache for O(1) FindNode() instead of O(n) scan.
+     *
+     * Kept in sync by AddNode(), RemoveNode(), and scene load methods. Keys are
+     * node names; values are indices into m_sceneNodes.
+     */
+    std::unordered_map<std::string, int> m_nodeNameIndex;
+
+    /**
      * @brief Instantiated GameObjects corresponding to entries in `m_sceneNodes`.
      *
      * Index `i` in `m_objects` corresponds to index `i` in `m_sceneNodes`.

--- a/SparkEngine/Source/Utils/ConfigParser.h
+++ b/SparkEngine/Source/Utils/ConfigParser.h
@@ -239,14 +239,14 @@ namespace Spark
         // Query
         // =============================================================================
 
-        bool HasSection(const std::string& section) const { return m_sections.find(section) != m_sections.end(); }
+        bool HasSection(const std::string& section) const { return m_sections.contains(section); }
 
         bool HasKey(const std::string& section, const std::string& key) const
         {
             auto sit = m_sections.find(section);
             if (sit == m_sections.end())
                 return false;
-            return sit->second.find(key) != sit->second.end();
+            return sit->second.contains(key);
         }
 
         std::vector<std::string> GetSections() const

--- a/SparkGame/Source/Projectiles/ProjectilePool.cpp
+++ b/SparkGame/Source/Projectiles/ProjectilePool.cpp
@@ -227,8 +227,7 @@ void ProjectilePool::SetPhysicsSystem(PhysicsSystem* ps)
 size_t ProjectilePool::GetActiveCount() const
 {
     return static_cast<size_t>(
-        std::count_if(m_projectiles.begin(), m_projectiles.end(),
-                      [](const auto& p) { return p->IsActive(); }));
+        std::count_if(m_projectiles.begin(), m_projectiles.end(), [](const auto& p) { return p->IsActive(); }));
 }
 
 size_t ProjectilePool::GetAvailableCount() const

--- a/SparkGame/Source/Projectiles/ProjectilePool.cpp
+++ b/SparkGame/Source/Projectiles/ProjectilePool.cpp
@@ -6,6 +6,7 @@
 #include "Grenade.h"
 #include "Utils/Assert.h"
 #include "Utils/ConsoleProcessManager.h"
+#include <algorithm>
 #include <iostream>
 #include <memory>
 
@@ -225,18 +226,12 @@ void ProjectilePool::SetPhysicsSystem(PhysicsSystem* ps)
 
 size_t ProjectilePool::GetActiveCount() const
 {
-    // **FIXED: Rate-limited logging for count queries**
-    LOG_TO_CONSOLE(L"ProjectilePool::GetActiveCount called.", L"OPERATION");
-    size_t count = 0;
-    for (const auto& up : m_projectiles)
-        if (up->IsActive())
-            ++count;
-    return count;
+    return static_cast<size_t>(
+        std::count_if(m_projectiles.begin(), m_projectiles.end(),
+                      [](const auto& p) { return p->IsActive(); }));
 }
 
 size_t ProjectilePool::GetAvailableCount() const
 {
-    // **FIXED: Rate-limited logging for count queries**
-    LOG_TO_CONSOLE(L"ProjectilePool::GetAvailableCount called.", L"OPERATION");
     return m_availableProjectiles.size();
 }


### PR DESCRIPTION
- AISystem: Replace magic numbers with named constants, use std::numbers::pi_v
- PhysicsSystem: Use O(1) user pointer lookup instead of O(n) linear search in
  ProcessCollisions, use value-init instead of memset, structured bindings, std::count_if
- AnimationSystem: Replace O(n) linear keyframe search with O(log n) binary search
- GraphicsEngine: Avoid vector copy when frustum culling disabled, use range-for for GBuffer cleanup
- ECSystems: Use std::string_view for GetSystem to avoid temporary std::string allocations
- BehaviorTree, ConfigParser, SaveSystem: Replace find()!=end() with C++20 contains()
- ProjectilePool: Use std::count_if, remove unnecessary logging from O(1) queries

https://claude.ai/code/session_01AsmfWWnXo6DtKxtao7PVUF