### PR TITLE
Fix compilation errors and warnings across Linux and Windows builds

### DIFF
--- a/SparkEditor/Source/Animation/AnimationTimeline.cpp
+++ b/SparkEditor/Source/Animation/AnimationTimeline.cpp
@@ -1144,7 +1144,6 @@ namespace SparkEditor
             if (trackBottom > timelineRect.y + timelineRect.w)
                 break;
 
-            XMFLOAT4 trackRect = {timelineRect.x, trackY, timelineRect.z, m_trackHeight};
             RenderTrack(track.get(), static_cast<int>(i));
 
             // Render keyframes for each visible curve

--- a/SparkEditor/Source/Communication/EngineInterface.cpp
+++ b/SparkEditor/Source/Communication/EngineInterface.cpp
@@ -107,8 +107,8 @@ namespace SparkEditor
             // Simulate memory usage fluctuation (+/- 1MB)
             m_currentMetrics.memoryUsage += memDist(rng) * 1024;
             m_currentMetrics.memoryUsage =
-                std::clamp(m_currentMetrics.memoryUsage, static_cast<int64_t>(256) * 1024 * 1024,
-                           static_cast<int64_t>(1024) * 1024 * 1024);
+                std::clamp(m_currentMetrics.memoryUsage, static_cast<size_t>(256) * 1024 * 1024,
+                           static_cast<size_t>(1024) * 1024 * 1024);
 
             timeSinceUpdate = 0.0f;
         }

--- a/SparkEditor/Source/Panels/PlayModeToolbarPanel.cpp
+++ b/SparkEditor/Source/Panels/PlayModeToolbarPanel.cpp
@@ -9,6 +9,7 @@
 #include "../Core/EditorIcons.h"
 #include "../../../SparkEngine/Source/Engine/Editor/PlayModeManager.h"
 #include <imgui.h>
+#include <imgui_internal.h>
 #include <iostream>
 #include <cmath>
 


### PR DESCRIPTION
- Fix std::clamp type mismatch in EngineInterface.cpp: use size_t casts instead of int64_t to match the memoryUsage field type
- Remove unused trackRect variable in AnimationTimeline.cpp to fix -Wunused-but-set-variable warning
- Add missing imgui_internal.h include in PlayModeToolbarPanel.cpp to resolve SeparatorEx/ImGuiSeparatorFlags_Vertical undeclared errors on MSVC

https://claude.ai/code/session_01AK7LKtooRModdSNuFVBCh2