### PR TITLE
Update docs, wiki, build checks, and CLAUDE.md pre-commit hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ SparkEngine is a C++20 open-source 3D game engine targeting first-person shooter
 
 ```bash
 # Generate (pick one)
-cmake --preset windows-release   # Windows MSVC
-cmake --preset linux-release     # Linux GCC
+cmake --preset windows-release       # Windows MSVC
+cmake --preset linux-gcc-release     # Linux GCC
 
 # Build
 cmake --build build --config Release
@@ -64,9 +64,48 @@ Physics → Animation → AI → Audio → Lifecycle → Render
 - `GraphicsEngine` — main thread render, `std::atomic` frame state
 - `NetworkManager` — queue mutex for message I/O and handler registration
 
+## Pre-commit checks (run before every commit)
+
+After finishing any code change, **always** run these checks in order:
+
+```bash
+# 1. Format check — ensure code matches .clang-format
+find SparkEngine/Source SparkEditor/Source SparkConsole/src SparkShaderCompiler/src SparkGame/Source \
+  -name '*.h' -o -name '*.cpp' | head -50 | xargs clang-format --dry-run --Werror 2>&1
+
+# 2. Fix formatting automatically (if step 1 fails)
+find SparkEngine/Source SparkEditor/Source SparkConsole/src SparkShaderCompiler/src SparkGame/Source \
+  -name '*.h' -o -name '*.cpp' | xargs clang-format -i
+
+# 3. Sanity check — CMake configure (Linux)
+cmake --preset linux-gcc-release 2>&1 | tail -20
+
+# 4. Compile — build and verify zero errors
+cmake --build build --config Release 2>&1 | tail -30
+
+# 5. Tests — run the test suite
+cd build && ctest --output-on-failure && cd ..
+```
+
+If any step fails, fix the issue before committing. CI enforces clang-format on every PR.
+
+## Documentation generation
+
+```bash
+# Generate API docs (requires doxygen + graphviz)
+cd docs && ./generate-docs.sh
+
+# Auto-regenerate when headers change
+cd docs && ./auto-update.sh check
+```
+
 ## Things to know
 
 - Use `EngineContext` service locator, not deprecated `g_graphics`/`g_input` globals
 - Cross-platform types live in `Core/Platform.h` (DirectXMath stubs on Linux)
 - Networking is disabled in default builds (`ENABLE_NETWORKING=OFF`)
 - VR/AR, DXR, DLSS/FSR are not implemented
+- `.clang-format` enforces Microsoft-based style (Allman braces, 120-col, 4-space indent)
+- `.clang-tidy` checks for bugprone, modernize, performance, and readability issues
+- Doxygen config lives in `docs/Doxyfile.txt`; wiki pages in `wiki/`
+- 35+ unit tests in `Tests/`; always run `ctest` after changes

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -149,6 +149,50 @@ Ensure these exist in `build\bin\` after a successful build:
 
 ---
 
+## CI / Code Quality Issues
+
+### clang-format check fails in CI
+
+The `check-format` job in `build.yml` enforces `.clang-format` on every PR. To fix locally:
+
+```bash
+# See what needs fixing
+find SparkEngine/Source SparkEditor/Source -name '*.h' -o -name '*.cpp' \
+  | xargs clang-format --dry-run --Werror
+
+# Auto-fix all files
+find SparkEngine/Source SparkEditor/Source -name '*.h' -o -name '*.cpp' \
+  | xargs clang-format -i
+```
+
+Ensure you have clang-format 18+ installed to match CI.
+
+### Tests fail on Linux but pass on Windows
+
+- Check for Windows-only headers (`<windows.h>`, `<d3d11.h>`) leaking into cross-platform code
+- Ensure `#ifdef _WIN32` guards around platform-specific code
+- Run with AddressSanitizer locally: `cmake --preset ci-linux-asan && cmake --build build`
+
+---
+
+## Linux-Specific Issues
+
+### CMake can't find dependencies
+
+```bash
+# Install build essentials
+sudo apt install build-essential cmake libx11-dev libxrandr-dev libgl1-mesa-dev
+
+# Ensure submodules are initialized
+git submodule update --init --recursive
+```
+
+### Linker errors on Linux
+
+Graphics features require stub implementations on Linux. If you see unresolved DirectX symbols, ensure `ENABLE_GRAPHICS=OFF` or that Platform.h stubs are in place.
+
+---
+
 ## Last Resort
 
 1. **Clean rebuild:**

--- a/docs/Doxyfile.txt
+++ b/docs/Doxyfile.txt
@@ -6,8 +6,8 @@
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "Spark Engine"
-PROJECT_NUMBER         = "1.0.0"
-PROJECT_BRIEF          = "A modular, high-performance C++ game engine for 3D FPS titles"
+PROJECT_NUMBER         = "0.1.0-dev"
+PROJECT_BRIEF          = "A modular, high-performance C++20 open-source game engine for 3D FPS titles"
 PROJECT_LOGO           = 
 OUTPUT_DIRECTORY       = ./output
 CREATE_SUBDIRS         = NO
