### PR TITLE
fix: third sweep — DrawText per-frame spam, DeleteObject error, resiz…

### DIFF
--- a/SparkEngine/Source/Graphics/GraphicsEngine.cpp
+++ b/SparkEngine/Source/Graphics/GraphicsEngine.cpp
@@ -2899,13 +2899,15 @@ void GraphicsEngine::OnResize(unsigned int width, unsigned int height)
         HRESULT resizeHr = m_swapChain->ResizeBuffers(0, width, height, DXGI_FORMAT_UNKNOWN, 0);
         if (FAILED(resizeHr))
         {
-            SPARK_LOG_ERROR("Graphics", "SwapChain::ResizeBuffers failed HR=0x%08lX for size %ux%u",
-                            static_cast<long>(resizeHr), width, height);
+            SPARK_LOG_EVERY_SECONDS(Spark::LogLevel::Error, "Graphics", 2,
+                                    "SwapChain::ResizeBuffers failed HR=0x%08lX for size %ux%u",
+                                    static_cast<long>(resizeHr), width, height);
         }
     }
     else
     {
-        SPARK_LOG_WARN("Graphics", "Swap chain not available during resize to %ux%u", width, height);
+        SPARK_LOG_EVERY_SECONDS(Spark::LogLevel::Warn, "Graphics", 2, "Swap chain not available during resize to %ux%u",
+                                width, height);
     }
 
     if (!m_device)

--- a/SparkGame/Source/Game/Console.h
+++ b/SparkGame/Source/Game/Console.h
@@ -25,23 +25,24 @@
 
 /**
  * @brief Simple text output function for console rendering
- * 
- * Basic text rendering utility that outputs text to the debug console.
- * This is a placeholder implementation that uses OutputDebugString.
- * 
+ *
+ * Placeholder for proper text rendering. The previous implementation
+ * used OutputDebugString which caused extreme spam (called per-line,
+ * per-frame whenever the console was visible).
+ *
  * @param text Text string to display
  * @param x Horizontal position (currently unused)
  * @param y Vertical position (currently unused)
  * @param scale Text scale factor (currently unused)
  * @param ctx DirectX device context (currently unused)
- * 
- * @note This is a simple implementation using OutputDebugString
- * @warning Parameters x, y, scale, and ctx are currently ignored
+ *
+ * @todo Replace with actual GPU text rendering (e.g. SpriteBatch or ImGui)
  */
-inline void DrawText(const std::wstring& text, float /*x*/, float /*y*/, float /*scale*/, ID3D11DeviceContext* /*ctx*/)
+inline void DrawText(const std::wstring& /*text*/, float /*x*/, float /*y*/, float /*scale*/,
+                     ID3D11DeviceContext* /*ctx*/)
 {
-    OutputDebugStringW(text.c_str());
-    OutputDebugStringW(L"\n");
+    // No-op: OutputDebugString was removed because it fired per-line per-frame
+    // and caused significant performance degradation when a debugger was attached.
 }
 
 /**

--- a/SparkGame/Source/Game/Game.cpp
+++ b/SparkGame/Source/Game/Game.cpp
@@ -1156,7 +1156,8 @@ bool Game::DeleteObject(size_t index)
 {
     if (!SPARK_BOUNDS_CHECK(index, m_gameObjects.size()))
     {
-        SPARK_LOG_ERROR("Game", "DeleteObject: index %zu out of bounds (size=%zu)", index, m_gameObjects.size());
+        SPARK_LOG_EVERY_SECONDS(Spark::LogLevel::Error, "Game", 5, "DeleteObject: index %zu out of bounds (size=%zu)",
+                                index, m_gameObjects.size());
         return false;
     }
 


### PR DESCRIPTION
…e warnings

- Console.h DrawText: remove OutputDebugStringW that fired per-line per-frame (20+ lines * 60fps = 1200+ calls/sec with debugger attached). Replaced with no-op pending proper GPU text rendering.
- Game::DeleteObject: rate-limit bounds-check error log to prevent spam when called in a loop with invalid indices
- GraphicsEngine::OnWindowResize: rate-limit ResizeBuffers failure and missing swap chain warnings during rapid resize events

https://claude.ai/code/session_01Dq12UZvYnJ7bsNnBnvq7RH