### PR TITLE
Refactor SparkGame: remove PlanetSide 2 references, add networking

### DIFF
--- a/SparkEngine/Source/Enums/GameSystemEnums.h
+++ b/SparkEngine/Source/Enums/GameSystemEnums.h
@@ -263,17 +263,17 @@ namespace SparkEditor
     /**
  * @brief Player class types for class-based FPS gameplay
  *
- * Inspired by PlanetSide 2 and Battlefield class systems.
+ * Generic FPS archetypes designed for the Spark Engine showcase.
  * Each class has unique stats, weapon loadouts, and abilities.
  */
     enum class PlayerClass
     {
-        LIGHT_ASSAULT = 0, ///< Fast, mobile class with jetpack ability and assault rifles
-        COMBAT_MEDIC = 1,  ///< Support healer with ARs and medical tools
-        ENGINEER = 2,      ///< Repair/builder class with SMGs and deployables
-        INFILTRATOR = 3,   ///< Stealth recon class with sniper rifles and cloak
-        HEAVY_ASSAULT = 4, ///< Tanky frontline class with LMGs and overshield
-        MAX_SUIT = 5,      ///< Heavy mech suit with dual weapons, extreme tankiness
+        SCOUT = 0,    ///< Fast, mobile class with jetpack ability and assault rifles
+        MEDIC = 1,    ///< Support healer with ARs and medical tools
+        ENGINEER = 2, ///< Repair/builder class with SMGs and deployables
+        RECON = 3,    ///< Stealth reconnaissance class with sniper rifles and cloak
+        VANGUARD = 4, ///< Tanky frontline class with LMGs and energy shield
+        TITAN = 5,    ///< Heavy exosuit with dual weapons, extreme tankiness
         COUNT = 6
     };
 
@@ -286,18 +286,18 @@ namespace SparkEditor
     enum class ClassAbility
     {
         NONE = 0,
-        JETPACK = 1,          ///< Light Assault: vertical thrust/flight
-        SPRINT_BOOST = 2,     ///< Light Assault: temporary speed burst
-        HEAL_AURA = 3,        ///< Combat Medic: area-of-effect healing
-        REVIVE = 4,           ///< Combat Medic: revive downed allies
+        JETPACK = 1,          ///< Scout: vertical thrust/flight
+        SPRINT_BOOST = 2,     ///< Scout: temporary speed burst
+        HEAL_AURA = 3,        ///< Medic: area-of-effect healing
+        REVIVE = 4,           ///< Medic: revive downed allies
         DEPLOY_TURRET = 5,    ///< Engineer: place an automated turret
         DEPLOY_BARRIER = 6,   ///< Engineer: place a defensive barrier
-        CLOAK = 7,            ///< Infiltrator: temporary invisibility
-        RECON_DART = 8,       ///< Infiltrator: reveal enemies on minimap
-        OVERSHIELD = 9,       ///< Heavy Assault: temporary shield boost
-        ROCKET_BARRAGE = 10,  ///< Heavy Assault: salvo of rockets
-        LOCKDOWN = 11,        ///< MAX: root in place for increased fire rate
-        EMERGENCY_REPAIR = 12 ///< MAX: self-repair burst
+        CLOAK = 7,            ///< Recon: temporary invisibility
+        SENSOR_PULSE = 8,     ///< Recon: reveal enemies on minimap
+        ENERGY_SHIELD = 9,    ///< Vanguard: temporary shield boost
+        ROCKET_BARRAGE = 10,  ///< Vanguard: salvo of rockets
+        LOCKDOWN = 11,        ///< Titan: root in place for increased fire rate
+        EMERGENCY_REPAIR = 12 ///< Titan: self-repair burst
     };
 
     /**

--- a/SparkGame/Source/Core/Main.cpp
+++ b/SparkGame/Source/Core/Main.cpp
@@ -64,7 +64,7 @@ SparkGameModule::~SparkGameModule()
 Spark::ModuleInfo SparkGameModule::GetModuleInfo() const
 {
     Spark::ModuleInfo info{};
-    info.name = "Spark Game";
+    info.name = "Spark Arena - Engine Showcase";
     info.version = "1.0.0";
     info.sdkVersion = SPARK_SDK_VERSION;
     info.loadOrder = 1000;
@@ -128,7 +128,7 @@ void SparkGameModule::OnRender()
 
 const char* SparkGameModule::GetGameName() const
 {
-    return "Spark Game";
+    return "Spark Arena";
 }
 
 const char* SparkGameModule::GetGameVersion() const
@@ -571,6 +571,84 @@ void SparkGameModule::RegisterGameConsoleCommands()
             return enable ? "HUD elements enabled" : "HUD elements disabled";
         },
         "Toggle HUD visibility (hud [on|off])");
+
+    // -------------------------------------------------------------------------
+    // Networking commands
+    // -------------------------------------------------------------------------
+
+#ifdef ENABLE_NETWORKING
+    console.RegisterCommand(
+        "net_host",
+        [game](const std::vector<std::string>& args) -> std::string
+        {
+            if (!game)
+                return "Game not available";
+            uint16_t port = 27015;
+            int maxClients = 32;
+            if (!args.empty())
+                port = static_cast<uint16_t>(std::stoi(args[0]));
+            if (args.size() > 1)
+                maxClients = std::stoi(args[1]);
+            return game->StartServer(port, maxClients) ? "Server started" : "Failed to start server";
+        },
+        "Host a server (net_host [port] [max_clients])");
+
+    console.RegisterCommand(
+        "net_connect",
+        [game](const std::vector<std::string>& args) -> std::string
+        {
+            if (args.empty())
+                return "Usage: net_connect <address> [port]";
+            if (!game)
+                return "Game not available";
+            uint16_t port = 27015;
+            if (args.size() > 1)
+                port = static_cast<uint16_t>(std::stoi(args[1]));
+            return game->ConnectToServer(args[0], port) ? "Connecting..." : "Failed to connect";
+        },
+        "Connect to a server (net_connect <address> [port])");
+
+    console.RegisterCommand(
+        "net_disconnect",
+        [game](const std::vector<std::string>&) -> std::string
+        {
+            if (!game)
+                return "Game not available";
+            game->DisconnectNetwork();
+            return "Disconnected";
+        },
+        "Disconnect from network");
+
+    console.RegisterCommand(
+        "net_status",
+        [game](const std::vector<std::string>&) -> std::string
+        {
+            if (!game)
+                return "Game not available";
+            return game->GetNetworkStatus();
+        },
+        "Show network status");
+
+    console.RegisterCommand(
+        "net_stats",
+        [game](const std::vector<std::string>&) -> std::string
+        {
+            if (!game)
+                return "Game not available";
+            auto stats = game->GetNetworkStats();
+            std::stringstream ss;
+            ss << "=== Network Stats ===\n";
+            ss << "Ping: " << stats.ping << "ms\n";
+            ss << "Jitter: " << stats.jitter << "ms\n";
+            ss << "Packet Loss: " << (stats.packetLoss * 100.0f) << "%\n";
+            ss << "Upload: " << stats.bandwidthUp << " KB/s\n";
+            ss << "Download: " << stats.bandwidthDown << " KB/s\n";
+            ss << "Sent: " << stats.packetsSent << " packets (" << stats.bytesSent << " bytes)\n";
+            ss << "Received: " << stats.packetsReceived << " packets (" << stats.bytesReceived << " bytes)\n";
+            return ss.str();
+        },
+        "Show network statistics");
+#endif // ENABLE_NETWORKING
 }
 
 // ===================================================================================

--- a/SparkGame/Source/Core/SparkGame.h
+++ b/SparkGame/Source/Core/SparkGame.h
@@ -1,15 +1,15 @@
 /**
  * @file SparkGame.h
- * @brief SparkGame module - implements both IModule and IGameModule
+ * @brief SparkGame module - Spark Engine FPS showcase
  * @author Spark Engine Team
  * @date 2025
  *
- * SparkGame is a DLL that the SparkEngine executable loads at runtime.
- * It implements both the new IModule interface (via Spark::IModule) and
- * the legacy IGameModule interface for backward compatibility.
+ * SparkGame is the initial engine showcase module loaded as a DLL at runtime.
+ * It demonstrates all major engine subsystems: rendering, physics, AI,
+ * animation, audio, networking, ECS, vehicles, and class-based FPS gameplay.
  *
- * The engine's ModuleManager will prefer the new CreateModule/DestroyModule
- * exports, but falls back to CreateGameModule/DestroyGameModule if needed.
+ * Implements both the new IModule interface (via Spark::IModule) and
+ * the legacy IGameModule interface for backward compatibility.
  */
 
 #pragma once