@@ -29,7 +29,7 @@ ABBREVIATE_BRIEF       = "The $name class" \
 ALWAYS_DETAILED_SEC    = NO
 INLINE_INHERITED_MEMB  = NO
 FULL_PATH_NAMES        = YES
-STRIP_FROM_PATH        = "../SparkEngine/Source/"
+STRIP_FROM_PATH        = "../"
 STRIP_FROM_INC_PATH    = 
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = YES
@@ -48,7 +48,7 @@ EXTENSION_MAPPING      =
 MARKDOWN_SUPPORT       = YES
 TOC_INCLUDE_HEADINGS   = 5
 AUTOLINK_SUPPORT       = YES
-BUILTIN_STL_SUPPORT    = NO
+BUILTIN_STL_SUPPORT    = YES
 CPP_CLI_SUPPORT        = NO
 SIP_SUPPORT            = NO
 IDL_PROPERTY_SUPPORT   = YES
@@ -119,7 +119,12 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 INPUT                  = "../SparkEngine/Source" \
                          "../SparkEditor/Source" \
-                         "../README.md"
+                         "../SparkConsole/src" \
+                         "../SparkShaderCompiler/src" \
+                         "../SparkGame/Source" \
+                         "../SparkSDK" \
+                         "../README.md" \
+                         "../TROUBLESHOOTING.md"
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \
                          *.cc \
@@ -221,7 +226,7 @@ HTML_EXTRA_FILES       =
 HTML_COLORSTYLE_HUE    = 220
 HTML_COLORSTYLE_SAT    = 100
 HTML_COLORSTYLE_GAMMA  = 80
-HTML_TIMESTAMP         = NO
+HTML_TIMESTAMP         = YES
 HTML_DYNAMIC_MENUS     = YES
 HTML_DYNAMIC_SECTIONS  = NO
 HTML_INDEX_NUM_ENTRIES = 100
@@ -345,12 +350,12 @@ UML_LIMIT_NUM_FIELDS   = 10
 TEMPLATE_RELATIONS     = NO
 INCLUDE_GRAPH          = YES
 INCLUDED_BY_GRAPH      = YES
-CALL_GRAPH             = NO
-CALLER_GRAPH           = NO
+CALL_GRAPH             = YES
+CALLER_GRAPH           = YES
 GRAPHICAL_HIERARCHY    = YES
 DIRECTORY_GRAPH        = YES
-DOT_IMAGE_FORMAT       = png
-INTERACTIVE_SVG        = NO
+DOT_IMAGE_FORMAT       = svg
+INTERACTIVE_SVG        = YES
 DOT_PATH               = 
 DOTFILE_DIRS           = 
 MSCFILE_DIRS           = 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,19 @@ See the [Wiki Home](../wiki/Home.md) for a full table of contents.
 
 This `docs/` directory contains tooling for auto-generated API documentation using Doxygen. It extracts documentation from C++ header files and produces a searchable, cross-referenced HTML site.
 
+### Covered Source Directories
+
+The Doxygen configuration indexes the following:
+
+| Directory | Description |
+|-----------|-------------|
+| `SparkEngine/Source/` | Core engine library (all subsystems) |
+| `SparkEditor/Source/` | ImGui visual editor (22 subsystems) |
+| `SparkConsole/src/` | Standalone debug console application |
+| `SparkShaderCompiler/src/` | Offline shader compilation tool |
+| `SparkGame/Source/` | Example FPS game module |
+| `SparkSDK/` | Public SDK headers |
+
 ### Quick Start
 
 ```bash
@@ -33,6 +46,7 @@ docs/
 |-- auto-update.sh         # Continuous monitoring script
 |-- output/
 |   |-- html/              # Full Doxygen HTML output
+|       |-- index.html     # Entry point — open in browser
 ```
 
 ### Writing Documentation
@@ -65,9 +79,10 @@ Supported tags: `@file`, `@brief`, `@param`, `@return`, `@note`, `@warning`, `@s
 ### Configuration
 
 **Doxygen (`Doxyfile.txt`)**
-- **Input**: `SparkEngine/Source/` and `SparkEditor/Source/`
-- **Output**: HTML with search, responsive design, source browser
-- **Diagrams**: Class hierarchies, collaboration graphs, include dependencies (requires GraphViz)
+- **Input**: All engine, editor, console, shader compiler, game, and SDK sources
+- **Output**: HTML with search, treeview navigation, source browser, timestamps
+- **Diagrams**: Class hierarchies, collaboration graphs, include dependencies, call/caller graphs (SVG, interactive)
+- **STL support**: Built-in STL type recognition enabled
 
 **Auto-Update (`auto-update.sh`)**
 - Watches `.h` and `.hpp` files in engine and editor source directories
@@ -78,7 +93,7 @@ Supported tags: `@file`, `@brief`, `@param`, `@return`, `@note`, `@warning`, `@s
 ### Dependencies
 
 - **Doxygen** 1.9+ — Documentation generator
