### PR TITLE
Fix cross-project integration: complete subsystem hookup across all m…

### DIFF
--- a/SparkEngine/Source/Core/EngineSetup.h
+++ b/SparkEngine/Source/Core/EngineSetup.h
@@ -27,6 +27,8 @@ class PhysicsSystem;
 class AudioEngine;
 class InputManager;
 class Timer;
+class SceneManager;
+class AngelScriptEngine;
 
 namespace Spark
 {
@@ -38,6 +40,9 @@ namespace Spark
     {
         class AISystem;
     }
+    class SaveSystem;
+    class CoroutineScheduler;
+    class NetworkManager;
 } // namespace Spark
 
 namespace Spark::EngineSetup
@@ -99,6 +104,36 @@ namespace Spark::EngineSetup
         if (auto* ai = ctx.GetAI())
         {
             ctx.RegisterSubsystem<Spark::AI::AISystem>(ai, DependsOn<Timer, PhysicsSystem>{});
+        }
+
+        // SaveSystem depends on nothing
+        if (auto* save = ctx.GetSaveSystem())
+        {
+            ctx.RegisterSubsystem<Spark::SaveSystem>(save, DependsOn<>{});
+        }
+
+        // CoroutineScheduler depends on Timer
+        if (auto* coroutines = ctx.GetCoroutineScheduler())
+        {
+            ctx.RegisterSubsystem<Spark::CoroutineScheduler>(coroutines, DependsOn<Timer>{});
+        }
+
+        // SceneManager depends on Graphics and Physics
+        if (auto* scene = ctx.GetSceneManager())
+        {
+            ctx.RegisterSubsystem<SceneManager>(scene, DependsOn<GraphicsEngine, PhysicsSystem>{});
+        }
+
+        // Scripting depends on Timer and EventBus
+        if (auto* script = ctx.GetScriptEngine())
+        {
+            ctx.RegisterSubsystem<AngelScriptEngine>(script, DependsOn<Timer, Spark::EventBus>{});
+        }
+
+        // Networking depends on Timer (only registered when ENABLE_NETWORKING=ON)
+        if (auto* network = ctx.GetNetwork())
+        {
+            ctx.RegisterSubsystem<Spark::NetworkManager>(network, DependsOn<Timer>{});
         }
     }
 
@@ -198,6 +233,10 @@ namespace Spark::EngineSetup
         bootstrap.Register({"Audio", []() { return true; }, []() {}, {"Timer", "Graphics"}});
         bootstrap.Register({"Animation", []() { return true; }, []() {}, {"Timer"}});
         bootstrap.Register({"AI", []() { return true; }, []() {}, {"Timer", "Physics", "JobSystem"}});
+        bootstrap.Register({"SaveSystem", []() { return true; }, []() {}, {}});
+        bootstrap.Register({"CoroutineScheduler", []() { return true; }, []() {}, {"Timer"}});
+        bootstrap.Register({"SceneManager", []() { return true; }, []() {}, {"Graphics", "Physics"}});
+        bootstrap.Register({"Scripting", []() { return true; }, []() {}, {"Timer", "EventBus"}});
 
         return bootstrap;
     }

--- a/SparkEngine/Source/Core/SparkEngine.cpp
+++ b/SparkEngine/Source/Core/SparkEngine.cpp
@@ -49,6 +49,7 @@
 #include "Utils/SparkConsole.h"
 #include "EngineSettings.h"
 #include "Engine/SaveSystem/SaveSystem.h"
+#include "Engine/Coroutine/CoroutineScheduler.h"
 #include "Audio/AudioEngine.h"
 #include "Physics/PhysicsSystem.h"
 #include "Graphics/GraphicsConsoleCommands.h"
@@ -295,7 +296,11 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR 
 
         // SaveSystem
         Spark::SaveSystem::GetInstance().Initialize("Saves");
+        EngineContext::Get()->SetSaveSystem(&Spark::SaveSystem::GetInstance());
         console.LogInfo("SaveSystem initialized");
+
+        // CoroutineScheduler
+        EngineContext::Get()->SetCoroutineScheduler(&Spark::CoroutineScheduler::GetInstance());
 
         // Register console commands (no graphics commands in headless)
         RegisterEngineConsoleCommands();