--- a/SparkGame/Source/Enums/GameSystemEnums.h
+++ b/SparkGame/Source/Enums/GameSystemEnums.h
@@ -263,17 +263,17 @@ namespace SparkEditor
     /**
  * @brief Player class types for class-based FPS gameplay
  *
- * Inspired by PlanetSide 2 and Battlefield class systems.
+ * Generic FPS archetypes designed for the Spark Engine showcase.
  * Each class has unique stats, weapon loadouts, and abilities.
  */
     enum class PlayerClass
     {
-        LIGHT_ASSAULT = 0, ///< Fast, mobile class with jetpack ability and assault rifles
-        COMBAT_MEDIC = 1,  ///< Support healer with ARs and medical tools
-        ENGINEER = 2,      ///< Repair/builder class with SMGs and deployables
-        INFILTRATOR = 3,   ///< Stealth recon class with sniper rifles and cloak
-        HEAVY_ASSAULT = 4, ///< Tanky frontline class with LMGs and overshield
-        MAX_SUIT = 5,      ///< Heavy mech suit with dual weapons, extreme tankiness
+        SCOUT = 0,    ///< Fast, mobile class with jetpack ability and assault rifles
+        MEDIC = 1,    ///< Support healer with ARs and medical tools
+        ENGINEER = 2, ///< Repair/builder class with SMGs and deployables
+        RECON = 3,    ///< Stealth reconnaissance class with sniper rifles and cloak
+        VANGUARD = 4, ///< Tanky frontline class with LMGs and energy shield
+        TITAN = 5,    ///< Heavy exosuit with dual weapons, extreme tankiness
         COUNT = 6
     };
 
