### PR TITLE
Add CPU performance and memory leak gap analysis documents

### DIFF
--- a/docs/gap-analysis/CPU_PERFORMANCE_GAP_ANALYSIS.md
+++ b/docs/gap-analysis/CPU_PERFORMANCE_GAP_ANALYSIS.md
@@ -1,0 +1,254 @@
+# SparkEngine CPU Performance — Gap Analysis
+
+> **Scope**: Engine-wide per-frame hot paths — ECS systems, AI, physics, networking, animation, rendering
+> **Date**: 2026-03-10
+> **Methodology**: Static source-code audit of update loops, per-frame methods, and algorithmic complexity.
+> Each gap is assigned a severity: **Critical**, **Major**, **Moderate**, **Minor**.
+
+---
+
+## Context
+
+SparkEngine's ECS execution order is Physics -> Animation -> AI -> Audio -> Lifecycle -> Render. Each system runs every frame on the main thread. The engine has a `Profiler` with scoped timers and a `PerformanceStats` tracker. Some subsystems are well-optimized (animation keyframes use binary search), but several hot paths contain O(n^2) algorithms, linear scans over large collections, and per-frame allocations that will cause frame drops as scene complexity grows.
+
+---
+
+## Critical Gaps
+
+### GAP-CPU01 — O(n^2) Entity State Interpolation in Lag Compensation
+
+**Files**:
+- `Engine/Networking/NetworkManager.cpp` (lines 167–195)
+
+**Impact**: `LagCompensator::RewindToTime()` uses nested loops to match entities across two snapshots by `networkID`. For each entity in the "before" snapshot, it scans all entities in the "after" snapshot. With 100 networked entities, this is 10,000 comparisons per lag-compensated query. In a multiplayer FPS with server-side hit detection, this runs for every projectile/hitscan check.
+
+**Evidence**:
+```cpp
+for (const auto& entityBefore : before->entities)
+{
+    for (const auto& entityAfter : after->entities)
+    {
+        if (entityBefore.networkID == entityAfter.networkID)
+        {
+            // ... interpolate ...
+            outSnapshot.entities.push_back(interpolated);
+            break;
+        }
+    }
+}
+```
+
+**What is needed**: Build an `std::unordered_map<uint32_t, const EntityState*>` for the "after" snapshot before the outer loop. Reduces complexity to O(n) with O(1) lookups.
+
+---
+
+### GAP-CPU02 — Linear Scan of All NavMesh Triangles for Nearest Point
+
+**Files**:
+- `Engine/AI/NavMesh.cpp` (lines 23–52)
+
+**Impact**: `NavMeshQuery::FindNearestPoint()` iterates every triangle in the navmesh, computing point-to-triangle projection and distance for each. With a 1000-triangle navmesh and 20 AI agents querying per frame, this is 20,000 projection calculations per frame. This is the core spatial query used by all AI navigation.
+
+**Evidence**:
+```cpp
+for (uint32_t i = 0; i < static_cast<uint32_t>(m_navMesh->triangles.size()); ++i)
+{
+    XMFLOAT3 projected = ProjectPointToTriangle(position, i);
+    float distSq = dx * dx + dy * dy + dz * dz;
+    if (distSq < bestDistSq) { ... }
+}
+```
+
+**What is needed**: Build a spatial index (grid or BVH) over navmesh triangles. Only test triangles whose bounding cells overlap the query sphere. Reduces per-query cost from O(T) to O(log T) or O(1) amortized.
+
+---
+
+### GAP-CPU03 — O(n*m) AI Perception Without Spatial Partitioning
+
+**Files**:
+- `Engine/AI/AISystem.cpp` (lines 65–109)
+
+**Impact**: Each AI agent's perception system checks distance to all potential targets every frame. With N agents and M targets, this is O(N*M) distance computations. In a scene with 50 enemies and 20 targets, that is 1,000 distance checks per frame. Combined with the navmesh scans (GAP-CPU02), the AI system dominates frame time.
+
+**Evidence**:
+```cpp
+if (distSq < ai.config.detectionRange * ai.config.detectionRange)
+{
+    ai.lastKnownTargetPos = targetTransform->position;
+}
+```
+
+No spatial partitioning limits the search radius. Every target is tested regardless of proximity.
+
+**What is needed**: Use a spatial grid or quadtree to bucket entities by position. For each agent, only check targets in nearby cells (cells within `detectionRange`). The engine's existing Octree in `Utils/` could be adapted for this purpose.
+
+---
+
+### GAP-CPU04 — Per-Pathfinding Vector Allocations
+
+**Files**:
+- `Engine/AI/NavMesh.cpp` (lines 83–88)
+
+**Impact**: Every A* pathfinding query allocates three full-sized vectors proportional to the total navmesh triangle count:
+
+```cpp
+std::vector<float> gCosts(triCount, 1e30f);
+std::vector<uint32_t> parents(triCount, UINT32_MAX);
+std::vector<bool> closed(triCount, false);
+```
+
+With a 2000-triangle navmesh, each query allocates ~24KB (8000 floats + 8000 uint32s + 2000 bools). If 10 agents request paths in a single frame, that is 240KB of heap allocation and deallocation per frame, causing allocator fragmentation and cache thrashing.
+
+**What is needed**: Pool these vectors per-agent or per-thread. Allocate once at initialization and clear/reuse each query. Alternatively, use a sparse `std::unordered_map<uint32_t, AStarNodeData>` for large navmeshes where paths traverse a small fraction of total triangles.
+
+---
+
+## Major Gaps
+
+### GAP-CPU05 — Linear Snapshot Search in Lag Compensator
+
+**Files**:
+- `Engine/Networking/NetworkManager.cpp` (lines 142–152)
+
+**Impact**: The lag compensator scans all history snapshots linearly to find the two snapshots bracketing a target timestamp. With 300 snapshots (5 seconds at 60fps), this is 300 iterations per lag-compensated query.
+
+**Evidence**:
+```cpp
+for (size_t i = 0; i < m_history.size(); ++i)
+{
+    if (m_history[i].timestamp <= targetTime) before = &m_history[i];
+    if (m_history[i].timestamp >= targetTime && !after) after = &m_history[i];
+}
+```
+
+The history is chronologically ordered, making binary search trivial.
+
+**What is needed**: Replace with `std::lower_bound()` on the timestamp field. Complexity drops from O(n) to O(log n). With 300 snapshots, this is ~9 comparisons instead of 300.
+
+---
+
+### GAP-CPU06 — vector::erase() for Physics Body Removal
+
+**Files**:
+- `Physics/PhysicsSystem.cpp` (lines 944–949)
+
+**Impact**: Removing a physics body performs a linear search followed by `vector::erase()`, which shifts all subsequent elements:
+
+```cpp
+auto it = std::find(m_bodies.begin(), m_bodies.end(), body);
+if (it != m_bodies.end())
+    m_bodies.erase(it);  // O(n) shift
+```
+
+With 200 physics bodies and frequent create/destroy cycles (bullets, debris, pickups), this is O(n) per removal with O(n) memory moves.
+
+**What is needed**: Use swap-and-pop removal (`std::swap(*it, m_bodies.back()); m_bodies.pop_back()`) for O(1) removal when order doesn't matter. For order-preserving removal, use a deferred deletion list processed at end-of-frame.
+
+---
+
+### GAP-CPU07 — shared_ptr Overhead for Physics Bodies
+
+**Files**:
+- `Physics/PhysicsSystem.cpp` (lines 841–924)
+
+**Impact**: Physics bodies are stored as `std::shared_ptr<PhysicsBody>` in `m_bodies`. Every access, copy, and removal involves atomic reference count operations. With 200+ dynamic bodies accessed every physics step, the atomic increments/decrements add measurable overhead — atomic operations prevent instruction reordering and force cache line synchronization.
+
+**What is needed**: Replace with `std::unique_ptr<PhysicsBody>` since ownership is exclusive to `PhysicsSystem`. Use raw non-owning pointers for external references (entity components pointing to their physics body). This eliminates all atomic overhead.
+
+---
+
+## Moderate Gaps
+
+### GAP-CPU08 — Linear System Name Lookup in ECS
+
+**Files**:
+- `Engine/ECS/Systems/ECSystems.h` (lines 614–632)
+
+**Impact**: `SystemManager::GetSystem(string_view name)` performs a linear string comparison over all registered systems:
+
+```cpp
+for (auto& system : m_systems)
+{
+    if (name == system->GetName())
+        return system.get();
+}
+```
+
+With 6–10 systems this is negligible, but if called multiple times per frame for runtime enable/disable logic, string comparisons add up.
+
+**What is needed**: Cache an `std::unordered_map<std::string, ISystem*>` at registration time for O(1) lookups.
+
+---
+
+### GAP-CPU09 — Profiler Overhead If Accidentally Enabled in Shipping
+
+**Files**:
+- `Utils/Profiler.h` (lines 279–298)
+
+**Impact**: The profiler is conditionally compiled behind `PROFILING_ENABLED`. If this macro is accidentally defined in shipping builds, `ScopedProfileTimer` objects call `std::chrono::high_resolution_clock::now()` on every scope entry and exit. Each call is 20–50ns, and with hundreds of profiled scopes per frame, this adds 10–50 microseconds of overhead.
+
+**Evidence**:
+```cpp
+#ifdef PROFILING_ENABLED
+#define PROFILE_SCOPE(name) ScopedProfileTimer _profile_##__LINE__(name)
+#else
+#define PROFILE_SCOPE(name)
+#endif
+```
+
+**What is needed**: Add a `static_assert` or CMake-level guard that prevents `PROFILING_ENABLED` from being set in Release/Shipping configurations. Alternatively, use a runtime flag with near-zero overhead when disabled (function pointer swap to no-op).
+
+---
+
+### GAP-CPU10 — Input Event Log Uses Front-Erase on Vector
+
+**Files**:
+- `Input/InputManager.cpp` (lines 744–748)
+
+**Impact**: `LogInputEvent()` erases from the front of `m_recentInputEvents` when it exceeds 100 entries:
+
+```cpp
+if (m_recentInputEvents.size() >= 100)
+    m_recentInputEvents.erase(m_recentInputEvents.begin());
+```
+
+Front-erase on `std::vector` is O(n), shifting all elements. With input events logged every frame, this is 100 element shifts per frame.
+
+**What is needed**: Replace with `std::deque` (O(1) front removal), a ring buffer (the engine already has `Utils/RingBuffer`), or a circular index over a fixed-size array.
+
+---
+
+### GAP-CPU11 — Animation State Machine Transition Lookup
+
+**Files**:
+- `Engine/Animation/AnimationSystem.cpp` (lines 127–130)
+
+**Impact**: Animation transitions are stored in a flat `std::vector`. When evaluating transitions each frame, all transitions must be checked against the current state. With 10 animated characters and 20 transitions per state machine, this is 200 linear scans per frame.
+
+**What is needed**: Index transitions by source state in an `std::unordered_map<AnimationStateID, std::vector<Transition>>`. Only check transitions leaving the current state, not all transitions.
+
+---
+
+## Minor Gaps
+
+### GAP-CPU12 — AI Path Vector Clearing Causes Allocator Churn
+
+**Files**:
+- `Engine/AI/AISystem.cpp` (lines 144–146)
+
+**Impact**: When an AI agent completes its path, `ai.currentPath.clear()` deallocates the vector's storage. The next pathfinding request allocates a new vector. Over thousands of path completions, this causes heap fragmentation.
+
+**What is needed**: Use `ai.currentPath.resize(0)` to keep the allocation, or swap with a pre-allocated path buffer.
+
+---
+
+### GAP-CPU13 — String Concatenation in Console Logging
+
+**Files**:
+- `Input/InputManager.cpp` (lines 319–350)
+
+**Impact**: Console log messages use `std::string` concatenation (`"text" + std::string(value) + "more text"`), creating temporary strings. These are in console command handlers (not per-frame), so the impact is low, but it violates the C++20 coding standard which recommends `std::format`.
+
+**What is needed**: Replace string concatenation with `std::format()` for consistency with C++20 coding standards. Low priority.
+
+---

