### PR TITLE
Add XMQuaternionRotationRollPitchYaw stub to Platform.h

### DIFF
--- a/SparkEngine/Source/Core/Platform.h
+++ b/SparkEngine/Source/Core/Platform.h
@@ -1101,6 +1101,18 @@ namespace DirectX
     }
 
     // Quaternion stubs
+    inline XMVECTOR XMQuaternionRotationRollPitchYaw(float pitch, float yaw, float roll)
+    {
+        float halfPitch = pitch * 0.5f;
+        float halfYaw = yaw * 0.5f;
+        float halfRoll = roll * 0.5f;
+        float sp = sinf(halfPitch), cp = cosf(halfPitch);
+        float sy = sinf(halfYaw), cy = cosf(halfYaw);
+        float sr = sinf(halfRoll), cr = cosf(halfRoll);
+        return {cy * sp * cr + sy * cp * sr, sy * cp * cr - cy * sp * sr,
+                cy * cp * sr - sy * sp * cr, cy * cp * cr + sy * sp * sr};
+    }
+
     inline XMVECTOR XMQuaternionRotationAxis(XMVECTOR axis, float angle)
     {
         XMVECTOR n = XMVector3Normalize(axis);

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -127,5 +127,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 75 |
 | Test cases | 917+ |
 | Wiki pages | 50 |
-| *Last synced* | *2026-03-12 21:53* |
+| *Last synced* | *2026-03-13 01:33* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
PhysicsSystem::PhysicsBody constructor calls XMQuaternionRotationRollPitchYaw to convert Euler angles to a quaternion, but this function was missing from the cross-platform DirectXMath stubs in Platform.h. Add the implementation using the standard half-angle quaternion formula.

https://claude.ai/code/session_017ha3Deu8RsN7LS87QfEXqQ