### PR TITLE
Fix missing FontAwesome icon definitions for DedicatedServerPanel

### DIFF
--- a/SparkEditor/Source/Core/EditorIcons.h
+++ b/SparkEditor/Source/Core/EditorIcons.h
@@ -155,4 +155,8 @@
 #define ICON_FA_SLIDERS_H "\xef\x87\x9e"   // U+F1DE (horizontal sliders)
 
 // === Networking / Server Icons ===
-#define ICON_FA_SERVER "\xef\x88\xb3" // U+F233
+#define ICON_FA_SERVER "\xef\x88\xb3"  // U+F233
+#define ICON_FA_PLUG "\xef\x87\xa6"    // U+F1E6
+#define ICON_FA_USERS "\xef\x83\x80"   // U+F0C0
+#define ICON_FA_SPINNER "\xef\x84\x90" // U+F110
+#define ICON_FA_REFRESH "\xef\x80\xa1" // U+F021 (arrows-rotate)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -101,5 +101,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 71 |
 | Test cases | 864+ |
 | Wiki pages | 45 |
-| *Last synced* | *2026-03-12 12:53* |
+| *Last synced* | *2026-03-12 13:11* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
Add ICON_FA_PLUG, ICON_FA_USERS, ICON_FA_SPINNER, and ICON_FA_REFRESH to EditorIcons.h. These were used in DedicatedServerPanel.cpp but never defined, causing build failures in all CI configurations.

https://claude.ai/code/session_01ESdCUkn3YAVTdHfZDi9qAz