--- a/docs/gap-analysis/MEMORY_LEAK_GAP_ANALYSIS.md
+++ b/docs/gap-analysis/MEMORY_LEAK_GAP_ANALYSIS.md
@@ -1,0 +1,227 @@
+# SparkEngine Memory Leak — Gap Analysis
+
+> **Scope**: Engine-wide memory management — ownership, RAII, container growth, resource lifecycle
+> **Date**: 2026-03-10
+> **Methodology**: Static source-code audit of allocation patterns, destructor correctness, container lifecycle, and resource ownership across all subsystems.
+> Each gap is assigned a severity: **Critical**, **Major**, **Moderate**, **Minor**.
+
+---
+
+## Context
+
+SparkEngine's CLAUDE.md coding standards mandate `std::unique_ptr` for owning pointers, raw pointers for non-owning references, no naked `new`/`delete`, and RAII for all resource management. The codebase largely follows these rules in the ECS, audio, and editor subsystems. However, the Bullet Physics integration uses extensive naked `new`, the event system has callback lifecycle issues, and several containers grow without bounds. These issues create memory leak risks ranging from slow accumulation to immediate corruption.
+
+---
+
+## Critical Gaps
+
+### GAP-ML01 — Bullet Physics Objects Allocated with Naked `new`
+
+**Files**:
+- `Physics/PhysicsSystem.cpp` (lines 640–648)
+
+**Impact**: Five core Bullet world objects are allocated with raw `new` and stored as raw pointers:
+
+```cpp
+m_collisionConfig = new btDefaultCollisionConfiguration();
+m_dispatcher = new btCollisionDispatcher(m_collisionConfig);
+m_broadphase = new btDbvtBroadphase();
+m_solver = new btSequentialImpulseConstraintSolver();
+m_dynamicsWorld = new btDiscreteDynamicsWorld(...);
+```
+
+While `Shutdown()` (lines 694–708) deletes them in reverse order, any exception or early return between `Initialize()` and `Shutdown()` leaks all five objects. If `Shutdown()` is never called (crash, forced exit), all Bullet memory leaks. Additionally, a `btGhostPairCallback` at line 648 is allocated with `new` and passed to the broadphase with no stored pointer — it is never explicitly deleted.
+
+**Evidence**: Lines 640–648 use naked `new`. Lines 694–708 use naked `delete`. No `std::unique_ptr` wrapping. No RAII guard.
+
+**What is needed**: Wrap each Bullet object in `std::unique_ptr` with a custom deleter that handles the reverse-order destruction dependency. At minimum, use a destructor guard that calls `Shutdown()` if not already called.
+
+---
+
+### GAP-ML02 — PhysicsBody Destructor Double-Deletes Collision Shapes
+
+**Files**:
+- `Physics/PhysicsSystem.cpp` (lines 190–199, 688–692)
+
+**Impact**: `PhysicsBody::~PhysicsBody()` deletes the collision shape retrieved from the Bullet body:
+
+```cpp
+PhysicsBody::~PhysicsBody()
+{
+    if (m_bulletBody)
+    {
+        delete m_bulletBody->getMotionState();
+        delete m_bulletBody->getCollisionShape();  // Shape from m_shapeCache
+        delete m_bulletBody;
+    }
+}
+```
+
+But collision shapes are also cached and deleted in `PhysicsSystem::Shutdown()`:
+
+```cpp
+for (auto& [hash, shape] : m_shapeCache)
+    delete shape;  // Same shape already deleted by ~PhysicsBody
+```
+
+If bodies are destroyed before `Shutdown()` (normal case), the shape is deleted by `~PhysicsBody`. When `Shutdown()` then iterates `m_shapeCache`, it deletes the same pointer again — **double-free/undefined behavior**. If bodies are destroyed *after* `Shutdown()` clears the cache, the body's destructor deletes a shape that was already freed.
+
+**What is needed**: Choose a single owner for collision shapes. Either: (a) `m_shapeCache` owns shapes and `PhysicsBody` holds a non-owning pointer (remove the `delete` from `~PhysicsBody`), or (b) each body owns its shape exclusively (remove from cache on body destruction). Option (a) is simpler and matches the caching pattern.
+
+---
+
+### GAP-ML03 — Collision Shape Creation Returns Raw `new` Pointers
+
+**Files**:
+- `Physics/PhysicsSystem.cpp` (lines 82–153)
+
+**Impact**: Shape factory methods use naked `new` for all Bullet collision shapes:
+
+```cpp
+shape = new btCylinderShape(...);
+shape = new btConeShape(...);
+return new btBoxShape(...);
+return new btSphereShape(...);
+btTriangleMesh* triMesh = new btTriangleMesh();
+btBvhTriangleMeshShape* meshShape = new btBvhTriangleMeshShape(triMesh, true);
+btConvexHullShape* convexShape = new btConvexHullShape();
+```
+
+These are stored in `m_shapeCache` (raw pointer map) with no RAII. If shape creation fails partway through (e.g., `btBvhTriangleMeshShape` construction throws after `triMesh` is allocated), intermediate objects leak.
+
+**What is needed**: Use `std::unique_ptr<btCollisionShape>` in `m_shapeCache`. Use `std::make_unique` or `std::unique_ptr` locals during creation to guarantee cleanup on exception.
+
+---
+
+## Major Gaps
+
+### GAP-ML04 — Event Subscription Callbacks Prevent Object Destruction
+
+**Files**:
+- `Engine/Events/EventSystem.h` (lines 84–91)
+
+**Impact**: `EventBus::Subscribe<T>()` stores callbacks as `std::function<void(const void*)>` that capture arbitrary state via lambda closures. If a subscriber captures `this` (common pattern: `bus.Subscribe<Event>([this](const Event& e) { ... })`), the `std::function` holds a copy of the pointer. If the subscribing object is destroyed without calling `Unsubscribe()`, the callback becomes a dangling pointer — invoking it causes use-after-free.
+
+There is no mechanism to automatically unsubscribe when an object is destroyed. No RAII subscription handle is returned. No weak reference pattern is used.
+
+**Evidence**: `Subscribe()` returns a `SubscriptionID` (uint64_t). If the subscriber loses this ID or doesn't store it, there is no way to unsubscribe. The `EventBus` has no way to detect that a subscriber's captured `this` pointer is invalid.
+
+**What is needed**: Return an RAII subscription handle (similar to `std::unique_lock`) that automatically calls `Unsubscribe()` in its destructor. Alternatively, use `std::weak_ptr`-based subscriptions that automatically expire when the subscriber is destroyed.
+
+---
+
+### GAP-ML05 — Unbounded Thread Vector Growth in InputManager
+
+**Files**:
+- `Input/InputManager.h` (line 83)
+- `Input/InputManager.cpp` (lines 456–463)
+
+**Impact**: `Console_SimulateKeyPress()` with a duration spawns a `std::thread` and appends it to `m_pendingTimedThreads`. Cleanup removes non-joinable threads, but completed threads remain joinable until explicitly joined. The vector grows with each timed key simulation and is only fully cleaned up in the destructor.
+
+**Evidence**:
+```cpp
+m_pendingTimedThreads.erase(std::remove_if(...,
+    [](std::thread& t) { return !t.joinable(); }), ...);
+m_pendingTimedThreads.emplace_back([this, virtualKey, keyName, duration]() { ... });
+```
+
+Completed threads are still joinable — they are only non-joinable after being joined or moved. The cleanup predicate (`!t.joinable()`) never matches completed threads, so the vector only grows.
+
+**What is needed**: Join completed threads before erasing. Use `std::jthread` (C++20) which auto-joins on destruction, or track thread completion with an atomic flag and join finished threads during cleanup.
+
+---
+
+### GAP-ML06 — RHI Resource Factory Returns Raw `new` Pointers
+
+**Files**:
+- `Graphics/RHI/D3D11/D3D11Device.cpp` (lines 614, 670, 786, 808, 904, 982)
+
+**Impact**: All D3D11 RHI resource factory methods return raw pointers from `new`:
+
+```cpp
+return new D3D11Buffer(desc, std::move(buffer));         // line 614
+return new D3D11Texture(desc, texture, std::move(srv), std::move(rtv), std::move(dsv)); // line 670
+return new D3D11Shader(desc, std::move(shaderObj), std::move(bytecodeBlob));  // line 786
+return new D3D11Sampler(desc, std::move(sampler));       // line 808
+return new D3D11PipelineState(desc, std::move(inputLayout), ...);  // line 904
+```
+
+Callers must manually call corresponding `Destroy*` methods or the GPU resources leak indefinitely. If a caller forgets, or if an exception occurs between creation and destruction, the resource leaks both CPU memory (the wrapper object) and GPU memory (the underlying D3D11 resource).
+
+**What is needed**: Return `std::unique_ptr<IRHIBuffer>`, `std::unique_ptr<IRHITexture>`, etc. from factory methods. This enforces RAII ownership and prevents leaks from forgotten cleanup.
+
+---
+
+## Moderate Gaps
+
+### GAP-ML07 — Audio Source Pool Uses Raw Pointers Alongside unique_ptr
+
+**Files**:
+- `Audio/AudioEngine.cpp` (lines 75–82)
+
+**Impact**: Audio sources are owned by `m_audioSources` (vector of `unique_ptr`) but tracked in `m_availableSources` as raw pointers:
+
+```cpp
+auto source = std::make_unique<AudioSource>();
+m_availableSources.push_back(source.get());
+m_audioSources.push_back(std::move(source));
+```
+
+If `m_audioSources` is resized (reallocation), all raw pointers in `m_availableSources` become dangling. While the pool is initialized once and doesn't grow, any future code that adds sources after initialization would trigger reallocation and invalidation.
+
+**What is needed**: Use stable containers (`std::deque` or `std::list`) for `m_audioSources`, or pre-allocate with `reserve()` and document the invariant that the vector must not grow after initialization.
+
+---
+
+### GAP-ML08 — Singleton Systems Have No Cleanup Ordering
+
+**Files**:
+- `Engine/SaveSystem/SaveSystem.h`, `Engine/Coroutine/CoroutineScheduler.h`, `Engine/Cinematic/Sequencer.h`
+
+**Impact**: Multiple engine singletons (`SaveSystem`, `CoroutineScheduler`, `SequencerManager`) use Meyer's singleton pattern (local static). Their destruction order during program exit is the reverse of first-access order, which is unpredictable. If singleton A's destructor accesses singleton B, and B was destroyed first, this is use-after-free.
+
+**Evidence**: All three singletons use the pattern:
+```cpp
+static SaveSystem& GetInstance() { static SaveSystem instance; return instance; }
+```
+
+No explicit `Shutdown()` is called before static destruction. No dependency ordering is enforced.
+
+**What is needed**: Add explicit `Initialize()`/`Shutdown()` methods with a defined call order in the engine's main loop shutdown sequence. Store singletons as `EngineContext`-owned `unique_ptr`s with deterministic destruction order.
+
+---
+
+### GAP-ML09 — No Leak Detection Tooling Integration
+
+**Files**: Engine-wide
+
+**Impact**: The engine has no integration with memory leak detection tools. No custom allocator tracks outstanding allocations. No debug-mode memory fill pattern detects use-after-free. The `Profiler` tracks timing but not memory usage.
+
+**What is needed**: In debug builds, integrate a leak detection system: override `operator new`/`delete` to track allocations with source file/line, or enable MSVC's CRT leak detection (`_CrtSetDbgFlag`). Add a `MemoryTracker` that logs outstanding allocations on shutdown.
+
+---
+
+## Minor Gaps
+
+### GAP-ML10 — Recent Input Events Vector Never Shrinks
+
+**Files**:
+- `Input/InputManager.h` (line 79, `m_recentInputEvents`)
+- `Input/InputManager.cpp` (lines 744–748)
+
+**Impact**: `m_recentInputEvents` is capped at 100 entries via front-erase, but the vector's capacity never shrinks. After 100 entries, the vector holds 100 elements but may have capacity for thousands (from earlier growth). The unused capacity is wasted memory.
+
+**What is needed**: Use a fixed-size ring buffer (the engine's `Utils/RingBuffer`) instead of a dynamic vector. This bounds both size and capacity.
+
+---
+
+### GAP-ML11 — PhysicsBody MotionState Deleted Without Ownership Clarity
+
+**Files**:
+- `Physics/PhysicsSystem.cpp` (lines 194, 872)
+
+**Impact**: `btDefaultMotionState` is allocated with `new` at line 872 and stored inside the `btRigidBody`. The `PhysicsBody` destructor deletes it at line 194 via `delete m_bulletBody->getMotionState()`. This works correctly but the ownership is implicit — there is no documentation that `PhysicsBody` owns the motion state. If Bullet's internal code also deletes the motion state (it doesn't by default, but a custom body subclass might), this becomes a double-free.
+
+**What is needed**: Store the motion state in a `std::unique_ptr<btDefaultMotionState>` member of `PhysicsBody` and pass the raw pointer to `btRigidBody`. Ownership is then explicit and documented by the type system.
+
+---


### PR DESCRIPTION
CPU analysis identifies O(n^2) algorithms in lag compensation and AI perception, per-frame heap allocations in A* pathfinding, and linear scans where spatial indexing or hash maps should be used.

Memory leak analysis covers Bullet Physics naked new/delete violations, double-free in PhysicsBody destructor vs shape cache, event subscription dangling callbacks, unbounded thread vector growth, and RHI factory methods returning raw pointers instead of unique_ptr.

https://claude.ai/code/session_011AsyJvTNshba8khzKgktFk