### PR TITLE
Add 7 gap analysis documents for uncovered subsystems

### DIFF
--- a/docs/gap-analysis/CINEMATIC_GAP_ANALYSIS.md
+++ b/docs/gap-analysis/CINEMATIC_GAP_ANALYSIS.md
@@ -1,0 +1,130 @@
+# SparkEngine Cinematic/Sequencer — Gap Analysis
+
+> **Scope**: `SparkEngine/Source/Engine/Cinematic/` (Sequencer, SequencerManager)
+> **Date**: 2026-03-10
+> **Methodology**: Static source-code audit of all `.h`/`.cpp` files under `Cinematic/`.
+> Each gap is assigned a severity: **Critical**, **Major**, **Moderate**, **Minor**.
+
+---
+
+## Context
+
+The Cinematic subsystem provides a timeline-based sequencer for cutscenes. It supports camera path animation (Catmull-Rom splines), entity transform/property keyframes, audio cues, event callbacks, subtitles, and screen fades. The architecture is clean with a base `SequencerTrack` class and typed track subclasses. `SequencerManager` is a singleton that manages named sequences and provides console integration. However, the system lacks serialization, editor integration, and has platform-specific type dependencies throughout its data structures.
+
+---
+
+## Major Gaps
+
+### GAP-CIN01 — No Sequence Serialization (Save/Load)
+
+**Files**:
+- `Cinematic/Sequencer.h` (full file — no serialization methods)
+
+**Impact**: Sequences can only be created programmatically via the builder API. There is no way to save a sequence to disk or load one from a file. This means cutscenes must be hardcoded in C++, making them impossible to author or iterate on without recompilation. For a game engine targeting FPS games, this makes cutscene content creation impractical.
+
+**Evidence**: `Sequence` class has no `Save()`, `Load()`, `Serialize()`, or `Deserialize()` methods. `SequencerManager` has no file I/O methods. No JSON, XML, or binary format is defined for sequences.
+
+**What is needed**: Define a JSON or binary format for sequences. Add `Sequence::SaveToFile(path)` and `Sequence::LoadFromFile(path)` methods. Register with the `ComponentSerializerRegistry` if sequences are tied to entities.
+
+---
+
+### GAP-CIN02 — No Editor Integration for Timeline Authoring
+
+**Files**:
+- `Cinematic/Sequencer.h`
+- `SparkEditor/Source/` (no Cinematic or Sequencer editor panel)
+
+**Impact**: The SparkEditor has 22 subsystem directories but no Cinematic/Sequencer panel. Cutscene authoring requires a visual timeline editor to place keyframes, preview camera paths, and synchronize audio/subtitle cues. Without this, the sequencer is only usable by engine programmers.
+
+**Evidence**: `SparkEditor/Source/` contains `Animation/`, `Lighting/`, `MaterialEditor/`, `Terrain/`, `VisualScripting/`, etc., but no `Cinematic/` or `Sequencer/` directory. The `Sequencer.h` API returns raw pointers to tracks that would need to be visualized in a timeline UI.
+
+**What is needed**: Create an ImGui-based timeline editor panel in the editor. Show tracks as horizontal lanes, keyframes as draggable points, and provide real-time preview with play/pause/scrub controls.
+
+---
+
+### GAP-CIN03 — Platform-Dependent Data Structures
+
+**Files**:
+- `Cinematic/Sequencer.h` (lines 47–51, 62–66, 89, 105, 113)
+
+**Impact**: `CameraKeyframe`, `VectorKeyframe`, `AudioCue`, `SubtitleCue`, and `FadeKeyframe` all use DirectXMath types (`XMFLOAT3`, `XMFLOAT4`) directly in their member definitions. These types are only available on Windows behind `#ifdef SPARK_PLATFORM_WINDOWS`, so the entire cinematic system fails to compile on Linux/macOS.
+
+**Evidence**: `XMFLOAT3 position` at line 48, `XMFLOAT3 lookAt` at line 49, `XMFLOAT4 color` at line 105, `XMFLOAT3 color` at line 113 — all without platform guards.
+
+**What is needed**: Use the engine's `Platform.h` cross-platform math stubs, or define platform-agnostic `Vector3`/`Vector4` types. Replace all DirectXMath types in public struct definitions.
+
+---
+
+### GAP-CIN04 — Singleton Pattern Outside EngineContext
+
+**Files**:
+- `Cinematic/Sequencer.h` (line 372, `SequencerManager::GetInstance()`)
+
+**Impact**: `SequencerManager` uses the singleton pattern but is not registered in `EngineContext`. Game modules cannot access the sequencer through the service locator. The singleton creates a hidden global dependency that is difficult to test and cannot be mocked.
+
+**Evidence**: `EngineContext.h` has no `GetSequencer()` method. `IEngineContext` interface does not include sequencer access. Game modules would need to call `Spark::Cinematic::SequencerManager::GetInstance()` directly, breaking the module boundary abstraction.
+
+**What is needed**: Register `SequencerManager` in `EngineContext` and expose it through `IEngineContext`. Allow injection for testing.
+
+---
+
+## Moderate Gaps
+
+### GAP-CIN05 — Entity References via Raw uint32_t
+
+**Files**:
+- `Cinematic/Sequencer.h` (lines 170, 199 — `uint32_t targetEntityID`)
+
+**Impact**: `EntityTransformTrack` and `EntityPropertyTrack` reference entities via raw `uint32_t` IDs. These IDs are EnTT entity handles that can be recycled. If a referenced entity is destroyed and its ID is reused, the sequencer will animate the wrong entity with no error. There is no validation that the entity still exists when the sequence runs.
+
+**Evidence**: `uint32_t targetEntityID = 0` in both track types. No `World&` reference is held to validate entity existence. No callback or notification when a referenced entity is destroyed.
+
+**What is needed**: Use a stable entity reference (e.g., UUID from the engine's UUID system) or validate entity existence each frame during playback. Log warnings when a referenced entity is missing.
+
+---
+
+### GAP-CIN06 — No Sequence Blending or Transitions
+
+**Files**:
+- `Cinematic/Sequencer.h` (lines 319–328 — playback control)
+
+**Impact**: Sequences can be played, paused, and stopped, but there is no facility to blend between two sequences. Transitioning from gameplay camera to a cutscene camera, or crossfading between two cutscenes, requires manual implementation. Abrupt camera cuts feel jarring.
+
+**What is needed**: Add a blend/crossfade API: `PlaySequenceWithBlend(name, blendDuration)` that interpolates between the current camera state and the sequence's first keyframe over the blend duration.
+
+---
+
+### GAP-CIN07 — No Skip/Fast-Forward with Event Guarantee
+
+**Files**:
+- `Cinematic/Sequencer.h` (lines 319–323 — `Play()`, `Pause()`, `Stop()`, `SetTime()`)
+
+**Impact**: There is no `Skip()` method. While `SetTime(duration)` can jump to the end, this skips over `EventCue` and `AudioCue` triggers that fall between the current time and the target time. `GetTriggeredCues(prevTime, currentTime)` (lines 226, 246) only fires cues in a time window — a large time jump would correctly fire all skipped events, but `Stop()` does not trigger remaining events.
+
+**What is needed**: Add a `Skip()` method that fires all remaining event cues in order before stopping the sequence. This ensures game state changes triggered by events (door opens, NPC spawns) are not lost when the player skips a cutscene.
+
+---
+
+## Minor Gaps
+
+### GAP-CIN08 — No Audio Integration with AudioEngine
+
+**Files**:
+- `Cinematic/Sequencer.h` (lines 83–89, `AudioCue` struct; lines 215–230, `AudioCueTrack`)
+
+**Impact**: `AudioCueTrack` stores `AudioCue` structs with `soundName` and `volume`, but there is no code that actually plays these sounds through the `AudioEngine`. The track identifies *when* to play sounds but does not connect to the audio system. Game code must manually handle `GetTriggeredCues()` and forward to `AudioEngine`.
+
+**What is needed**: Either integrate `AudioEngine` playback directly into `Sequence::Update()`, or provide a default audio callback that is set automatically when the `AudioEngine` is available.
+
+---
+
+### GAP-CIN09 — Documented API Methods Not Present
+
+**Files**:
+- `Cinematic/Sequencer.h` (file-level doc comment mentions features not in the API)
+
+**Impact**: The file doc comment mentions capabilities that don't exist in the class API: no `Repeat()` method for looping a section, no `WithInterval()` for timed repetition, no `Blend()` for sequence transitions. While `SetLooping(bool)` exists for full-sequence looping, there is no section repeat or partial loop.
+
+**What is needed**: Either implement the documented features or update the documentation to accurately reflect the current API.
+
+---

--- a/docs/gap-analysis/CORE_INFRASTRUCTURE_GAP_ANALYSIS.md
+++ b/docs/gap-analysis/CORE_INFRASTRUCTURE_GAP_ANALYSIS.md
@@ -1,0 +1,154 @@
+# SparkEngine Core Infrastructure — Gap Analysis
+
+> **Scope**: `SparkEngine/Source/Core/` (EngineContext, IEngineContext, Platform), `SparkEngine/Source/Engine/World/` (DayNightCycle), Engine-wide architectural patterns
+> **Date**: 2026-03-10
+> **Methodology**: Static source-code audit of Core/ headers, EngineContext, IEngineContext, and cross-cutting architectural analysis of all subsystem access patterns.
+> Each gap is assigned a severity: **Critical**, **Major**, **Moderate**, **Minor**.
+
+---
+
+## Context
+
+The Core subsystem provides the foundational infrastructure: `EngineContext` (service locator), `IEngineContext` (module-facing interface), `Platform.h` (cross-platform type stubs), and the `SparkEngine` main class. The `EngineContext` currently exposes six subsystems: Graphics, Input, Timer, EventBus, Audio, and Physics. However, the engine has grown to include 14+ subsystems (AI, Animation, Networking, Scripting, SaveSystem, Coroutines, Sequencer, Procedural Generation, DayNightCycle, etc.), most of which bypass `EngineContext` entirely and use singletons for global access.
+
+---
+
+## Critical Gaps
+
+### GAP-CI01 — EngineContext Only Exposes 6 of 14+ Subsystems
+
+**Files**:
+- `Core/EngineContext.h` (lines 33–44, getter methods)
+- `Core/Spark/IEngineContext.h` (interface)
+
+**Impact**: `EngineContext` and `IEngineContext` only provide access to: `GraphicsEngine`, `InputManager`, `Timer`, `EventBus`, `AudioEngine`, and `PhysicsSystem`. The following subsystems are **not** accessible through the service locator and rely on their own singleton patterns:
+
+| Subsystem | Access Pattern | File |
+|-----------|---------------|------|
+| AnimationSystem | Unknown | `Engine/Animation/` |
+| AISystem | Unknown | `Engine/AI/` |
+| NetworkManager | Singleton likely | `Engine/Networking/` |
+| ScriptEngine | Unknown | `Engine/Scripting/` |
+| SaveSystem | `GetInstance()` | `Engine/SaveSystem/SaveSystem.h` |
+| CoroutineScheduler | `GetInstance()` | `Engine/Coroutine/CoroutineScheduler.h` |
+| SequencerManager | `GetInstance()` | `Engine/Cinematic/Sequencer.h` |
+| DayNightCycle | Instance-based | `Engine/World/DayNightCycle.h` |
+| PlatformInputManager | `GetInstance()` | `Input/PlatformInput.h` |
+
+This defeats the purpose of the service locator pattern. Game modules (loaded as DLLs) receive an `IEngineContext*` but cannot access most engine systems through it. They must call singleton `GetInstance()` methods directly, creating tight coupling and making subsystems impossible to mock for testing.
+
+**Evidence**: `EngineContext.h` has exactly 6 `Get*()` methods and 6 `Set*()` methods. `IEngineContext` declares the same 6 virtual getters. No other subsystem is registered.
+
+**What is needed**: Expand `IEngineContext` and `EngineContext` to include all subsystems. Add `Get*()` and `Set*()` for each. Consider a generic `GetSystem<T>()` template method for extensibility. Gradually remove singleton patterns from subsystems.
+
+---
+
+## Major Gaps
+
+### GAP-CI02 — No Scene or World Management System
+
+**Files**:
+- `Engine/World/` directory (contains only `DayNightCycle.h`)
+
+**Impact**: Despite having a `World/` directory, the engine has no `SceneManager` or `WorldManager`. There is no system for: loading/unloading game levels, managing scene transitions (with loading screens), tracking which scene is active, or coordinating subsystem state between scenes. The ECS `World` (from the ECS subsystem) manages entities but not level/scene lifecycle.
+
+**Evidence**: `Engine/World/` contains only `DayNightCycle.h`. No `SceneManager.h`, `LevelLoader.h`, or similar file exists. `SaveMetadata::sceneName` (in `SaveSystem.h`) stores a scene name but there is no `SceneManager` to load it during deserialization. The editor has `SparkEditor/Source/SceneSystem/` but this is editor-side, not engine-side.
+
+**What is needed**: Create an engine-side `SceneManager` that handles: scene definition (list of assets, entities, settings per scene), loading/unloading scenes (with progress callbacks for loading screens), scene transitions (fade out, load, fade in), and integration with `SaveSystem` (load scene before restoring entity state).
+
+---
+
+### GAP-CI03 — No Engine-Level Asset Management Pipeline
+
+**Files**:
+- `Core/` directory
+- `SparkEditor/Source/AssetPipeline/`, `SparkEditor/Source/AssetBrowser/`
+
+**Impact**: The engine has no runtime asset management system. The editor has `AssetPipeline/` and `AssetBrowser/` directories, but these are editor-only tools. At runtime, there is no central asset registry, no reference counting, no async asset loading, and no asset dependency tracking. Each subsystem loads its own resources independently (e.g., `SoundEffect::Load()`, shader loading in `GraphicsEngine`).
+
+**What is needed**: Create a runtime `AssetManager` in the engine core that provides: asset registry (path to loaded asset mapping), reference counting for shared assets, async loading with completion callbacks, and asset hot-reload support.
+
+---
+
+### GAP-CI04 — InputManager Exposed Instead of PlatformInputManager
+
+**Files**:
+- `Core/EngineContext.h` (lines 35–36, `GetInput()` returns `InputManager*`)
+- `Input/PlatformInput.h` (`PlatformInputManager` — modern, cross-platform)
+
+**Impact**: `EngineContext` exposes the legacy `InputManager` (Win32-only, no action mapping, no gamepad) rather than the modern `PlatformInputManager` (cross-platform, pluggable backends, action/axis mapping). Game modules using `context->GetInput()` get the inferior, platform-locked input system. See INPUT_GAP_ANALYSIS.md GAP-I01 for details.
+
+**What is needed**: Replace `InputManager*` with `PlatformInputManager*` in `EngineContext` and `IEngineContext`.
+
+---
+
+## Moderate Gaps
+
+### GAP-CI05 — DLL Module System Status Unclear
+
+**Files**:
+- `Core/` directory (likely contains `GameModuleLoader` or `ModuleManager`)
+- `SparkGame/Source/` (example game module)
+
+**Impact**: The engine architecture supports loading game modules as DLLs (evidenced by `SparkGame/` being a separate module and `IEngineContext` being a module-facing interface). However, the status of hot-reloading is unclear. If the module system supports hot-reload, it needs careful handling of: module unload (release all resources), state preservation across reloads, and pointer invalidation (raw pointers held by the engine become dangling when the DLL is unloaded).
+
+**What is needed**: Document the module loading lifecycle. If hot-reload is supported, add a `OnModuleUnload()` callback that modules implement to release resources. If not supported, document that modules require engine restart.
+
+---
+
+### GAP-CI06 — No Engine Lifecycle Events
+
+**Files**:
+- `Core/EngineContext.h`, `Core/Spark/IEngineContext.h`
+
+**Impact**: There are no engine lifecycle callbacks (OnStartup, OnShutdown, OnPause, OnResume, OnFocusLost, OnFocusGained). Subsystems that need to respond to engine state changes (e.g., pause audio when window loses focus, save state on shutdown) must be explicitly called by the main loop. There is no event-driven lifecycle notification.
+
+**What is needed**: Add lifecycle events to `EventBus` (e.g., `EngineStartupEvent`, `EngineShutdownEvent`, `EnginePauseEvent`, `WindowFocusEvent`). Publish these from the main engine loop. Subsystems subscribe to respond to lifecycle changes.
+
+---
+
+### GAP-CI07 — Octree/Spatial Partitioning Not Integrated
+
+**Files**:
+- `Utils/` (likely contains `Octree.h` based on test evidence)
+- Engine subsystems (Graphics, Physics, AI)
+
+**Impact**: An Octree data structure exists in `Utils/` and is tested (`TestFrustumCulling.cpp` suggests spatial partitioning exists). However, it is unclear whether the Octree is integrated into: the graphics pipeline for frustum culling, the physics system for broad-phase collision, the AI system for spatial queries (nearest enemy, line-of-sight), or the audio system for spatial audio queries.
+
+**What is needed**: Audit Octree usage across subsystems. Ensure it is used for frustum culling in the renderer and broad-phase in physics. Expose spatial query APIs (e.g., `QueryRadius(center, radius)`, `QueryFrustum(frustum)`) through a central `SpatialIndex` in the engine context.
+
+---
+
+### GAP-CI08 — Platform.h Cross-Platform Stubs Completeness Unknown
+
+**Files**:
+- `Core/Platform.h`
+
+**Impact**: `Platform.h` defines `SPARK_PLATFORM_WINDOWS`, `SPARK_PLATFORM_LINUX`, `SPARK_PLATFORM_MACOS` and provides DirectXMath stubs for non-Windows. However, the completeness of these stubs is unclear. If `XMFLOAT3`, `XMFLOAT4`, `XMMATRIX`, etc. stubs are incomplete or non-functional, no subsystem that uses DirectXMath types will work on Linux/macOS.
+
+**What is needed**: Audit `Platform.h` stubs against all DirectXMath usage across the codebase. Ensure all used types and functions have working cross-platform implementations. Consider using GLM or a purpose-built math library as the cross-platform backend.
+
+---
+
+## Minor Gaps
+
+### GAP-CI09 — No Configuration/Settings Persistence System
+
+**Files**: Core directory
+
+**Impact**: There is no engine-wide configuration system for persisting settings (graphics quality, audio volume, key bindings, window resolution) between sessions. Each subsystem manages its own settings independently with no unified save/load mechanism for user preferences.
+
+**What is needed**: Create an `EngineSettings` class that reads/writes a configuration file (JSON or INI). Subsystems register their configurable values. Settings are loaded at startup and saved on change or shutdown.
+
+---
+
+### GAP-CI10 — Version Constants Defined But Not Centralized
+
+**Files**:
+- `Core/EngineContext.h` (lines 54–55, `GetEngineVersion()`, `GetSDKVersion()`)
+
+**Impact**: `EngineContext` has `GetEngineVersion()` and `GetSDKVersion()` methods, but the version values are defined in the `.cpp` file and not exposed as compile-time constants. Other subsystems that need version information (save system versioning, network protocol versioning) cannot access it without going through EngineContext.
+
+**What is needed**: Define `SPARK_ENGINE_VERSION_MAJOR`, `SPARK_ENGINE_VERSION_MINOR`, `SPARK_ENGINE_VERSION_PATCH` as compile-time constants in `Platform.h` or a dedicated `Version.h`.
+
+---

--- a/docs/gap-analysis/COROUTINE_GAP_ANALYSIS.md
+++ b/docs/gap-analysis/COROUTINE_GAP_ANALYSIS.md
@@ -1,0 +1,142 @@
+# SparkEngine Coroutine System — Gap Analysis
+
+> **Scope**: `SparkEngine/Source/Engine/Coroutine/` (CoroutineScheduler, Coroutine, YieldInstruction)
+> **Date**: 2026-03-10
+> **Methodology**: Static source-code audit of all `.h`/`.cpp` files under `Coroutine/`.
+> Each gap is assigned a severity: **Critical**, **Major**, **Moderate**, **Minor**.
+
+---
+
+## Context
+
+The Coroutine system provides a lightweight cooperative task scheduler for gameplay code. It supports sequencing actions with yields (`WaitForSeconds`, `WaitForFrames`, `WaitUntil`, `WaitForEndOfFrame`) via a builder-pattern API. The system is implemented entirely in the header (`CoroutineScheduler.h`) with inline method bodies. `CoroutineScheduler` is a singleton that ticks all active coroutines each frame. The implementation is simple and functional for basic use cases, but has significant gaps in error handling, documented-but-missing features, and integration with the rest of the engine.
+
+---
+
+## Major Gaps
+
+### GAP-CO01 — Documented Features Not Implemented
+
+**Files**:
+- `Coroutine/CoroutineScheduler.h` (lines 33–37, usage example in doc comment)
+
+**Impact**: The file-level documentation shows usage of `Repeat(5, callback)` and `.WithInterval(10.0f)` in the "wave spawner" example, but neither method exists in the `Coroutine` class API. The builder pattern only has `Do()`, `WaitForSeconds()`, `WaitForFrames()`, `WaitUntil()`, and `YieldFrame()`. Any developer following the documented usage example will get a compile error.
+
+**Evidence**: The `Coroutine` class (lines 159–275) has no `Repeat()` or `WithInterval()` method. The doc comment at line 34 shows `scheduler.StartCoroutine("wave_spawner").Repeat(5, [&](int wave) { SpawnWave(wave); }).WithInterval(10.0f);` — this code does not compile.
+
+**What is needed**: Either implement `Repeat(int count, std::function<void(int)>)` and `WithInterval(float seconds)` methods, or update the documentation to remove the example and accurately describe the current API.
+
+---
+
+### GAP-CO02 — Entity Binding Documented But Not Implemented
+
+**Files**:
+- `Coroutine/CoroutineScheduler.h` (line 18, feature list)
+
+**Impact**: The feature list documents "Entity binding — auto-cancel when an entity is destroyed" but the `Coroutine` class has no entity reference, no `BindToEntity()` method, and no mechanism to detect entity destruction. Coroutines referencing destroyed entities will continue running and may access invalid data.
+
+**Evidence**: The `Coroutine` class members (lines 258–274) have `m_name`, `m_steps`, `m_currentStep`, and `m_cancelled` — no entity ID or World reference. The `CoroutineScheduler` has no entity integration.
+
+**What is needed**: Add `Coroutine& BindToEntity(uint32_t entityID)` that stores an entity reference. In `CoroutineScheduler::Update()`, check if bound entities still exist and cancel orphaned coroutines. Requires a `World&` reference or callback mechanism.
+
+---
+
+### GAP-CO03 — No Error Handling in Action Callbacks
+
+**Files**:
+- `Coroutine/CoroutineScheduler.h` (lines 238–243, `Update()` method)
+
+**Impact**: If a `Do()` callback throws an exception, the coroutine's `Update()` method propagates the exception to the `CoroutineScheduler::Update()` loop, which will abort iteration over the remaining coroutines. All coroutines after the throwing one are skipped for that frame. The scheduler state is not corrupted (the erase-remove cleanup at line 366 still runs), but the behavior is unpredictable.
+
+**Evidence**: `step.action()` at line 242 is called with no try/catch. The enclosing `while` loop and the `for` loop in `CoroutineScheduler::Update()` have no exception handling.
+
+**What is needed**: Wrap `step.action()` in a try/catch. On exception, log the error, cancel the offending coroutine, and continue processing remaining coroutines. Consider a per-coroutine error callback.
+
+---
+
+### GAP-CO04 — Singleton Pattern Outside EngineContext
+
+**Files**:
+- `Coroutine/CoroutineScheduler.h` (lines 290–294, `GetInstance()`)
+
+**Impact**: `CoroutineScheduler` is a global singleton not registered in `EngineContext`. This creates a hidden dependency, makes testing difficult (can't inject a mock), and means game modules must access it directly rather than through the service locator.
+
+**Evidence**: `EngineContext.h` has no `GetCoroutineScheduler()` method. Free functions `StartCoroutine()` and `StopCoroutine()` (lines 385–394) directly reference the global singleton.
+
+**What is needed**: Register `CoroutineScheduler` in `EngineContext`. The free-function convenience wrappers can remain but should route through the context when available.
+
+---
+
+## Moderate Gaps
+
+### GAP-CO05 — Not Using C++20 Coroutines
+
+**Files**:
+- `Coroutine/CoroutineScheduler.h` (full file)
+
+**Impact**: The engine targets C++20 but the coroutine system uses a custom callback-based builder pattern rather than C++20 `co_yield`/`co_await` coroutines. While the current approach works, C++20 coroutines would provide more natural syntax, stack-like local variable preservation across yields, and compiler-optimized suspension/resumption.
+
+**Evidence**: No `#include <coroutine>`, no `co_yield`, no `co_await`, no `promise_type`. The system uses `std::function<void()>` callbacks and explicit yield instruction objects.
+
+**What is needed**: This is an enhancement, not a bug. Consider adding a C++20 coroutine wrapper as an alternative API (e.g., `Task<void> MyCoroutine()`) that coexists with the current builder API. The builder API is simpler for basic sequences; C++20 coroutines are better for complex logic with local state.
+
+---
+
+### GAP-CO06 — No Pause/Resume for Individual Coroutines
+
+**Files**:
+- `Coroutine/CoroutineScheduler.h` (lines 159–275, `Coroutine` class)
+
+**Impact**: Individual coroutines can only be cancelled (`Cancel()`), not paused and resumed. If the game pauses (menu, cutscene), there is no way to freeze a specific coroutine without cancelling it. `StopAll()` cancels everything permanently.
+
+**Evidence**: `Coroutine` has `Cancel()` and `IsCancelled()` but no `Pause()`/`Resume()`/`IsPaused()` methods.
+
+**What is needed**: Add `Pause()` and `Resume()` methods to `Coroutine`. In `Update()`, skip paused coroutines without removing them. Add `PauseAll()`/`ResumeAll()` to `CoroutineScheduler` for game pause scenarios.
+
+---
+
+### GAP-CO07 — No Coroutine Tags or Group Management
+
+**Files**:
+- `Coroutine/CoroutineScheduler.h` (lines 302–306, `StartCoroutine`)
+
+**Impact**: Coroutines are identified only by name. There is no tag or group system to cancel or pause categories of coroutines (e.g., "stop all UI coroutines" or "pause all gameplay coroutines"). `StopCoroutine(name)` requires knowing the exact name.
+
+**What is needed**: Add an optional tag parameter: `StartCoroutine(name, tag)`. Add `StopByTag(tag)` and `PauseByTag(tag)` to `CoroutineScheduler`.
+
+---
+
+## Minor Gaps
+
+### GAP-CO08 — No Priority or Execution Order Guarantees
+
+**Files**:
+- `Coroutine/CoroutineScheduler.h` (lines 354–370, `Update()`)
+
+**Impact**: Coroutines are ticked in insertion order (the order they were created). There is no priority system to ensure certain coroutines run before others. For most gameplay use cases this is fine, but ordering-sensitive systems (e.g., a coroutine that must run after physics but before rendering) have no control.
+
+**What is needed**: Optional priority parameter on `StartCoroutine()`. Sort coroutines by priority before ticking.
+
+---
+
+### GAP-CO09 — No Coroutine Nesting or Sub-Coroutines
+
+**Files**:
+- `Coroutine/CoroutineScheduler.h` (full file)
+
+**Impact**: A coroutine cannot yield on another coroutine. In Unity, `yield return StartCoroutine(OtherCoroutine())` allows composition. The current system has no equivalent — starting a sub-coroutine from within a `Do()` callback works but the parent does not wait for it to finish.
+
+**What is needed**: Add `WaitForCoroutine(name)` yield instruction that pauses until the named coroutine completes.
+
+---
+
+### GAP-CO10 — Header-Only Implementation May Increase Compile Times
+
+**Files**:
+- `Coroutine/CoroutineScheduler.h` (full file — all method bodies inline)
+
+**Impact**: The entire coroutine system is implemented inline in the header. Every translation unit that includes this header gets the full implementation, increasing compile times. For a header this size (~400 lines) the impact is modest, but it prevents link-time deduplication of template instantiations.
+
+**What is needed**: Move non-template method implementations to a `.cpp` file. Keep only the `YieldInstruction` subclasses and short inline methods in the header.
+
+---

--- a/docs/gap-analysis/EVENT_SYSTEM_GAP_ANALYSIS.md
+++ b/docs/gap-analysis/EVENT_SYSTEM_GAP_ANALYSIS.md
@@ -1,0 +1,154 @@
+# SparkEngine Event System — Gap Analysis
+
+> **Scope**: `SparkEngine/Source/Engine/Events/` (EventBus, built-in event types)
+> **Date**: 2026-03-10
+> **Methodology**: Static source-code audit of all `.h`/`.cpp` files under `Events/`.
+> Each gap is assigned a severity: **Critical**, **Major**, **Moderate**, **Minor**.
+
+---
+
+## Context
+
+The Event subsystem provides a type-safe publish/subscribe event bus using C++ RTTI (`std::type_index`) for event routing. The `EventBus` class supports `Subscribe<T>()`, `Unsubscribe<T>()`, `Publish<T>()`, and `ClearSubscriptions<T>()`. Eight built-in event types are defined (`EntityDamagedEvent`, `EntityKilledEvent`, `ItemPickedUpEvent`, `QuestCompletedEvent`, `WeatherChangedEvent`, `TimeOfDayChangedEvent`, `CollisionEvent`, `PlayerRespawnEvent`). The EventBus is registered in `EngineContext`. However, there are critical thread-safety issues, no evidence of actual subsystem integration, and the system lacks queued dispatch.
+
+---
+
+## Critical Gaps
+
+### GAP-EV01 — Potential Deadlock in Publish()
+
+**Files**:
+- `Events/EventSystem.h` (lines 124–137, `Publish<T>()`)
+
+**Impact**: `Publish()` acquires `m_mutex` (non-recursive `std::mutex`) and then invokes subscriber callbacks while still holding the lock. If any callback calls `Subscribe()`, `Unsubscribe()`, or `Publish()` on the **same** `EventBus` instance, the thread will attempt to re-acquire the same non-recursive mutex, causing a **deadlock**. This is a realistic scenario: an `EntityKilledEvent` handler might publish a `PlayerRespawnEvent`, or an event handler might unsubscribe itself.
+
+**Evidence**: Line 126: `std::lock_guard<std::mutex> lock(m_mutex)` — acquired before callback invocation. Line 133: `sub.callback(&event)` — executed while lock is held. `m_mutex` is `std::mutex` (line 179), not `std::recursive_mutex`. The subscriber list is copied at line 132 (`auto subs = it->second`), which prevents iterator invalidation but does **not** prevent mutex re-acquisition deadlock.
+
+**What is needed**: Either use `std::recursive_mutex` (simple fix but masks design issues), or release the lock before invoking callbacks (copy the subscriber list, unlock, then iterate). The preferred fix is to copy-and-unlock:
+
+```cpp
+template <typename T> void Publish(const T& event) {
+    std::vector<Subscription> subs;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        auto it = m_subscribers.find(std::type_index(typeid(T)));
+        if (it == m_subscribers.end()) return;
+        subs = it->second;
+    }
+    for (const auto& sub : subs)
+        sub.callback(&event);
+}
+```
+
+---
+
+## Major Gaps
+
+### GAP-EV02 — No Subsystem Integration (Dead Event Types)
+
+**Files**:
+- `Events/EventSystem.h` (lines 188–253, built-in event types)
+- All other engine subsystems
+
+**Impact**: Eight built-in event types are defined but there is no evidence that any engine subsystem publishes or subscribes to them. `CollisionEvent` should be published by the physics system, `WeatherChangedEvent` by the weather system, `TimeOfDayChangedEvent` by `DayNightCycle`, and `EntityDamagedEvent`/`EntityKilledEvent` by the health/combat system. Without actual publishers and subscribers, the event system is infrastructure without content.
+
+**Evidence**: Grep for `Publish<EntityDamagedEvent>`, `Publish<CollisionEvent>`, `Subscribe<WeatherChangedEvent>`, etc. across the codebase shows no usage outside the `EventSystem.h` definitions. `DayNightCycle.h` includes `EventSystem.h` but it is unclear if it publishes `TimeOfDayChangedEvent`.
+
+**What is needed**: Wire up event publishing in the relevant subsystems. At minimum: `PhysicsSystem` should publish `CollisionEvent`, `DayNightCycle` should publish `TimeOfDayChangedEvent`, the health component system should publish `EntityDamagedEvent`/`EntityKilledEvent`.
+
+---
+
+### GAP-EV03 — No Deferred/Queued Event Dispatch
+
+**Files**:
+- `Events/EventSystem.h` (lines 124–137, `Publish<T>()`)
+
+**Impact**: All events are dispatched synchronously on the calling thread. There is no option to queue events for processing at a specific point in the frame (e.g., after physics but before rendering). This creates ordering dependencies: if system A publishes an event during its update, and system B subscribes to it, the callback runs during system A's update rather than during system B's update.
+
+**Evidence**: `Publish()` immediately invokes all callbacks. No `QueueEvent()`, `FlushEvents()`, or `ProcessDeferredEvents()` method exists.
+
+**What is needed**: Add a deferred dispatch mode: `Queue<T>(event)` stores events in a type-erased queue, and `FlushQueue()` dispatches all queued events in order. Allow both immediate and deferred dispatch. This is especially important for events that trigger entity creation/destruction, which should not happen mid-system-update.
+
+---
+
+### GAP-EV04 — RTTI Dependency
+
+**Files**:
+- `Events/EventSystem.h` (lines 38, 88, 103, 127, 146, 164 — `std::type_index`, `typeid`)
+
+**Impact**: The EventBus relies on C++ RTTI (`std::type_index(typeid(T))`) for event type routing. If RTTI is disabled (`-fno-rtti` on GCC/Clang), the entire event system fails to compile. Some game projects disable RTTI for performance or binary size reasons.
+
+**Evidence**: Every public template method uses `std::type_index(typeid(T))` as the map key.
+
+**What is needed**: Provide a compile-time type ID alternative (e.g., `template<typename T> constexpr size_t TypeID()` using `__COUNTER__` or a manual registration macro) that works when RTTI is disabled. Keep RTTI as the default but allow opt-out.
+
+---
+
+## Moderate Gaps
+
+### GAP-EV05 — No Event Priority or Ordering Control
+
+**Files**:
+- `Events/EventSystem.h` (lines 84–91, `Subscribe<T>()`)
+
+**Impact**: Subscribers are invoked in registration order with no way to control priority. If two systems both subscribe to `EntityKilledEvent`, there is no guarantee which runs first. Systems that need to run before others (e.g., score tracking before respawn) cannot express ordering requirements.
+
+**What is needed**: Add an optional `priority` parameter to `Subscribe()` (default 0). Sort subscribers by priority (highest first) when dispatching. This is a common pattern in event systems.
+
+---
+
+### GAP-EV06 — No Event Filtering
+
+**Files**:
+- `Events/EventSystem.h` (full `Subscribe<T>()` template)
+
+**Impact**: Subscribers receive all events of a given type. There is no way to filter by event content (e.g., "only `EntityDamagedEvent` where `entityId == myId`"). Every subscriber must check event fields and discard irrelevant events, adding overhead when many entities subscribe to the same event type.
+
+**What is needed**: Add a filtered subscribe overload: `Subscribe<T>(predicate, callback)` where `predicate` is `std::function<bool(const T&)>`. The predicate is evaluated before the callback is invoked.
+
+---
+
+### GAP-EV07 — Subscriber List Copy on Every Publish
+
+**Files**:
+- `Events/EventSystem.h` (line 132, `auto subs = it->second`)
+
+**Impact**: Every `Publish()` call copies the entire subscriber vector for the event type. This is done to allow safe iteration if a callback modifies the subscriber list, which is a reasonable safety measure. However, for frequently published events (e.g., `CollisionEvent` fired every frame for every contact), the vector copy adds per-frame allocation overhead.
+
+**What is needed**: Use a "dirty flag" pattern — only copy when a modification has occurred since the last publish. Alternatively, use a stable subscriber list with tombstones for removed entries, avoiding copies entirely.
+
+---
+
+## Minor Gaps
+
+### GAP-EV08 — No Event History or Replay for Debugging
+
+**Files**: All event files
+
+**Impact**: No facility to record published events for debugging or replay. When debugging gameplay issues, knowing what events were fired and in what order is critical. The console integration does not include event logging.
+
+**What is needed**: Add an optional event history ring buffer that stores the last N events (type name, timestamp, serialized data). Expose via console command (e.g., `event history 20`).
+
+---
+
+### GAP-EV09 — No Wildcard or Catch-All Subscription
+
+**Files**:
+- `Events/EventSystem.h` (full file)
+
+**Impact**: There is no way to subscribe to all event types at once. A debugging or logging system that wants to observe all engine events must subscribe to each type individually.
+
+**What is needed**: Add a `SubscribeAll(std::function<void(const std::type_index&, const void*)>)` method for type-erased catch-all subscriptions.
+
+---
+
+### GAP-EV10 — No Unsubscribe-by-Type Without Knowing SubscriptionID
+
+**Files**:
+- `Events/EventSystem.h` (lines 100–113, `Unsubscribe<T>(id)`)
+
+**Impact**: `Unsubscribe` requires both the event type `T` and the `SubscriptionID`. If a subscriber loses its ID (e.g., a system that subscribes during initialization but doesn't store the ID), it cannot unsubscribe. `ClearSubscriptions<T>()` removes *all* subscribers for a type, which is too broad.
+
+**What is needed**: Add `UnsubscribeAll(SubscriptionID id)` that searches all event types for the given ID. Alternatively, return an RAII handle from `Subscribe()` that auto-unsubscribes on destruction.
+
+---

--- a/docs/gap-analysis/INPUT_GAP_ANALYSIS.md
+++ b/docs/gap-analysis/INPUT_GAP_ANALYSIS.md
@@ -1,0 +1,135 @@
+# SparkEngine Input — Gap Analysis
+
+> **Scope**: `SparkEngine/Source/Input/` (InputManager, GamepadInput, PlatformInput)
+> **Date**: 2026-03-10
+> **Methodology**: Static source-code audit of all `.h`/`.cpp` files under `Input/`.
+> Each gap is assigned a severity: **Critical**, **Major**, **Moderate**, **Minor**.
+
+---
+
+## Context
+
+The Input subsystem has three layers: a low-level `InputManager` (Win32-only keyboard/mouse), a `GamepadInput` class (XInput-only gamepad), and a higher-level `PlatformInputManager` with a pluggable backend architecture (`IPlatformInputBackend`). The platform abstraction layer (`PlatformInput.h`) is well-designed with unified `KeyCode`/`GamepadBtn` enums, action/axis mapping, and an SDL2 backend stub. However, the legacy `InputManager` class is still the one registered in `EngineContext`, and the two systems are not integrated.
+
+---
+
+## Critical Gaps
+
+### GAP-I01 — Two Competing Input Systems, Neither Fully Integrated
+
+**Files**:
+- `Input/InputManager.h` — Legacy system registered in `EngineContext`
+- `Input/PlatformInput.h` — Modern abstraction, not registered in `EngineContext`
+
+**Impact**: The engine has two parallel input systems that duplicate functionality. `InputManager` is the one exposed through `EngineContext::GetInput()`, but it uses raw Win32 `HWND`, `UINT`, `WPARAM`, and `LPARAM` types throughout its public API, making it unusable on non-Windows platforms. `PlatformInputManager` was designed to replace it with cross-platform backends, but it exists as a separate singleton and is not wired into the engine context or game module interface.
+
+**Evidence**: `EngineContext.h` forward-declares and stores `InputManager*`, not `PlatformInputManager*`. `InputManager::HandleMessage()` takes `UINT message, WPARAM wParam, LPARAM lParam` — Win32 types. `PlatformInputManager` takes `void* windowHandle` and has its own `HandleWindowMessage()` with platform-neutral `uint32_t`/`uintptr_t` parameter types.
+
+**What is needed**: Migrate `EngineContext` to expose `PlatformInputManager` (or `IPlatformInputBackend`) instead of `InputManager`. Deprecate `InputManager` and route all game code through the platform-agnostic layer. Update `IEngineContext` interface to use `PlatformInputManager*`.
+
+---
+
+### GAP-I02 — SDL2 Backend Compile-Gated and Likely Untested
+
+**Files**:
+- `Input/PlatformInput.h` (`SDL2InputBackend` class, lines 516–563)
+
+**Impact**: The SDL2 backend (the only cross-platform backend) is gated behind `#ifdef SPARK_SDL2_AVAILABLE`, which is not defined anywhere in the CMake build system. SDL2 is not listed as a dependency. The backend class is declared but there is no evidence of implementation or testing. Linux and macOS builds therefore have no functional input backend.
+
+**Evidence**: `SPARK_SDL2_AVAILABLE` does not appear in any `CMakeLists.txt`. No SDL2 find module or dependency is present. The class body is header-only declarations with no corresponding `.cpp` for SDL2-specific logic.
+
+**What is needed**: Either integrate SDL2 as an optional dependency with a CMake find module and `ENABLE_SDL2` toggle, or implement a Linux evdev/libinput backend. At minimum, provide a null input backend that compiles and returns safe defaults.
+
+---
+
+## Major Gaps
+
+### GAP-I03 — InputManager Key Binding System Is Keyboard-Only
+
+**Files**:
+- `Input/InputManager.h` (lines 72–74, `m_keyBindings`)
+
+**Impact**: `InputManager` has a key binding system (`Console_BindKey`, `Console_IsActionActive`) but it only maps action names to integer virtual key codes. It cannot bind gamepad buttons, mouse buttons, or analog axes to actions. The `GamepadInput` class has its own separate `BindAction()` system that is not connected to `InputManager`'s bindings.
+
+**Evidence**: `m_keyBindings` is `std::unordered_map<std::string, int>` — maps action names to Win32 virtual key codes only. `GamepadInput::BindAction()` is a separate API with its own `ActionBinding` struct.
+
+**What is needed**: `PlatformInputManager` already solves this with unified `BindAction(name, KeyCode)` and `BindAction(name, GamepadBtn)`. Complete the migration to `PlatformInputManager` to get unified input bindings across all devices.
+
+---
+
+### GAP-I04 — No Touch or Gesture Input Support
+
+**Files**: All input files
+
+**Impact**: No support for touch screens, multi-touch gestures, or stylus input. While the engine targets desktop FPS games primarily, touch support is necessary for any potential mobile or tablet builds, and increasingly relevant for touch-enabled laptops.
+
+**What is needed**: Add `TouchEvent` types to the `InputEvent` struct in `PlatformInput.h` (touch begin/move/end with finger ID and position). Implement touch handling in the SDL2 backend (SDL2 has built-in touch support).
+
+---
+
+### GAP-I05 — No Input Serialization or Config File Persistence
+
+**Files**: `Input/InputManager.h`, `Input/PlatformInput.h`
+
+**Impact**: Neither input system can save or load key bindings to/from a configuration file. Players cannot persist their custom key bindings between sessions. The `Console_BindKey()` changes are lost on restart.
+
+**What is needed**: Add `SaveBindings(filepath)` and `LoadBindings(filepath)` methods to `PlatformInputManager`. Use a simple JSON or INI format. Load bindings at startup and save when modified.
+
+---
+
+## Moderate Gaps
+
+### GAP-I06 — HandleMessage Thread Safety Concern
+
+**Files**:
+- `Input/InputManager.h` (line 81, `m_inputMutex`; line 131, `HandleMessage`)
+
+**Impact**: `HandleMessage()` is called from the Win32 `WndProc` callback, which runs on the window's message pump thread. Meanwhile, `Update()` and query methods run on the main game thread. While `m_inputMutex` exists, it is unclear whether `HandleMessage()` acquires it before modifying `m_keyStates` and mouse position. If not, concurrent reads and writes cause data races.
+
+**What is needed**: Verify `.cpp` implementation acquires the mutex in `HandleMessage()`. Alternatively, use a double-buffer pattern: `HandleMessage()` writes to a pending buffer, `Update()` swaps buffers under the lock.
+
+---
+
+### GAP-I07 — Console_SimulateKeyPress Uses Threads for Timed Release
+
+**Files**:
+- `Input/InputManager.h` (lines 83, 344)
+
+**Impact**: `Console_SimulateKeyPress(keyName, duration)` spawns a `std::thread` to sleep for `duration` milliseconds then release the key. These threads are stored in `m_pendingTimedThreads` and joined in the destructor. This pattern is fragile: if many simulated presses are requested, many threads are spawned. If the `InputManager` is destroyed while threads are sleeping, the destructor blocks.
+
+**What is needed**: Use the `CoroutineScheduler` or a timer callback instead of spawning OS threads. Alternatively, use `WaitForSeconds` from the coroutine system to defer the key release.
+
+---
+
+### GAP-I08 — No Input Buffering for Frame-Perfect Actions
+
+**Files**: All input files
+
+**Impact**: Input is sampled once per frame in `Update()`. If a key press and release occur between two `Update()` calls (common at low frame rates), the press is lost. For an FPS game, this means fast button presses (e.g., quick melee, weapon switch) can be dropped.
+
+**What is needed**: Buffer input events as they arrive in `HandleMessage()` and process the full buffer in `Update()`. Track "pressed this frame" as "was pressed at any point since last Update" rather than instantaneous state.
+
+---
+
+## Minor Gaps
+
+### GAP-I09 — Mouse Wheel/Scroll Not Handled in InputManager
+
+**Files**:
+- `Input/InputManager.h` (line 131, `HandleMessage` — lists WM_MOUSEMOVE but not WM_MOUSEWHEEL)
+
+**Impact**: The `InputManager::HandleMessage()` documentation lists the handled messages and does not include `WM_MOUSEWHEEL`. Scroll wheel input may be silently ignored. The `PlatformInputManager`'s `Win32InputBackend` does handle `WM_MOUSEWHEEL` via `GetMouseScroll()`, so this only affects code using the legacy `InputManager`.
+
+**What is needed**: Add `WM_MOUSEWHEEL` handling to `InputManager::HandleMessage()` or complete migration to `PlatformInputManager` which already supports it.
+
+---
+
+### GAP-I10 — No Input Recording/Playback for Debugging
+
+**Files**: All input files
+
+**Impact**: No facility to record input sequences and replay them. This would be valuable for automated testing, bug reproduction, and demo recording. `m_recentInputEvents` stores recent events for console display but cannot replay them.
+
+**What is needed**: Add optional input recording that serializes timestamped events to a file, and a playback mode that feeds recorded events back into the system. Useful for automated testing.
+
+---

--- a/docs/gap-analysis/PROCEDURAL_GENERATION_GAP_ANALYSIS.md
+++ b/docs/gap-analysis/PROCEDURAL_GENERATION_GAP_ANALYSIS.md
@@ -1,0 +1,140 @@
+# SparkEngine Procedural Generation — Gap Analysis
+
+> **Scope**: `SparkEngine/Source/Engine/Procedural/` (NoiseGenerator, HeightmapGenerator, ProceduralMesh, ObjectPlacer, WaveFunctionCollapse)
+> **Date**: 2026-03-10
+> **Methodology**: Static source-code audit of all `.h`/`.cpp` files under `Procedural/`.
+> Each gap is assigned a severity: **Critical**, **Major**, **Moderate**, **Minor**.
+
+---
+
+## Context
+
+The Procedural Generation subsystem provides noise functions (Perlin, Simplex, Worley, FBM, ridged multifractal, domain warping), heightmap generation with erosion simulation, procedural mesh primitives (plane, box, sphere, cylinder, cone, torus, terrain, rock, tree), rule-based object placement, and Wave Function Collapse for room/dungeon layouts. The API is clean and functional with static utility methods. However, the system is entirely standalone with no integration into the ECS, editor, or rendering pipeline, and all spatial types are Windows-only.
+
+---
+
+## Major Gaps
+
+### GAP-PG01 — Platform-Dependent Data Structures Throughout
+
+**Files**:
+- `Procedural/ProceduralGeneration.h` (lines 119–122, `ProceduralVertex`; lines 164, 174–178, `PlacementRule`/`PlacementResult`)
+
+**Impact**: `ProceduralVertex` uses `XMFLOAT3` and `XMFLOAT2` for position/normal/texcoord. `PlacementRule` uses `XMFLOAT2` for scale range. `PlacementResult` uses `XMFLOAT3` for position/rotation/scale. All these types are DirectXMath types available only on Windows. The entire procedural generation system fails to compile on Linux/macOS.
+
+**Evidence**: `#include <DirectXMath.h>` at line 19, guarded by `SPARK_PLATFORM_WINDOWS`. The struct definitions using these types (lines 119–178) are outside the guard, causing compile errors on non-Windows.
+
+**What is needed**: Use platform-agnostic math types (e.g., from `Platform.h` stubs) or define local `struct Vector3 { float x, y, z; }` types within the procedural namespace.
+
+---
+
+### GAP-PG02 — No Integration with ECS
+
+**Files**:
+- `Procedural/ProceduralGeneration.h` (full file)
+
+**Impact**: Generated meshes (`ProceduralMeshData`) and placement results (`PlacementResult`) are returned as raw data structs. There is no method to create ECS entities from generated content. `ObjectPlacer::PlaceObjects()` returns placement positions but does not create entities in the World. Game code must manually iterate results, create entities, and attach mesh/transform components.
+
+**Evidence**: No `#include` of any ECS headers. No `World&` parameter in any method. `PlacementResult` contains `objectType` (a string) and transform data but no entity creation.
+
+**What is needed**: Add helper methods: `CreateEntitiesFromPlacements(World&, placements, meshMap)` that creates entities with `Transform`, `MeshRenderer`, and `NameComponent` for each placement result. Consider an `ECS/ProceduralSystem` that wraps the generation pipeline.
+
+---
+
+### GAP-PG03 — No Editor Integration
+
+**Files**:
+- `Procedural/ProceduralGeneration.h`
+- `SparkEditor/Source/` (no Procedural directory)
+
+**Impact**: The SparkEditor has terrain tools (`SparkEditor/Source/Terrain/`) but no procedural generation panel. Users cannot configure noise parameters, preview heightmaps, tweak placement rules, or run WFC layouts from within the editor. All procedural generation must be done via code.
+
+**Evidence**: `SparkEditor/Source/` contains `Terrain/` but no `Procedural/` directory. The `HeightmapSettings` struct has 11 parameters that would benefit from visual sliders and real-time preview.
+
+**What is needed**: Create an ImGui-based procedural generation panel in the editor with parameter sliders, heightmap preview (as a 2D texture or 3D mesh), placement rule editors, and WFC tile configuration.
+
+---
+
+### GAP-PG04 — No Integration with Rendering Pipeline
+
+**Files**:
+- `Procedural/ProceduralGeneration.h` (lines 124–128, `ProceduralMeshData`)
+
+**Impact**: `ProceduralMeshData` contains raw vertex/index arrays but has no method to create GPU buffers (vertex buffer, index buffer) or `MeshRenderer` components. Converting procedural mesh data to renderable meshes requires manual D3D11 buffer creation and shader setup that is not encapsulated anywhere.
+
+**Evidence**: `ProceduralMeshData` has `std::vector<ProceduralVertex>` and `std::vector<uint32_t>` — CPU-side data only. No `CreateGPUMesh()`, `ToVertexBuffer()`, or similar method.
+
+**What is needed**: Add a `ProceduralMeshData::CreateRenderMesh(GraphicsEngine&)` method or a utility in the Graphics subsystem that accepts `ProceduralMeshData` and returns a renderable mesh handle.
+
+---
+
+## Moderate Gaps
+
+### GAP-PG05 — WFC Implementation Status Unclear
+
+**Files**:
+- `Procedural/ProceduralGeneration.h` (lines 213–241, `WaveFunctionCollapse`)
+
+**Impact**: The Wave Function Collapse class has a clean public API (`AddTile`, `SetGridSize`, `Collapse`, `GetResult`) with internal methods (`FindMinEntropyCell`, `Propagate`, `AreSocketsCompatible`). However, WFC is a complex algorithm and it is unclear from the header alone whether the implementation is complete and correct. The `Collapse()` method returns `bool` for success/contradiction but there is no documentation on failure modes, constraint definitions, or socket format conventions.
+
+**Evidence**: No test file specifically for WFC (the test file `TestNoiseGenerator.cpp` covers noise, not WFC). Socket compatibility uses string matching (`AreSocketsCompatible(string, string)`) but the matching convention (exact match? prefix? complementary pairs?) is undocumented.
+
+**What is needed**: Add documentation for the socket format convention. Write unit tests for WFC with known-good tile sets. Document edge cases (grid too small, conflicting constraints, no valid solution).
+
+---
+
+### GAP-PG06 — No Streaming or Chunked Generation
+
+**Files**:
+- `Procedural/ProceduralGeneration.h` (full file)
+
+**Impact**: All generation methods produce the entire result at once. `HeightmapGenerator::Generate()` creates the full heightmap in memory. For large open worlds, this requires generating and storing the entire world before rendering begins. There is no chunked or streaming generation that produces terrain/objects incrementally as the player moves.
+
+**What is needed**: Add a `ChunkedHeightmapGenerator` that generates terrain in fixed-size chunks on demand. Track generated chunks and generate neighbors as the camera approaches chunk boundaries. Combine with LOD for distant chunks.
+
+---
+
+### GAP-PG07 — No Biome System
+
+**Files**:
+- `Procedural/ProceduralGeneration.h` (lines 155–171, `PlacementRule`)
+
+**Impact**: `PlacementRule` defines constraints per object type (density, height range, slope range), but there is no biome system that groups placement rules, terrain textures, and noise parameters into coherent environments. Creating a world with forests, deserts, and mountains requires manually defining separate rule sets and blending between them.
+
+**What is needed**: Add a `Biome` struct that groups: noise parameters (frequency, amplitude), terrain texture weights, a set of `PlacementRule`s, and a biome mask noise function. Add `BiomeMixer` that blends between biomes based on temperature/moisture noise maps.
+
+---
+
+### GAP-PG08 — Generated Meshes Have No LOD Integration
+
+**Files**:
+- `Procedural/ProceduralGeneration.h` (lines 130–149, `ProceduralMesh` methods)
+
+**Impact**: Procedural meshes are generated at a single level of detail. `CreateSphere(radius, 16, 16)` always produces 16x16 subdivisions. For distant objects, these meshes are over-detailed. The engine has a `MeshLOD` system (tested in `TestMeshLOD.cpp`) but procedural meshes do not integrate with it.
+
+**What is needed**: Add LOD parameters or a `GenerateLODs(meshData, levels)` utility that produces progressively simplified meshes. Register the LOD chain with the engine's `MeshLOD` system.
+
+---
+
+## Minor Gaps
+
+### GAP-PG09 — L-System Tree Generation Described as "Very Simplified"
+
+**Files**:
+- `Procedural/ProceduralGeneration.h` (line 148, `CreateTree`)
+
+**Impact**: The `CreateTree()` method is documented as "very simplified L-system." It takes height, branch count, and seed but does not expose L-system grammar rules, iteration depth, branch angle, or leaf generation. The result is likely a basic branching cylinder rather than a realistic tree.
+
+**What is needed**: Expose L-system parameters (axiom, rules, iterations, angle) for configurable tree generation. Add leaf mesh generation. Consider integrating SpeedTree-style billboard LODs for distant trees.
+
+---
+
+### GAP-PG10 — No Undo for Procedural Modifications
+
+**Files**: All procedural files
+
+**Impact**: Running a procedural generation pass (heightmap generation, object placement) produces results that cannot be undone within the editor. If the result is unsatisfactory, the user must re-run with different parameters.
+
+**What is needed**: Integrate with the editor's undo system (if one exists in `SparkEditor/Source/CommandHistory.h`). Snapshot the pre-generation state and allow undo back to it.
+
+---

--- a/docs/gap-analysis/SAVE_SYSTEM_GAP_ANALYSIS.md
+++ b/docs/gap-analysis/SAVE_SYSTEM_GAP_ANALYSIS.md
@@ -1,0 +1,138 @@
+# SparkEngine Save System — Gap Analysis
+
+> **Scope**: `SparkEngine/Source/Engine/SaveSystem/` (SaveSystem, ComponentSerializerRegistry)
+> **Date**: 2026-03-10
+> **Methodology**: Static source-code audit of all `.h`/`.cpp` files under `SaveSystem/`.
+> Each gap is assigned a severity: **Critical**, **Major**, **Moderate**, **Minor**.
+
+---
+
+## Context
+
+The Save subsystem provides ECS-aware game state persistence. It serializes the entire World (entities + components) to compressed JSON via a `ComponentSerializerRegistry` that maps type names to serialize/deserialize function pairs. The system supports named save slots, quicksave/quickload, rotating autosave, and console integration. `SaveSystem` is a singleton with a well-documented API including in-memory snapshots via `SerializeWorld()`/`DeserializeWorld()`. However, there are concerns about missing dependencies, platform-specific types in portable data, and no corruption protection.
+
+---
+
+## Critical Gaps
+
+### GAP-SS01 — RapidJSON and Miniz Dependencies Not Visible
+
+**Files**:
+- `SaveSystem/SaveSystem.h` (lines 520–521, doc comment references "JSON compressed with miniz deflate")
+- Project `CMakeLists.txt` files
+- `ThirdParty/` or dependency directories
+
+**Impact**: The `SaveSystem` documentation states it uses "RapidJSON" for JSON serialization and "miniz" for deflate compression. However, neither library appears as a dependency in the CMake build system or third-party directory. If these libraries are not actually linked, `WriteToFile()` and `ReadFromFile()` — the core I/O methods — may be stubbed or non-functional.
+
+**Evidence**: No `find_package(RapidJSON)`, `add_subdirectory(miniz)`, or similar CMake calls found. No `rapidjson/` or `miniz/` directory in the source tree. The `.h` file does not `#include` any RapidJSON or miniz headers.
+
+**What is needed**: Either integrate RapidJSON and miniz as actual dependencies (add to CMake, include headers in `.cpp` file), or switch to a header-only JSON library (e.g., nlohmann/json) and zlib/miniz. Verify that `WriteToFile()`/`ReadFromFile()` actually compile and produce valid save files.
+
+---
+
+## Major Gaps
+
+### GAP-SS02 — Platform-Dependent Types in Save Metadata
+
+**Files**:
+- `SaveSystem/SaveSystem.h` (line 198, `DirectX::XMFLOAT3 playerPosition`)
+
+**Impact**: `SaveMetadata` contains `DirectX::XMFLOAT3 playerPosition`, a Windows-only type. Save files written on Windows cannot be read on Linux/macOS (the type doesn't exist), and the `SaveSystem.h` header fails to compile on non-Windows platforms. This makes save files non-portable across platforms.
+
+**Evidence**: `#include <DirectXMath.h>` at line 79, guarded by `SPARK_PLATFORM_WINDOWS`. `XMFLOAT3` usage at line 198 is outside the guard, causing compile errors on non-Windows.
+
+**What is needed**: Replace `DirectX::XMFLOAT3 playerPosition` with a platform-agnostic type (e.g., three `float` members, or the engine's cross-platform math stub from `Platform.h`).
+
+---
+
+### GAP-SS03 — No Save Corruption Detection
+
+**Files**:
+- `SaveSystem/SaveSystem.h` (lines 807–820, `WriteToFile`/`ReadFromFile`)
+
+**Impact**: Save files have no integrity verification. If a save file is partially written (power failure, crash during save), truncated, or corrupted on disk, `ReadFromFile()` will attempt to decompress and parse invalid data. The result is undefined — likely a crash, silent data loss, or a partially loaded world. There is no checksum, magic number, or file header to detect corruption before parsing.
+
+**What is needed**: Add a file header with a magic number (e.g., `"SPRK"`) and a CRC32/SHA256 checksum of the compressed data. Verify the checksum before decompression. Use atomic writes (write to temp file, then rename) to prevent partial saves.
+
+---
+
+### GAP-SS04 — Singleton Pattern Outside EngineContext
+
+**Files**:
+- `SaveSystem/SaveSystem.h` (lines 577, `SaveSystem::GetInstance()`)
+
+**Impact**: `SaveSystem` uses the singleton pattern but is not registered in `EngineContext`. Game modules access it via `SaveSystem::GetInstance()` directly, bypassing the service locator. This creates a hidden global dependency and makes testing difficult.
+
+**Evidence**: `EngineContext.h` has no `GetSaveSystem()` method. `IEngineContext` does not expose the save system.
+
+**What is needed**: Register `SaveSystem` in `EngineContext` and expose through `IEngineContext`.
+
+---
+
+## Moderate Gaps
+
+### GAP-SS05 — Version Migration System Documented But Not Implemented
+
+**Files**:
+- `SaveSystem/SaveSystem.h` (lines 149–155, `version` field; lines 615–617, Load doc comment)
+
+**Impact**: `SaveMetadata::version` defaults to 1, and the `Load()` documentation mentions "applies version migrations if the save format version differs from the current engine version." However, there is no migration code, no migration registry, and no mechanism to upgrade old save files. If the save format changes, old saves will fail to load with no recovery path.
+
+**What is needed**: Implement a migration registry: `RegisterMigration(fromVersion, toVersion, migrationFunc)`. In `Load()`, check `metadata.version` against the current version and apply migrations in sequence. At minimum, log a clear error when version mismatch is detected.
+
+---
+
+### GAP-SS06 — Not Thread-Safe, No Async Save Option
+
+**Files**:
+- `SaveSystem/SaveSystem.h` (lines 537–541, thread safety documentation)
+
+**Impact**: The documentation explicitly states "SaveSystem is not thread-safe" and suggests serializing on the main thread then writing from a background thread. However, no helper method or utility is provided for this pattern. For large game worlds, `Save()` on the main thread causes a frame stutter. The suggested workaround requires game code to manually call `SerializeWorld()` and then manage a background thread for `WriteToFile()`.
+
+**What is needed**: Add an `AsyncSave()` method that serializes on the main thread and queues the file write to a worker thread. Return a future or callback for completion notification.
+
+---
+
+### GAP-SS07 — No Cloud Save Support
+
+**Files**: All save system files
+
+**Impact**: Save files are written to the local filesystem only. No abstraction exists for cloud save backends (Steam Cloud, Epic Online Services, Xbox Live, etc.). Games shipping on multiple storefronts must implement cloud save separately.
+
+**What is needed**: Abstract the storage backend behind an interface (`ISaveStorage`) with `Write()`, `Read()`, `Exists()`, `Delete()`, `List()` methods. Provide a `LocalFileSaveStorage` implementation (current behavior) and allow game code to plug in platform-specific cloud storage implementations.
+
+---
+
+### GAP-SS08 — RegisterBuiltins() Scope Unclear
+
+**Files**:
+- `SaveSystem/SaveSystem.h` (lines 479–486, `RegisterBuiltins()`)
+
+**Impact**: `RegisterBuiltins()` is documented as registering "Transform, NameComponent, HealthComponent, RigidBodyComponent, MeshRenderer, Camera, AudioSourceComponent, LightComponent, AnimationController, AIComponent, and more." The vague "and more" makes it unclear which components are actually serializable. If a component type is not registered, it is silently skipped during save — the developer has no way to know data was lost.
+
+**What is needed**: Enumerate all registered component types explicitly in documentation or provide a `ListRegisteredTypes()` method. Log a warning when saving an entity with components that have no registered serializer.
+
+---
+
+## Minor Gaps
+
+### GAP-SS09 — No Save File Size Limits or Warnings
+
+**Files**: All save system files
+
+**Impact**: No check on save file size. A world with thousands of entities could produce multi-megabyte save files without warning. No limit prevents filling disk space.
+
+**What is needed**: Log a warning when save file size exceeds a configurable threshold (e.g., 100MB). Optionally set a maximum save file size with an error if exceeded.
+
+---
+
+### GAP-SS10 — CustomState Is Stringly-Typed
+
+**Files**:
+- `SaveSystem/SaveSystem.h` (lines 336–349, `SaveData::customState`)
+
+**Impact**: `customState` is `std::unordered_map<std::string, std::string>` — all values are strings. Storing numeric, boolean, or structured data requires manual string conversion. There is no validation or schema for custom state keys.
+
+**What is needed**: Consider using a `std::variant<std::string, int, float, bool>` value type, or document the recommended encoding conventions. This is a minor ergonomic issue.
+
+---


### PR DESCRIPTION
Extends gap analysis coverage from 12 to 19 documents, adding:
- Input: dual system conflict, SDL2 backend unimplemented, no config persistence
- Cinematic/Sequencer: no serialization, no editor timeline, platform-dependent types
- Coroutine: documented features missing (Repeat/WithInterval), no error handling
- Event System: deadlock risk in Publish(), no subsystem integration, no queued dispatch
- Save System: missing RapidJSON/miniz deps, no corruption detection, platform types
- Procedural Generation: no ECS/editor/renderer integration, platform-dependent types
- Core Infrastructure: EngineContext exposes 6/14+ subsystems, no scene management

https://claude.ai/code/session_011AsyJvTNshba8khzKgktFk