@@ -394,7 +399,10 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR 
     // 5f. Register SaveSystem with EngineContext
     EngineContext::Get()->SetSaveSystem(&Spark::SaveSystem::GetInstance());
 
-    // 5g. Register AssetRegistry for handle-based asset lookups
+    // 5g. Register CoroutineScheduler with EngineContext
+    EngineContext::Get()->SetCoroutineScheduler(&Spark::CoroutineScheduler::GetInstance());
+
+    // 5h. Register AssetRegistry for handle-based asset lookups
     static Spark::AssetRegistry g_assetRegistry;
     EngineContext::Get()->RegisterSystem<Spark::AssetRegistry>(&g_assetRegistry);
 
@@ -1188,6 +1196,7 @@ void RegisterEngineConsoleCommands()
             ss << "  SaveSystem: " << (ctx->GetSaveSystem() ? "YES" : "NO") << "\n";
             ss << "  Scene:      " << (ctx->GetSceneManager() ? "YES" : "NO") << "\n";
             ss << "  Scripting:  " << (ctx->GetScriptEngine() ? "YES" : "NO") << "\n";
+            ss << "  Coroutines: " << (ctx->GetCoroutineScheduler() ? "YES" : "NO") << "\n";
             ss << "  Headless:   " << (ctx->IsHeadless() ? "YES" : "NO") << "\n";
             auto* assetReg = ctx->GetSystem<Spark::AssetRegistry>();
             ss << "  AssetReg:   " << (assetReg ? "YES" : "NO");
@@ -1230,6 +1239,7 @@ void RegisterEngineConsoleCommands()
 #include "EngineSettings.h"
 #include "Engine/Events/EventSystem.h"
 #include "Engine/SaveSystem/SaveSystem.h"
+#include "Engine/Coroutine/CoroutineScheduler.h"
 #include "Graphics/GraphicsEngine.h"
 #include "Input/InputManager.h"
 #include "Audio/AudioEngine.h"
@@ -1555,6 +1565,7 @@ static void RegisterEngineConsoleCommandsLinux()
             ss << "  SaveSystem: " << (ctx->GetSaveSystem() ? "YES" : "NO") << "\n";
             ss << "  Scene:      " << (ctx->GetSceneManager() ? "YES" : "NO") << "\n";
             ss << "  Scripting:  " << (ctx->GetScriptEngine() ? "YES" : "NO") << "\n";
+            ss << "  Coroutines: " << (ctx->GetCoroutineScheduler() ? "YES" : "NO") << "\n";
             ss << "  Headless:   " << (ctx->IsHeadless() ? "YES" : "NO") << "\n";
             auto* assetReg = ctx->GetSystem<Spark::AssetRegistry>();
             ss << "  AssetReg:   " << (assetReg ? "YES" : "NO");
@@ -1634,6 +1645,8 @@ int main(int argc, char* argv[])
         }
 
         Spark::SaveSystem::GetInstance().Initialize("Saves");
+        EngineContext::Get()->SetSaveSystem(&Spark::SaveSystem::GetInstance());
+        EngineContext::Get()->SetCoroutineScheduler(&Spark::CoroutineScheduler::GetInstance());
         RegisterEngineConsoleCommandsLinux();
         LogMissingModuleWarnings();
 
@@ -1751,6 +1764,7 @@ int main(int argc, char* argv[])
     Spark::EngineSetup::RegisterCoreSubsystems(*EngineContext::Get());
     Spark::EngineSetup::InitializeJobSystem();
     EngineContext::Get()->SetSaveSystem(&Spark::SaveSystem::GetInstance());
+    EngineContext::Get()->SetCoroutineScheduler(&Spark::CoroutineScheduler::GetInstance());
     static Spark::AssetRegistry g_linuxAssetRegistry;
     EngineContext::Get()->RegisterSystem<Spark::AssetRegistry>(&g_linuxAssetRegistry);
 
@@ -1990,6 +2004,13 @@ int main(int argc, char* argv[])
         EngineContext::Get()->SetPhysics(g_physicsOwned.get());
     }
 #endif
