### PR TITLE
Fix ImGui::SeparatorEx compile errors by replacing with portable Vert…

### DIFF
--- a/SparkEditor/Source/Panels/AssetDependencyPanel.cpp
+++ b/SparkEditor/Source/Panels/AssetDependencyPanel.cpp
@@ -7,6 +7,7 @@
 
 #include "AssetDependencyPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../Utils/ImGuiUtils.h"
 #include <imgui.h>
 #include <iostream>
 #include <fstream>
@@ -376,9 +377,7 @@ namespace SparkEditor
             ImGui::EndPopup();
         }
 
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
 
         ImGui::Checkbox(ICON_FA_SLIDERS " Filters", &m_showFilterPanel);
         ImGui::SameLine();
@@ -388,9 +387,7 @@ namespace SparkEditor
         ImGui::SameLine();
         ImGui::Checkbox(ICON_FA_LIST_ALT " List", &m_showListView);
 
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
         ImGui::Text(ICON_FA_SITEMAP " Assets: %zu  Edges: %zu", m_nodes.size(), m_edges.size());
     }
 

--- a/SparkEditor/Source/Panels/AudioMixerPanel.cpp
+++ b/SparkEditor/Source/Panels/AudioMixerPanel.cpp
@@ -19,6 +19,7 @@
 // Project and third-party headers
 #include "AudioMixerPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../Utils/ImGuiUtils.h"
 
 namespace SparkEditor
 {
@@ -552,9 +553,7 @@ namespace SparkEditor
             ImGui::EndDisabled();
         }
 
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
 
         // Toggle snapshot manager
         if (ImGui::Button(ICON_FA_SAVE " Snapshots"))
@@ -578,9 +577,7 @@ namespace SparkEditor
             m_showEffectChain = !m_showEffectChain;
         }
 
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
 
         // Strip width slider
         ImGui::SetNextItemWidth(100.0f);

--- a/SparkEditor/Source/Panels/DialogueEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/DialogueEditorPanel.cpp
@@ -7,6 +7,7 @@
 
 #include "DialogueEditorPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../Utils/ImGuiUtils.h"
 #include <algorithm>
 #include <cmath>
 #include <fstream>
@@ -528,9 +529,7 @@ namespace SparkEditor
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Save current dialogue");
 
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
 
         // Add node buttons
         if (ImGui::Button(ICON_FA_PLUS " NPC Line"))
@@ -551,9 +550,7 @@ namespace SparkEditor
             AddNode(DialogueNodeType::Condition, pos);
         }
 
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
 
         // Preview mode toggle
         if (m_previewMode)
@@ -583,9 +580,7 @@ namespace SparkEditor
         // Dialogue name
         if (m_currentDialogue)
         {
-            ImGui::SameLine();
-            ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-            ImGui::SameLine();
+            SparkEditor::VerticalSeparator();
 
             char nameBuf[256];
             std::snprintf(nameBuf, sizeof(nameBuf), "%s", m_currentDialogue->name.c_str());

--- a/SparkEditor/Source/Panels/MaterialEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/MaterialEditorPanel.cpp
@@ -7,6 +7,7 @@
 
 #include "MaterialEditorPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../Utils/ImGuiUtils.h"
 #include <imgui.h>
 #include <iostream>
 #include <cmath>
@@ -456,9 +457,7 @@ namespace SparkEditor
             ImGui::EndPopup();
         }
 
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
 
         // Preview shape selector
         ImGui::Text("Shape:");

--- a/SparkEditor/Source/Panels/ParticleEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/ParticleEditorPanel.cpp
@@ -7,6 +7,7 @@
 
 #include "ParticleEditorPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../Utils/ImGuiUtils.h"
 #include <algorithm>
 #include <cmath>
 #include <fstream>
@@ -262,9 +263,7 @@ namespace SparkEditor
             SaveEffect();
         }
 
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
 
         // Playback controls
         if (m_previewPlaying)
@@ -289,9 +288,7 @@ namespace SparkEditor
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Playback speed");
 
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
 
         // Preset library toggle
         bool presetActive = m_showPresetLibrary;
@@ -312,9 +309,7 @@ namespace SparkEditor
         // Effect name
         if (m_currentEffect)
         {
-            ImGui::SameLine();
-            ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-            ImGui::SameLine();
+            SparkEditor::VerticalSeparator();
 
             char nameBuf[256];
             std::snprintf(nameBuf, sizeof(nameBuf), "%s", m_currentEffect->name.c_str());

--- a/SparkEditor/Source/Panels/PlayModeToolbarPanel.cpp
+++ b/SparkEditor/Source/Panels/PlayModeToolbarPanel.cpp
@@ -7,9 +7,9 @@
 
 #include "PlayModeToolbarPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../Utils/ImGuiUtils.h"
 #include "../../../SparkEngine/Source/Engine/Editor/PlayModeManager.h"
 #include <imgui.h>
-#include <imgui_internal.h>
 #include <iostream>
 #include <cmath>
 
@@ -92,29 +92,19 @@ namespace SparkEditor
         }
 
         RenderTransportControls();
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
 
         RenderTimeScaleControls();
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
 
         RenderSubsystemToggles();
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
 
         RenderCameraModeSelector();
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
 
         RenderLiveEditControls();
-        ImGui::SameLine();
-        ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
-        ImGui::SameLine();
+        SparkEditor::VerticalSeparator();
 
         RenderStatusDisplay();
 

--- a/SparkEditor/Source/Utils/ImGuiUtils.h
+++ b/SparkEditor/Source/Utils/ImGuiUtils.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <imgui.h>
+
+namespace SparkEditor
+{
+
+    /// Draw a vertical separator line between SameLine() items.
+    /// Usage: ImGui::SameLine(); VerticalSeparator(); ImGui::SameLine();
+    inline void VerticalSeparator()
+    {
+        ImGui::SameLine();
+        const float height = ImGui::GetFrameHeight();
+        const ImVec2 pos = ImGui::GetCursorScreenPos();
+        ImGui::GetWindowDrawList()->AddLine(ImVec2(pos.x, pos.y), ImVec2(pos.x, pos.y + height),
+                                            ImGui::GetColorU32(ImGuiCol_Separator), 1.0f);
+        ImGui::Dummy(ImVec2(4.0f, height));
+        ImGui::SameLine();
+    }
+
+} // namespace SparkEditor


### PR DESCRIPTION
…icalSeparator helper

ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical) is an internal API that is not available in all ImGui configurations. Replace all 16 call sites across 6 editor panels with a new SparkEditor::VerticalSeparator() utility that draws a vertical line using the public ImGui draw list API.

Files changed:
- NEW: SparkEditor/Source/Utils/ImGuiUtils.h (VerticalSeparator helper)
- AssetDependencyPanel.cpp (2 occurrences)
- AudioMixerPanel.cpp (2 occurrences)
- ParticleEditorPanel.cpp (3 occurrences)
- PlayModeToolbarPanel.cpp (5 occurrences)
- DialogueEditorPanel.cpp (3 occurrences)
- MaterialEditorPanel.cpp (1 occurrence)

https://claude.ai/code/session_01H9q2uceuH89FDQ8K4aDzhS