@@ -286,18 +286,18 @@ namespace SparkEditor
     enum class ClassAbility
     {
         NONE = 0,
-        JETPACK = 1,          ///< Light Assault: vertical thrust/flight
-        SPRINT_BOOST = 2,     ///< Light Assault: temporary speed burst
-        HEAL_AURA = 3,        ///< Combat Medic: area-of-effect healing
-        REVIVE = 4,           ///< Combat Medic: revive downed allies
+        JETPACK = 1,          ///< Scout: vertical thrust/flight
+        SPRINT_BOOST = 2,     ///< Scout: temporary speed burst
+        HEAL_AURA = 3,        ///< Medic: area-of-effect healing
+        REVIVE = 4,           ///< Medic: revive downed allies
         DEPLOY_TURRET = 5,    ///< Engineer: place an automated turret
         DEPLOY_BARRIER = 6,   ///< Engineer: place a defensive barrier
-        CLOAK = 7,            ///< Infiltrator: temporary invisibility
-        RECON_DART = 8,       ///< Infiltrator: reveal enemies on minimap
-        OVERSHIELD = 9,       ///< Heavy Assault: temporary shield boost
-        ROCKET_BARRAGE = 10,  ///< Heavy Assault: salvo of rockets
-        LOCKDOWN = 11,        ///< MAX: root in place for increased fire rate
-        EMERGENCY_REPAIR = 12 ///< MAX: self-repair burst
+        CLOAK = 7,            ///< Recon: temporary invisibility
+        SENSOR_PULSE = 8,     ///< Recon: reveal enemies on minimap
+        ENERGY_SHIELD = 9,    ///< Vanguard: temporary shield boost
+        ROCKET_BARRAGE = 10,  ///< Vanguard: salvo of rockets
+        LOCKDOWN = 11,        ///< Titan: root in place for increased fire rate
+        EMERGENCY_REPAIR = 12 ///< Titan: self-repair burst
     };
 
     /**

--- a/SparkGame/Source/Game/ClassSystem.cpp
+++ b/SparkGame/Source/Game/ClassSystem.cpp
@@ -99,12 +99,12 @@ namespace Spark
 
     bool ClassSystem::Initialize()
     {
-        InitLightAssault();
-        InitCombatMedic();
+        InitScout();
+        InitMedic();
         InitEngineer();
-        InitInfiltrator();
-        InitHeavyAssault();
-        InitMAXSuit();
+        InitRecon();
+        InitVanguard();
+        InitTitan();
         return true;
     }
 
@@ -130,14 +130,14 @@ namespace Spark
     }
 
     // ============================================================================
-    // Class Definitions - PlanetSide 2 / Battlefield Inspired
+    // Class Definitions - Spark Engine Showcase Archetypes
     // ============================================================================
 
-    void ClassSystem::InitLightAssault()
+    void ClassSystem::InitScout()
     {
         ClassDefinition def;
-        def.classType = PlayerClass::LIGHT_ASSAULT;
-        def.name = "Light Assault";
+        def.classType = PlayerClass::SCOUT;
+        def.name = "Scout";
         def.description = "Fast and agile class with jetpack for vertical mobility. "
                           "Excels at flanking and ambush tactics.";
 
@@ -184,14 +184,14 @@ namespace Spark
         def.allowedWeapons = {WeaponType::ASSAULT_RIFLE, WeaponType::SUBMACHINE_GUN, WeaponType::PISTOL,
                               WeaponType::SHOTGUN,       WeaponType::THROWING_KNIFE, WeaponType::MELEE_WEAPON};
 
-        m_classes[static_cast<int>(PlayerClass::LIGHT_ASSAULT)] = def;
+        m_classes[static_cast<int>(PlayerClass::SCOUT)] = def;
     }
 
-    void ClassSystem::InitCombatMedic()
+    void ClassSystem::InitMedic()
     {
         ClassDefinition def;
-        def.classType = PlayerClass::COMBAT_MEDIC;
-        def.name = "Combat Medic";
+        def.classType = PlayerClass::MEDIC;
+        def.name = "Medic";
         def.description = "Support class that heals and revives allies. "
                           "Well-armed with assault rifles for frontline combat.";
 
@@ -239,7 +239,7 @@ namespace Spark
         def.allowedWeapons = {WeaponType::ASSAULT_RIFLE,  WeaponType::RIFLE,        WeaponType::PISTOL,
                               WeaponType::SUBMACHINE_GUN, WeaponType::MEDICAL_TOOL, WeaponType::MELEE_WEAPON};
 
-        m_classes[static_cast<int>(PlayerClass::COMBAT_MEDIC)] = def;
+        m_classes[static_cast<int>(PlayerClass::MEDIC)] = def;
     }
 
     void ClassSystem::InitEngineer()
@@ -297,11 +297,11 @@ namespace Spark
         m_classes[static_cast<int>(PlayerClass::ENGINEER)] = def;
     }
 
-    void ClassSystem::InitInfiltrator()
+    void ClassSystem::InitRecon()
     {
         ClassDefinition def;
-        def.classType = PlayerClass::INFILTRATOR;
-        def.name = "Infiltrator";
+        def.classType = PlayerClass::RECON;
+        def.name = "Recon";
         def.description = "Stealth reconnaissance class with cloaking technology. "
                           "Deadly at range with sniper rifles, fragile up close.";
 
@@ -337,7 +337,7 @@ namespace Spark
         def.primaryAbility.durationMax = 12.0f; // 12 seconds of cloak
         def.primaryAbility.energyCost = 20.0f;
 
-        def.secondaryAbility.type = ClassAbility::RECON_DART;
+        def.secondaryAbility.type = ClassAbility::SENSOR_PULSE;
         def.secondaryAbility.cooldownMax = 25.0f;
         def.secondaryAbility.durationMax = 15.0f; // 15 second scan duration
         def.secondaryAbility.energyCost = 15.0f;
@@ -351,15 +351,15 @@ namespace Spark
                               WeaponType::CROSSBOW,     WeaponType::THROWING_KNIFE, WeaponType::SCANNER,
                               WeaponType::MELEE_WEAPON};
 
-        m_classes[static_cast<int>(PlayerClass::INFILTRATOR)] = def;
+        m_classes[static_cast<int>(PlayerClass::RECON)] = def;
     }
 
-    void ClassSystem::InitHeavyAssault()
+    void ClassSystem::InitVanguard()
     {
         ClassDefinition def;
-        def.classType = PlayerClass::HEAVY_ASSAULT;
-        def.name = "Heavy Assault";
-        def.description = "Frontline tank class with overshield and heavy weapons. "
+        def.classType = PlayerClass::VANGUARD;
+        def.name = "Vanguard";
+        def.description = "Frontline tank class with energy shield and heavy weapons. "
                           "Dominates direct combat but trades mobility for power.";
 
         // Stats - tanky, slow, high firepower
@@ -386,10 +386,10 @@ namespace Spark
         def.loadout.secondary = LoadoutSlot(WeaponType::ROCKET_LAUNCHER, 2);
         def.loadout.sidearm = LoadoutSlot(WeaponType::PISTOL, 2);
 
-        // Abilities: Overshield + Rocket Barrage
-        def.primaryAbility.type = ClassAbility::OVERSHIELD;
+        // Abilities: Energy Shield + Rocket Barrage
+        def.primaryAbility.type = ClassAbility::ENERGY_SHIELD;
         def.primaryAbility.cooldownMax = 15.0f;
-        def.primaryAbility.durationMax = 10.0f; // 10 second overshield
+        def.primaryAbility.durationMax = 10.0f; // 10 second energy shield
         def.primaryAbility.energyCost = 30.0f;
 
         def.secondaryAbility.type = ClassAbility::ROCKET_BARRAGE;
@@ -406,14 +406,14 @@ namespace Spark
                               WeaponType::ASSAULT_RIFLE, WeaponType::MINIGUN,         WeaponType::SHOTGUN,
                               WeaponType::MELEE_WEAPON};
 
-        m_classes[static_cast<int>(PlayerClass::HEAVY_ASSAULT)] = def;
+        m_classes[static_cast<int>(PlayerClass::VANGUARD)] = def;
     }
 
-    void ClassSystem::InitMAXSuit()
+    void ClassSystem::InitTitan()
     {
         ClassDefinition def;
-        def.classType = PlayerClass::MAX_SUIT;
-        def.name = "MAX Suit";
+        def.classType = PlayerClass::TITAN;
+        def.name = "Titan";
         def.description = "Mechanized assault exosuit with extreme armor and dual weapons. "
                           "Walking fortress that dominates infantry combat.";
 
@@ -460,7 +460,7 @@ namespace Spark
                               WeaponType::ROCKET_LAUNCHER, WeaponType::FLAMETHROWER, WeaponType::PLASMA_RIFLE,
                               WeaponType::MELEE_WEAPON};
 
-        m_classes[static_cast<int>(PlayerClass::MAX_SUIT)] = def;
+        m_classes[static_cast<int>(PlayerClass::TITAN)] = def;
     }
 
     // ============================================================================
@@ -612,18 +612,18 @@ namespace Spark
     {
         switch (classType)
         {
-        case PlayerClass::LIGHT_ASSAULT:
-            return "Light Assault";
-        case PlayerClass::COMBAT_MEDIC:
-            return "Combat Medic";
+        case PlayerClass::SCOUT:
+            return "Scout";
+        case PlayerClass::MEDIC:
+            return "Medic";
         case PlayerClass::ENGINEER:
             return "Engineer";
-        case PlayerClass::INFILTRATOR:
-            return "Infiltrator";
-        case PlayerClass::HEAVY_ASSAULT:
-            return "Heavy Assault";
-        case PlayerClass::MAX_SUIT:
-            return "MAX Suit";
+        case PlayerClass::RECON:
+            return "Recon";
+        case PlayerClass::VANGUARD:
+            return "Vanguard";
+        case PlayerClass::TITAN:
+            return "Titan";
         default:
             return "Unknown";
         }
@@ -633,17 +633,17 @@ namespace Spark
     {
         switch (classType)
         {
-        case PlayerClass::LIGHT_ASSAULT:
+        case PlayerClass::SCOUT:
             return "Fast and agile with jetpack. Flanking specialist.";
-        case PlayerClass::COMBAT_MEDIC:
+        case PlayerClass::MEDIC:
             return "Heals and revives allies. Frontline support.";
         case PlayerClass::ENGINEER:
             return "Deploys turrets and barriers. Area denial expert.";
-        case PlayerClass::INFILTRATOR:
+        case PlayerClass::RECON:
             return "Stealth recon with sniper rifles. Intel gatherer.";
-        case PlayerClass::HEAVY_ASSAULT:
-            return "Tanky frontline with LMGs and overshield.";
-        case PlayerClass::MAX_SUIT:
+        case PlayerClass::VANGUARD:
+            return "Tanky frontline with LMGs and energy shield.";
+        case PlayerClass::TITAN:
             return "Mechanized exosuit. Walking fortress.";
         default:
             return "Unknown class.";
@@ -668,10 +668,10 @@ namespace Spark
             return "Deploy Barrier";
         case ClassAbility::CLOAK:
             return "Cloak";
-        case ClassAbility::RECON_DART:
-            return "Recon Dart";
-        case ClassAbility::OVERSHIELD:
-            return "Overshield";
+        case ClassAbility::SENSOR_PULSE:
+            return "Sensor Pulse";
+        case ClassAbility::ENERGY_SHIELD:
+            return "Energy Shield";
         case ClassAbility::ROCKET_BARRAGE:
             return "Rocket Barrage";
         case ClassAbility::LOCKDOWN:

--- a/SparkGame/Source/Game/ClassSystem.h
+++ b/SparkGame/Source/Game/ClassSystem.h
@@ -1,13 +1,12 @@
 /**
  * @file ClassSystem.h
- * @brief FPS class system inspired by PlanetSide 2 and Battlefield
+ * @brief FPS class system for the Spark Engine showcase
  * @author Spark Engine Team
  * @date 2025
  *
  * Implements a full class-based loadout and ability system with six distinct
- * classes: Light Assault, Combat Medic, Engineer, Infiltrator, Heavy Assault,
- * and MAX Suit. Each class has unique stats, weapon loadouts, passive traits,
- * and active abilities.
+ * archetypes: Scout, Medic, Engineer, Recon, Vanguard, and Titan. Each class
+ * has unique stats, weapon loadouts, passive traits, and active abilities.
  */
 
 #pragma once
