### PR TITLE
chore: update SparkBuild scripts to pull CI artifacts + both Linux bu…

### DIFF
--- a/.github/workflows/update-sparkbuild.yml
+++ b/.github/workflows/update-sparkbuild.yml
@@ -6,8 +6,12 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
     inputs:
+      source:
+        description: "Where to pull binaries from: 'artifacts' (latest CI build) or 'release' (tagged release)"
+        required: false
+        default: "artifacts"
       tag:
-        description: "Release tag to download (default: latest)"
+        description: "Release tag to download when source=release (default: latest)"
         required: false
         default: "latest"
 
@@ -20,20 +24,115 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
-      - name: Determine tag
-        id: tag
+      - name: Determine source and tag
+        id: config
         run: |
+          SOURCE="${{ github.event.inputs.source || 'artifacts' }}"
           TAG="${{ github.event.inputs.tag || 'latest' }}"
+          echo "source=$SOURCE" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "[*] Source: $SOURCE  Tag: $TAG"
 
-      - name: Fetch latest SparkBuild release info
-        id: release
+      # -----------------------------------------------------------------------
+      # Path A: Download from latest successful CI run artifacts
+      # -----------------------------------------------------------------------
+
+      - name: Find latest successful SparkBuild CI run
+        id: ci_run
+        if: steps.config.outputs.source == 'artifacts'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${{ steps.tag.outputs.tag }}"
+          RUNS=$(curl -sL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/Krilliac/SparkBuild/actions/runs?status=success&per_page=1")
+
+          RUN_ID=$(echo "$RUNS" | jq -r '.workflow_runs[0].id')
+          RUN_NAME=$(echo "$RUNS" | jq -r '.workflow_runs[0].name')
+          RUN_SHA=$(echo "$RUNS" | jq -r '.workflow_runs[0].head_sha')
+
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "run_sha=$RUN_SHA" >> "$GITHUB_OUTPUT"
+          echo "[*] Latest successful run: $RUN_ID ($RUN_NAME @ ${RUN_SHA:0:7})"
+
+      - name: Download CI artifacts
+        id: download_artifacts
+        if: steps.config.outputs.source == 'artifacts'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ steps.ci_run.outputs.run_id }}
+        run: |
+          ARTIFACTS=$(curl -sL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/Krilliac/SparkBuild/actions/runs/$RUN_ID/artifacts")
+
+          # Artifact name -> local path in tools/
+          declare -A MAP=(
+            ["SparkBuild-Windows"]="tools/SparkBuild.exe"
+            ["SparkBuild-Linux-gcc"]="tools/SparkBuild-linux-gcc"
+            ["SparkBuild-Linux-clang"]="tools/SparkBuild-linux-clang"
+            ["SparkBuild-macOS"]="tools/SparkBuild-macos"
+          )
+
+          for artifact_name in "${!MAP[@]}"; do
+            dest="${MAP[$artifact_name]}"
+            artifact_id=$(echo "$ARTIFACTS" | jq -r --arg n "$artifact_name" '.artifacts[] | select(.name==$n) | .id')
+
+            printf "  %-30s -> %s\n" "$artifact_name" "$dest"
+
+            if [ -z "$artifact_id" ] || [ "$artifact_id" = "null" ]; then
+              echo "    [~] Not found in run $RUN_ID (skipped)"
+              continue
+            fi
+
+            zip_url="https://api.github.com/repos/Krilliac/SparkBuild/actions/artifacts/$artifact_id/zip"
+            tmp_zip=$(mktemp --suffix=.zip)
+            tmp_dir=$(mktemp -d)
+
+            if curl -fsSL \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                "$zip_url" -o "$tmp_zip" 2>/dev/null; then
+              unzip -q -o "$tmp_zip" -d "$tmp_dir"
+              binary=$(find "$tmp_dir" -maxdepth 2 -type f | sort | head -1)
+              if [ -n "$binary" ]; then
+                cp "$binary" "$dest"
+                case "$dest" in
+                  *-linux-*|*-macos) chmod +x "$dest" ;;
+                esac
+                echo "    [+] OK ($(du -h "$dest" | cut -f1))"
+              else
+                echo "    [~] Zip was empty (skipped)"
+              fi
+            else
+              echo "    [~] Download failed (skipped)"
+            fi
+
+            rm -f "$tmp_zip"
+            rm -rf "$tmp_dir"
+          done
+
+          # Backward-compat symlink: SparkBuild-linux -> SparkBuild-linux-gcc
+          if [ -f tools/SparkBuild-linux-gcc ]; then
+            ln -sf SparkBuild-linux-gcc tools/SparkBuild-linux
+            echo "  [*] Symlink: SparkBuild-linux -> SparkBuild-linux-gcc"
+          fi
+
+      # -----------------------------------------------------------------------
+      # Path B: Download from a tagged GitHub Release
+      # -----------------------------------------------------------------------
+
+      - name: Fetch latest SparkBuild release info
+        id: release
+        if: steps.config.outputs.source == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.config.outputs.tag }}"
 
           if [ "$TAG" = "latest" ]; then
             RELEASE=$(curl -sL \
@@ -51,98 +150,122 @@ jobs:
           echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
 
           # Extract download URLs for each platform binary
-          WIN_URL=$(echo "$RELEASE" | jq -r '.assets[] | select(.name == "SparkBuild.exe") | .browser_download_url')
-          LINUX_URL=$(echo "$RELEASE" | jq -r '.assets[] | select(.name == "SparkBuild-linux") | .browser_download_url')
-          MACOS_URL=$(echo "$RELEASE" | jq -r '.assets[] | select(.name == "SparkBuild-macos") | .browser_download_url')
+          WIN_URL=$(echo "$RELEASE"   | jq -r '.assets[] | select(.name == "SparkBuild.exe")         | .browser_download_url')
+          GCC_URL=$(echo "$RELEASE"   | jq -r '.assets[] | select(.name == "SparkBuild-linux-gcc")   | .browser_download_url')
+          CLANG_URL=$(echo "$RELEASE" | jq -r '.assets[] | select(.name == "SparkBuild-linux-clang") | .browser_download_url')
+          MACOS_URL=$(echo "$RELEASE" | jq -r '.assets[] | select(.name == "SparkBuild-macos")       | .browser_download_url')
 
-          echo "win_url=$WIN_URL" >> "$GITHUB_OUTPUT"
-          echo "linux_url=$LINUX_URL" >> "$GITHUB_OUTPUT"
+          echo "win_url=$WIN_URL"     >> "$GITHUB_OUTPUT"
+          echo "gcc_url=$GCC_URL"     >> "$GITHUB_OUTPUT"
+          echo "clang_url=$CLANG_URL" >> "$GITHUB_OUTPUT"
           echo "macos_url=$MACOS_URL" >> "$GITHUB_OUTPUT"
 
           echo "[*] Latest SparkBuild release: $LATEST_TAG"
-          echo "    Windows URL: $WIN_URL"
-          echo "    Linux URL:   $LINUX_URL"
-          echo "    macOS URL:   $MACOS_URL"
 
-      - name: Compute current checksums
-        id: check
-        run: |
-          for file in SparkBuild.exe SparkBuild-linux SparkBuild-macos; do
-            key=$(echo "$file" | tr '.-' '_')
-            if [ -f "tools/$file" ]; then
-              SHA=$(sha256sum "tools/$file" | awk '{print $1}')
-            else
-              SHA="none"
-            fi
-            echo "${key}_sha=$SHA" >> "$GITHUB_OUTPUT"
-          done
-
-      - name: Download SparkBuild binaries
+      - name: Download SparkBuild release binaries
+        if: steps.config.outputs.source == 'release'
         env:
-          WIN_URL: ${{ steps.release.outputs.win_url }}
-          LINUX_URL: ${{ steps.release.outputs.linux_url }}
+          WIN_URL:   ${{ steps.release.outputs.win_url }}
+          GCC_URL:   ${{ steps.release.outputs.gcc_url }}
+          CLANG_URL: ${{ steps.release.outputs.clang_url }}
           MACOS_URL: ${{ steps.release.outputs.macos_url }}
         run: |
-          download() {
+          dl() {
             local url="$1" dest="$2" label="$3"
             if [ -n "$url" ] && [ "$url" != "null" ]; then
               echo "[*] Downloading $label ..."
-              curl -L -o "$dest" "$url"
-              echo "[+] Downloaded to $dest"
+              curl -fsSL -o "$dest" "$url"
+              echo "[+] $dest ($(du -h "$dest" | cut -f1))"
             else
-              echo "[~] No $label asset found in this release, skipping."
+              echo "[~] No $label asset found in release, skipping."
             fi
           }
 
-          download "$WIN_URL"   "tools/SparkBuild.exe"   "SparkBuild.exe (Windows)"
-          download "$LINUX_URL" "tools/SparkBuild-linux"  "SparkBuild-linux (Linux)"
-          download "$MACOS_URL" "tools/SparkBuild-macos"  "SparkBuild-macos (macOS)"
+          dl "$WIN_URL"   "tools/SparkBuild.exe"         "SparkBuild.exe (Windows)"
+          dl "$GCC_URL"   "tools/SparkBuild-linux-gcc"   "SparkBuild-linux-gcc (Linux/GCC)"
+          dl "$CLANG_URL" "tools/SparkBuild-linux-clang" "SparkBuild-linux-clang (Linux/Clang)"
+          dl "$MACOS_URL" "tools/SparkBuild-macos"       "SparkBuild-macos (macOS)"
 
-          # Ensure Linux/macOS binaries are executable
-          [ -f tools/SparkBuild-linux ] && chmod +x tools/SparkBuild-linux
-          [ -f tools/SparkBuild-macos ] && chmod +x tools/SparkBuild-macos
+          [ -f tools/SparkBuild-linux-gcc ]   && chmod +x tools/SparkBuild-linux-gcc
+          [ -f tools/SparkBuild-linux-clang ] && chmod +x tools/SparkBuild-linux-clang
+          [ -f tools/SparkBuild-macos ]       && chmod +x tools/SparkBuild-macos
 
-      - name: Check if any binary changed
+          # Backward-compat symlink: SparkBuild-linux -> SparkBuild-linux-gcc
+          if [ -f tools/SparkBuild-linux-gcc ]; then
+            ln -sf SparkBuild-linux-gcc tools/SparkBuild-linux
+            echo "[*] Symlink: SparkBuild-linux -> SparkBuild-linux-gcc"
+          fi
+
+      # -----------------------------------------------------------------------
+      # Common: detect changes, open PR
+      # -----------------------------------------------------------------------
+
+      - name: Compute checksums before/after
         id: diff
         run: |
           changed=false
 
-          check_changed() {
-            local file="$1" old_sha="$2"
-            if [ -f "tools/$file" ]; then
-              NEW_SHA=$(sha256sum "tools/$file" | awk '{print $1}')
-              if [ "$NEW_SHA" != "$old_sha" ]; then
-                echo "[+] $file has been updated (sha256: $NEW_SHA)."
-                changed=true
-              else
-                echo "[=] $file is already up to date."
-              fi
+          for file in SparkBuild.exe SparkBuild-linux-gcc SparkBuild-linux-clang SparkBuild-macos; do
+            path="tools/$file"
+            if [ -f "$path" ]; then
+              SHA=$(sha256sum "$path" | awk '{print $1}')
+              echo "[=] $file  sha256: $SHA"
+              # Track any file present as "changed" relative to a non-existent prior state;
+              # git will show actual diff below
             fi
-          }
+          done
 
-          check_changed "SparkBuild.exe"   "${{ steps.check.outputs.SparkBuild_exe_sha }}"
-          check_changed "SparkBuild-linux"  "${{ steps.check.outputs.SparkBuild_linux_sha }}"
-          check_changed "SparkBuild-macos"  "${{ steps.check.outputs.SparkBuild_macos_sha }}"
+          if git diff --quiet -- tools/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "[=] No binary changes detected."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "[+] Binary changes detected."
+            git diff --stat -- tools/
+          fi
 
-          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+      - name: Determine PR description details
+        id: pr_meta
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          SOURCE="${{ steps.config.outputs.source }}"
+          if [ "$SOURCE" = "artifacts" ]; then
+            RUN_SHA="${{ steps.ci_run.outputs.run_sha }}"
+            echo "ref=CI run \`${{ steps.ci_run.outputs.run_id }}\` (commit \`${RUN_SHA:0:7}\`)" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=release \`${{ steps.release.outputs.latest_tag }}\`" >> "$GITHUB_OUTPUT"
+          fi
+
+          win_status="$([ -f tools/SparkBuild.exe ]         && echo '✅ Updated' || echo '⏭️ Not available')"
+          gcc_status="$([ -f tools/SparkBuild-linux-gcc ]   && echo '✅ Updated' || echo '⏭️ Not available')"
+          clang_status="$([ -f tools/SparkBuild-linux-clang ] && echo '✅ Updated' || echo '⏭️ Not available')"
+          macos_status="$([ -f tools/SparkBuild-macos ]     && echo '✅ Updated' || echo '⏭️ Not available')"
+
+          echo "win_status=$win_status"     >> "$GITHUB_OUTPUT"
+          echo "gcc_status=$gcc_status"     >> "$GITHUB_OUTPUT"
+          echo "clang_status=$clang_status" >> "$GITHUB_OUTPUT"
+          echo "macos_status=$macos_status" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: "chore: update SparkBuild binaries to ${{ steps.release.outputs.latest_tag }}"
+          commit-message: "chore: update SparkBuild binaries from ${{ steps.pr_meta.outputs.ref }}"
           branch: chore/update-sparkbuild
-          title: "chore: update SparkBuild binaries to ${{ steps.release.outputs.latest_tag }}"
+          title: "chore: update SparkBuild binaries from ${{ steps.pr_meta.outputs.ref }}"
           body: |
-            Automated weekly update of SparkBuild binaries from [Krilliac/SparkBuild](https://github.com/Krilliac/SparkBuild).
+            Automated update of SparkBuild binaries from [Krilliac/SparkBuild](https://github.com/Krilliac/SparkBuild).
 
-            **Release:** ${{ steps.release.outputs.latest_tag }}
+            **Source:** ${{ steps.pr_meta.outputs.ref }}
 
             | Binary | Platform | Status |
             |--------|----------|--------|
-            | `tools/SparkBuild.exe` | Windows | ${{ steps.release.outputs.win_url && '✅ Updated' || '⏭️ Not available' }} |
-            | `tools/SparkBuild-linux` | Linux | ${{ steps.release.outputs.linux_url && '✅ Updated' || '⏭️ Not available' }} |
-            | `tools/SparkBuild-macos` | macOS | ${{ steps.release.outputs.macos_url && '✅ Updated' || '⏭️ Not available' }} |
+            | `tools/SparkBuild.exe` | Windows | ${{ steps.pr_meta.outputs.win_status }} |
+            | `tools/SparkBuild-linux-gcc` | Linux (GCC) | ${{ steps.pr_meta.outputs.gcc_status }} |
+            | `tools/SparkBuild-linux-clang` | Linux (Clang) | ${{ steps.pr_meta.outputs.clang_status }} |
+            | `tools/SparkBuild-macos` | macOS | ${{ steps.pr_meta.outputs.macos_status }} |
+
+            > `SparkBuild-linux` is a symlink to `SparkBuild-linux-gcc` for backward compatibility.
 
             ---
             *This PR was created automatically by the [update-sparkbuild](.github/workflows/update-sparkbuild.yml) workflow.*

--- a/tools/update-sparkbuild.ps1
+++ b/tools/update-sparkbuild.ps1
@@ -1,40 +1,184 @@
-# update-sparkbuild.ps1 -- Download SparkBuild binaries from GitHub Releases
+# update-sparkbuild.ps1 -- Download SparkBuild binaries
 #
-# Downloads Windows, Linux, and macOS binaries.
+# By default fetches from the latest GitHub Release.
+# Pass -Artifacts to instead pull from the latest successful CI run.
 #
-# Usage:  .\tools\update-sparkbuild.ps1            (fetches "latest" release)
-#         .\tools\update-sparkbuild.ps1 v1.0.0     (fetches a specific version)
+# Usage:
+#   .\tools\update-sparkbuild.ps1                  (latest release)
+#   .\tools\update-sparkbuild.ps1 v1.0.0           (specific release tag)
+#   .\tools\update-sparkbuild.ps1 -Artifacts       (latest CI build artifacts)
+#   $env:GH_TOKEN="<token>"; .\tools\update-sparkbuild.ps1 -Artifacts
 
 param(
-    [string]$Tag = "latest"
+    [string]$Tag = "latest",
+    [switch]$Artifacts
 )
 
 $ErrorActionPreference = "Stop"
-$repo = "Krilliac/SparkBuild"
+$Repo = "Krilliac/SparkBuild"
+$ScriptDir = $PSScriptRoot
 
-# Map of asset name -> local filename
-$binaries = @(
-    @{ Asset = "SparkBuild.exe";   Local = "SparkBuild.exe"   }
-    @{ Asset = "SparkBuild-linux"; Local = "SparkBuild-linux" }
-    @{ Asset = "SparkBuild-macos"; Local = "SparkBuild-macos" }
-)
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
-Write-Host "[*] Fetching SparkBuild binaries ($Tag) from $repo ..."
-Write-Host ""
+function Invoke-GHApi {
+    param([string]$Url)
+    $headers = @{ "Accept" = "application/vnd.github+json" }
+    if ($env:GH_TOKEN) { $headers["Authorization"] = "Bearer $env:GH_TOKEN" }
+    (Invoke-WebRequest -Uri $Url -Headers $headers -UseBasicParsing).Content | ConvertFrom-Json
+}
 
-foreach ($bin in $binaries) {
-    $asset = $bin.Asset
-    $dest  = Join-Path $PSScriptRoot $bin.Local
-    $url   = "https://github.com/$repo/releases/download/$Tag/$asset"
+function Save-File {
+    param([string]$Url, [string]$Dest, [string]$Label = $Dest)
+    Write-Host "    Downloading $Label ..."
+    $headers = @{}
+    if ($env:GH_TOKEN) { $headers["Authorization"] = "Bearer $env:GH_TOKEN" }
+    Invoke-WebRequest -Uri $Url -OutFile $Dest -Headers $headers -UseBasicParsing
+}
 
-    Write-Host ("    {0,-20} -> {1}" -f $asset, $dest)
+function Set-Symlink {
+    param([string]$Target, [string]$Link)
+    if (Test-Path $Link) { Remove-Item $Link -Force }
+    New-Item -ItemType SymbolicLink -Path $Link -Target $Target | Out-Null
+}
 
-    try {
-        Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
-        Write-Host "    [+] OK"
-    } catch {
-        Write-Host "    [~] Not available (skipped)"
+# ---------------------------------------------------------------------------
+# Artifact download (latest successful CI run)
+# ---------------------------------------------------------------------------
+
+function Get-Artifacts {
+    Write-Host "[*] Fetching latest CI build artifacts from $Repo ..."
+    Write-Host ""
+
+    $runs = Invoke-GHApi "https://api.github.com/repos/$Repo/actions/runs?status=success&per_page=1"
+    $runId = $runs.workflow_runs[0].id
+    if (-not $runId) {
+        Write-Error "Could not find a successful CI run. Check GH_TOKEN or network."
+        exit 1
     }
+    Write-Host "[*] Latest successful run: $runId"
+    Write-Host ""
+
+    $artifactList = Invoke-GHApi "https://api.github.com/repos/$Repo/actions/runs/$runId/artifacts"
+
+    # Artifact name -> local filename
+    $artifactMap = [ordered]@{
+        "SparkBuild-Windows"     = "SparkBuild.exe"
+        "SparkBuild-Linux-gcc"   = "SparkBuild-linux-gcc"
+        "SparkBuild-Linux-clang" = "SparkBuild-linux-clang"
+        "SparkBuild-macOS"       = "SparkBuild-macos"
+    }
+
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
+    New-Item -ItemType Directory -Path $tmp | Out-Null
+
+    foreach ($artifactName in $artifactMap.Keys) {
+        $localName = $artifactMap[$artifactName]
+        $dest = Join-Path $ScriptDir $localName
+
+        $artifact = $artifactList.artifacts | Where-Object { $_.name -eq $artifactName } | Select-Object -First 1
+        Write-Host ("    {0,-30} -> {1}" -f $artifactName, $dest)
+
+        if (-not $artifact) {
+            Write-Host "    [~] Not found in this run (skipped)"
+            continue
+        }
+
+        $zipUrl = "https://api.github.com/repos/$Repo/actions/artifacts/$($artifact.id)/zip"
+        $zipFile = Join-Path $tmp "$artifactName.zip"
+        $extractDir = Join-Path $tmp $artifactName
+
+        try {
+            Save-File -Url $zipUrl -Dest $zipFile -Label $artifactName
+            Expand-Archive -Path $zipFile -DestinationPath $extractDir -Force
+            $binary = Get-ChildItem -Path $extractDir -File -Recurse | Sort-Object FullName | Select-Object -First 1
+            if ($binary) {
+                Copy-Item $binary.FullName -Destination $dest -Force
+                Write-Host "    [+] OK"
+            }
+            else {
+                Write-Host "    [~] Zip was empty (skipped)"
+            }
+        }
+        catch {
+            Write-Host "    [~] Download failed (skipped)"
+        }
+    }
+
+    Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+
+    # Convenience copy/symlink: SparkBuild-linux -> gcc build (backward compat)
+    $gccBin = Join-Path $ScriptDir "SparkBuild-linux-gcc"
+    if (Test-Path $gccBin) {
+        try {
+            Set-Symlink -Target "SparkBuild-linux-gcc" -Link (Join-Path $ScriptDir "SparkBuild-linux")
+            Write-Host ""
+            Write-Host "[*] Symlink: SparkBuild-linux -> SparkBuild-linux-gcc"
+        }
+        catch {
+            # Symlinks may require elevated permissions on Windows; copy instead
+            Copy-Item $gccBin -Destination (Join-Path $ScriptDir "SparkBuild-linux") -Force
+            Write-Host "[*] Copied SparkBuild-linux-gcc -> SparkBuild-linux (symlink unavailable)"
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Release download
+# ---------------------------------------------------------------------------
+
+function Get-Release {
+    Write-Host "[*] Fetching SparkBuild release ($Tag) from $Repo ..."
+    Write-Host ""
+
+    # Asset name -> local filename
+    $binaries = [ordered]@{
+        "SparkBuild.exe"         = "SparkBuild.exe"
+        "SparkBuild-linux-gcc"   = "SparkBuild-linux-gcc"
+        "SparkBuild-linux-clang" = "SparkBuild-linux-clang"
+        "SparkBuild-macos"       = "SparkBuild-macos"
+    }
+
+    foreach ($asset in $binaries.Keys) {
+        $localName = $binaries[$asset]
+        $dest = Join-Path $ScriptDir $localName
+        $url = "https://github.com/$Repo/releases/download/$Tag/$asset"
+
+        Write-Host ("    {0,-25} -> {1}" -f $asset, $dest)
+        try {
+            Save-File -Url $url -Dest $dest -Label $asset
+            Write-Host "    [+] OK"
+        }
+        catch {
+            Write-Host "    [~] Not available (skipped)"
+        }
+    }
+
+    # Convenience copy/symlink: SparkBuild-linux -> gcc build (backward compat)
+    $gccBin = Join-Path $ScriptDir "SparkBuild-linux-gcc"
+    if (Test-Path $gccBin) {
+        try {
+            Set-Symlink -Target "SparkBuild-linux-gcc" -Link (Join-Path $ScriptDir "SparkBuild-linux")
+            Write-Host ""
+            Write-Host "[*] Symlink: SparkBuild-linux -> SparkBuild-linux-gcc"
+        }
+        catch {
+            Copy-Item $gccBin -Destination (Join-Path $ScriptDir "SparkBuild-linux") -Force
+            Write-Host "[*] Copied SparkBuild-linux-gcc -> SparkBuild-linux (symlink unavailable)"
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if ($Artifacts) {
+    Get-Artifacts
+}
+else {
+    Get-Release
 }
 
 Write-Host ""

--- a/tools/update-sparkbuild.sh
+++ b/tools/update-sparkbuild.sh
@@ -1,58 +1,196 @@
 #!/usr/bin/env bash
-# update-sparkbuild.sh -- Download SparkBuild binaries from GitHub Releases
+# update-sparkbuild.sh -- Download SparkBuild binaries
 #
-# Downloads Windows, Linux, and macOS binaries.
+# By default fetches from the latest GitHub Release.
+# Pass --artifacts to instead pull from the latest successful CI run.
 #
-# Usage:  ./tools/update-sparkbuild.sh              (fetches "latest" release)
-#         ./tools/update-sparkbuild.sh v1.0.0       (fetches a specific version)
+# Usage:
+#   ./tools/update-sparkbuild.sh                   (latest release)
+#   ./tools/update-sparkbuild.sh v1.0.0            (specific release tag)
+#   ./tools/update-sparkbuild.sh --artifacts       (latest CI build artifacts)
+#   GH_TOKEN=<token> ./tools/update-sparkbuild.sh --artifacts
 
 set -e
 
-TAG="${1:-latest}"
 REPO="Krilliac/SparkBuild"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Map of asset name -> local filename
-declare -A BINARIES=(
-    ["SparkBuild.exe"]="SparkBuild.exe"
-    ["SparkBuild-linux"]="SparkBuild-linux"
-    ["SparkBuild-macos"]="SparkBuild-macos"
-)
+MODE="release"
+TAG="latest"
+
+for arg in "$@"; do
+    case "$arg" in
+        --artifacts) MODE="artifacts" ;;
+        *)           TAG="$arg" ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 download() {
-    local url="$1" dest="$2"
+    local url="$1" dest="$2" label="${3:-$dest}"
+    echo "    Downloading $label ..."
     if command -v curl &>/dev/null; then
-        curl -fL -o "$dest" "$url"
+        curl -fsSL ${GH_TOKEN:+-H "Authorization: Bearer $GH_TOKEN"} -o "$dest" "$url"
     elif command -v wget &>/dev/null; then
-        wget -O "$dest" "$url"
+        wget -q -O "$dest" "$url"
     else
         echo "[-] Neither curl nor wget found." >&2
         return 1
     fi
 }
 
-echo "[*] Fetching SparkBuild binaries ($TAG) from $REPO ..."
-echo
+api_get() {
+    local url="$1"
+    curl -sL \
+        -H "Accept: application/vnd.github+json" \
+        ${GH_TOKEN:+-H "Authorization: Bearer $GH_TOKEN"} \
+        "$url"
+}
 
-for asset in "${!BINARIES[@]}"; do
-    LOCAL="${BINARIES[$asset]}"
-    DEST="$SCRIPT_DIR/$LOCAL"
-    URL="https://github.com/$REPO/releases/download/$TAG/$asset"
+make_executable() {
+    local file="$1"
+    [ -f "$file" ] && chmod +x "$file"
+}
 
-    printf "    %-20s -> %s\n" "$asset" "$DEST"
+# ---------------------------------------------------------------------------
+# Artifact download (latest successful CI run)
+# ---------------------------------------------------------------------------
 
-    if download "$URL" "$DEST" 2>/dev/null; then
-        # Make Linux/macOS binaries executable
-        case "$LOCAL" in
-            SparkBuild-linux|SparkBuild-macos)
-                chmod +x "$DEST"
-                ;;
-        esac
-        echo "    [+] OK"
-    else
-        echo "    [~] Not available (skipped)"
+download_artifacts() {
+    echo "[*] Fetching latest CI build artifacts from $REPO ..."
+    echo
+
+    local runs
+    runs=$(api_get "https://api.github.com/repos/$REPO/actions/runs?status=success&per_page=1")
+    local run_id
+    run_id=$(echo "$runs" | grep -o '"id":[0-9]*' | head -1 | cut -d: -f2)
+
+    if [ -z "$run_id" ]; then
+        echo "[-] Could not find a successful CI run. Check GH_TOKEN or network." >&2
+        exit 1
     fi
-done
+    echo "[*] Latest successful run: $run_id"
+    echo
+
+    local artifacts
+    artifacts=$(api_get "https://api.github.com/repos/$REPO/actions/runs/$run_id/artifacts")
+
+    # Artifact name -> local filename inside tools/
+    declare -A ARTIFACT_MAP=(
+        ["SparkBuild-Windows"]="SparkBuild.exe"
+        ["SparkBuild-Linux-gcc"]="SparkBuild-linux-gcc"
+        ["SparkBuild-Linux-clang"]="SparkBuild-linux-clang"
+        ["SparkBuild-macOS"]="SparkBuild-macos"
+    )
+
+    local tmp
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+
+    for artifact_name in "${!ARTIFACT_MAP[@]}"; do
+        local local_name="${ARTIFACT_MAP[$artifact_name]}"
+        local dest="$SCRIPT_DIR/$local_name"
+
+        # Extract artifact id via simple grep (avoids jq dependency)
+        local artifact_block
+        artifact_block=$(echo "$artifacts" | tr '{}' '\n' | grep "\"name\":\"$artifact_name\"")
+        local artifact_id
+        artifact_id=$(echo "$artifact_block" | grep -o '"id":[0-9]*' | head -1 | cut -d: -f2)
+
+        printf "    %-30s -> %s\n" "$artifact_name" "$dest"
+
+        if [ -z "$artifact_id" ]; then
+            echo "    [~] Not found in this run (skipped)"
+            continue
+        fi
+
+        local zip_url="https://api.github.com/repos/$REPO/actions/artifacts/$artifact_id/zip"
+        local zip_file="$tmp/${artifact_name}.zip"
+        local extract_dir="$tmp/$artifact_name"
+
+        if download "$zip_url" "$zip_file" "$artifact_name" 2>/dev/null; then
+            mkdir -p "$extract_dir"
+            unzip -q -o "$zip_file" -d "$extract_dir"
+            # Pick the first regular file from the extracted archive
+            local binary
+            binary=$(find "$extract_dir" -maxdepth 2 -type f | sort | head -1)
+            if [ -n "$binary" ]; then
+                cp "$binary" "$dest"
+                case "$local_name" in
+                    SparkBuild-linux-*|SparkBuild-macos)
+                        chmod +x "$dest" ;;
+                esac
+                echo "    [+] OK"
+            else
+                echo "    [~] Zip was empty (skipped)"
+            fi
+        else
+            echo "    [~] Download failed (skipped)"
+        fi
+    done
+
+    # Convenience symlink: SparkBuild-linux -> gcc build (backward compat)
+    if [ -f "$SCRIPT_DIR/SparkBuild-linux-gcc" ]; then
+        ln -sf SparkBuild-linux-gcc "$SCRIPT_DIR/SparkBuild-linux"
+        echo
+        echo "[*] Symlink: SparkBuild-linux -> SparkBuild-linux-gcc"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Release download
+# ---------------------------------------------------------------------------
+
+download_release() {
+    echo "[*] Fetching SparkBuild release ($TAG) from $REPO ..."
+    echo
+
+    # Asset name -> local filename
+    declare -A BINARIES=(
+        ["SparkBuild.exe"]="SparkBuild.exe"
+        ["SparkBuild-linux-gcc"]="SparkBuild-linux-gcc"
+        ["SparkBuild-linux-clang"]="SparkBuild-linux-clang"
+        ["SparkBuild-macos"]="SparkBuild-macos"
+    )
+
+    for asset in "${!BINARIES[@]}"; do
+        local local_name="${BINARIES[$asset]}"
+        local dest="$SCRIPT_DIR/$local_name"
+        local url="https://github.com/$REPO/releases/download/$TAG/$asset"
+
+        printf "    %-25s -> %s\n" "$asset" "$dest"
+
+        if download "$url" "$dest" "$asset" 2>/dev/null; then
+            case "$local_name" in
+                SparkBuild-linux-*|SparkBuild-macos)
+                    chmod +x "$dest" ;;
+            esac
+            echo "    [+] OK"
+        else
+            echo "    [~] Not available (skipped)"
+        fi
+    done
+
+    # Convenience symlink: SparkBuild-linux -> gcc build (backward compat)
+    if [ -f "$SCRIPT_DIR/SparkBuild-linux-gcc" ]; then
+        ln -sf SparkBuild-linux-gcc "$SCRIPT_DIR/SparkBuild-linux"
+        echo
+        echo "[*] Symlink: SparkBuild-linux -> SparkBuild-linux-gcc"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if [ "$MODE" = "artifacts" ]; then
+    download_artifacts
+else
+    download_release
+fi
 
 echo
 echo "[*] Done."


### PR DESCRIPTION
…ilds

- update-sparkbuild.sh: add --artifacts flag to download from the latest successful CI run (GitHub Actions artifacts API); add SparkBuild-linux-gcc and SparkBuild-linux-clang as separate binaries; keep SparkBuild-linux as a backward-compat symlink pointing to the gcc build.
- update-sparkbuild.ps1: mirror the same changes for Windows PowerShell; add -Artifacts switch, handle SparkBuild-Linux-gcc/-clang, fall back to file copy when symlinks require elevation.
- update-sparkbuild.yml: default source changed from 'release' to 'artifacts'; workflow now queries the SparkBuild repo's latest successful run, downloads all four artifacts (Windows, Linux-gcc, Linux-clang, macOS), and falls back to tagged releases via the new 'release' input. PR body updated with the full four-binary table.

Closes: pull in latest CI builds + Linux splits per run 23039222260