### PR TITLE
refactor: modernize public APIs with C++17/20 idioms

### DIFF
--- a/SparkEngine/Source/Engine/VR/VRSystem.cpp
+++ b/SparkEngine/Source/Engine/VR/VRSystem.cpp
@@ -48,10 +48,9 @@ namespace Spark::VR
         // Update m_headPosition, m_headOrientation, controllers, eye matrices
     }
 
-    void VRSystem::GetRecommendedRenderSize(int& width, int& height) const
+    std::pair<int, int> VRSystem::GetRecommendedRenderSize() const
     {
-        width = m_recommendedWidth;
-        height = m_recommendedHeight;
+        return {m_recommendedWidth, m_recommendedHeight};
     }
 
     void VRSystem::TriggerHaptic(bool isLeft, float amplitude, float duration)

--- a/SparkEngine/Source/Engine/VR/VRSystem.h
+++ b/SparkEngine/Source/Engine/VR/VRSystem.h
@@ -30,6 +30,7 @@
 #include <vector>
 #include <cstdint>
 #include <functional>
+#include <utility>
 
 namespace Spark::VR
 {
@@ -129,8 +130,11 @@ namespace Spark::VR
         const VREye& GetLeftEye() const { return m_leftEye; }
         const VREye& GetRightEye() const { return m_rightEye; }
 
-        /** @brief Get the recommended render target size per eye. */
-        void GetRecommendedRenderSize(int& width, int& height) const;
+        /**
+         * @brief Get the recommended render target size per eye.
+         * @return Pair of {width, height}
+         */
+        std::pair<int, int> GetRecommendedRenderSize() const;
 
         // --- Controllers ---
 

--- a/SparkEngine/Source/Graphics/FrustumCulling.h
+++ b/SparkEngine/Source/Graphics/FrustumCulling.h
@@ -117,7 +117,7 @@ namespace Spark::Graphics
     {
       public:
         /** @brief Plane indices for readability. */
-        enum PlaneIndex
+        enum class PlaneIndex : int
         {
             Left = 0,
             Right,
@@ -127,6 +127,8 @@ namespace Spark::Graphics
             Far,
             Count
         };
+
+        static constexpr int kPlaneCount = static_cast<int>(PlaneIndex::Count);
 
         /**
      * @brief Extract the six frustum planes from a view-projection matrix.
@@ -138,21 +140,22 @@ namespace Spark::Graphics
      */
         void ExtractPlanes(const DirectX::XMMATRIX& viewProj)
         {
+            using enum PlaneIndex;
             DirectX::XMFLOAT4X4 m;
             DirectX::XMStoreFloat4x4(&m, viewProj);
 
             // Left: row3 + row0
-            m_planes[Left] = {m._14 + m._11, m._24 + m._21, m._34 + m._31, m._44 + m._41};
+            m_planes[static_cast<int>(Left)] = {m._14 + m._11, m._24 + m._21, m._34 + m._31, m._44 + m._41};
             // Right: row3 - row0
-            m_planes[Right] = {m._14 - m._11, m._24 - m._21, m._34 - m._31, m._44 - m._41};
+            m_planes[static_cast<int>(Right)] = {m._14 - m._11, m._24 - m._21, m._34 - m._31, m._44 - m._41};
             // Bottom: row3 + row1
-            m_planes[Bottom] = {m._14 + m._12, m._24 + m._22, m._34 + m._32, m._44 + m._42};
+            m_planes[static_cast<int>(Bottom)] = {m._14 + m._12, m._24 + m._22, m._34 + m._32, m._44 + m._42};
             // Top: row3 - row1
-            m_planes[Top] = {m._14 - m._12, m._24 - m._22, m._34 - m._32, m._44 - m._42};
+            m_planes[static_cast<int>(Top)] = {m._14 - m._12, m._24 - m._22, m._34 - m._32, m._44 - m._42};
             // Near: row2 (DirectX convention: 0 <= z <= w)
-            m_planes[Near] = {m._13, m._23, m._33, m._43};
+            m_planes[static_cast<int>(Near)] = {m._13, m._23, m._33, m._43};
             // Far: row3 - row2
-            m_planes[Far] = {m._14 - m._13, m._24 - m._23, m._34 - m._33, m._44 - m._43};
+            m_planes[static_cast<int>(Far)] = {m._14 - m._13, m._24 - m._23, m._34 - m._33, m._44 - m._43};
 
             for (auto& plane : m_planes)
             {
@@ -173,7 +176,7 @@ namespace Spark::Graphics
         {
             bool allInside = true;
 
-            for (int i = 0; i < Count; ++i)
+            for (int i = 0; i < kPlaneCount; ++i)
             {
                 const Plane& p = m_planes[i];
 
@@ -216,7 +219,7 @@ namespace Spark::Graphics
         {
             bool allInside = true;
 
-            for (int i = 0; i < Count; ++i)
+            for (int i = 0; i < kPlaneCount; ++i)
             {
                 float dist = m_planes[i].DistanceToPoint(sphere.center);
 
@@ -243,7 +246,7 @@ namespace Spark::Graphics
      */
         bool IsPointInside(const DirectX::XMFLOAT3& point) const
         {
-            for (int i = 0; i < Count; ++i)
+            for (int i = 0; i < kPlaneCount; ++i)
             {
                 if (m_planes[i].DistanceToPoint(point) < 0.0f)
                 {
@@ -257,7 +260,7 @@ namespace Spark::Graphics
         const Plane& GetPlane(int index) const { return m_planes[index]; }
 
       private:
-        std::array<Plane, Count> m_planes;
+        std::array<Plane, kPlaneCount> m_planes;
     };
 
 } // namespace Spark::Graphics

--- a/SparkEngine/Source/Graphics/GlobalIllumination.h
+++ b/SparkEngine/Source/Graphics/GlobalIllumination.h
@@ -46,6 +46,7 @@
 #include <cmath>
 #include <functional>
 #include <unordered_map>
+#include <tuple>
 
 // =============================================================================
 // Spherical Harmonics Constants
@@ -136,12 +137,21 @@ struct IrradianceVolume
         return {sx, sy, sz};
     }
 
-    /** @brief Get the 3D grid index for a linear probe index */
-    void GetProbeGridIndex(uint32_t linearIndex, uint32_t& outX, uint32_t& outY, uint32_t& outZ) const
+    /**
+     * @brief 3D grid index for a probe in the irradiance volume
+     */
+    struct GridIndex
     {
-        outX = linearIndex % resolutionX;
-        outY = (linearIndex / resolutionX) % resolutionY;
-        outZ = linearIndex / (resolutionX * resolutionY);
+        uint32_t x = 0;
+        uint32_t y = 0;
+        uint32_t z = 0;
+    };
+
+    /** @brief Get the 3D grid index for a linear probe index */
+    GridIndex GetProbeGridIndex(uint32_t linearIndex) const
+    {
+        return {linearIndex % resolutionX, (linearIndex / resolutionX) % resolutionY,
+                linearIndex / (resolutionX * resolutionY)};
     }
 };
 
@@ -747,16 +757,16 @@ class GlobalIlluminationSystem
 
     // ---- Accessors ----
 
-    GISettings& GetSettings() { return m_settings; }
-    const GISettings& GetSettings() const { return m_settings; }
+    GISettings& GetSettings() noexcept { return m_settings; }
+    const GISettings& GetSettings() const noexcept { return m_settings; }
     void SetSettings(const GISettings& settings) { m_settings = settings; }
 
-    const std::vector<LightProbe>& GetProbes() const { return m_probes; }
-    uint32_t GetProbeCount() const { return static_cast<uint32_t>(m_probes.size()); }
+    const std::vector<LightProbe>& GetProbes() const noexcept { return m_probes; }
+    uint32_t GetProbeCount() const noexcept { return static_cast<uint32_t>(m_probes.size()); }
 
-    const IrradianceVolume& GetIrradianceVolume() const { return m_irradianceVolume; }
+    const IrradianceVolume& GetIrradianceVolume() const noexcept { return m_irradianceVolume; }
 
-    bool IsInitialized() const { return m_initialized; }
+    bool IsInitialized() const noexcept { return m_initialized; }
 
     /** @brief Get a specific probe by index */
     const LightProbe* GetProbe(uint32_t index) const

--- a/SparkEngine/Source/Graphics/UpscalingSystem.h
+++ b/SparkEngine/Source/Graphics/UpscalingSystem.h
@@ -41,6 +41,16 @@
 #include <string>
 #include <algorithm>
 #include <cmath>
+#include <utility>
+
+/**
+ * @brief Resolution as a width/height pair, enabling structured bindings
+ */
+struct Resolution
+{
+    uint32_t width = 0;
+    uint32_t height = 0;
+};
 
 // =============================================================================
 // Upscaling Enums
@@ -171,26 +181,23 @@ struct UpscalingSettings
      * @brief Calculate the render resolution for the given display resolution
      * @param displayWidth  Target display width
      * @param displayHeight Target display height
-     * @param outWidth      Computed render width
-     * @param outHeight     Computed render height
+     * @return Computed render resolution (use structured bindings: auto [w, h] = ...)
      */
-    void CalculateRenderResolution(uint32_t displayWidth, uint32_t displayHeight, uint32_t& outWidth,
-                                   uint32_t& outHeight) const
+    Resolution CalculateRenderResolution(uint32_t displayWidth, uint32_t displayHeight) const
     {
         if (mode == UpscalingMode::None)
         {
-            outWidth = displayWidth;
-            outHeight = displayHeight;
-            return;
+            return {displayWidth, displayHeight};
         }
 
         float scale = GetRenderScale(quality);
-        outWidth = std::max(1u, static_cast<uint32_t>(static_cast<float>(displayWidth) * scale));
-        outHeight = std::max(1u, static_cast<uint32_t>(static_cast<float>(displayHeight) * scale));
+        uint32_t w = std::max(1u, static_cast<uint32_t>(static_cast<float>(displayWidth) * scale));
+        uint32_t h = std::max(1u, static_cast<uint32_t>(static_cast<float>(displayHeight) * scale));
 
         // Ensure even dimensions for compute shader dispatch alignment
-        outWidth = (outWidth + 1u) & ~1u;
-        outHeight = (outHeight + 1u) & ~1u;
+        w = (w + 1u) & ~1u;
+        h = (h + 1u) & ~1u;
+        return {w, h};
     }
 };
 
@@ -407,26 +414,20 @@ class UpscalingSystem
 
     /**
      * @brief Get the current render resolution (internal, before upscaling)
+     * @return Render resolution (use structured bindings: auto [w, h] = ...)
      */
-    void GetRenderResolution(uint32_t& outWidth, uint32_t& outHeight) const
-    {
-        outWidth = m_renderWidth;
-        outHeight = m_renderHeight;
-    }
+    Resolution GetRenderResolution() const noexcept { return {m_renderWidth, m_renderHeight}; }
 
     /**
      * @brief Get the display resolution (output, after upscaling)
+     * @return Display resolution (use structured bindings: auto [w, h] = ...)
      */
-    void GetDisplayResolution(uint32_t& outWidth, uint32_t& outHeight) const
-    {
-        outWidth = m_displayWidth;
-        outHeight = m_displayHeight;
-    }
+    Resolution GetDisplayResolution() const noexcept { return {m_displayWidth, m_displayHeight}; }
 
     /**
      * @brief Get the current render scale factor
      */
-    float GetCurrentRenderScale() const
+    float GetCurrentRenderScale() const noexcept
     {
         if (m_settings.mode == UpscalingMode::None)
         {
@@ -617,30 +618,28 @@ class UpscalingSystem
     void SetSharpness(float sharpness) { m_settings.sharpness = std::clamp(sharpness, 0.0f, 1.0f); }
 
     /** @brief Check if the system is initialized */
-    bool IsInitialized() const { return m_initialized; }
+    bool IsInitialized() const noexcept { return m_initialized; }
 
     /** @brief Check if any upscaling is active */
-    bool IsActive() const { return m_settings.mode != UpscalingMode::None; }
+    bool IsActive() const noexcept { return m_settings.mode != UpscalingMode::None; }
 
     /**
      * @brief Get the recommended render size for a given display resolution and quality
      * @param displayWidth  Target display width
      * @param displayHeight Target display height
      * @param quality       Quality preset
-     * @param outWidth      Recommended render width
-     * @param outHeight     Recommended render height
+     * @return Recommended render resolution
      */
-    static void GetRecommendedRenderSize(uint32_t displayWidth, uint32_t displayHeight, UpscalingQuality quality,
-                                         uint32_t& outWidth, uint32_t& outHeight);
+    static Resolution GetRecommendedRenderSize(uint32_t displayWidth, uint32_t displayHeight, UpscalingQuality quality);
 
     /** @brief Check if FSR 1.0 is available (always true — shader-based) */
-    bool IsFSR1Available() const { return true; }
+    bool IsFSR1Available() const noexcept { return true; }
 
     /** @brief Check if FSR 2.0 is available (requires compute shader support) */
-    bool IsFSR2Available() const { return m_fsr2Available; }
+    bool IsFSR2Available() const noexcept { return m_fsr2Available; }
 
     /** @brief Check if compute shaders were compiled successfully */
-    bool AreShadersCompiled() const { return m_shadersCompiled; }
+    bool AreShadersCompiled() const noexcept { return m_shadersCompiled; }
 
     // ---- Console Integration ----
 
@@ -788,7 +787,9 @@ class UpscalingSystem
 
     void UpdateRenderResolution()
     {
-        m_settings.CalculateRenderResolution(m_displayWidth, m_displayHeight, m_renderWidth, m_renderHeight);
+        auto [w, h] = m_settings.CalculateRenderResolution(m_displayWidth, m_displayHeight);
+        m_renderWidth = w;
+        m_renderHeight = h;
     }
 
     /** @brief Compile all upscaling compute shaders from inline HLSL */

--- a/SparkEngine/Source/Input/InputManager.cpp
+++ b/SparkEngine/Source/Input/InputManager.cpp
@@ -237,17 +237,14 @@ bool InputManager::WasMouseButtonReleased(int button) const
     return !m_mouseButtons[button] && m_prevMouseButtons[button];
 }
 
-bool InputManager::GetMouseDelta(int& deltaX, int& deltaY) const
+MousePoint InputManager::GetMouseDelta() const
 {
-    deltaX = m_mouseDeltaX;
-    deltaY = m_mouseDeltaY;
-    return (m_mouseDeltaX != 0 || m_mouseDeltaY != 0);
+    return {m_mouseDeltaX, m_mouseDeltaY};
 }
 
-void InputManager::GetMousePosition(int& x, int& y) const
+MousePoint InputManager::GetMousePosition() const
 {
-    x = m_mouseX;
-    y = m_mouseY;
+    return {m_mouseX, m_mouseY};
 }
 
 void InputManager::CaptureMouse(bool capture)
@@ -932,19 +929,18 @@ bool InputManager::WasMouseButtonReleased(int button) const
     return !m_mouseButtons[button] && m_prevMouseButtons[button];
 }
 
-bool InputManager::GetMouseDelta(int& deltaX, int& deltaY) const
+MousePoint InputManager::GetMouseDelta() const
 {
-    deltaX = static_cast<int>(m_mouseDeltaX * m_mouseSensitivity);
-    deltaY = static_cast<int>(m_mouseDeltaY * m_mouseSensitivity);
+    int deltaX = static_cast<int>(m_mouseDeltaX * m_mouseSensitivity);
+    int deltaY = static_cast<int>(m_mouseDeltaY * m_mouseSensitivity);
     if (m_invertMouseY)
         deltaY = -deltaY;
-    return true;
+    return {deltaX, deltaY};
 }
 
-void InputManager::GetMousePosition(int& x, int& y) const
+MousePoint InputManager::GetMousePosition() const
 {
-    x = m_mouseX;
-    y = m_mouseY;
+    return {m_mouseX, m_mouseY};
 }
 
 void InputManager::CaptureMouse(bool capture)

--- a/SparkEngine/Source/Input/InputManager.h
+++ b/SparkEngine/Source/Input/InputManager.h
@@ -14,6 +14,7 @@
 
 #include "Utils/Assert.h"
 #include "../Core/framework.h"
+#include "InputTypes.h"
 #include <unordered_map>
 #include <functional>
 #include <mutex>
@@ -204,26 +205,23 @@ class InputManager
 
     /**
      * @brief Get mouse movement delta since last frame
-     * 
+     *
      * Returns the pixel delta movement of the mouse cursor since the last frame.
      * Applies sensitivity, dead zone, and acceleration settings.
-     * 
-     * @param deltaX Output parameter for horizontal mouse movement
-     * @param deltaY Output parameter for vertical mouse movement
-     * @return true if delta values are valid, false otherwise
+     *
+     * @return MousePoint with dx/dy values; check non-zero for valid movement
      */
-    bool GetMouseDelta(int& deltaX, int& deltaY) const;
+    MousePoint GetMouseDelta() const;
 
     /**
      * @brief Get current mouse cursor position
-     * 
+     *
      * Returns the current pixel coordinates of the mouse cursor relative
      * to the client area of the window.
-     * 
-     * @param x Output parameter for horizontal cursor position
-     * @param y Output parameter for vertical cursor position
+     *
+     * @return MousePoint with x/y position in client coordinates
      */
-    void GetMousePosition(int& x, int& y) const;
+    MousePoint GetMousePosition() const;
 
     /**
      * @brief Capture or release the mouse cursor

--- a/SparkEngine/Source/Input/InputTypes.h
+++ b/SparkEngine/Source/Input/InputTypes.h
@@ -1,0 +1,19 @@
+/**
+ * @file InputTypes.h
+ * @brief Shared input type definitions
+ * @author Spark Engine Team
+ * @date 2026
+ */
+
+#pragma once
+
+/**
+ * @brief 2D integer point for mouse position and movement deltas
+ *
+ * Supports C++17 structured bindings: auto [x, y] = input.GetMousePosition();
+ */
+struct MousePoint
+{
+    int x = 0;
+    int y = 0;
+};

--- a/SparkEngine/Source/Input/PlatformInput.cpp
+++ b/SparkEngine/Source/Input/PlatformInput.cpp
@@ -211,16 +211,14 @@ namespace Spark::Input
         return !m_keyStates[idx] && m_prevKeyStates[idx];
     }
 
-    void Win32InputBackend::GetMousePosition(int& x, int& y) const
+    MousePoint Win32InputBackend::GetMousePosition() const
     {
-        x = m_mouseX;
-        y = m_mouseY;
+        return {m_mouseX, m_mouseY};
     }
 
-    void Win32InputBackend::GetMouseDelta(int& dx, int& dy) const
+    MousePoint Win32InputBackend::GetMouseDelta() const
     {
-        dx = m_mouseDeltaX;
-        dy = m_mouseDeltaY;
+        return {m_mouseDeltaX, m_mouseDeltaY};
     }
 
     float Win32InputBackend::GetMouseScroll() const
@@ -636,16 +634,14 @@ namespace Spark::Input
         return (idx < m_keyStates.size()) ? (!m_keyStates[idx] && m_prevKeyStates[idx]) : false;
     }
 
-    void SDL2InputBackend::GetMousePosition(int& x, int& y) const
+    MousePoint SDL2InputBackend::GetMousePosition() const
     {
-        x = m_mouseX;
-        y = m_mouseY;
+        return {m_mouseX, m_mouseY};
     }
 
-    void SDL2InputBackend::GetMouseDelta(int& dx, int& dy) const
+    MousePoint SDL2InputBackend::GetMouseDelta() const
     {
-        dx = m_mouseDeltaX;
-        dy = m_mouseDeltaY;
+        return {m_mouseDeltaX, m_mouseDeltaY};
     }
 
     float SDL2InputBackend::GetMouseScroll() const
@@ -853,15 +849,16 @@ namespace Spark::Input
             }
 
             // Mouse movement events
-            int dx = 0, dy = 0;
-            m_backend->GetMouseDelta(dx, dy);
-            if (dx != 0 || dy != 0)
+            auto mouseDelta = m_backend->GetMouseDelta();
+            if (mouseDelta.x != 0 || mouseDelta.y != 0)
             {
                 InputEvent evt{};
                 evt.type = InputEvent::Type::MouseMove;
-                m_backend->GetMousePosition(evt.mouseX, evt.mouseY);
-                evt.mouseDeltaX = dx;
-                evt.mouseDeltaY = dy;
+                auto mousePos = m_backend->GetMousePosition();
+                evt.mouseX = mousePos.x;
+                evt.mouseY = mousePos.y;
+                evt.mouseDeltaX = mouseDelta.x;
+                evt.mouseDeltaY = mouseDelta.y;
                 for (const auto& cb : m_eventCallbacks)
                 {
                     cb(evt);
@@ -944,30 +941,23 @@ namespace Spark::Input
         return m_backend ? m_backend->WasKeyReleased(key) : false;
     }
 
-    void PlatformInputManager::GetMousePosition(int& x, int& y) const
+    MousePoint PlatformInputManager::GetMousePosition() const
     {
         if (m_backend)
-            m_backend->GetMousePosition(x, y);
-        else
-        {
-            x = 0;
-            y = 0;
-        }
+            return m_backend->GetMousePosition();
+        return {0, 0};
     }
 
-    void PlatformInputManager::GetMouseDelta(int& dx, int& dy) const
+    MousePoint PlatformInputManager::GetMouseDelta() const
     {
         if (m_backend)
         {
-            m_backend->GetMouseDelta(dx, dy);
-            dx = static_cast<int>(dx * m_globalSensitivity);
-            dy = static_cast<int>(dy * m_globalSensitivity);
+            auto delta = m_backend->GetMouseDelta();
+            delta.x = static_cast<int>(delta.x * m_globalSensitivity);
+            delta.y = static_cast<int>(delta.y * m_globalSensitivity);
+            return delta;
         }
-        else
-        {
-            dx = 0;
-            dy = 0;
-        }
+        return {0, 0};
     }
 
     float PlatformInputManager::GetMouseScroll() const

--- a/SparkEngine/Source/Input/PlatformInput.h
+++ b/SparkEngine/Source/Input/PlatformInput.h
@@ -60,7 +60,11 @@
 #include <functional>
 #include <memory>
 #include <cstdint>
+#include <utility>
 #include <array>
+
+// Forward-declare MousePoint (defined in InputTypes.h)
+#include "InputTypes.h"
 
 namespace Spark::Input
 {
@@ -387,11 +391,11 @@ namespace Spark::Input
         /** @brief Check if a key was released this frame @param key The key to query @return true if just released */
         virtual bool WasKeyReleased(KeyCode key) const = 0;
 
-        /** @brief Get the current mouse position @param x [out] X position @param y [out] Y position */
-        virtual void GetMousePosition(int& x, int& y) const = 0;
+        /** @brief Get the current mouse position @return MousePoint with x/y coordinates */
+        virtual MousePoint GetMousePosition() const = 0;
 
-        /** @brief Get mouse movement since last frame @param dx [out] X delta @param dy [out] Y delta */
-        virtual void GetMouseDelta(int& dx, int& dy) const = 0;
+        /** @brief Get mouse movement since last frame @return MousePoint with dx/dy deltas */
+        virtual MousePoint GetMouseDelta() const = 0;
 
         /** @brief Get the mouse scroll wheel delta @return Scroll delta (positive = up) */
         virtual float GetMouseScroll() const = 0;
@@ -450,8 +454,8 @@ namespace Spark::Input
         bool WasKeyPressed(KeyCode key) const override;
         bool WasKeyReleased(KeyCode key) const override;
 
-        void GetMousePosition(int& x, int& y) const override;
-        void GetMouseDelta(int& dx, int& dy) const override;
+        MousePoint GetMousePosition() const override;
+        MousePoint GetMouseDelta() const override;
         float GetMouseScroll() const override;
 
         void SetMouseCapture(bool capture) override;
@@ -524,8 +528,8 @@ namespace Spark::Input
         bool WasKeyPressed(KeyCode key) const override;
         bool WasKeyReleased(KeyCode key) const override;
 
-        void GetMousePosition(int& x, int& y) const override;
-        void GetMouseDelta(int& dx, int& dy) const override;
+        MousePoint GetMousePosition() const override;
+        MousePoint GetMouseDelta() const override;
         float GetMouseScroll() const override;
 
         void SetMouseCapture(bool capture) override;
@@ -618,11 +622,11 @@ namespace Spark::Input
         /** @brief Check if a key was released this frame @param key Key to query @return true if just released */
         bool WasKeyReleased(KeyCode key) const;
 
-        /** @brief Get current mouse position in window coordinates @param x [out] X position @param y [out] Y position */
-        void GetMousePosition(int& x, int& y) const;
+        /** @brief Get current mouse position in window coordinates @return MousePoint with x/y */
+        MousePoint GetMousePosition() const;
 
-        /** @brief Get mouse movement since last frame @param dx [out] X delta @param dy [out] Y delta */
-        void GetMouseDelta(int& dx, int& dy) const;
+        /** @brief Get mouse movement since last frame @return MousePoint with dx/dy */
+        MousePoint GetMouseDelta() const;
 
         /** @brief Get mouse scroll wheel delta @return Scroll delta (positive = up) */
         float GetMouseScroll() const;

--- a/SparkEngine/Source/Physics/ClothSimulation.cpp
+++ b/SparkEngine/Source/Physics/ClothSimulation.cpp
@@ -180,19 +180,14 @@ namespace Spark::Physics
         return s_emptyParticles;
     }
 
-    void ClothSimulation::GetClothDimensions(uint32_t clothId, int& width, int& height) const
+    std::pair<int, int> ClothSimulation::GetClothDimensions(uint32_t clothId) const
     {
         auto it = m_clothInstances.find(clothId);
         if (it != m_clothInstances.end())
         {
-            width = it->second.width;
-            height = it->second.height;
+            return {it->second.width, it->second.height};
         }
-        else
-        {
-            width = 0;
-            height = 0;
-        }
+        return {0, 0};
     }
 
     void ClothSimulation::SimulateCloth(ClothInstance& cloth, float deltaTime)

--- a/SparkEngine/Source/Physics/ClothSimulation.h
+++ b/SparkEngine/Source/Physics/ClothSimulation.h
@@ -50,6 +50,7 @@
 #include <vector>
 #include <unordered_map>
 #include <cstdint>
+#include <utility>
 
 namespace Spark::Physics
 {
@@ -237,11 +238,15 @@ namespace Spark::Physics
      */
         const std::vector<ClothParticle>& GetParticles(uint32_t clothId) const;
 
-        /** @brief Get the cloth grid dimensions. */
-        void GetClothDimensions(uint32_t clothId, int& width, int& height) const;
+        /**
+         * @brief Get the cloth grid dimensions.
+         * @param clothId Cloth handle.
+         * @return Pair of {width, height}
+         */
+        std::pair<int, int> GetClothDimensions(uint32_t clothId) const;
 
         /** @brief Get the number of active cloth instances. */
-        size_t GetInstanceCount() const { return m_clothInstances.size(); }
+        size_t GetInstanceCount() const noexcept { return m_clothInstances.size(); }
 
         // --- Console integration ---
 

--- a/SparkEngine/Source/Utils/ConsoleVariable.h
+++ b/SparkEngine/Source/Utils/ConsoleVariable.h
@@ -36,6 +36,7 @@
 #include <mutex>
 #include <sstream>
 #include <algorithm>
+#include <concepts>
 #include <type_traits>
 #include <cstdint>
 
@@ -78,7 +79,7 @@ namespace Spark
         String
     };
 
-    inline const char* CVarTypeToString(CVarType type)
+    inline std::string_view CVarTypeToString(CVarType type) noexcept
     {
         switch (type)
         {
@@ -226,7 +227,14 @@ namespace Spark
     // CVar<T> - Typed console variable
     // ============================================================================
 
-    template <typename T> class CVar : public ICVar
+    /**
+     * @brief Concept constraining CVar to supported types: int, float, bool, std::string
+     */
+    template <typename T>
+    concept CVarType_c =
+        std::is_same_v<T, int> || std::is_same_v<T, float> || std::is_same_v<T, bool> || std::is_same_v<T, std::string>;
+
+    template <CVarType_c T> class CVar : public ICVar
     {
       public:
         using ChangeCallback = std::function<void(const T& oldValue, const T& newValue)>;

--- a/SparkEngine/Source/Utils/Logger.cpp
+++ b/SparkEngine/Source/Utils/Logger.cpp
@@ -52,9 +52,11 @@ namespace Spark
         char buf[4096];
         int offset = 0;
 
-        offset += snprintf(buf + offset, sizeof(buf) - offset, "[%s.%03d] [TID:%s] [%-5s] [%-10s] %s", timeBuf,
-                           static_cast<int>(ms), tidStr.c_str(), LogLevelToString(msg.level),
-                           LogCategoryToString(msg.category), msg.message.c_str());
+        auto levelStr = LogLevelToString(msg.level);
+        auto catStr = LogCategoryToString(msg.category);
+        offset += snprintf(buf + offset, sizeof(buf) - offset, "[%s.%03d] [TID:%s] [%-5.*s] [%-10.*s] %s", timeBuf,
+                           static_cast<int>(ms), tidStr.c_str(), static_cast<int>(levelStr.size()), levelStr.data(),
+                           static_cast<int>(catStr.size()), catStr.data(), msg.message.c_str());
 
         // Append source location if available
         if (!msg.file.empty())

--- a/SparkEngine/Source/Utils/Logger.h
+++ b/SparkEngine/Source/Utils/Logger.h
@@ -63,7 +63,7 @@ namespace Spark
     /**
      * @brief Convert LogLevel to string representation
      */
-    inline const char* LogLevelToString(LogLevel level)
+    inline std::string_view LogLevelToString(LogLevel level) noexcept
     {
         switch (level)
         {
@@ -112,7 +112,7 @@ namespace Spark
     /**
      * @brief Convert LogCategory to string representation
      */
-    inline const char* LogCategoryToString(LogCategory cat)
+    inline std::string_view LogCategoryToString(LogCategory cat) noexcept
     {
         switch (cat)
         {

--- a/SparkEngine/Source/Utils/SparkConsole.cpp
+++ b/SparkEngine/Source/Utils/SparkConsole.cpp
@@ -735,7 +735,7 @@ namespace Spark
                 else
                 {
                     LogError("Invalid value '" + newVal + "' for " + command +
-                             " (type: " + CVarTypeToString(cvar->GetType()) + ")");
+                             " (type: " + std::string(CVarTypeToString(cvar->GetType())) + ")");
                     m_stats.totalCommandsFailed++;
                     return false;
                 }

--- a/SparkGame/Source/Game/Game.cpp
+++ b/SparkGame/Source/Game/Game.cpp
@@ -750,8 +750,8 @@ void Game::HandleInput(float dt)
         return;
     }
 
-    int dx = 0, dy = 0;
-    if (m_input->GetMouseDelta(dx, dy))
+    auto [dx, dy] = m_input->GetMouseDelta();
+    if (dx != 0 || dy != 0)
     {
         constexpr float mouseSens = 0.005f;
         m_camera->Yaw(dx * mouseSens);

--- a/Tests/TestClothSimulation.cpp
+++ b/Tests/TestClothSimulation.cpp
@@ -34,8 +34,7 @@ TEST(Cloth_ParticleCount)
     const auto& particles = cloth.GetParticles(id);
     EXPECT_EQ(particles.size(), static_cast<size_t>(12)); // 4 * 3 = 12
 
-    int w = 0, h = 0;
-    cloth.GetClothDimensions(id, w, h);
+    auto [w, h] = cloth.GetClothDimensions(id);
     EXPECT_EQ(w, 4);
     EXPECT_EQ(h, 3);
 }

--- a/Tests/TestUpscalingSystem.cpp
+++ b/Tests/TestUpscalingSystem.cpp
@@ -34,8 +34,7 @@ TEST(Upscaling_RenderResolutionCalculation)
     settings.mode = UpscalingMode::FSR1;
     settings.quality = UpscalingQuality::Performance;
 
-    uint32_t w = 0, h = 0;
-    settings.CalculateRenderResolution(1920, 1080, w, h);
+    auto [w, h] = settings.CalculateRenderResolution(1920, 1080);
 
     // At Performance quality (~50%), 1920x1080 -> ~960x540
     EXPECT_GT(w, 900u);
@@ -45,11 +44,11 @@ TEST(Upscaling_RenderResolutionCalculation)
 
     // 4K at Balanced quality (~58%)
     settings.quality = UpscalingQuality::Balanced;
-    settings.CalculateRenderResolution(3840, 2160, w, h);
-    EXPECT_GT(w, 2100u);
-    EXPECT_LT(w, 2400u);
-    EXPECT_GT(h, 1100u);
-    EXPECT_LT(h, 1350u);
+    auto [w2, h2] = settings.CalculateRenderResolution(3840, 2160);
+    EXPECT_GT(w2, 2100u);
+    EXPECT_LT(w2, 2400u);
+    EXPECT_GT(h2, 1100u);
+    EXPECT_LT(h2, 1350u);
 }
 
 TEST(Upscaling_ModeInputRequirements)
@@ -97,8 +96,7 @@ TEST(Upscaling_SettingsDefaults)
     EXPECT_GE(settings.sharpness, 0.0f);
 
     // When mode is None, CalculateRenderResolution returns display res
-    uint32_t w = 0, h = 0;
-    settings.CalculateRenderResolution(1920, 1080, w, h);
+    auto [w, h] = settings.CalculateRenderResolution(1920, 1080);
     EXPECT_EQ(w, 1920u);
     EXPECT_EQ(h, 1080u);
 }

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -120,12 +120,12 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 <!-- AUTO:stats -->
 | Metric | Count |
 |--------|-------|
-| Header files | 343 |
+| Header files | 344 |
 | ECS Components | 37 |
 | ECS Systems | 47 |
 | Editor Panels | 32 |
 | Test files | 71 |
 | Test cases | 864+ |
 | Wiki pages | 50 |
-| *Last synced* | *2026-03-12 15:56* |
+| *Last synced* | *2026-03-12 17:14* |
 <!-- /AUTO:stats -->

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -127,5 +127,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 71 |
 | Test cases | 864+ |
 | Wiki pages | 50 |
-| *Last synced* | *2026-03-12 17:14* |
+| *Last synced* | *2026-03-12 17:27* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
Convert output-parameter APIs to return structured types enabling structured bindings (UpscalingSystem, InputManager, PlatformInput, VRSystem, ClothSimulation, GlobalIllumination). Convert FrustumCulling PlaneIndex to enum class. Add string_view returns for enum-to-string converters. Add noexcept to pure getters. Add C++20 concept constraint to CVar template.

https://claude.ai/code/session_01C4c4ECFtERg5KaQg3LuaS2