+
+    // Register core subsystems with dependency metadata
+    Spark::EngineSetup::RegisterCoreSubsystems(*EngineContext::Get());
+    Spark::EngineSetup::InitializeJobSystem();
+    Spark::SaveSystem::GetInstance().Initialize("Saves");
+    EngineContext::Get()->SetSaveSystem(&Spark::SaveSystem::GetInstance());
+    EngineContext::Get()->SetCoroutineScheduler(&Spark::CoroutineScheduler::GetInstance());
 
     g_moduleManager = std::make_unique<ModuleManager>();
 

--- a/SparkEngine/Source/Core/SparkEngine.h
+++ b/SparkEngine/Source/Core/SparkEngine.h
@@ -25,7 +25,7 @@ class GraphicsEngine;
 class InputManager;
 class Timer;
 class SparkEngineCamera;
-class GameModuleLoader;
+class ModuleManager;
 class IGameModule;
 
 #ifdef SPARK_PLATFORM_WINDOWS

--- a/SparkGame/Source/Core/Main.cpp
+++ b/SparkGame/Source/Core/Main.cpp
@@ -17,6 +17,7 @@
 #include "Game/GameMode.h"
 #include "Game/InventorySystem.h"
 #include "Game/QuestSystem.h"
+#include "Core/EngineContext.h"
 #include "Engine/Events/EventSystem.h"
 #include "Utils/SparkConsole.h"
 
@@ -78,13 +79,30 @@ bool SparkGameModule::OnLoad(Spark::IEngineContext* context)
     if (!Initialize(context->GetGraphics(), context->GetInput()))
         return false;
 
-    // Wire up EventBus so game systems can communicate via events
-    if (g_game && context->GetEventBus())
-        g_game->SetEventBus(context->GetEventBus());
+    if (g_game)
+    {
+        // Wire up EventBus so game systems can communicate via events
+        if (context->GetEventBus())
+            g_game->SetEventBus(context->GetEventBus());
 
-    // Wire up physics system for projectile area queries (explosions)
-    if (g_game && context->GetPhysics())
-        g_game->SetPhysicsSystem(context->GetPhysics());
+        // Wire up physics system for projectile area queries (explosions)
+        if (context->GetPhysics())
+            g_game->SetPhysicsSystem(context->GetPhysics());
+
+        // Wire up SceneManager from the engine context if the game doesn't own one
+        // (Game creates its own SceneManager, but the engine context should know about it)
+        if (auto* sceneMgr = g_game->GetSceneManager())
+        {
+            if (!context->GetSceneManager())
+            {
+                // Register the game's SceneManager with the engine context so
+                // the editor and other modules can access it
+                auto* ctx = dynamic_cast<EngineContext*>(context);
+                if (ctx)
+                    ctx->SetSceneManager(sceneMgr);
+            }
+        }
+    }
 
     return true;
 }


### PR DESCRIPTION
…odules

- Remove stale g_moduleLoader declaration from SparkEngine.h (replaced by g_moduleManager/ModuleManager which is the actual implementation)
- Register CoroutineScheduler with EngineContext in all startup paths (Windows windowed, Windows headless, Linux headless, Linux SDL2, Linux fallback) so game modules can access coroutine scheduling
- Register SaveSystem with EngineContext in headless and Linux paths that were missing it (Windows windowed already had it)
- Add EngineSetup dependency registration for SaveSystem, CoroutineScheduler, SceneManager, AngelScriptEngine, and NetworkManager so they participate in topological init/shutdown ordering
- Add EngineBootstrap descriptors for SaveSystem, CoroutineScheduler, SceneManager, and Scripting subsystems
- Wire SparkGame's SceneManager into EngineContext during OnLoad so the editor and other modules can discover it via context->GetSceneManager()
- Add CoroutineScheduler status to engine_subsystems console command output in both Windows and Linux code paths
- Add missing EngineSetup::RegisterCoreSubsystems and InitializeJobSystem calls in the Linux no-SDL2 fallback path

All 647 tests pass, zero build warnings, clang-format clean.

https://claude.ai/code/session_01PLabtQY6qyCJdP9QGsY6zF