-- **GraphViz** — Diagram rendering (optional but recommended)
+- **GraphViz** — Diagram rendering (required for class/call graphs)
 
 ```bash
 # Ubuntu/Debian

--- a/docs/auto-update.sh
+++ b/docs/auto-update.sh
@@ -9,7 +9,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 GENERATE_SCRIPT="$SCRIPT_DIR/generate-docs.sh"
-WATCH_DIRS=("$PROJECT_ROOT/SparkEngine/Source" "$PROJECT_ROOT/SparkEditor/Source")
+WATCH_DIRS=("$PROJECT_ROOT/SparkEngine/Source" "$PROJECT_ROOT/SparkEditor/Source" "$PROJECT_ROOT/SparkConsole/src" "$PROJECT_ROOT/SparkShaderCompiler/src" "$PROJECT_ROOT/SparkGame/Source" "$PROJECT_ROOT/SparkSDK")
 CHECKSUM_FILE="$SCRIPT_DIR/.doc_checksums"
 LOCK_FILE="$SCRIPT_DIR/.update_lock"
 

--- a/docs/generate-docs.sh
+++ b/docs/generate-docs.sh
@@ -75,8 +75,9 @@ generate_doxygen() {
     
     cd "$DOCS_DIR"
     
-    # Run Doxygen
-    if doxygen Doxyfile; then
+    # Run Doxygen (uses Doxyfile.txt which indexes SparkEngine, SparkEditor,
+    # SparkConsole, SparkShaderCompiler, SparkGame, and SparkSDK sources)
+    if doxygen Doxyfile.txt; then
         log_success "Doxygen documentation generated successfully"
     else
         log_error "Doxygen generation failed"
@@ -308,7 +309,7 @@ enhance_documentation() {
 generate_module_pages() {
     log_info "Generating module-specific documentation..."
     
-    local modules=("Audio" "Graphics" "Core" "Input" "Physics" "Camera" "Utils" "Game" "Engine")
+    local modules=("Audio" "Graphics" "Core" "Input" "Physics" "Camera" "Utils" "Game" "Engine" "AI" "Animation" "Networking" "Scripting" "ECS" "SaveSystem")
     
     for module in "${modules[@]}"; do
         local module_file="$WIKI_DIR/${module,,}.html"

--- a/wiki/Build-System-and-CMake-Modules.md
+++ b/wiki/Build-System-and-CMake-Modules.md
@@ -198,12 +198,27 @@ Enables `find_package(SparkEngine)` for standalone game projects.
 | `build.ps1` | Windows | PowerShell build script |
 | `build.sh` | Linux/macOS | Bash build script |
 
+## Documentation Generation
+
+```bash
+# Generate Doxygen API docs (requires doxygen + graphviz)
+cd docs && ./generate-docs.sh
+
+# Or via CMake custom target (if Doxygen is found)
+cmake --build build --target docs
+```
+
+See [docs/README.md](../docs/README.md) for full documentation tooling details.
+
 ## CI/CD (GitHub Actions)
 
 ### build.yml
 
 Runs on every push to `main`, `develop`, and `feature/*` branches:
-- **Platforms:** Windows (VS 2022), Linux (GCC, Clang)
+- **Format check:** clang-format enforcement (rejects PRs with violations)
+- **Prompt validation:** Anti-drift and overload checks for AI prompt files
+- **Sanitizers:** AddressSanitizer + UBSanitizer on Linux
+- **Platforms:** Windows (VS 2022, VS 2026), Linux (GCC, Clang)
 - **Configurations:** Debug and Release matrix
 - **Artifacts:** Retained for 7 days
 

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -26,6 +26,44 @@ SparkEngine is licensed under the **MIT License**. All contributions are subject
    ```
 6. Push and open a Pull Request
 
+## Pre-Commit Quality Checks
+
+Before opening a PR, run these checks locally. CI enforces all of them automatically.
+
+### 1. Format with clang-format
+
+The repo ships a `.clang-format` (Microsoft-based, Allman braces, 4-space indent, 120-col limit). CI rejects PRs with formatting violations.
+
+```bash
+# Check formatting (dry run — reports violations without changing files)
+find SparkEngine/Source SparkEditor/Source -name '*.h' -o -name '*.cpp' \
+  | xargs clang-format --dry-run --Werror
+
+# Auto-fix formatting
+find SparkEngine/Source SparkEditor/Source -name '*.h' -o -name '*.cpp' \
+  | xargs clang-format -i
+```
+
+### 2. Static analysis with clang-tidy
+
+```bash
+# Generate compile_commands.json, then run clang-tidy
+cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+clang-tidy -p build SparkEngine/Source/**/*.cpp
+```
+
+### 3. Build and test
+
+```bash
+cmake --preset linux-gcc-release     # or windows-release
+cmake --build build --config Release
+cd build && ctest --output-on-failure
+```
+
+All checks must pass before submitting a PR.
+
+---
+
 ## Code Style
 
 ### Language Standard

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -68,7 +68,22 @@ Pre-built binaries are published on every commit to `master`:
 - [Build System and CMake Modules](Build-System-and-CMake-Modules) — CMake configuration and CI/CD
 - [Testing](Testing) — Unit tests and test framework
 - [Troubleshooting](Troubleshooting) — Common issues and solutions
-- [Contributing](Contributing) — How to contribute
+- [Contributing](Contributing) — How to contribute (includes pre-commit checks)
+
+### Reference
+- [API Documentation](../docs/README.md) — Doxygen-generated API reference (class diagrams, call graphs, source browser)
+
+## Code Quality
+
+SparkEngine enforces code quality automatically:
+
+- **clang-format** — Enforced in CI on every PR (Microsoft-based style, Allman braces, 120-col, 4-space indent)
+- **clang-tidy** — Static analysis for bugprone, modernize, performance, and readability checks
+- **35+ unit tests** — CTest suite covering all major subsystems
+- **AddressSanitizer / UBSanitizer** — Memory safety checks in CI
+- **CodeQL** — GitHub security scanning
+
+See [Contributing](Contributing) for the full pre-commit checklist.
 
 ## License
 

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -113,14 +113,24 @@ ctest --test-dir build --output-on-failure
 ## CI Integration
 
 Tests run automatically on every push via GitHub Actions:
-- Windows (VS 2022) — Debug and Release
+- Windows (VS 2022, VS 2026) — Debug and Release
 - Linux (GCC, Clang) — Debug and Release
-- Sanitizer builds (ASan, TSan) for memory and thread safety
+- AddressSanitizer + UBSanitizer builds for memory safety
+- clang-format check (rejects PRs with formatting violations)
+- CodeQL security scanning
+
+### Running Sanitizer Builds Locally
+
+```bash
+cmake --preset ci-linux-asan
+cmake --build build
+cd build && ctest --output-on-failure
+```
 
 ---
 
 ## See Also
 
-- [Build System and CMake Modules](Build-System-and-CMake-Modules) — BUILD_TESTS flag
+- [Build System and CMake Modules](Build-System-and-CMake-Modules) — BUILD_TESTS flag and CI details
 - [Getting Started](Getting-Started) — Building the project
-- [Contributing](Contributing) — Contribution workflow and adding tests
+- [Contributing](Contributing) — Contribution workflow, pre-commit checks, and adding tests

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -35,3 +35,6 @@
 - [Testing](Testing)
 - [Troubleshooting](Troubleshooting)
 - [Contributing](Contributing)
+
+### Reference
+- [API Docs (Doxygen)](../docs/README.md)


### PR DESCRIPTION
- CLAUDE.md: Add pre-commit checks section (clang-format, CMake configure, compile, ctest), fix preset names to match CMakePresets.json, add documentation generation commands, expand "Things to know" section
- Doxyfile.txt: Add SparkConsole, SparkShaderCompiler, SparkGame, SparkSDK to input sources; enable STL support, call/caller graphs, interactive SVG diagrams, HTML timestamps; update project version to 0.1.0-dev
- docs/generate-docs.sh: Fix Doxyfile reference (Doxyfile.txt), add all engine subsystem modules to page generation
- docs/auto-update.sh: Watch all source directories (not just Engine/Editor)
- docs/README.md: Document all indexed source directories, update Doxygen config description with new features (call graphs, SVG, STL)
- wiki/Contributing.md: Add pre-commit quality checks section (clang-format, clang-tidy, build+test) with copy-paste commands
- wiki/Home.md: Add Code Quality section and API Documentation reference
- wiki/_Sidebar.md: Add Reference section with API docs link
- wiki/Build-System-and-CMake-Modules.md: Add documentation generation section, expand CI/CD description with format checks and sanitizers
- wiki/Testing.md: Add sanitizer build instructions, update CI description with VS 2026 and CodeQL
- TROUBLESHOOTING.md: Add CI/code quality troubleshooting (clang-format fixes, cross-platform test failures), Linux-specific build issues

Verified: CMake configures, builds, and all tests pass.

https://claude.ai/code/session_01EabWYnsXwj6eBzxDNpDURy