### PR TITLE
fix: include Assert.h in RenderDevice.cpp to resolve ASSERT_MSG ident…

### DIFF
--- a/SparkEngine/Source/Graphics/RenderDevice.cpp
+++ b/SparkEngine/Source/Graphics/RenderDevice.cpp
@@ -3,6 +3,7 @@
 
 #include "RenderDevice.h"
 #include "RHI/RHIFactory.h"
+#include "../Utils/Assert.h"
 #include <d3d11.h>
 
 namespace Spark::Graphics


### PR DESCRIPTION
…ifier not found

RenderDevice.cpp used ASSERT_MSG at lines 19-20 but never included the header that defines it. Add the missing #include "../Utils/Assert.h".

https://claude.ai/code/session_01NZHr6KPiJLUxs7GvS8UXiM