### PR TITLE
Fix MSVC build: undefine Windows SendMessage macro in NetworkManager.h

### DIFF
--- a/SparkEngine/Source/Engine/Networking/NetworkManager.h
+++ b/SparkEngine/Source/Engine/Networking/NetworkManager.h
@@ -53,6 +53,12 @@ constexpr SOCKET INVALID_SOCKET = -1;
 constexpr int SOCKET_ERROR = -1;
 #endif // SPARK_PLATFORM_WINDOWS
 
+// Windows headers define SendMessage as a macro (SendMessageA/SendMessageW).
+// Undefine it so our NetworkManager::SendMessage method compiles correctly.
+#ifdef SendMessage
+#undef SendMessage
+#endif
+
 #endif // ENABLE_NETWORKING
 
 namespace Spark::Net

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -101,5 +101,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 70 |
 | Test cases | 837+ |
 | Wiki pages | 44 |
-| *Last synced* | *2026-03-12 07:33* |
+| *Last synced* | *2026-03-12 07:47* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
The Win32 API defines SendMessage as a macro expanding to SendMessageA/ SendMessageW (winuser.h), which collides with NetworkManager::SendMessage. Adding #undef SendMessage after the platform socket includes prevents the macro from mangling our method name and fixes the C2660/C2039/C2065 errors in the Windows CI build.

https://claude.ai/code/session_01Jpre1mNLCZsbr5FAp9cVDj