@@ -94,14 +93,14 @@ namespace Spark
  */
     struct ClassDefinition
     {
-        PlayerClass classType = PlayerClass::LIGHT_ASSAULT;
+        PlayerClass classType = PlayerClass::SCOUT;
         std::string name;
         std::string description;
 
         // Base stats
         float baseHealth = 100.0f;
         float baseArmor = 0.0f;
-        float baseShield = 0.0f; ///< Rechargeable shield (like PS2)
+        float baseShield = 0.0f; ///< Rechargeable energy shield
         float shieldRechargeRate = 10.0f;
         float shieldRechargeDelay = 6.0f;
         float baseSpeed = 5.0f;
@@ -286,12 +285,12 @@ namespace Spark
         static int GetClassCount() { return static_cast<int>(PlayerClass::COUNT); }
 
       private:
-        void InitLightAssault();
-        void InitCombatMedic();
+        void InitScout();
+        void InitMedic();
         void InitEngineer();
-        void InitInfiltrator();
-        void InitHeavyAssault();
-        void InitMAXSuit();
+        void InitRecon();
+        void InitVanguard();
+        void InitTitan();
 
         std::unordered_map<int, ClassDefinition> m_classes;
         std::vector<Deployable> m_deployables;

--- a/SparkGame/Source/Game/Game.cpp
+++ b/SparkGame/Source/Game/Game.cpp
@@ -107,9 +107,9 @@ HRESULT Game::Initialize(GraphicsEngine* graphics, InputManager* input)
         return hr;
     }
 
-    // Set default class (Light Assault)
-    m_player->SetClass(PlayerClass::LIGHT_ASSAULT, m_classSystem.get());
-    LOG_TO_CONSOLE_IMMEDIATE(L"Player class set to Light Assault (default)", L"SUCCESS");
+    // Set default class (Scout)
+    m_player->SetClass(PlayerClass::SCOUT, m_classSystem.get());
+    LOG_TO_CONSOLE_IMMEDIATE(L"Player class set to Scout (default)", L"SUCCESS");
 
     /* Projectile pool --------------------------------------*/
     m_projectilePool = std::make_unique<ProjectilePool>(100);
@@ -448,6 +448,14 @@ void Game::Shutdown()
     m_sceneManager.reset();
     m_eventBus = nullptr;
 
+#ifdef ENABLE_NETWORKING
+    if (m_networkInitialized)
+    {
+        Spark::Net::NetworkManager::GetInstance().Shutdown();
+        m_networkInitialized = false;
+    }
+#endif
+
     LOG_TO_CONSOLE_IMMEDIATE(L"Game shutdown complete - all systems cleaned up.", L"INFO");
 }
 
@@ -593,6 +601,27 @@ void Game::Update(float dt)
     if (m_hudSystem)
         m_hudSystem->Update(dt);
     Spark::QuestOps::UpdateTimers(m_playerQuests, m_questRegistry, dt);
