### PR TITLE
Add missing ICON_FA_SERVER constant to EditorIcons.h

### DIFF
--- a/SparkEditor/Source/Core/EditorIcons.h
+++ b/SparkEditor/Source/Core/EditorIcons.h
@@ -153,3 +153,6 @@
 #define ICON_FA_STREAM "\xef\x95\x90"      // U+F550
 #define ICON_FA_PLUS_SQUARE "\xef\x83\xbe" // U+F0FE
 #define ICON_FA_SLIDERS_H "\xef\x87\x9e"   // U+F1DE (horizontal sliders)
+
+// === Networking / Server Icons ===
+#define ICON_FA_SERVER "\xef\x88\xb3" // U+F233

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -101,5 +101,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 71 |
 | Test cases | 864+ |
 | Wiki pages | 45 |
-| *Last synced* | *2026-03-12 10:36* |
+| *Last synced* | *2026-03-12 12:53* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
The DedicatedServerPanel and EditorUI reference ICON_FA_SERVER but it was never defined, causing the ASan CI build to fail with "'ICON_FA_SERVER' was not declared in this scope".  Add the Font Awesome server icon (U+F233) to EditorIcons.h under a new Networking / Server Icons section.

https://claude.ai/code/session_014nnu2BdqkEtmen28nrNxHW