+
+#ifdef ENABLE_NETWORKING
+    // Update networking - process incoming messages, send outgoing state
+    if (m_networkInitialized)
+    {
+        auto& netMgr = Spark::Net::NetworkManager::GetInstance();
+        netMgr.Update(dt);
+
+        // Replicate player position to network
+        if (m_player && netMgr.GetRole() != Spark::Net::NetworkRole::None)
+        {
+            auto pos = m_player->GetPosition();
+            auto vel = m_player->GetVelocity();
+            // Send client input state for prediction/reconciliation
+            Spark::Net::ClientInputState inputState{};
+            inputState.deltaTime = dt;
+            inputState.timestamp = netMgr.GetServerTime();
+            netMgr.SendClientInput(inputState);
+        }
+    }
+#endif
 
     // Update advanced systems through main GraphicsEngine
     if (m_graphics)
@@ -784,17 +813,17 @@ void Game::HandleInput(float dt)
 
     // Class switching with F5-F10 keys
     if (m_input->WasKeyPressed(VK_F5))
-        SetPlayerClass(PlayerClass::LIGHT_ASSAULT);
+        SetPlayerClass(PlayerClass::SCOUT);
     if (m_input->WasKeyPressed(VK_F6))
-        SetPlayerClass(PlayerClass::COMBAT_MEDIC);
+        SetPlayerClass(PlayerClass::MEDIC);
     if (m_input->WasKeyPressed(VK_F7))
         SetPlayerClass(PlayerClass::ENGINEER);
     if (m_input->WasKeyPressed(VK_F8))
-        SetPlayerClass(PlayerClass::INFILTRATOR);
+        SetPlayerClass(PlayerClass::RECON);
     if (m_input->WasKeyPressed(VK_F9))
-        SetPlayerClass(PlayerClass::HEAVY_ASSAULT);
+        SetPlayerClass(PlayerClass::VANGUARD);
     if (m_input->WasKeyPressed(VK_F10))
-        SetPlayerClass(PlayerClass::MAX_SUIT);
+        SetPlayerClass(PlayerClass::TITAN);
 
     // Cycle classes with [ and ]
     if (m_input->WasKeyPressed(VK_OEM_4))
@@ -1405,7 +1434,7 @@ PlayerClass Game::GetPlayerClass() const
 {
     if (m_player)
         return m_player->GetClass();
-    return PlayerClass::LIGHT_ASSAULT;
+    return PlayerClass::SCOUT;
 }
 
 void Game::CycleNextClass()
@@ -1906,3 +1935,104 @@ bool Game::PlayerExitVehicle()
         return false;
     return m_player->ExitVehicle();
 }
+
+// ============================================================================
+// NETWORKING SYSTEM
+// ============================================================================
+
+#ifdef ENABLE_NETWORKING
+
+bool Game::StartServer(uint16_t port, int maxClients)
+{
+    auto& netMgr = Spark::Net::NetworkManager::GetInstance();
+    if (!m_networkInitialized)
+    {
+        if (!netMgr.Initialize())
+        {
+            LOG_TO_CONSOLE_IMMEDIATE(L"NetworkManager::Initialize() failed", L"ERROR");
+            return false;
+        }
+        m_networkInitialized = true;
+    }
+
+    if (!netMgr.StartServer(port, maxClients))
+    {
+        LOG_TO_CONSOLE_IMMEDIATE(L"Failed to start server on port " + std::to_wstring(port), L"ERROR");
+        return false;
+    }
+
+    LOG_TO_CONSOLE_IMMEDIATE(L"Server started on port " + std::to_wstring(port) + L" (max " +
+                                 std::to_wstring(maxClients) + L" clients)",
+                             L"SUCCESS");
+
+    // Register player entity for replication
+    Spark::Net::ReplicatedEntity playerEntity{};
+    playerEntity.entityType = "Player";
+    playerEntity.ownerID = netMgr.GetLocalClientID();
+    if (m_player)
+    {
+        auto pos = m_player->GetPosition();
+        playerEntity.position = {pos.x, pos.y, pos.z};
+    }
+    netMgr.RegisterReplicatedEntity(playerEntity);
+
+    return true;
+}
+
+bool Game::ConnectToServer(const std::string& address, uint16_t port)
+{
+    auto& netMgr = Spark::Net::NetworkManager::GetInstance();
+    if (!m_networkInitialized)
+    {
+        if (!netMgr.Initialize())
+        {
+            LOG_TO_CONSOLE_IMMEDIATE(L"NetworkManager::Initialize() failed", L"ERROR");
+            return false;
+        }
+        m_networkInitialized = true;
+    }
+
+    std::wstring addr(address.begin(), address.end());
+    LOG_TO_CONSOLE_IMMEDIATE(L"Connecting to " + addr + L":" + std::to_wstring(port) + L"...", L"INFO");
+    netMgr.Connect(address, port, "Player");
+    return true;
+}
+
+void Game::DisconnectNetwork()
+{
+    auto& netMgr = Spark::Net::NetworkManager::GetInstance();
+    if (netMgr.GetRole() == Spark::Net::NetworkRole::Server)
+    {
+        netMgr.StopServer();
+        LOG_TO_CONSOLE_IMMEDIATE(L"Server stopped", L"INFO");
+    }
+    else if (netMgr.GetRole() == Spark::Net::NetworkRole::Client)
+    {
+        netMgr.Disconnect();
+        LOG_TO_CONSOLE_IMMEDIATE(L"Disconnected from server", L"INFO");
+    }
+}
+
+bool Game::IsNetworkActive() const
+{
+    if (!m_networkInitialized)
+        return false;
+    auto& netMgr = Spark::Net::NetworkManager::GetInstance();
+    return netMgr.GetRole() != Spark::Net::NetworkRole::None;
+}
+
+std::string Game::GetNetworkStatus() const
+{
+    if (!m_networkInitialized)
+        return "Networking not initialized";
+    return Spark::Net::NetworkManager::GetInstance().Console_GetStatus();
+}
+
+Spark::Net::NetworkStats Game::GetNetworkStats() const
+{
+    if (!m_networkInitialized)
+        return {};
+    return Spark::Net::NetworkManager::GetInstance().GetStats();
+}
+
+#endif // ENABLE_NETWORKING

--- a/SparkGame/Source/Game/Game.h
+++ b/SparkGame/Source/Game/Game.h
@@ -1,13 +1,14 @@
 /**
  * @file Game.h
- * @brief Main game class managing the core game loop and scene systems
+ * @brief Main game class - Spark Arena engine showcase
  * @author Spark Engine Team
  * @date 2025
- * 
+ *
  * The Game class serves as the central coordinator for all game systems,
  * managing the main game loop, scene updates, rendering operations, and
- * coordination between different engine subsystems like graphics, input,
- * camera, and game objects.
+ * coordination between all engine subsystems including graphics, input,
+ * physics, networking, AI, animation, and more. This is the primary
+ * showcase module demonstrating Spark Engine capabilities.
  */
 
 #pragma once
@@ -24,6 +25,7 @@
 #include "HUDSystem.h"
 #include "InventorySystem.h"
 #include "QuestSystem.h"
+#include "Engine/Networking/NetworkManager.h"
 #include <memory>
 #include <vector>
 
@@ -442,6 +444,48 @@ class SPARK_GAME_API Game
      */
     void CreateTestScene(const std::string& sceneType);
 
+    // ============================================================================
+    // NETWORKING SYSTEM
+    // ============================================================================
+
+#ifdef ENABLE_NETWORKING
+    /**
+     * @brief Start a local server for multiplayer
+     * @param port Server listen port (default 27015)
+     * @param maxClients Maximum connected clients
+     * @return true if server started successfully
+     */
+    bool StartServer(uint16_t port = 27015, int maxClients = 32);
+
+    /**
+     * @brief Connect to a remote server
+     * @param address Server IP address or hostname
+     * @param port Server port
+     * @return true if connection initiated
+     */
+    bool ConnectToServer(const std::string& address, uint16_t port = 27015);
+
+    /**
+     * @brief Disconnect from current server or stop hosting
+     */
+    void DisconnectNetwork();
+
+    /**
+     * @brief Check if networking is active (server or client)
+     */
+    bool IsNetworkActive() const;
+
+    /**
+     * @brief Get network role description string
+     */
+    std::string GetNetworkStatus() const;
+
+    /**
+     * @brief Get network statistics (ping, packet loss, etc.)
+     */
+    Spark::Net::NetworkStats GetNetworkStats() const;
+#endif // ENABLE_NETWORKING
+
   private:
     /**
      * @brief Update the camera based on input and game state
@@ -495,6 +539,10 @@ class SPARK_GAME_API Game
     Spark::QuestRegistry m_questRegistry;          ///< Quest definitions
     Spark::QuestJournalComponent m_playerQuests;   ///< Player quest journal
     Spark::EventBus* m_eventBus{nullptr};          ///< Engine event bus (not owned)
+
+#ifdef ENABLE_NETWORKING
+    bool m_networkInitialized{false}; ///< Whether networking subsystem was initialized
+#endif
 
     // Scene objects
     std::vector<std::unique_ptr<GameObject>> m_gameObjects; ///< All game objects in the scene

--- a/SparkGame/Source/Game/HUDSystem.h
+++ b/SparkGame/Source/Game/HUDSystem.h
@@ -117,7 +117,7 @@ namespace Spark
         // Visibility toggles
         bool showHealthBar = true;
         bool showArmorBar = true;
-        bool showShieldBar = true; ///< Rechargeable shield bar (PS2 style)
+        bool showShieldBar = true; ///< Rechargeable energy shield bar
         bool showAmmoCounter = true;
         bool showCrosshair = true;
         bool showDamageIndicators = true;
@@ -132,9 +132,9 @@ namespace Spark
         bool showAbilityBar = true;     ///< Primary/secondary ability cooldowns
         bool showEnergyBar = true;      ///< Ability energy pool
         bool showLoadoutSlots = true;   ///< Weapon loadout slots (1-4)
-        bool showOvershield = true;     ///< Heavy Assault overshield indicator
-        bool showJetpackFuel = true;    ///< Light Assault jetpack fuel gauge
-        bool showCloakIndicator = true; ///< Infiltrator cloak status
+        bool showEnergyShield = true;   ///< Vanguard energy shield indicator
+        bool showJetpackFuel = true;    ///< Scout jetpack fuel gauge
+        bool showCloakIndicator = true; ///< Recon cloak status
 
         // Crosshair settings
         CrosshairStyle crosshairStyle = CrosshairStyle::Dynamic;
@@ -185,7 +185,7 @@ namespace Spark
         struct
         {
             int r = 100, g = 200, b = 255, a = 180;
-        } overshieldColor; ///< Overshield (light blue)
+        } energyShieldColor; ///< Energy shield (light blue)
         struct
         {
             int r = 255, g = 165, b = 0, a = 220;
@@ -440,7 +440,7 @@ namespace Spark
         void UpdateLowHealthEffects(float dt);
 
         // Class system HUD state
-        SparkEditor::PlayerClass m_currentClass = SparkEditor::PlayerClass::LIGHT_ASSAULT;
+        SparkEditor::PlayerClass m_currentClass = SparkEditor::PlayerClass::SCOUT;
         float m_classChangeTimer = 0.0f;
         std::string m_classChangeName;
         static constexpr float CLASS_CHANGE_DURATION = 3.0f;

--- a/SparkGame/Source/Game/Player.cpp
+++ b/SparkGame/Source/Game/Player.cpp
@@ -235,7 +235,7 @@ void Player::RenderWeapon(const XMMATRIX& view, const XMMATRIX& proj)
     }
 }
 
-// Damage & healing - enhanced with class system (shield, resistance, overshield)
+// Damage & healing - enhanced with class system (shield, resistance, energy shield)
 void Player::TakeDamage(float dmg)
 {
     LOG_TO_CONSOLE(L"Player::TakeDamage called. dmg=" + std::to_wstring(dmg), L"OPERATION");
@@ -254,7 +254,7 @@ void Player::TakeDamage(float dmg)
     // Apply class damage resistance
     float effectiveDmg = dmg * (1.0f - m_damageResistance);
 
-    // Cloaked infiltrator takes bonus damage (de-cloaks on hit)
+    // Cloaked recon takes bonus damage (de-cloaks on hit)
     if (m_cloakActive)
     {
         m_cloakActive = false;
@@ -262,11 +262,11 @@ void Player::TakeDamage(float dmg)
         effectiveDmg *= 1.5f; // 50% bonus damage while cloaked
     }
 
-    // Overshield absorbs damage first (Heavy Assault)
-    if (m_overshieldHP > 0.0f)
+    // Energy shield absorbs damage first (Vanguard)
+    if (m_energyShieldHP > 0.0f)
     {
-        float shieldAbsorbed = std::min(effectiveDmg, m_overshieldHP);
-        m_overshieldHP -= shieldAbsorbed;
+        float shieldAbsorbed = std::min(effectiveDmg, m_energyShieldHP);
+        m_energyShieldHP -= shieldAbsorbed;
         effectiveDmg -= shieldAbsorbed;
     }
 
@@ -524,8 +524,8 @@ void Player::HandleInput(float)
     if (m_input->WasKeyPressed('G'))
         ActivateSecondaryAbility();
 
-    // Jetpack hold (Light Assault) - hold Space while in air
-    if (m_playerClass == PlayerClass::LIGHT_ASSAULT && m_primaryAbility.isActive)
+    // Jetpack hold (Scout) - hold Space while in air
+    if (m_playerClass == PlayerClass::SCOUT && m_primaryAbility.isActive)
     {
         m_jetpackActive = m_input->IsKeyDown(VK_SPACE) && m_jetpackFuel > 0.0f;
     }
@@ -548,7 +548,7 @@ void Player::UpdateMovement(float dt)
     if (m_currentVehicle)
         return;
 
-    // MAX lockdown prevents all movement
+    // Titan lockdown prevents all movement
     if (m_lockedDown)
         return;
 
@@ -564,14 +564,14 @@ void Player::UpdateMovement(float dt)
         speed *= m_crouchMultiplier;
     }
 
-    // Cloaked infiltrator moves slightly slower
+    // Cloaked recon moves slightly slower
     if (m_cloakActive)
     {
         speed *= 0.75f;
     }
 
-    // Heavy Assault overshield active = slower
-    if (m_overshieldHP > 0.0f && m_primaryAbility.isActive && m_playerClass == PlayerClass::HEAVY_ASSAULT)
+    // Vanguard energy shield active = slower
+    if (m_energyShieldHP > 0.0f && m_primaryAbility.isActive && m_playerClass == PlayerClass::VANGUARD)
     {
         speed *= 0.8f;
     }
@@ -799,7 +799,7 @@ void Player::ApplyClassStats(const Spark::ClassDefinition& classDef)
     m_jetpackActive = false;
     m_jetpackFuel = m_jetpackMaxFuel;
     m_cloakActive = false;
-    m_overshieldHP = 0.0f;
+    m_energyShieldHP = 0.0f;
     m_lockedDown = false;
     m_energy = m_maxEnergy;
 }
@@ -820,8 +820,8 @@ bool Player::ActivatePrimaryAbility()
         case ClassAbility::CLOAK:
             m_cloakActive = true;
             break;
-        case ClassAbility::OVERSHIELD:
-            m_overshieldHP = m_overshieldMaxHP;
+        case ClassAbility::ENERGY_SHIELD:
+            m_energyShieldHP = m_energyShieldMaxHP;
             break;
         case ClassAbility::LOCKDOWN:
             m_lockedDown = true;
@@ -850,7 +850,7 @@ bool Player::ActivateSecondaryAbility()
         switch (m_secondaryAbility.type)
         {
         case ClassAbility::EMERGENCY_REPAIR:
-            // MAX self-repair: restore 50% health
+            // Titan self-repair: restore 50% health
             Heal(m_maxHealth * 0.5f);
             break;
         case ClassAbility::HEAL_AURA:
@@ -919,7 +919,7 @@ void Player::EquipTool()
 
 void Player::UpdateClassMechanics(float dt)
 {
-    // Shield recharge (PlanetSide 2 style)
+    // Shield recharge (delayed regeneration)
     m_shieldRechargeTimer += dt;
     if (m_shieldRechargeTimer >= m_shieldRechargeDelay && m_shield < m_maxShield)
     {
@@ -933,8 +933,8 @@ void Player::UpdateClassMechanics(float dt)
     m_primaryAbility.Update(dt);
     m_secondaryAbility.Update(dt);
 
-    // Class-specific passive: Combat Medic health regen
-    if (m_playerClass == PlayerClass::COMBAT_MEDIC && m_health < m_maxHealth)
+    // Class-specific passive: Medic health regen
+    if (m_playerClass == PlayerClass::MEDIC && m_health < m_maxHealth)
     {
         m_health = std::min(m_maxHealth, m_health + 2.0f * dt);
     }
@@ -942,16 +942,16 @@ void Player::UpdateClassMechanics(float dt)
     // Class-specific updates
     switch (m_playerClass)
     {
-    case PlayerClass::LIGHT_ASSAULT:
+    case PlayerClass::SCOUT:
         UpdateJetpack(dt);
         break;
-    case PlayerClass::INFILTRATOR:
+    case PlayerClass::RECON:
         UpdateCloak(dt);
         break;
-    case PlayerClass::HEAVY_ASSAULT:
-        UpdateOvershield(dt);
+    case PlayerClass::VANGUARD:
+        UpdateEnergyShield(dt);
         break;
-    case PlayerClass::MAX_SUIT:
+    case PlayerClass::TITAN:
         // Lockdown: deactivate when ability ends
         if (m_lockedDown && !m_primaryAbility.isActive)
         {
@@ -986,7 +986,7 @@ void Player::UpdateJetpack(float dt)
 
 void Player::UpdateCloak(float dt)
 {
-    // Firing decloaks the infiltrator
+    // Firing decloaks the recon
     if (m_cloakActive && m_isFiring)
     {
         m_cloakActive = false;
@@ -1000,22 +1000,22 @@ void Player::UpdateCloak(float dt)
     }
 }
 
-void Player::UpdateOvershield(float dt)
+void Player::UpdateEnergyShield(float dt)
 {
-    // Overshield decays slowly
-    if (m_overshieldHP > 0.0f && m_primaryAbility.isActive)
+    // Energy shield decays slowly
+    if (m_energyShieldHP > 0.0f && m_primaryAbility.isActive)
     {
-        m_overshieldHP -= 5.0f * dt; // Slow decay
-        if (m_overshieldHP <= 0.0f)
+        m_energyShieldHP -= 5.0f * dt; // Slow decay
+        if (m_energyShieldHP <= 0.0f)
         {
-            m_overshieldHP = 0.0f;
+            m_energyShieldHP = 0.0f;
         }
     }
 
-    // Overshield disappears when ability ends
+    // Energy shield disappears when ability ends
     if (!m_primaryAbility.isActive)
     {
-        m_overshieldHP = 0.0f;
+        m_energyShieldHP = 0.0f;
     }
 }
 

--- a/SparkGame/Source/Game/Player.h
+++ b/SparkGame/Source/Game/Player.h
@@ -608,9 +608,9 @@ class SPARK_GAME_API Player : public GameObject
     float m_speed{5}, m_jumpHeight{3};       ///< Movement speed and jump height
 
     // Class system
-    PlayerClass m_playerClass{PlayerClass::LIGHT_ASSAULT}; ///< Current class
-    Spark::ClassSystem* m_classSystem{nullptr};            ///< Reference to class system
-    float m_shield{0}, m_maxShield{50};                    ///< Rechargeable shield
+    PlayerClass m_playerClass{PlayerClass::SCOUT}; ///< Current class
+    Spark::ClassSystem* m_classSystem{nullptr};    ///< Reference to class system
+    float m_shield{0}, m_maxShield{50};            ///< Rechargeable shield
     float m_shieldRechargeRate{10.0f};
     float m_shieldRechargeDelay{6.0f};
     float m_shieldRechargeTimer{0.0f};     ///< Timer since last damage
@@ -631,9 +631,9 @@ class SPARK_GAME_API Player : public GameObject
     float m_jetpackMaxFuel{100.0f};
     float m_jetpackThrust{8.0f};
     bool m_cloakActive{false};
-    float m_overshieldHP{0.0f};
-    float m_overshieldMaxHP{200.0f};
-    bool m_lockedDown{false}; ///< MAX lockdown state
+    float m_energyShieldHP{0.0f};
+    float m_energyShieldMaxHP{200.0f};
+    bool m_lockedDown{false}; ///< Titan lockdown state
 
     // Movement
     DirectX::XMFLOAT3 m_velocity{};              ///< Current velocity vector
@@ -744,22 +744,22 @@ class SPARK_GAME_API Player : public GameObject
     void UpdateClassMechanics(float dt);
 
     /**
-     * @brief Handle jetpack mechanics for Light Assault
+     * @brief Handle jetpack mechanics for Scout
      * @param dt Delta time
      */
     void UpdateJetpack(float dt);
 
     /**
-     * @brief Handle cloak mechanics for Infiltrator
+     * @brief Handle cloak mechanics for Recon
      * @param dt Delta time
      */
     void UpdateCloak(float dt);
 
     /**
-     * @brief Handle overshield mechanics for Heavy Assault
+     * @brief Handle energy shield mechanics for Vanguard
      * @param dt Delta time
      */
-    void UpdateOvershield(float dt);
+    void UpdateEnergyShield(float dt);
 
     /**
      * @brief Apply class definition stats to player

--- a/SparkGame/Source/Game/VehicleSystem.cpp
+++ b/SparkGame/Source/Game/VehicleSystem.cpp
@@ -598,7 +598,7 @@ namespace Spark
     {
         VehicleDefinition def;
         def.type = VehicleType::BUGGY;
-        def.name = "Harasser Buggy";
+        def.name = "Striker Buggy";
         def.description = "Fast light attack vehicle with a mounted gun";
         def.maxHealth = 400.0f;
         def.maxArmor = 50.0f;
@@ -637,7 +637,7 @@ namespace Spark
     {
         VehicleDefinition def;
         def.type = VehicleType::TANK;
-        def.name = "Vanguard MBT";
+        def.name = "Sentinel MBT";
         def.description = "Heavy main battle tank with powerful cannon";
         def.maxHealth = 2000.0f;
         def.maxArmor = 500.0f;
@@ -673,7 +673,7 @@ namespace Spark
     {
         VehicleDefinition def;
         def.type = VehicleType::APC;
-        def.name = "Sunderer APC";
+        def.name = "Bulwark APC";
         def.description = "Armored transport with mobile spawn capability";
         def.maxHealth = 1500.0f;
         def.maxArmor = 300.0f;
@@ -720,7 +720,7 @@ namespace Spark
     {
         VehicleDefinition def;
         def.type = VehicleType::MOTORCYCLE;
-        def.name = "Flash Motorcycle";
+        def.name = "Bolt Motorcycle";
         def.description = "Ultra-fast single-rider recon vehicle";
         def.maxHealth = 200.0f;
         def.maxArmor = 0.0f;
@@ -747,7 +747,7 @@ namespace Spark
     {
         VehicleDefinition def;
         def.type = VehicleType::TRUCK;
-        def.name = "ANT Transport";
+        def.name = "Hauler Transport";
         def.description = "Heavy resource transport truck";
         def.maxHealth = 1000.0f;
         def.maxArmor = 200.0f;
@@ -777,7 +777,7 @@ namespace Spark
     {
         VehicleDefinition def;
         def.type = VehicleType::HELICOPTER;
-        def.name = "Valkyrie Gunship";
+        def.name = "Raptor Gunship";
         def.description = "Versatile VTOL attack helicopter";
         def.maxHealth = 800.0f;
         def.maxArmor = 100.0f;
@@ -821,7 +821,7 @@ namespace Spark
     {
         VehicleDefinition def;
         def.type = VehicleType::JET;
-        def.name = "Mosquito Fighter";
+        def.name = "Talon Fighter";
         def.description = "Single-seat high-speed combat aircraft";
         def.maxHealth = 600.0f;
         def.maxArmor = 50.0f;
@@ -855,7 +855,7 @@ namespace Spark
     {
         VehicleDefinition def;
         def.type = VehicleType::DROPSHIP;
-        def.name = "Galaxy Dropship";
+        def.name = "Titan Dropship";
         def.description = "Massive troop transport aircraft";
         def.maxHealth = 3000.0f;
         def.maxArmor = 400.0f;

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -127,5 +127,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 75 |
 | Test cases | 917+ |
 | Wiki pages | 50 |
-| *Last synced* | *2026-03-13 02:30* |
+| *Last synced* | *2026-03-13 03:26* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
Replace all PlanetSide 2-inspired naming and references with generic engine showcase archetypes. Integrate networking support via NetworkManager with console commands for hosting, connecting, and monitoring network state.

Key changes:
- Rename player classes: LightAssault→Scout, CombatMedic→Medic, Infiltrator→Recon, HeavyAssault→Vanguard, MAXSuit→Titan
- Rename abilities: Overshield→EnergyShield, ReconDart→SensorPulse
- Rename vehicles to generic names (Striker, Sentinel, Bulwark, etc.)
- Add networking methods to Game (StartServer, ConnectToServer, etc.)
- Add net_host/net_connect/net_disconnect/net_status/net_stats console commands guarded by ENABLE_NETWORKING
- Update both SparkEngine and SparkGame copies of GameSystemEnums.h
- Brand module as "Spark Arena - Engine Showcase"

https://claude.ai/code/session_011cb3d3Agvi144CbwdhJbxo