### PR TITLE
Add project-wide validation, defensive/offensive programming, and dia…

### DIFF
--- a/SparkEditor/CMakeLists.txt
+++ b/SparkEditor/CMakeLists.txt
@@ -108,6 +108,11 @@ list(FILTER SPARK_EDITOR_SOURCES EXCLUDE REGEX ".*_Updated\\.cpp$")
 list(FILTER SPARK_EDITOR_SOURCES EXCLUDE REGEX ".*_EngineIntegrated\\.cpp$")
 list(FILTER SPARK_EDITOR_SOURCES EXCLUDE REGEX ".*_AutoConnect\\.(cpp|h)$")
 
+# Engine utility sources needed by validation/logging macros
+list(APPEND SPARK_EDITOR_SOURCES
+    "${CMAKE_SOURCE_DIR}/SparkEngine/Source/Utils/Logger.cpp"
+)
+
 # Create executable
 if(WIN32)
     add_executable(SparkEditor WIN32 ${SPARK_EDITOR_SOURCES})

--- a/SparkEditor/Source/Animation/AnimationTimeline.cpp
+++ b/SparkEditor/Source/Animation/AnimationTimeline.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "AnimationTimeline.h"
+#include "Utils/Validate.h"
 #include <imgui.h>
 #include <algorithm>
 #include <cmath>
@@ -274,6 +275,8 @@ namespace SparkEditor
 
     bool AnimationTimeline::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "AnimationTimeline initializing");
         CreateNewClip("Default Animation", 5.0f, 30.0f);
         m_isInitialized = true;
         return true;
@@ -281,6 +284,7 @@ namespace SparkEditor
 
     void AnimationTimeline::Update(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (!m_currentClip)
             return;
 
@@ -320,6 +324,7 @@ namespace SparkEditor
 
     void AnimationTimeline::Render()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (!m_isVisible)
             return;
 
@@ -380,6 +385,8 @@ namespace SparkEditor
 
     void AnimationTimeline::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "AnimationTimeline shutting down");
         m_currentClip.reset();
         m_selection.Clear();
         m_playbackState = PlaybackState::STOPPED;
@@ -416,6 +423,7 @@ namespace SparkEditor
 
     void AnimationTimeline::CreateNewClip(const std::string& name, float duration, float frameRate)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Editor, name);
         auto clip = std::make_unique<AnimationClip>();
         clip->name = name;
         clip->duration = duration;
@@ -430,6 +438,7 @@ namespace SparkEditor
 
     bool AnimationTimeline::LoadAnimationClip(const std::string& filePath)
     {
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !filePath.empty(), false);
         std::ifstream file(filePath);
         if (!file.is_open())
             return false;
@@ -525,6 +534,7 @@ namespace SparkEditor
 
     bool AnimationTimeline::SaveAnimationClip(const std::string& filePath)
     {
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !filePath.empty(), false);
         if (!m_currentClip)
             return false;
 
@@ -898,6 +908,7 @@ namespace SparkEditor
 
     void AnimationTimeline::CalculateAutoTangents(AnimationCurve* curve)
     {
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Editor, curve);
         if (!curve)
             return;
         auto& kfs = curve->keyframes;

--- a/SparkEditor/Source/AssetBrowser/AssetDatabase.cpp
+++ b/SparkEditor/Source/AssetBrowser/AssetDatabase.cpp
@@ -14,6 +14,7 @@
 #include <sstream>
 
 #include "AssetDatabase.h"
+#include "Utils/Validate.h"
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -105,6 +106,7 @@ namespace SparkEditor
 
     bool AssetDatabase::Initialize(const std::string& assetDirectory)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "AssetDatabase::Initialize() - Directory: " << assetDirectory << "\n";
 
         m_assetDirectory = assetDirectory;

--- a/SparkEditor/Source/AssetPipeline/AdvancedAssetPipeline.cpp
+++ b/SparkEditor/Source/AssetPipeline/AdvancedAssetPipeline.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "AdvancedAssetPipeline.h"
+#include "Utils/Validate.h"
 
 #include <imgui.h>
 
@@ -761,6 +762,7 @@ namespace SparkEditor
 
     bool AdvancedAssetPipeline::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         // Register default processors
         RegisterProcessor(std::make_unique<TextureProcessor>());
         RegisterProcessor(std::make_unique<MeshProcessor>());
@@ -954,6 +956,8 @@ namespace SparkEditor
     bool AdvancedAssetPipeline::ProcessAsset(const std::string& assetPath, const AssetImportSettings& settings,
                                              std::function<void(const AssetMetadata&)> callback)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !assetPath.empty(), false);
         if (!fs::exists(assetPath))
         {
             return false;

--- a/SparkEditor/Source/Communication/CollaborativeEditSession.cpp
+++ b/SparkEditor/Source/Communication/CollaborativeEditSession.cpp
@@ -4,17 +4,10 @@
  */
 
 #include "CollaborativeEditSession.h"
+#include "Utils/Validate.h"
 
 #include <algorithm>
 #include <sstream>
-
-// Use engine logging if available, otherwise fall back to stderr
-#ifndef SPARK_LOG_INFO
-#include <cstdio>
-#define SPARK_LOG_INFO(cat, fmt, ...) fprintf(stderr, "[" cat "] " fmt "\n", ##__VA_ARGS__)
-#define SPARK_LOG_WARN(cat, fmt, ...) fprintf(stderr, "[" cat " WARN] " fmt "\n", ##__VA_ARGS__)
-#define SPARK_LOG_DEBUG(cat, fmt, ...) fprintf(stderr, "[" cat " DEBUG] " fmt "\n", ##__VA_ARGS__)
-#endif
 
 namespace SparkEditor
 {
@@ -36,9 +29,11 @@ namespace SparkEditor
 
     bool CollaborativeEditSession::Host(uint16_t port, const std::string& userName)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !userName.empty(), false);
         if (m_connected.load(std::memory_order_acquire))
         {
-            SPARK_LOG_WARN("CollabEdit", "Already connected.");
+            SPARK_LOG_WARN(Spark::LogCategory::Editor, "Already connected.");
             return false;
         }
 
@@ -61,16 +56,19 @@ namespace SparkEditor
 
         m_connected.store(true, std::memory_order_release);
 
-        SPARK_LOG_INFO("CollabEdit", "Hosting session on port %u as '%s' (PeerID=%u).", port, userName.c_str(),
-                       m_localPeerID);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Hosting session on port %u as '%s' (PeerID=%u).", port,
+                       userName.c_str(), m_localPeerID);
         return true;
     }
 
     bool CollaborativeEditSession::Connect(const std::string& address, uint16_t port, const std::string& userName)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !address.empty(), false);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !userName.empty(), false);
         if (m_connected.load(std::memory_order_acquire))
         {
-            SPARK_LOG_WARN("CollabEdit", "Already connected.");
+            SPARK_LOG_WARN(Spark::LogCategory::Editor, "Already connected.");
             return false;
         }
 
@@ -93,13 +91,14 @@ namespace SparkEditor
 
         m_connected.store(true, std::memory_order_release);
 
-        SPARK_LOG_INFO("CollabEdit", "Connected to %s:%u as '%s' (PeerID=%u).", address.c_str(), port, userName.c_str(),
-                       m_localPeerID);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Connected to %s:%u as '%s' (PeerID=%u).", address.c_str(), port,
+                       userName.c_str(), m_localPeerID);
         return true;
     }
 
     void CollaborativeEditSession::Disconnect()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (!m_connected.load(std::memory_order_acquire))
             return;
 
@@ -127,7 +126,7 @@ namespace SparkEditor
             m_peers.clear();
         }
 
-        SPARK_LOG_INFO("CollabEdit", "Disconnected from session.");
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Disconnected from session.");
     }
 
     // ============================================================================
@@ -136,6 +135,7 @@ namespace SparkEditor
 
     void CollaborativeEditSession::Update(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (!m_connected.load(std::memory_order_acquire))
             return;
 
@@ -183,8 +183,8 @@ namespace SparkEditor
         // Validate nodeId length to prevent excessively long identifiers
         if (nodeId.size() >= 256)
         {
-            SPARK_LOG_WARN("CollabEdit", "SetLocalSelection rejected: nodeId exceeds 255 chars (length=%zu).",
-                           nodeId.size());
+            SPARK_LOG_WARN(Spark::LogCategory::Editor,
+                           "SetLocalSelection rejected: nodeId exceeds 255 chars (length=%zu).", nodeId.size());
             return;
         }
 
@@ -209,7 +209,8 @@ namespace SparkEditor
             m_outgoingMessages.push(std::move(msg));
         }
 
-        SPARK_LOG_INFO("CollabEdit", "Local selection changed to '%s' (PeerID=%u).", nodeId.c_str(), m_localPeerID);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Local selection changed to '%s' (PeerID=%u).", nodeId.c_str(),
+                       m_localPeerID);
     }
 
     void CollaborativeEditSession::SetLocalViewportCamera(const DirectX::XMFLOAT3& position,
@@ -308,19 +309,19 @@ namespace SparkEditor
         // Validate the EditMessage
         if (message.nodeId.empty())
         {
-            SPARK_LOG_WARN("CollabEdit", "BroadcastEdit rejected: nodeId is empty.");
+            SPARK_LOG_WARN(Spark::LogCategory::Editor, "BroadcastEdit rejected: nodeId is empty.");
             return;
         }
 
         if (message.sourceEditor == INVALID_PEER)
         {
-            SPARK_LOG_WARN("CollabEdit", "BroadcastEdit rejected: sourceEditor is not set.");
+            SPARK_LOG_WARN(Spark::LogCategory::Editor, "BroadcastEdit rejected: sourceEditor is not set.");
             return;
         }
 
         if (static_cast<uint8_t>(message.type) > static_cast<uint8_t>(EditMessageType::ComponentModified))
         {
-            SPARK_LOG_WARN("CollabEdit", "BroadcastEdit rejected: invalid EditMessageType (%u).",
+            SPARK_LOG_WARN(Spark::LogCategory::Editor, "BroadcastEdit rejected: invalid EditMessageType (%u).",
                            static_cast<unsigned>(message.type));
             return;
         }
@@ -347,7 +348,7 @@ namespace SparkEditor
             m_outgoingMessages.push(std::move(msg));
         }
 
-        SPARK_LOG_INFO("CollabEdit", "BroadcastEdit: type=%u nodeId='%s' from PeerID=%u.",
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "BroadcastEdit: type=%u nodeId='%s' from PeerID=%u.",
                        static_cast<unsigned>(outgoing.type), outgoing.nodeId.c_str(), outgoing.sourceEditor);
 
         // Still call the local callback for immediate local processing
@@ -407,7 +408,7 @@ namespace SparkEditor
             return;
         }
 
-        SPARK_LOG_DEBUG("CollabEdit", "Processing %zu incoming messages.", localQueue.size());
+        SPARK_LOG_DEBUG(Spark::LogCategory::Editor, "Processing %zu incoming messages.", localQueue.size());
 
         while (!localQueue.empty())
         {
@@ -447,7 +448,7 @@ namespace SparkEditor
             case InternalMessageType::EditBroadcast:
             {
                 m_editsReceived++;
-                SPARK_LOG_INFO("CollabEdit", "Received edit: type=%u nodeId='%s' from PeerID=%u.",
+                SPARK_LOG_INFO(Spark::LogCategory::Editor, "Received edit: type=%u nodeId='%s' from PeerID=%u.",
                                static_cast<unsigned>(msg.editMessage.type), msg.editMessage.nodeId.c_str(),
                                msg.sourcePeer);
 
@@ -471,7 +472,7 @@ namespace SparkEditor
                     newLock.lockTime = std::chrono::steady_clock::now();
                     m_nodeLocks[msg.nodeId] = newLock;
 
-                    SPARK_LOG_INFO("CollabEdit", "Lock granted on '%s' to PeerID=%u.", msg.nodeId.c_str(),
+                    SPARK_LOG_INFO(Spark::LogCategory::Editor, "Lock granted on '%s' to PeerID=%u.", msg.nodeId.c_str(),
                                    msg.sourcePeer);
 
                     if (m_onLockChanged)
@@ -490,8 +491,8 @@ namespace SparkEditor
                 {
                     m_nodeLocks.erase(it);
 
-                    SPARK_LOG_INFO("CollabEdit", "Lock released on '%s' by PeerID=%u.", msg.nodeId.c_str(),
-                                   msg.sourcePeer);
+                    SPARK_LOG_INFO(Spark::LogCategory::Editor, "Lock released on '%s' by PeerID=%u.",
+                                   msg.nodeId.c_str(), msg.sourcePeer);
 
                     if (m_onLockChanged)
                     {
@@ -509,8 +510,8 @@ namespace SparkEditor
                     m_peers[msg.sourcePeer].lastActivityTime = m_sessionTime;
                 }
 
-                SPARK_LOG_INFO("CollabEdit", "Peer connected: '%s' (PeerID=%u).", msg.peerInfo.userName.c_str(),
-                               msg.sourcePeer);
+                SPARK_LOG_INFO(Spark::LogCategory::Editor, "Peer connected: '%s' (PeerID=%u).",
+                               msg.peerInfo.userName.c_str(), msg.sourcePeer);
 
                 if (m_onPeerConnected)
                 {
@@ -526,7 +527,7 @@ namespace SparkEditor
                     m_peers.erase(msg.sourcePeer);
                 }
 
-                SPARK_LOG_INFO("CollabEdit", "Peer disconnected: PeerID=%u.", msg.sourcePeer);
+                SPARK_LOG_INFO(Spark::LogCategory::Editor, "Peer disconnected: PeerID=%u.", msg.sourcePeer);
 
                 if (m_onPeerDisconnected)
                 {
@@ -547,7 +548,7 @@ namespace SparkEditor
             auto it = m_peers.find(m_localPeerID);
             if (it == m_peers.end())
             {
-                SPARK_LOG_WARN("CollabEdit", "BroadcastPresence: local peer not found in peers map.");
+                SPARK_LOG_WARN(Spark::LogCategory::Editor, "BroadcastPresence: local peer not found in peers map.");
                 return;
             }
 
@@ -569,8 +570,9 @@ namespace SparkEditor
             m_outgoingMessages.push(std::move(msg));
         }
 
-        SPARK_LOG_DEBUG("CollabEdit", "Presence broadcast: PeerID=%u selection='%s' pos=(%.1f,%.1f,%.1f).",
-                        m_localPeerID, localPeerSnapshot.selectedNode.c_str(), localPeerSnapshot.viewportCameraPos.x,
+        SPARK_LOG_DEBUG(Spark::LogCategory::Editor,
+                        "Presence broadcast: PeerID=%u selection='%s' pos=(%.1f,%.1f,%.1f).", m_localPeerID,
+                        localPeerSnapshot.selectedNode.c_str(), localPeerSnapshot.viewportCameraPos.x,
                         localPeerSnapshot.viewportCameraPos.y, localPeerSnapshot.viewportCameraPos.z);
     }
 

--- a/SparkEditor/Source/Communication/EngineInterface.cpp
+++ b/SparkEditor/Source/Communication/EngineInterface.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "EngineInterface.h"
+#include "Utils/Validate.h"
 #include <iostream>
 #include <chrono>
 #include <thread>
@@ -31,6 +32,9 @@ namespace SparkEditor
 
     bool EngineInterface::Initialize(const std::string& pipeName)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !pipeName.empty(), false);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "EngineInterface initializing with pipe: %s", pipeName.c_str());
         std::cout << "EngineInterface::Initialize() with pipe: " << pipeName << "\n";
 
         m_pipeName = pipeName;
@@ -65,6 +69,8 @@ namespace SparkEditor
 
     void EngineInterface::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "EngineInterface shutting down");
         std::cout << "EngineInterface::Shutdown()\n";
 
         m_isShuttingDown = true;
@@ -84,6 +90,7 @@ namespace SparkEditor
 
     void EngineInterface::Update(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         // Update metrics (simulated when not connected to a real engine)
         static float timeSinceUpdate = 0.0f;
         timeSinceUpdate += deltaTime;
@@ -125,6 +132,8 @@ namespace SparkEditor
 
     bool EngineInterface::Connect(float timeoutSeconds)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "EngineInterface connecting (timeout: %.1fs)", timeoutSeconds);
         std::cout << "Attempting to connect to engine (timeout: " << timeoutSeconds << "s)\n";
 
         // For now, simulate a connection
@@ -149,6 +158,8 @@ namespace SparkEditor
 
     void EngineInterface::Disconnect()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "EngineInterface disconnecting");
         std::cout << "Disconnecting from engine\n";
 
         m_isConnected = false;

--- a/SparkEditor/Source/Core/EditorApplication.cpp
+++ b/SparkEditor/Source/Core/EditorApplication.cpp
@@ -10,6 +10,7 @@
 #include "EditorFonts.h"
 #include "EditorCrashHandler.h"
 #include "../Utils/SparkConsole.h"
+#include "Utils/Validate.h"
 #include <memory>
 #include <iostream>
 #include <stdexcept>
@@ -62,6 +63,7 @@ namespace SparkEditor
 
     bool EditorApplication::Initialize(const EditorConfig& config)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         auto& console = Spark::SimpleConsole::GetInstance();
         console.LogInfo("Initializing Enhanced Spark Engine Editor...");
 
@@ -109,6 +111,8 @@ namespace SparkEditor
 
 #ifdef _WIN32
         // Pass the DirectX device to panels that need it (Scene View)
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Editor, m_device.Get(), false);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Editor, m_context.Get(), false);
         if (m_device && m_context)
         {
             m_ui->SetGraphicsDevice(m_device.Get(), m_context.Get());
@@ -411,6 +415,7 @@ namespace SparkEditor
 
     void EditorApplication::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         auto& console = Spark::SimpleConsole::GetInstance();
         console.LogInfo("Shutting down enhanced editor...");
 
@@ -726,6 +731,7 @@ namespace SparkEditor
 
     void EditorApplication::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         auto& console = Spark::SimpleConsole::GetInstance();
         console.LogInfo("Shutting down enhanced editor...");
 
@@ -773,6 +779,7 @@ namespace SparkEditor
 
     void EditorApplication::Update(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         // Update UI system
         if (m_ui)
         {

--- a/SparkEditor/Source/Core/EditorCrashHandler.cpp
+++ b/SparkEditor/Source/Core/EditorCrashHandler.cpp
@@ -7,6 +7,7 @@
 
 #include "EditorCrashHandler.h"
 #include "EditorLogger.h"
+#include "Utils/Validate.h"
 #include <iostream>
 #include <fstream>
 #include <filesystem>
@@ -69,6 +70,9 @@ namespace SparkEditor
 
     bool EditorCrashHandler::Initialize(const std::string& crashDirectory, EditorLogger* logger)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !crashDirectory.empty(), false);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "EditorCrashHandler initializing");
         std::cout << "EditorCrashHandler initializing...\n";
 
         m_crashDirectory = crashDirectory;
@@ -95,6 +99,8 @@ namespace SparkEditor
 
     void EditorCrashHandler::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "EditorCrashHandler shutting down");
         std::cout << "EditorCrashHandler shutting down...\n";
 
         // Signal auto-save thread to stop
@@ -137,6 +143,7 @@ namespace SparkEditor
     void EditorCrashHandler::HandleAssertion(const std::string& expression, const char* file, int line,
                                              const std::string& message)
     {
+        SPARK_WARN_IF(Spark::LogCategory::Editor, expression.empty(), "HandleAssertion called with empty expression");
         std::lock_guard<std::mutex> lock(m_statsMutex);
         m_stats.assertionFailures++;
 
@@ -915,6 +922,7 @@ namespace SparkEditor
 
     bool EditorCrashHandler::SaveCrashLog(const CrashInfo& crashInfo, const std::string& filePath)
     {
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !filePath.empty(), false);
         std::ofstream file(filePath);
         if (!file.is_open())
         {

--- a/SparkEditor/Source/Core/EditorFonts.cpp
+++ b/SparkEditor/Source/Core/EditorFonts.cpp
@@ -7,6 +7,7 @@
 
 #include "EditorFonts.h"
 #include "EditorIcons.h"
+#include "Utils/Validate.h"
 #include <iostream>
 #include <filesystem>
 
@@ -21,6 +22,9 @@ namespace SparkEditor
 
     void EditorFonts::LoadFonts(float baseFontSize)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Loading editor fonts (baseFontSize=%.1f)", baseFontSize);
+        SPARK_WARN_IF(Spark::LogCategory::Editor, baseFontSize <= 0.0f, "Font size is non-positive");
         ImGuiIO& io = ImGui::GetIO();
 
         // Font search paths (relative to executable)

--- a/SparkEditor/Source/Core/EditorLogger.cpp
+++ b/SparkEditor/Source/Core/EditorLogger.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "EditorLogger.h"
+#include "Utils/Validate.h"
 #include <iostream>
 #include <iomanip>
 #include <sstream>
@@ -199,6 +200,7 @@ namespace SparkEditor
 
     void EditorLogger::RemoveTarget(LogTarget* target)
     {
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Editor, target);
         std::lock_guard<std::mutex> lock(m_mutex);
         m_targets.erase(std::remove_if(m_targets.begin(), m_targets.end(),
                                        [target](const std::unique_ptr<LogTarget>& ptr) { return ptr.get() == target; }),
@@ -241,6 +243,7 @@ namespace SparkEditor
 
     bool EditorLogger::ExportLogs(const std::string& filename, std::function<bool(const LogEntry&)> filter) const
     {
+        SPARK_WARN_IF(Spark::LogCategory::Editor, filename.empty(), "ExportLogs called with empty filename");
         std::ofstream file(filename);
         if (!file.is_open())
         {

--- a/SparkEditor/Source/Core/EditorPanel.cpp
+++ b/SparkEditor/Source/Core/EditorPanel.cpp
@@ -6,15 +6,21 @@
  */
 
 #include "EditorPanel.h"
+#include "Utils/Validate.h"
 #include <imgui.h>
 
 namespace SparkEditor
 {
 
-    EditorPanel::EditorPanel(const std::string& name, const std::string& id) : m_name(name), m_id(id), m_title(name) {}
+    EditorPanel::EditorPanel(const std::string& name, const std::string& id) : m_name(name), m_id(id), m_title(name)
+    {
+        SPARK_WARN_IF(Spark::LogCategory::Editor, name.empty(), "EditorPanel created with empty name");
+        SPARK_WARN_IF(Spark::LogCategory::Editor, id.empty(), "EditorPanel created with empty id");
+    }
 
     bool EditorPanel::BeginPanel()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (!m_isVisible)
         {
             return false;

--- a/SparkEditor/Source/Core/EditorPluginManager.cpp
+++ b/SparkEditor/Source/Core/EditorPluginManager.cpp
@@ -8,6 +8,7 @@
 #include "EditorPluginManager.h"
 #include "EditorPanel.h"
 #include "../Utils/SparkConsole.h"
+#include "Utils/Validate.h"
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -33,6 +34,7 @@ namespace SparkEditor
     bool EditorPluginManager::RegisterPluginInstance(std::unique_ptr<IEditorPlugin> plugin, bool isFromDLL,
                                                      void* libraryHandle, DestroyEditorPluginFn destroyFn)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (!plugin)
         {
             Spark::SimpleConsole::GetInstance().LogError("EditorPluginManager: Cannot register null plugin");
@@ -64,6 +66,9 @@ namespace SparkEditor
 
     bool EditorPluginManager::LoadPlugin(const std::string& path)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !path.empty(), false);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Loading plugin from '%s'", path.c_str());
         Spark::SimpleConsole::GetInstance().LogInfo("EditorPluginManager: Loading plugin from '" + path + "'...");
 
         void* handle = nullptr;
@@ -124,6 +129,9 @@ namespace SparkEditor
 
     bool EditorPluginManager::UnloadPlugin(const std::string& name)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !name.empty(), false);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Unloading plugin '%s'", name.c_str());
         auto it = FindPlugin(name);
         if (it == m_plugins.end())
         {

--- a/SparkEditor/Source/Core/EditorTheme.cpp
+++ b/SparkEditor/Source/Core/EditorTheme.cpp
@@ -7,6 +7,7 @@
 
 #include "EditorTheme.h"
 #include "Utils/LocalFileCache.h"
+#include "Utils/Validate.h"
 #include <imgui.h>
 #include <algorithm>
 #include <cmath>
@@ -93,6 +94,8 @@ namespace SparkEditor
 
     bool EditorTheme::ApplyTheme(const std::string& themeName)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !themeName.empty(), false);
         if (s_registeredThemes.empty())
         {
             InitializeDefaultThemes();
@@ -321,6 +324,8 @@ namespace SparkEditor
 
     void EditorTheme::InitializeDefaultThemes()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Initializing default editor themes");
         RegisterTheme(CreateSparkThemeImpl());
         RegisterTheme(CreateUnityProTheme());
         RegisterTheme(CreateUnrealProTheme());
@@ -1067,6 +1072,7 @@ namespace SparkEditor
     bool ThemeCustomizer::ExportTheme(const EditorThemeData& theme, const std::string& filepath,
                                       Spark::LocalFileCache* cache)
     {
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !filepath.empty(), false);
         try
         {
             std::ofstream file(filepath);
@@ -1152,6 +1158,7 @@ namespace SparkEditor
     bool ThemeCustomizer::ImportTheme(const std::string& filepath, EditorThemeData& outTheme,
                                       Spark::LocalFileCache* cache)
     {
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !filepath.empty(), false);
         try
         {
             std::string content;

--- a/SparkEditor/Source/Core/EditorUI.cpp
+++ b/SparkEditor/Source/Core/EditorUI.cpp
@@ -10,6 +10,7 @@
 #include "EditorFonts.h"
 #include "EditorIcons.h"
 #include "../Utils/SparkConsole.h"
+#include "Utils/Validate.h"
 #include "../Panels/SceneViewPanel.h"
 #include "../Panels/SimpleConsolePanel.h"
 #include "../Panels/SimpleHierarchyPanel.h"
@@ -67,6 +68,7 @@ namespace SparkEditor
 
     bool EditorUI::Initialize(const EditorConfig& config)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         auto& console = Spark::SimpleConsole::GetInstance();
         console.LogInfo("Initializing Enhanced EditorUI with full configuration...");
 
@@ -320,6 +322,7 @@ namespace SparkEditor
 
     void EditorUI::Render()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (!m_isInitialized)
             return;
 
@@ -363,12 +366,15 @@ namespace SparkEditor
         RenderModalDialogs();
 
         // Render project browser modal (on top of everything)
+        SPARK_WARN_IF(Spark::LogCategory::Editor, m_projectBrowserPanel == nullptr,
+                      "Project browser panel is null during render");
         if (m_projectBrowserPanel && m_projectBrowserPanel->IsModalActive())
         {
             m_projectBrowserPanel->Render();
         }
 
         // Render command palette overlay (on top of everything)
+        SPARK_WARN_IF(Spark::LogCategory::Editor, m_commandPalette == nullptr, "Command palette is null during render");
         if (m_commandPalette)
         {
             m_commandPalette->Render();
@@ -410,6 +416,7 @@ namespace SparkEditor
 
     void EditorUI::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         auto& console = Spark::SimpleConsole::GetInstance();
         console.LogInfo("Shutting down EditorUI...");
 

--- a/SparkEditor/Source/Core/ProjectManager.cpp
+++ b/SparkEditor/Source/Core/ProjectManager.cpp
@@ -7,6 +7,7 @@
 
 #include "ProjectManager.h"
 #include "Utils/LocalFileCache.h"
+#include "Utils/Validate.h"
 #include <iostream>
 #include <filesystem>
 #include <fstream>
@@ -193,6 +194,11 @@ namespace SparkEditor
     bool ProjectManager::CreateProject(const std::string& projectName, const std::string& parentDirectory,
                                        ProjectTemplate templateType, const std::string& description)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !projectName.empty(), false);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !parentDirectory.empty(), false);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Creating project '%s' in '%s'", projectName.c_str(),
+                       parentDirectory.c_str());
         // If engine root is set and templates exist, use template-based creation
         if (!m_engineRoot.empty())
         {
@@ -374,6 +380,9 @@ namespace SparkEditor
 
     bool ProjectManager::OpenProject(const std::string& sparkprojectPath)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !sparkprojectPath.empty(), false);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Loading project from '%s'", sparkprojectPath.c_str());
         std::cout << "Opening project: " << sparkprojectPath << "\n";
 
         // Accept either a .sparkproject file or a directory containing one
@@ -431,11 +440,13 @@ namespace SparkEditor
 
     bool ProjectManager::SaveProject()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (!m_hasOpenProject)
         {
             std::cerr << "No project is currently open\n";
             return false;
         }
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Saving project '%s'", m_currentProject.name.c_str());
         std::cout << "Saving project: " << m_currentProject.name << "\n";
         m_currentProject.lastModified = GetCurrentTimestamp();
         return SaveProjectFile();

--- a/SparkEditor/Source/Gizmos/GizmoSystem.cpp
+++ b/SparkEditor/Source/Gizmos/GizmoSystem.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "GizmoSystem.h"
+#include "Utils/Validate.h"
 #include <imgui.h>
 #include <cmath>
 #include <algorithm>
@@ -114,6 +115,7 @@ namespace SparkEditor
 
     bool GizmoSystem::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         m_device = device;
         m_context = context;
 
@@ -141,6 +143,7 @@ namespace SparkEditor
 
     void GizmoSystem::Update(float /*deltaTime*/)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         // Animation timers could be updated here for gizmo pulse effects.
         // Currently no animated state is required.
     }

--- a/SparkEditor/Source/Integration/ExternalConsoleIntegration.cpp
+++ b/SparkEditor/Source/Integration/ExternalConsoleIntegration.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "ExternalConsoleIntegration.h"
+#include "Utils/Validate.h"
 #include <iostream>
 #include <chrono>
 #include <sstream>
@@ -37,6 +38,8 @@ namespace SparkEditor
 
     bool ExternalConsoleIntegration::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "ExternalConsoleIntegration initializing");
         std::cout << "Initializing Enhanced External Console Integration with Engine-Style Logging\n";
 
         m_running = true;
@@ -65,6 +68,8 @@ namespace SparkEditor
     {
         if (m_running)
         {
+            SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+            SPARK_LOG_INFO(Spark::LogCategory::Editor, "ExternalConsoleIntegration shutting down");
             std::cout << "Shutting down Enhanced External Console Integration\n";
 
             try
@@ -218,6 +223,8 @@ namespace SparkEditor
 
     bool ExternalConsoleIntegration::ConnectToEngine(const std::string& host, int port)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !host.empty(), false);
         std::cout << "Connecting to external Spark Console with Engine-Style Logging...\n";
 
         // Try to launch SparkConsole.exe
@@ -323,6 +330,7 @@ namespace SparkEditor
 
     bool ExternalConsoleIntegration::SendCommand(const std::string& command)
     {
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !command.empty(), false);
         if (!m_connected)
         {
             std::cout << "Cannot send command: not connected to console\n";

--- a/SparkEditor/Source/Integration/SparkEngineIntegration.cpp
+++ b/SparkEditor/Source/Integration/SparkEngineIntegration.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "SparkEngineIntegration.h"
+#include "Utils/Validate.h"
 #include <chrono>
 #include <thread>
 #include <iostream>
@@ -35,14 +36,18 @@ namespace SparkEditor
 
     bool SparkEngineIntegration::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         m_device = device;
         m_context = context;
         m_isInitialized = true;
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "SparkEngineIntegration initialized");
         return true;
     }
 
     void SparkEngineIntegration::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "SparkEngineIntegration shutting down");
         if (IsConnected() || m_connectionStatus.load() == EngineConnectionStatus::Connecting)
         {
             DisconnectFromEngine();
@@ -71,6 +76,8 @@ namespace SparkEditor
             return false;
         }
 
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Connecting to engine at '%s' with project '%s'", enginePath.c_str(),
+                       projectPath.c_str());
         m_enginePath = enginePath;
         m_projectPath = projectPath;
         m_shouldStop.store(false);
@@ -84,6 +91,7 @@ namespace SparkEditor
 
     void SparkEngineIntegration::DisconnectFromEngine()
     {
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Disconnecting from engine");
         m_shouldStop.store(true);
 
         if (m_communicationThread.joinable())

--- a/SparkEditor/Source/LevelStreaming/LevelStreamingSystem.cpp
+++ b/SparkEditor/Source/LevelStreaming/LevelStreamingSystem.cpp
@@ -1,4 +1,5 @@
 #include "LevelStreamingSystem.h"
+#include "Utils/Validate.h"
 
 using namespace DirectX;
 namespace SparkEditor
@@ -53,10 +54,14 @@ namespace SparkEditor
 
     bool LevelStreamingSystem::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
         return true;
     }
 
-    void LevelStreamingSystem::Update(float /*deltaTime*/) {}
+    void LevelStreamingSystem::Update(float /*deltaTime*/)
+    {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+    }
 
     void LevelStreamingSystem::Render() {}
 

--- a/SparkEditor/Source/Lighting/LightingTools.cpp
+++ b/SparkEditor/Source/Lighting/LightingTools.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "LightingTools.h"
+#include "Utils/Validate.h"
 #include <imgui.h>
 #include <cmath>
 #include <algorithm>
@@ -39,6 +40,7 @@ namespace SparkEditor
 
     bool LightingTools::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
         if (!device || !context)
         {
             return false;

--- a/SparkEditor/Source/MaterialEditor/MaterialEditor.cpp
+++ b/SparkEditor/Source/MaterialEditor/MaterialEditor.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "MaterialEditor.h"
+#include "Utils/Validate.h"
 
 #include <imgui.h>
 
@@ -28,6 +29,7 @@ namespace SparkEditor
 
     bool MaterialEditor::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         InitializeNodeTypes();
         CreateNewMaterial("Default Material");
         return true;

--- a/SparkEditor/Source/Panels/AssetBrowserPanel.cpp
+++ b/SparkEditor/Source/Panels/AssetBrowserPanel.cpp
@@ -15,6 +15,7 @@
 #include "AssetBrowserPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../Core/EditorFonts.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 
 namespace SparkEditor
 {
@@ -23,6 +24,7 @@ namespace SparkEditor
 
     bool AssetBrowserPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Asset Browser panel\n";
         return true;
     }
@@ -405,6 +407,7 @@ namespace SparkEditor
 
     void AssetBrowserPanel::ImportAsset(const std::string& filePath)
     {
+        SPARK_VALIDATE_NOT_EMPTY(LogCategory::Editor, filePath);
         std::filesystem::path sourcePath(filePath);
 
         if (!std::filesystem::exists(sourcePath))

--- a/SparkEditor/Source/Panels/AssetBrowserPanel.cpp
+++ b/SparkEditor/Source/Panels/AssetBrowserPanel.cpp
@@ -24,7 +24,7 @@ namespace SparkEditor
 
     bool AssetBrowserPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Asset Browser panel\n";
         return true;
     }
@@ -407,7 +407,7 @@ namespace SparkEditor
 
     void AssetBrowserPanel::ImportAsset(const std::string& filePath)
     {
-        SPARK_VALIDATE_NOT_EMPTY(LogCategory::Editor, filePath);
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Editor, filePath);
         std::filesystem::path sourcePath(filePath);
 
         if (!std::filesystem::exists(sourcePath))

--- a/SparkEditor/Source/Panels/AssetDependencyPanel.cpp
+++ b/SparkEditor/Source/Panels/AssetDependencyPanel.cpp
@@ -8,6 +8,7 @@
 #include "AssetDependencyPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../Utils/ImGuiUtils.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 #include <fstream>
@@ -39,6 +40,7 @@ namespace SparkEditor
 
     bool AssetDependencyPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Asset Dependency panel\n";
         m_filter = DependencyFilter{};
         m_graphOffset = ImVec2(0.0f, 0.0f);

--- a/SparkEditor/Source/Panels/AssetDependencyPanel.cpp
+++ b/SparkEditor/Source/Panels/AssetDependencyPanel.cpp
@@ -40,7 +40,7 @@ namespace SparkEditor
 
     bool AssetDependencyPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Asset Dependency panel\n";
         m_filter = DependencyFilter{};
         m_graphOffset = ImVec2(0.0f, 0.0f);

--- a/SparkEditor/Source/Panels/AudioMixerPanel.cpp
+++ b/SparkEditor/Source/Panels/AudioMixerPanel.cpp
@@ -20,6 +20,7 @@
 #include "AudioMixerPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../Utils/ImGuiUtils.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 
 namespace SparkEditor
 {
@@ -59,6 +60,7 @@ namespace SparkEditor
 
     bool AudioMixerPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Audio);
         if (m_isInitialized)
         {
             return true;

--- a/SparkEditor/Source/Panels/AudioMixerPanel.cpp
+++ b/SparkEditor/Source/Panels/AudioMixerPanel.cpp
@@ -60,7 +60,7 @@ namespace SparkEditor
 
     bool AudioMixerPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Audio);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
         if (m_isInitialized)
         {
             return true;

--- a/SparkEditor/Source/Panels/BuildCookPanel.cpp
+++ b/SparkEditor/Source/Panels/BuildCookPanel.cpp
@@ -11,6 +11,7 @@
 
 #include "BuildCookPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 
 namespace SparkEditor
 {
@@ -21,6 +22,7 @@ namespace SparkEditor
 
     bool BuildCookPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Build & Cook panel\n";
         ApplyProfileDefaults(BuildProfile::Development);
         return true;
@@ -38,6 +40,7 @@ namespace SparkEditor
                 m_isBuildRunning = false;
                 m_buildStatus = "Build Complete";
                 m_buildLog.push_back({"Build completed successfully!", "info"});
+                SPARK_LOG_INFO(LogCategory::Editor, "Build completed successfully");
             }
         }
     }
@@ -362,6 +365,7 @@ namespace SparkEditor
             ImGui::BeginDisabled();
         if (ImGui::Button(ICON_FA_HAMMER " Build", btnSize))
         {
+            SPARK_LOG_INFO(LogCategory::Editor, "Build started");
             m_isBuildRunning = true;
             m_buildProgress = 0.0f;
             m_buildStatus = "Building...";

--- a/SparkEditor/Source/Panels/BuildCookPanel.cpp
+++ b/SparkEditor/Source/Panels/BuildCookPanel.cpp
@@ -22,7 +22,7 @@ namespace SparkEditor
 
     bool BuildCookPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Build & Cook panel\n";
         ApplyProfileDefaults(BuildProfile::Development);
         return true;
@@ -40,7 +40,7 @@ namespace SparkEditor
                 m_isBuildRunning = false;
                 m_buildStatus = "Build Complete";
                 m_buildLog.push_back({"Build completed successfully!", "info"});
-                SPARK_LOG_INFO(LogCategory::Editor, "Build completed successfully");
+                SPARK_LOG_INFO(Spark::LogCategory::Editor, "Build completed successfully");
             }
         }
     }
@@ -365,7 +365,7 @@ namespace SparkEditor
             ImGui::BeginDisabled();
         if (ImGui::Button(ICON_FA_HAMMER " Build", btnSize))
         {
-            SPARK_LOG_INFO(LogCategory::Editor, "Build started");
+            SPARK_LOG_INFO(Spark::LogCategory::Editor, "Build started");
             m_isBuildRunning = true;
             m_buildProgress = 0.0f;
             m_buildStatus = "Building...";

--- a/SparkEditor/Source/Panels/ConsolePanel.cpp
+++ b/SparkEditor/Source/Panels/ConsolePanel.cpp
@@ -74,7 +74,7 @@ namespace SparkEditor
 
     bool ConsolePanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (m_isInitialized)
         {
             return true;
@@ -111,7 +111,7 @@ namespace SparkEditor
 
     void ConsolePanel::Render()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (!BeginPanel())
         {
             EndPanel();

--- a/SparkEditor/Source/Panels/ConsolePanel.cpp
+++ b/SparkEditor/Source/Panels/ConsolePanel.cpp
@@ -22,6 +22,7 @@
 // Project and third-party headers
 #include "ConsolePanel.h"
 #include "../Core/EditorLogger.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 
 namespace SparkEditor
 {
@@ -73,6 +74,7 @@ namespace SparkEditor
 
     bool ConsolePanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         if (m_isInitialized)
         {
             return true;
@@ -109,6 +111,7 @@ namespace SparkEditor
 
     void ConsolePanel::Render()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         if (!BeginPanel())
         {
             EndPanel();

--- a/SparkEditor/Source/Panels/DebugVisualizerPanel.cpp
+++ b/SparkEditor/Source/Panels/DebugVisualizerPanel.cpp
@@ -22,7 +22,7 @@ namespace SparkEditor
 
     bool DebugVisualizerPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Debug Visualizer panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/DebugVisualizerPanel.cpp
+++ b/SparkEditor/Source/Panels/DebugVisualizerPanel.cpp
@@ -11,6 +11,7 @@
 
 #include "DebugVisualizerPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 
 namespace SparkEditor
 {
@@ -21,6 +22,7 @@ namespace SparkEditor
 
     bool DebugVisualizerPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Debug Visualizer panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/DedicatedServerPanel.cpp
+++ b/SparkEditor/Source/Panels/DedicatedServerPanel.cpp
@@ -30,7 +30,7 @@ namespace SparkEditor
 
     bool DedicatedServerPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Dedicated Server panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/DedicatedServerPanel.cpp
+++ b/SparkEditor/Source/Panels/DedicatedServerPanel.cpp
@@ -12,6 +12,7 @@
 
 #include "DedicatedServerPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 
 namespace SparkEditor
 {
@@ -29,6 +30,7 @@ namespace SparkEditor
 
     bool DedicatedServerPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Dedicated Server panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/DialogueEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/DialogueEditorPanel.cpp
@@ -8,6 +8,7 @@
 #include "DialogueEditorPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../Utils/ImGuiUtils.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <algorithm>
 #include <cmath>
 #include <fstream>
@@ -34,6 +35,7 @@ namespace SparkEditor
 
     bool DialogueEditorPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Dialogue Editor panel\n";
         NewDialogue();
         m_isInitialized = true;

--- a/SparkEditor/Source/Panels/DialogueEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/DialogueEditorPanel.cpp
@@ -35,7 +35,7 @@ namespace SparkEditor
 
     bool DialogueEditorPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Dialogue Editor panel\n";
         NewDialogue();
         m_isInitialized = true;

--- a/SparkEditor/Source/Panels/FPSToolsPanel.cpp
+++ b/SparkEditor/Source/Panels/FPSToolsPanel.cpp
@@ -7,6 +7,7 @@
 
 #include "FPSToolsPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 #include <cstdio>
@@ -19,6 +20,7 @@ namespace SparkEditor
 
     bool FPSToolsPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing FPS Tools panel\n";
 
         // Default spawn points

--- a/SparkEditor/Source/Panels/FPSToolsPanel.cpp
+++ b/SparkEditor/Source/Panels/FPSToolsPanel.cpp
@@ -20,7 +20,7 @@ namespace SparkEditor
 
     bool FPSToolsPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing FPS Tools panel\n";
 
         // Default spawn points

--- a/SparkEditor/Source/Panels/GameViewPanel.cpp
+++ b/SparkEditor/Source/Panels/GameViewPanel.cpp
@@ -8,6 +8,7 @@
 #include "GameViewPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../Core/EditorFonts.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 #include <cmath>
@@ -26,6 +27,7 @@ namespace SparkEditor
 
     bool GameViewPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Game View panel with full FPS HUD\n";
 
         // Pre-populate scoreboard for preview

--- a/SparkEditor/Source/Panels/GameViewPanel.cpp
+++ b/SparkEditor/Source/Panels/GameViewPanel.cpp
@@ -27,7 +27,7 @@ namespace SparkEditor
 
     bool GameViewPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Game View panel with full FPS HUD\n";
 
         // Pre-populate scoreboard for preview

--- a/SparkEditor/Source/Panels/HierarchyPanel.cpp
+++ b/SparkEditor/Source/Panels/HierarchyPanel.cpp
@@ -18,6 +18,7 @@
 #include "HierarchyPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../CommandHistory.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 
 namespace SparkEditor
 {
@@ -28,6 +29,7 @@ namespace SparkEditor
 
     bool HierarchyPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Hierarchy panel\n";
         return true;
     }
@@ -43,6 +45,7 @@ namespace SparkEditor
 
     void HierarchyPanel::Render()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         if (!IsVisible())
             return;
 

--- a/SparkEditor/Source/Panels/HierarchyPanel.cpp
+++ b/SparkEditor/Source/Panels/HierarchyPanel.cpp
@@ -29,7 +29,7 @@ namespace SparkEditor
 
     bool HierarchyPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Hierarchy panel\n";
         return true;
     }
@@ -45,7 +45,7 @@ namespace SparkEditor
 
     void HierarchyPanel::Render()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (!IsVisible())
             return;
 

--- a/SparkEditor/Source/Panels/InspectorPanel.cpp
+++ b/SparkEditor/Source/Panels/InspectorPanel.cpp
@@ -12,6 +12,7 @@
 #include "../Core/EditorIcons.h"
 #include "../Core/EditorFonts.h"
 #include "../CommandHistory.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 #include <algorithm>
@@ -24,6 +25,7 @@ namespace SparkEditor
 
     bool InspectorPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Inspector panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/InspectorPanel.cpp
+++ b/SparkEditor/Source/Panels/InspectorPanel.cpp
@@ -25,7 +25,7 @@ namespace SparkEditor
 
     bool InspectorPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Inspector panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/MaterialEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/MaterialEditorPanel.cpp
@@ -8,6 +8,7 @@
 #include "MaterialEditorPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../Utils/ImGuiUtils.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 #include <cmath>
@@ -25,6 +26,7 @@ namespace SparkEditor
 
     bool MaterialEditorPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Material Editor panel\n";
 
         SetIcon(ICON_FA_PALETTE);

--- a/SparkEditor/Source/Panels/MaterialEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/MaterialEditorPanel.cpp
@@ -26,7 +26,7 @@ namespace SparkEditor
 
     bool MaterialEditorPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Material Editor panel\n";
 
         SetIcon(ICON_FA_PALETTE);

--- a/SparkEditor/Source/Panels/ObjectPlacementPanel.cpp
+++ b/SparkEditor/Source/Panels/ObjectPlacementPanel.cpp
@@ -22,7 +22,7 @@ namespace SparkEditor
 
     bool ObjectPlacementPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Object Placement panel\n";
 
         // Populate built-in prefab library

--- a/SparkEditor/Source/Panels/ObjectPlacementPanel.cpp
+++ b/SparkEditor/Source/Panels/ObjectPlacementPanel.cpp
@@ -11,6 +11,7 @@
 
 #include "ObjectPlacementPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 
 namespace SparkEditor
 {
@@ -21,6 +22,7 @@ namespace SparkEditor
 
     bool ObjectPlacementPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Object Placement panel\n";
 
         // Populate built-in prefab library

--- a/SparkEditor/Source/Panels/ParticleEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/ParticleEditorPanel.cpp
@@ -35,7 +35,7 @@ namespace SparkEditor
 
     bool ParticleEditorPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Particle Editor panel\n";
         InitializePresets();
         NewEffect();

--- a/SparkEditor/Source/Panels/ParticleEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/ParticleEditorPanel.cpp
@@ -8,6 +8,7 @@
 #include "ParticleEditorPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../Utils/ImGuiUtils.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <algorithm>
 #include <cmath>
 #include <fstream>
@@ -34,6 +35,7 @@ namespace SparkEditor
 
     bool ParticleEditorPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Particle Editor panel\n";
         InitializePresets();
         NewEffect();

--- a/SparkEditor/Source/Panels/PerformanceProfilerPanel.cpp
+++ b/SparkEditor/Source/Panels/PerformanceProfilerPanel.cpp
@@ -16,6 +16,7 @@
 
 #include "PerformanceProfilerPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 
 namespace SparkEditor
 {
@@ -149,6 +150,7 @@ namespace SparkEditor
 
     bool PerformanceProfilerPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Performance Profiler panel\n";
         ClearData();
         m_isInitialized = true;

--- a/SparkEditor/Source/Panels/PerformanceProfilerPanel.cpp
+++ b/SparkEditor/Source/Panels/PerformanceProfilerPanel.cpp
@@ -150,7 +150,7 @@ namespace SparkEditor
 
     bool PerformanceProfilerPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Performance Profiler panel\n";
         ClearData();
         m_isInitialized = true;

--- a/SparkEditor/Source/Panels/Physics2DPanel.cpp
+++ b/SparkEditor/Source/Panels/Physics2DPanel.cpp
@@ -8,6 +8,7 @@
 #include "Physics2DPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../Core/EditorFonts.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 #include <algorithm>
@@ -27,6 +28,7 @@ namespace SparkEditor
 
     bool Physics2DPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Physics);
         std::cout << "Initializing Physics 2D panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/Physics2DPanel.cpp
+++ b/SparkEditor/Source/Panels/Physics2DPanel.cpp
@@ -28,7 +28,7 @@ namespace SparkEditor
 
     bool Physics2DPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Physics);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
         std::cout << "Initializing Physics 2D panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/PlayModeToolbarPanel.cpp
+++ b/SparkEditor/Source/Panels/PlayModeToolbarPanel.cpp
@@ -9,6 +9,7 @@
 #include "../Core/EditorIcons.h"
 #include "../Utils/ImGuiUtils.h"
 #include "../../../SparkEngine/Source/Engine/Editor/PlayModeManager.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 #include <cmath>
@@ -24,6 +25,7 @@ namespace SparkEditor
 
     bool PlayModeToolbarPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Play Mode Toolbar panel\n";
 
         SetIcon(ICON_FA_PLAY);

--- a/SparkEditor/Source/Panels/PlayModeToolbarPanel.cpp
+++ b/SparkEditor/Source/Panels/PlayModeToolbarPanel.cpp
@@ -25,7 +25,7 @@ namespace SparkEditor
 
     bool PlayModeToolbarPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Play Mode Toolbar panel\n";
 
         SetIcon(ICON_FA_PLAY);

--- a/SparkEditor/Source/Panels/PrefabEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/PrefabEditorPanel.cpp
@@ -21,7 +21,7 @@ namespace SparkEditor
 
     bool PrefabEditorPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         m_isInitialized = true;
         return true;
     }

--- a/SparkEditor/Source/Panels/PrefabEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/PrefabEditorPanel.cpp
@@ -7,6 +7,7 @@
 
 #include "PrefabEditorPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <algorithm>
 
@@ -20,6 +21,7 @@ namespace SparkEditor
 
     bool PrefabEditorPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         m_isInitialized = true;
         return true;
     }

--- a/SparkEditor/Source/Panels/ProjectBrowserPanel.cpp
+++ b/SparkEditor/Source/Panels/ProjectBrowserPanel.cpp
@@ -53,7 +53,7 @@ namespace SparkEditor
 
     bool ProjectBrowserPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         m_isInitialized = true;
         return true;
     }

--- a/SparkEditor/Source/Panels/ProjectBrowserPanel.cpp
+++ b/SparkEditor/Source/Panels/ProjectBrowserPanel.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "ProjectBrowserPanel.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <imgui_internal.h>
 #include <filesystem>
@@ -52,6 +53,7 @@ namespace SparkEditor
 
     bool ProjectBrowserPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         m_isInitialized = true;
         return true;
     }

--- a/SparkEditor/Source/Panels/RuntimeInspectorPanel.cpp
+++ b/SparkEditor/Source/Panels/RuntimeInspectorPanel.cpp
@@ -11,6 +11,7 @@
 
 #include "RuntimeInspectorPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 
 #include <imgui.h>
 
@@ -220,6 +221,7 @@ namespace SparkEditor
 
     bool RuntimeInspectorPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Runtime Inspector panel\n";
         m_isInitialized = true;
         return true;

--- a/SparkEditor/Source/Panels/RuntimeInspectorPanel.cpp
+++ b/SparkEditor/Source/Panels/RuntimeInspectorPanel.cpp
@@ -221,7 +221,7 @@ namespace SparkEditor
 
     bool RuntimeInspectorPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Runtime Inspector panel\n";
         m_isInitialized = true;
         return true;

--- a/SparkEditor/Source/Panels/SceneStatisticsPanel.cpp
+++ b/SparkEditor/Source/Panels/SceneStatisticsPanel.cpp
@@ -7,6 +7,7 @@
 
 #include "SceneStatisticsPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <algorithm>
 #include <cmath>
@@ -19,6 +20,7 @@ namespace SparkEditor
 
     bool SceneStatisticsPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         m_fpsHistory.fill(0.0f);
         m_frameTimeHistory.fill(0.0f);
         m_drawCallHistory.fill(0.0f);

--- a/SparkEditor/Source/Panels/SceneStatisticsPanel.cpp
+++ b/SparkEditor/Source/Panels/SceneStatisticsPanel.cpp
@@ -20,7 +20,7 @@ namespace SparkEditor
 
     bool SceneStatisticsPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         m_fpsHistory.fill(0.0f);
         m_frameTimeHistory.fill(0.0f);
         m_drawCallHistory.fill(0.0f);

--- a/SparkEditor/Source/Panels/SceneStatsPanel.cpp
+++ b/SparkEditor/Source/Panels/SceneStatsPanel.cpp
@@ -31,7 +31,7 @@ namespace SparkEditor
 
     bool SceneStatsPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Scene Stats panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/SceneStatsPanel.cpp
+++ b/SparkEditor/Source/Panels/SceneStatsPanel.cpp
@@ -16,6 +16,7 @@
 
 #include "SceneStatsPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 
 namespace SparkEditor
 {
@@ -30,6 +31,7 @@ namespace SparkEditor
 
     bool SceneStatsPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Scene Stats panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/SceneViewPanel.cpp
+++ b/SparkEditor/Source/Panels/SceneViewPanel.cpp
@@ -8,6 +8,7 @@
 #include "SceneViewPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../Core/EditorFonts.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 
@@ -18,6 +19,7 @@ namespace SparkEditor
 
     bool SceneViewPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Scene View panel\n";
         return true;
     }
@@ -29,6 +31,7 @@ namespace SparkEditor
 
     void SceneViewPanel::Render()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         if (!IsVisible())
             return;
 

--- a/SparkEditor/Source/Panels/SceneViewPanel.cpp
+++ b/SparkEditor/Source/Panels/SceneViewPanel.cpp
@@ -19,7 +19,7 @@ namespace SparkEditor
 
     bool SceneViewPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Scene View panel\n";
         return true;
     }
@@ -31,7 +31,7 @@ namespace SparkEditor
 
     void SceneViewPanel::Render()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (!IsVisible())
             return;
 

--- a/SparkEditor/Source/Panels/SearchPanel.cpp
+++ b/SparkEditor/Source/Panels/SearchPanel.cpp
@@ -19,7 +19,7 @@ namespace SparkEditor
 
     bool SearchPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         InitializeSampleData();
         m_isInitialized = true;
         return true;

--- a/SparkEditor/Source/Panels/SearchPanel.cpp
+++ b/SparkEditor/Source/Panels/SearchPanel.cpp
@@ -7,6 +7,7 @@
 
 #include "SearchPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <algorithm>
 #include <cctype>
@@ -18,6 +19,7 @@ namespace SparkEditor
 
     bool SearchPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         InitializeSampleData();
         m_isInitialized = true;
         return true;

--- a/SparkEditor/Source/Panels/SimpleConsolePanel.cpp
+++ b/SparkEditor/Source/Panels/SimpleConsolePanel.cpp
@@ -9,6 +9,7 @@
 #include "../Core/EditorIcons.h"
 #include "../Core/EditorFonts.h"
 #include "../Utils/SparkConsole.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 #include <sstream>
@@ -43,6 +44,7 @@ namespace SparkEditor
 
     bool SimpleConsolePanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Enhanced Console panel with SparkConsole integration\n";
 
         // Initialize SparkConsole system

--- a/SparkEditor/Source/Panels/SimpleConsolePanel.cpp
+++ b/SparkEditor/Source/Panels/SimpleConsolePanel.cpp
@@ -44,7 +44,7 @@ namespace SparkEditor
 
     bool SimpleConsolePanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Enhanced Console panel with SparkConsole integration\n";
 
         // Initialize SparkConsole system

--- a/SparkEditor/Source/Panels/SimpleHierarchyPanel.cpp
+++ b/SparkEditor/Source/Panels/SimpleHierarchyPanel.cpp
@@ -25,7 +25,7 @@ namespace SparkEditor
 
     bool SimpleHierarchyPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Simple Hierarchy panel\n";
 
         // Add some default objects

--- a/SparkEditor/Source/Panels/SimpleHierarchyPanel.cpp
+++ b/SparkEditor/Source/Panels/SimpleHierarchyPanel.cpp
@@ -14,6 +14,7 @@
 #include "SimpleHierarchyPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../Core/EditorFonts.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 
 namespace SparkEditor
 {
@@ -24,6 +25,7 @@ namespace SparkEditor
 
     bool SimpleHierarchyPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Simple Hierarchy panel\n";
 
         // Add some default objects

--- a/SparkEditor/Source/Panels/SpriteAnimationEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/SpriteAnimationEditorPanel.cpp
@@ -8,6 +8,7 @@
 #include "SpriteAnimationEditorPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../Core/EditorFonts.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 #include <algorithm>
@@ -24,6 +25,7 @@ namespace SparkEditor
 
     bool SpriteAnimationEditorPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Sprite Animation Editor panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/SpriteAnimationEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/SpriteAnimationEditorPanel.cpp
@@ -25,7 +25,7 @@ namespace SparkEditor
 
     bool SpriteAnimationEditorPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Sprite Animation Editor panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/SpriteEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/SpriteEditorPanel.cpp
@@ -8,6 +8,7 @@
 #include "SpriteEditorPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../Core/EditorFonts.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 #include <algorithm>
@@ -21,6 +22,7 @@ namespace SparkEditor
 
     bool SpriteEditorPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Sprite Editor panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/SpriteEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/SpriteEditorPanel.cpp
@@ -22,7 +22,7 @@ namespace SparkEditor
 
     bool SpriteEditorPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Sprite Editor panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/TilemapEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/TilemapEditorPanel.cpp
@@ -23,7 +23,7 @@ namespace SparkEditor
 
     bool TilemapEditorPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Tilemap Editor panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/TilemapEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/TilemapEditorPanel.cpp
@@ -8,6 +8,7 @@
 #include "TilemapEditorPanel.h"
 #include "../Core/EditorIcons.h"
 #include "../Core/EditorFonts.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 #include <algorithm>
@@ -22,6 +23,7 @@ namespace SparkEditor
 
     bool TilemapEditorPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Tilemap Editor panel\n";
         return true;
     }

--- a/SparkEditor/Source/Panels/UndoHistoryPanel.cpp
+++ b/SparkEditor/Source/Panels/UndoHistoryPanel.cpp
@@ -7,6 +7,7 @@
 
 #include "UndoHistoryPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 
 namespace SparkEditor
@@ -19,6 +20,7 @@ namespace SparkEditor
 
     bool UndoHistoryPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         m_isInitialized = true;
         return true;
     }

--- a/SparkEditor/Source/Panels/UndoHistoryPanel.cpp
+++ b/SparkEditor/Source/Panels/UndoHistoryPanel.cpp
@@ -20,7 +20,7 @@ namespace SparkEditor
 
     bool UndoHistoryPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         m_isInitialized = true;
         return true;
     }

--- a/SparkEditor/Source/Panels/WeaponEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/WeaponEditorPanel.cpp
@@ -7,6 +7,7 @@
 
 #include "WeaponEditorPanel.h"
 #include "../Core/EditorIcons.h"
+#include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 #include <cstdio>
@@ -20,6 +21,7 @@ namespace SparkEditor
 
     bool WeaponEditorPanel::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Editor);
         std::cout << "Initializing Weapon Editor panel\n";
 
         // Populate with default weapon data

--- a/SparkEditor/Source/Panels/WeaponEditorPanel.cpp
+++ b/SparkEditor/Source/Panels/WeaponEditorPanel.cpp
@@ -21,7 +21,7 @@ namespace SparkEditor
 
     bool WeaponEditorPanel::Initialize()
     {
-        SPARK_TRACE_ENTER(LogCategory::Editor);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Weapon Editor panel\n";
 
         // Populate with default weapon data

--- a/SparkEditor/Source/Prefabs/PrefabAsset.cpp
+++ b/SparkEditor/Source/Prefabs/PrefabAsset.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "PrefabAsset.h"
+#include "Utils/Validate.h"
 #include <algorithm>
 #include <fstream>
 
@@ -18,6 +19,7 @@ namespace SparkEditor
 
     void PrefabAsset::AddComponent(const SerializedComponent& component)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Editor, component.typeName);
         // Replace if component of same type already exists
         auto it = std::find_if(m_components.begin(), m_components.end(),
                                [&](const SerializedComponent& c) { return c.typeName == component.typeName; });
@@ -35,6 +37,7 @@ namespace SparkEditor
 
     bool PrefabAsset::RemoveComponent(const std::string& typeName)
     {
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !typeName.empty(), false);
         auto it = std::find_if(m_components.begin(), m_components.end(),
                                [&](const SerializedComponent& c) { return c.typeName == typeName; });
 
@@ -63,6 +66,8 @@ namespace SparkEditor
 
     bool PrefabAsset::Save(const std::string& path)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Editor, !path.empty(), false);
         // Simple text-based serialization for the prefab
         std::ofstream file(path);
         if (!file.is_open())
@@ -126,6 +131,7 @@ namespace SparkEditor
 
     PrefabAsset PrefabAsset::Load(const std::string& path)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         PrefabAsset prefab;
         std::ifstream file(path);
         if (!file.is_open())

--- a/SparkEditor/Source/Prefabs/PrefabManager.cpp
+++ b/SparkEditor/Source/Prefabs/PrefabManager.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "PrefabManager.h"
+#include "Utils/Validate.h"
 #include <algorithm>
 #include <filesystem>
 #include <iostream>
@@ -16,6 +17,7 @@ namespace SparkEditor
 
     bool PrefabManager::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         CreateSamplePrefabs();
         return true;
     }
@@ -28,6 +30,7 @@ namespace SparkEditor
 
     PrefabAsset* PrefabManager::CreatePrefabFromEntity(uint64_t entityId, const std::string& prefabName)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         // Create a new prefab and populate it with the entity's components
         PrefabAsset prefab(prefabName);
 
@@ -81,6 +84,7 @@ namespace SparkEditor
 
     bool PrefabManager::SavePrefab(const std::string& name, const std::string& directory)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         auto it = m_prefabs.find(name);
         if (it == m_prefabs.end())
         {
@@ -94,6 +98,7 @@ namespace SparkEditor
 
     PrefabAsset* PrefabManager::LoadPrefab(const std::string& filePath)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         PrefabAsset prefab = PrefabAsset::Load(filePath);
         if (prefab.GetName().empty())
         {

--- a/SparkEditor/Source/Profiler/PerformanceProfiler.cpp
+++ b/SparkEditor/Source/Profiler/PerformanceProfiler.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "../Profiler/PerformanceProfiler.h"
+#include "Utils/Validate.h"
 #include <imgui.h>
 #include <iostream>
 #include <algorithm>
@@ -117,6 +118,7 @@ namespace SparkEditor
 
     bool PerformanceProfiler::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         std::cout << "Initializing Performance Profiler panel\n";
         m_isProfiling = true;
         return true;

--- a/SparkEditor/Source/SceneSystem/SceneFile.cpp
+++ b/SparkEditor/Source/SceneSystem/SceneFile.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "SceneFile.h"
+#include "Utils/Validate.h"
 #include <algorithm>
 #include <chrono>
 #include <cstring>
@@ -61,6 +62,7 @@ namespace SparkEditor
 
     std::vector<SceneObject*> SceneFile::FindObjectsByName(const std::string& name)
     {
+        SPARK_WARN_IF(Spark::LogCategory::Editor, name.empty(), "FindObjectsByName called with empty name");
         std::vector<SceneObject*> result;
         for (auto& obj : objects)
         {
@@ -87,6 +89,8 @@ namespace SparkEditor
 
     void SceneFile::AddAssetReference(const std::string& assetPath, const std::string& assetType)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Editor, assetPath);
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Editor, assetType);
         // Check if already referenced
         for (const auto& ref : assetReferences)
         {
@@ -103,6 +107,7 @@ namespace SparkEditor
 
     bool SceneFile::Validate(std::vector<std::string>& errors) const
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         bool valid = true;
 
         if (header.magic != SCENE_FILE_MAGIC)

--- a/SparkEditor/Source/SceneSystem/SceneManager.cpp
+++ b/SparkEditor/Source/SceneSystem/SceneManager.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "SceneManager.h"
+#include "Utils/Validate.h"
 #include <iostream>
 
 namespace SparkEditor
@@ -36,6 +37,9 @@ namespace SparkEditor
 
     bool SceneManager::CreateNewScene(const std::string& sceneName)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Scene, !sceneName.empty(), false);
+        SPARK_LOG_INFO(Spark::LogCategory::Scene, "Creating new scene '%s'", sceneName.c_str());
         std::cout << "Creating new scene: " << sceneName << "\n";
         m_currentScenePath = sceneName + ".scene";
         m_hasUnsavedChanges = true;
@@ -44,6 +48,9 @@ namespace SparkEditor
 
     bool SceneManager::LoadScene(const std::string& scenePath)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Scene, !scenePath.empty(), false);
+        SPARK_LOG_INFO(Spark::LogCategory::Scene, "Loading scene from '%s'", scenePath.c_str());
         std::cout << "Loading scene: " << scenePath << "\n";
         m_currentScenePath = scenePath;
         m_hasUnsavedChanges = false;
@@ -52,6 +59,9 @@ namespace SparkEditor
 
     bool SceneManager::SaveScene(const std::string& scenePath)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Scene, !scenePath.empty(), false);
+        SPARK_LOG_INFO(Spark::LogCategory::Scene, "Saving scene to '%s'", scenePath.c_str());
         std::cout << "Saving scene: " << scenePath << "\n";
         m_currentScenePath = scenePath;
         m_hasUnsavedChanges = false;

--- a/SparkEditor/Source/SceneSystem/SceneSerializer.cpp
+++ b/SparkEditor/Source/SceneSystem/SceneSerializer.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "SceneSerializer.h"
+#include "Utils/Validate.h"
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -25,6 +26,8 @@ namespace SparkEditor
     SerializationResult SceneSerializer::SaveScene(const SceneFile& scene, const std::string& filePath,
                                                    SerializationFormat format)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Scene, !filePath.empty(), SerializationResult{});
         auto startTime = std::chrono::high_resolution_clock::now();
 
         SerializationFormat actualFormat = format;
@@ -60,6 +63,8 @@ namespace SparkEditor
 
     SerializationResult SceneSerializer::LoadScene(const std::string& filePath, SceneFile& outScene)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Scene, !filePath.empty(), SerializationResult{});
         auto startTime = std::chrono::high_resolution_clock::now();
 
         SerializationFormat format = DetectFormat(filePath);

--- a/SparkEditor/Source/Search/CommandPalette.cpp
+++ b/SparkEditor/Source/Search/CommandPalette.cpp
@@ -7,6 +7,7 @@
 
 #include "CommandPalette.h"
 #include "../Core/EditorIcons.h"
+#include "Utils/Validate.h"
 #include <imgui.h>
 #include <algorithm>
 #include <cctype>
@@ -19,6 +20,8 @@ namespace SparkEditor
     void CommandPalette::RegisterAction(const std::string& name, const std::string& category,
                                         std::function<void()> callback, const std::string& shortcut)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Editor, name);
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Editor, category);
         PaletteAction action;
         action.name = name;
         action.category = category;
@@ -64,6 +67,7 @@ namespace SparkEditor
 
     void CommandPalette::Render()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (!m_isOpen)
         {
             return;

--- a/SparkEditor/Source/Terrain/TerrainEditor.cpp
+++ b/SparkEditor/Source/Terrain/TerrainEditor.cpp
@@ -1,4 +1,5 @@
 #include "TerrainEditor.h"
+#include "Utils/Validate.h"
 
 using namespace DirectX;
 namespace SparkEditor
@@ -68,6 +69,7 @@ namespace SparkEditor
 
     bool TerrainEditor::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         return true;
     }
 

--- a/SparkEditor/Source/UndoRedo/UndoRedoManager.cpp
+++ b/SparkEditor/Source/UndoRedo/UndoRedoManager.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "UndoRedoManager.h"
+#include "Utils/Validate.h"
 #include <algorithm>
 
 namespace SparkEditor
@@ -15,6 +16,7 @@ namespace SparkEditor
 
     void UndoRedoManager::ExecuteCommand(std::unique_ptr<EditorCommand> command)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         if (!command)
         {
             return;
@@ -44,6 +46,8 @@ namespace SparkEditor
 
     bool UndoRedoManager::Undo()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_WARN_IF(Spark::LogCategory::Editor, m_undoStack.empty(), "Undo called on empty undo stack");
         if (!CanUndo())
         {
             return false;
@@ -62,6 +66,8 @@ namespace SparkEditor
 
     bool UndoRedoManager::Redo()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
+        SPARK_WARN_IF(Spark::LogCategory::Editor, m_redoStack.empty(), "Redo called on empty redo stack");
         if (!CanRedo())
         {
             return false;

--- a/SparkEditor/Source/VersionControl/VersionControlSystem.cpp
+++ b/SparkEditor/Source/VersionControl/VersionControlSystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "VersionControlSystem.h"
+#include "Utils/Validate.h"
 #include <imgui.h>
 #include <cstdio>
 #include <cstring>
@@ -176,6 +177,7 @@ namespace SparkEditor
 
     bool VersionControlSystem::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         m_isEnabled = true;
 
         // Register default merge handlers

--- a/SparkEditor/Source/VisualScripting/VisualScriptingSystem.cpp
+++ b/SparkEditor/Source/VisualScripting/VisualScriptingSystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "VisualScriptingSystem.h"
+#include "Utils/Validate.h"
 #include <algorithm>
 #include <cctype>
 #include <cmath>
@@ -2388,6 +2389,7 @@ namespace SparkEditor
 
     bool VisualScriptingSystem::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scripting);
         m_executor = std::make_unique<ScriptExecutor>();
         InitializeBuiltInNodes();
         return true;

--- a/SparkEngine/Source/Audio/AudioEngine.cpp
+++ b/SparkEngine/Source/Audio/AudioEngine.cpp
@@ -4,6 +4,7 @@
 #include "Utils/Assert.h"
 #include "Utils/SparkError.h"
 #include "../Utils/SparkConsole.h"
+#include "../Utils/Validate.h"
 #include <algorithm>
 #include <iostream>
 #include <sstream>
@@ -42,15 +43,16 @@ AudioEngine::~AudioEngine()
 
 HRESULT AudioEngine::Initialize(size_t maxSources)
 {
-    SPARK_LOG_INFO("Audio", "AudioEngine::Initialize -- maxSources=%zu", maxSources);
-    ASSERT_MSG(maxSources > 0, "AudioEngine maxSources must be positive");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+    SPARK_LOG_INFO(Spark::LogCategory::Audio, "AudioEngine::Initialize -- maxSources=%zu", maxSources);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Audio, maxSources > 0, "AudioEngine maxSources must be positive");
     m_maxSources = maxSources;
     m_settings.maxSources = static_cast<int>(maxSources);
 
     HRESULT hr = XAudio2Create(&m_xAudio2, 0, XAUDIO2_DEFAULT_PROCESSOR);
     if (FAILED(hr))
     {
-        SPARK_LOG_FATAL("Audio",
+        SPARK_LOG_FATAL(Spark::LogCategory::Audio,
                         "XAudio2Create failed HR=0x%08lX -- "
                         "Check audio drivers and Windows Audio Service",
                         static_cast<long>(hr));
@@ -60,7 +62,7 @@ HRESULT AudioEngine::Initialize(size_t maxSources)
     hr = m_xAudio2->CreateMasteringVoice(&m_masterVoice);
     if (FAILED(hr))
     {
-        SPARK_LOG_FATAL("Audio",
+        SPARK_LOG_FATAL(Spark::LogCategory::Audio,
                         "CreateMasteringVoice failed HR=0x%08lX -- "
                         "No audio output device available?",
                         static_cast<long>(hr));
@@ -75,12 +77,13 @@ HRESULT AudioEngine::Initialize(size_t maxSources)
     for (size_t i = 0; i < m_maxSources; ++i)
     {
         auto source = std::make_unique<AudioSource>();
-        ASSERT_NOT_NULL(source.get());
+        SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Audio, source.get());
         source->SourceID = m_nextSourceID++;
         m_availableSources.push_back(source.get());
         m_audioSources.push_back(std::move(source));
     }
 
+    SPARK_LOG_INFO(Spark::LogCategory::Audio, "AudioEngine initialization complete - audio ready");
     Spark::SimpleConsole::GetInstance().Log(
         "AudioEngine initialization complete with console integration - audio ready.", "SUCCESS");
     return S_OK;
@@ -88,6 +91,7 @@ HRESULT AudioEngine::Initialize(size_t maxSources)
 
 void AudioEngine::Update(float deltaTime)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
     static bool firstFrame = true;
     if (firstFrame)
     {
@@ -106,6 +110,8 @@ void AudioEngine::Update(float deltaTime)
 
 void AudioEngine::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+    SPARK_LOG_INFO(Spark::LogCategory::Audio, "AudioEngine::Shutdown called");
     Spark::SimpleConsole::GetInstance().Log("AudioEngine::Shutdown called.", "INFO");
     StopAllSounds();
     m_soundEffects.clear();
@@ -137,12 +143,14 @@ void AudioEngine::Shutdown()
 
 HRESULT AudioEngine::LoadSound(const std::string& name, const std::wstring& filename)
 {
-    ASSERT_MSG(!name.empty(), "Sound name must be non-empty");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Audio, !name.empty(), "Sound name must be non-empty");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Audio, !filename.empty(), "Sound filename must be non-empty");
     auto sound = std::make_unique<SoundEffect>();
-    ASSERT_NOT_NULL(sound.get());
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Audio, sound.get());
 
     HRESULT hr = sound->LoadFromFile(filename);
-    ASSERT_MSG(SUCCEEDED(hr), "SoundEffect::LoadFromFile failed");
+    SPARK_WARN_IF(Spark::LogCategory::Audio, FAILED(hr), "SoundEffect::LoadFromFile failed");
     if (FAILED(hr))
     {
         Spark::SimpleConsole::GetInstance().Log("Failed to load sound '" + name + "' from file", "ERROR");
@@ -177,7 +185,8 @@ SoundEffect* AudioEngine::GetSound(const std::string& name)
 
 AudioSource* AudioEngine::PlaySound(const std::string& name, float volume, float pitch, bool loop)
 {
-    ASSERT_MSG(!name.empty(), "Sound name must be non-empty");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Audio, !name.empty(), "Sound name must be non-empty");
     SoundEffect* sound = GetSound(name);
     if (!sound)
     {
@@ -195,21 +204,21 @@ AudioSource* AudioEngine::PlaySound(const std::string& name, float volume, float
     if (!src->Voice)
     {
         HRESULT hr = CreateSourceVoice(sound->GetFormat(), &src->Voice);
-        ASSERT_MSG(SUCCEEDED(hr), "CreateSourceVoice failed");
+        SPARK_WARN_IF(Spark::LogCategory::Audio, FAILED(hr), "CreateSourceVoice failed");
         if (FAILED(hr))
             return nullptr;
     }
 
     if (volume < 0.0f || volume > 1.0f)
     {
-        SPARK_LOG_EVERY_SECONDS(Spark::LogLevel::Warn, "Audio", 5, "PlaySound '%s': volume %.2f clamped to [0,1]",
-                                name.c_str(), volume);
+        SPARK_LOG_EVERY_SECONDS(Spark::LogLevel::Warn, Spark::LogCategory::Audio, 5,
+                                "PlaySound '%s': volume %.2f clamped to [0,1]", name.c_str(), volume);
         volume = std::clamp(volume, 0.0f, 1.0f);
     }
     if (pitch <= 0.0f)
     {
-        SPARK_LOG_EVERY_SECONDS(Spark::LogLevel::Warn, "Audio", 5, "PlaySound '%s': pitch %.2f invalid, reset to 1.0",
-                                name.c_str(), pitch);
+        SPARK_LOG_EVERY_SECONDS(Spark::LogLevel::Warn, Spark::LogCategory::Audio, 5,
+                                "PlaySound '%s': pitch %.2f invalid, reset to 1.0", name.c_str(), pitch);
         pitch = 1.0f;
     }
 
@@ -225,14 +234,14 @@ AudioSource* AudioEngine::PlaySound(const std::string& name, float volume, float
 
     XAUDIO2_BUFFER buffer = {};
     buffer.AudioBytes = sound->GetDataSize();
-    ASSERT_MSG(buffer.AudioBytes > 0, "Empty audio data");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Audio, buffer.AudioBytes > 0, "Empty audio data");
     buffer.pAudioData = sound->GetData();
     buffer.Flags = XAUDIO2_END_OF_STREAM;
     if (loop)
         buffer.LoopCount = XAUDIO2_LOOP_INFINITE;
 
     HRESULT hr = src->Voice->SubmitSourceBuffer(&buffer);
-    ASSERT_MSG(SUCCEEDED(hr), "SubmitSourceBuffer failed");
+    SPARK_WARN_IF(Spark::LogCategory::Audio, FAILED(hr), "SubmitSourceBuffer failed");
     if (FAILED(hr))
         return nullptr;
 
@@ -260,7 +269,7 @@ AudioSource* AudioEngine::PlaySound3D(const std::string& name, const XMFLOAT3& p
 
 void AudioEngine::StopSound(AudioSource* source)
 {
-    ASSERT_NOT_NULL(source);
+    SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Audio, source);
     if (source->IsPlaying && source->Voice)
     {
         source->Voice->Stop();
@@ -731,7 +740,7 @@ AudioSource* AudioEngine::GetAvailableSource()
 
 void AudioEngine::ReturnSource(AudioSource* source)
 {
-    ASSERT_NOT_NULL(source);
+    SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Audio, source);
     source->IsPlaying = false;
     source->Sound = nullptr;
     m_availableSources.push_back(source);
@@ -853,7 +862,7 @@ void AudioEngine::Apply3DAudioToSource(AudioSource* source)
 
 HRESULT AudioEngine::CreateSourceVoice(const WAVEFORMATEX& format, IXAudio2SourceVoice** voice)
 {
-    ASSERT_MSG(m_xAudio2 != nullptr, "XAudio2 not initialized");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Audio, m_xAudio2 != nullptr, "XAudio2 not initialized");
     return m_xAudio2->CreateSourceVoice(voice, &format);
 }
 
@@ -869,7 +878,7 @@ IXAudio2SubmixVoice* AudioEngine::CreateSubmixVoice(uint32_t inputChannels, uint
     HRESULT hr = m_xAudio2->CreateSubmixVoice(&submixVoice, inputChannels, inputSampleRate);
     if (FAILED(hr))
     {
-        SPARK_LOG_ERROR("Audio", "CreateSubmixVoice failed HR=0x%08lX", static_cast<long>(hr));
+        SPARK_LOG_ERROR(Spark::LogCategory::Audio, "CreateSubmixVoice failed HR=0x%08lX", static_cast<long>(hr));
         Spark::SimpleConsole::GetInstance().Log("CreateSubmixVoice failed", "ERROR");
         return nullptr;
     }

--- a/SparkEngine/Source/Audio/AudioMixer.cpp
+++ b/SparkEngine/Source/Audio/AudioMixer.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "AudioMixer.h"
+#include "../Utils/Validate.h"
 
 #include <algorithm>
 #include <cmath>
@@ -16,6 +17,8 @@ namespace Spark::Audio
 
     void AudioMixer::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+        SPARK_LOG_INFO(Spark::LogCategory::Audio, "AudioMixer::Initialize - creating default bus hierarchy");
         CreateBus("Master", "");
         CreateBus("SFX", "Master");
         CreateBus("Music", "Master");
@@ -32,6 +35,7 @@ namespace Spark::Audio
 
     void AudioMixer::CreateBus(const std::string& name, const std::string& parentBus)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Audio, name);
         BusState state;
         state.bus.name = name;
         state.bus.parentBus = parentBus;
@@ -128,6 +132,7 @@ namespace Spark::Audio
 
     void AudioMixer::AddReverbZone(const ReverbZone& zone)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Audio, zone.name);
         m_reverbZones.push_back(zone);
         // Sort by priority (highest first)
         std::sort(m_reverbZones.begin(), m_reverbZones.end(),
@@ -244,6 +249,7 @@ namespace Spark::Audio
 
     void AudioMixer::SaveSnapshot(const std::string& name)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Audio, name);
         Snapshot snapshot;
         for (const auto& [busName, state] : m_buses)
         {
@@ -254,6 +260,7 @@ namespace Spark::Audio
 
     void AudioMixer::RestoreSnapshot(const std::string& name, float blendTime)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Audio, name);
         auto it = m_snapshots.find(name);
         if (it == m_snapshots.end())
         {

--- a/SparkEngine/Source/Audio/MusicManager.cpp
+++ b/SparkEngine/Source/Audio/MusicManager.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "MusicManager.h"
+#include "../Utils/Validate.h"
 #include <sstream>
 #include <cmath>
 #include <algorithm>
@@ -194,6 +195,8 @@ namespace Spark::Audio
 
     void MusicManager::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+        SPARK_LOG_INFO(Spark::LogCategory::Audio, "MusicManager::Initialize");
         m_isPlaying = false;
         m_isPaused = false;
         m_isCrossfading = false;
@@ -211,6 +214,8 @@ namespace Spark::Audio
 
     void MusicManager::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+        SPARK_LOG_INFO(Spark::LogCategory::Audio, "MusicManager::Shutdown");
         Stop(0.0f);
         m_tracks.clear();
         m_playlists.clear();
@@ -235,6 +240,8 @@ namespace Spark::Audio
 
     void MusicManager::Play(const std::string& trackName, float fadeInDuration)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Audio, trackName);
         if (m_tracks.find(trackName) == m_tracks.end())
             return;
 
@@ -250,6 +257,7 @@ namespace Spark::Audio
 
     void MusicManager::Stop(float fadeOutDuration)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
         if (fadeOutDuration > 0.0f)
         {
             AudioMixer::GetInstance().FadeBus(AudioBus::Music, 0.0f, fadeOutDuration);
@@ -269,6 +277,8 @@ namespace Spark::Audio
 
     void MusicManager::CrossfadeTo(const std::string& trackName, float duration)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Audio, trackName);
         if (m_tracks.find(trackName) == m_tracks.end())
             return;
         if (trackName == m_currentTrack)
@@ -287,6 +297,8 @@ namespace Spark::Audio
 
     void MusicManager::PlayPlaylist(const std::string& playlistName)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Audio, playlistName);
         auto it = m_playlists.find(playlistName);
         if (it == m_playlists.end())
             return;

--- a/SparkEngine/Source/Audio/OpenALAudioEngine.cpp
+++ b/SparkEngine/Source/Audio/OpenALAudioEngine.cpp
@@ -12,6 +12,7 @@
 #if !defined(SPARK_PLATFORM_WINDOWS)
 
 #include "OpenALAudioEngine.h"
+#include "../Utils/Validate.h"
 
 #ifdef SPARK_OPENAL_AVAILABLE
 #include <AL/al.h>
@@ -98,6 +99,7 @@ namespace Spark::Audio
 
     bool OpenALAudioEngine::Initialize(size_t maxSources)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
 #ifdef SPARK_OPENAL_AVAILABLE
         m_maxSources = maxSources;
 
@@ -153,6 +155,7 @@ namespace Spark::Audio
         }
 
         m_initialized = true;
+        SPARK_LOG_INFO(Spark::LogCategory::Audio, "OpenAL audio engine initialized: %zu sources", m_sources.size());
         fprintf(stdout, "[OpenAL] Audio engine initialized: %zu sources, device: %s\n", m_sources.size(),
                 alcGetString(m_device, ALC_DEVICE_SPECIFIER));
         return true;
@@ -172,6 +175,7 @@ namespace Spark::Audio
 
     void OpenALAudioEngine::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
 #ifdef SPARK_OPENAL_AVAILABLE
         if (!m_initialized)
             return;
@@ -215,12 +219,16 @@ namespace Spark::Audio
         }
 
         m_initialized = false;
+        SPARK_LOG_INFO(Spark::LogCategory::Audio, "OpenAL audio engine shut down");
         fprintf(stdout, "[OpenAL] Audio engine shut down\n");
 #endif
     }
 
     bool OpenALAudioEngine::LoadSound(const std::string& name, const std::string& filename)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+        SPARK_WARN_IF(Spark::LogCategory::Audio, name.empty(), "LoadSound called with empty name");
+        SPARK_WARN_IF(Spark::LogCategory::Audio, filename.empty(), "LoadSound called with empty filename");
 #ifdef SPARK_OPENAL_AVAILABLE
         if (!m_initialized)
             return false;
@@ -274,6 +282,7 @@ namespace Spark::Audio
 
     OpenALSource* OpenALAudioEngine::PlaySound(const std::string& name, float volume, float pitch, bool loop)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
 #ifdef SPARK_OPENAL_AVAILABLE
         if (!m_initialized)
             return nullptr;
@@ -322,6 +331,7 @@ namespace Spark::Audio
     OpenALSource* OpenALAudioEngine::PlaySound3D(const std::string& name, const Float3& position, float volume,
                                                  float pitch, bool loop)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
 #ifdef SPARK_OPENAL_AVAILABLE
         if (!m_initialized)
             return nullptr;
@@ -374,8 +384,9 @@ namespace Spark::Audio
 
     void OpenALAudioEngine::StopSound(OpenALSource* source)
     {
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Audio, source);
 #ifdef SPARK_OPENAL_AVAILABLE
-        if (!source || !source->IsPlaying)
+        if (!source->IsPlaying)
             return;
         alSourceStop(source->alSource);
         alSourcei(source->alSource, AL_BUFFER, 0);

--- a/SparkEngine/Source/Audio/SoundEffect.cpp
+++ b/SparkEngine/Source/Audio/SoundEffect.cpp
@@ -1,6 +1,7 @@
 #include "Core/Platform.h"
 #include "SoundEffect.h"
 #include "Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include <fstream>
 #include <cmath>
 #include <random>
@@ -22,7 +23,8 @@ SoundEffect::~SoundEffect()
 
 HRESULT SoundEffect::LoadFromFile(const std::wstring& filename)
 {
-    ASSERT_ALWAYS_MSG(!filename.empty(), "SoundEffect::LoadFromFile - empty filename");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Audio, !filename.empty(), "SoundEffect::LoadFromFile - empty filename");
 
 #ifdef SPARK_PLATFORM_WINDOWS
     std::ifstream file(filename, std::ios::binary | std::ios::ate);
@@ -35,7 +37,7 @@ HRESULT SoundEffect::LoadFromFile(const std::wstring& filename)
         return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
 
     std::streamsize size = file.tellg();
-    ASSERT_ALWAYS_MSG(size > 0, "Zero-length WAV file");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Audio, size > 0, "Zero-length WAV file");
     file.seekg(0, std::ios::beg);
 
     std::vector<BYTE> buffer(static_cast<size_t>(size));
@@ -47,7 +49,9 @@ HRESULT SoundEffect::LoadFromFile(const std::wstring& filename)
 
 HRESULT SoundEffect::LoadFromMemory(const BYTE* data, DWORD dataSize)
 {
-    ASSERT_ALWAYS(data && dataSize);
+    SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Audio, data);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Audio, dataSize > 0, "LoadFromMemory called with zero dataSize");
     return ParseWAVFile(data, dataSize);
 }
 
@@ -68,7 +72,8 @@ float SoundEffect::GetDuration() const
 // ---------------------------------------------------------------------------
 HRESULT SoundEffect::ParseWAVFile(const BYTE* data, DWORD size)
 {
-    ASSERT_ALWAYS(data && size >= 44); // minimum WAV header
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Audio, data);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Audio, size >= 44, "WAV data too small for minimum header");
 
     DWORD fmtSize = 0, fmtPos = 0;
     if (FAILED(FindChunk(data, size, 0x20746d66, fmtSize, fmtPos))) // 'fmt '
@@ -91,8 +96,8 @@ HRESULT SoundEffect::ParseWAVFile(const BYTE* data, DWORD size)
 
 HRESULT SoundEffect::FindChunk(const BYTE* data, DWORD dataSize, DWORD fourCC, DWORD& outSize, DWORD& outPos)
 {
-    ASSERT(dataSize > 12); // RIFF header size
-    DWORD offset = 12;     // skip RIFF + WAVE ids
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Audio, dataSize > 12, "WAV data too small for RIFF header");
+    DWORD offset = 12; // skip RIFF + WAVE ids
 
     while (offset + 8 <= dataSize)
     {
@@ -125,7 +130,7 @@ void SoundEffectFactory::GenerateWaveform(std::vector<short>& samples, float fre
 {
     const DWORD SR = 44100;
     const DWORD count = static_cast<DWORD>(dur * SR);
-    ASSERT_ALWAYS(count);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Audio, count > 0, "GenerateWaveform: sample count must be positive");
 
     samples.resize(count);
     for (DWORD i = 0; i < count; ++i)
@@ -139,7 +144,7 @@ void SoundEffectFactory::GenerateWaveform(std::vector<short>& samples, float fre
 
 std::unique_ptr<SoundEffect> SoundEffectFactory::CreateFromSamples(const std::vector<short>& samples, DWORD SR)
 {
-    ASSERT_ALWAYS(!samples.empty());
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Audio, !samples.empty(), "CreateFromSamples: samples must not be empty");
 
     auto se = std::make_unique<SoundEffect>();
 

--- a/SparkEngine/Source/Camera/SparkEngineCamera.cpp
+++ b/SparkEngine/Source/Camera/SparkEngineCamera.cpp
@@ -2,6 +2,7 @@
 #include "SparkEngineCamera.h"
 #include "Utils/Assert.h"
 #include "../Utils/SparkConsole.h"
+#include "../Utils/Validate.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
 #endif // SPARK_PLATFORM_WINDOWS
@@ -52,10 +53,9 @@ using namespace DirectX;
 
 void SparkEngineCamera::Initialize(float aspectRatio)
 {
-    LOG_TO_CONSOLE_IMMEDIATE(std::wstring(L"SparkEngineCamera::Initialize called. aspectRatio=") +
-                                 std::to_wstring(aspectRatio),
-                             L"OPERATION");
-    ASSERT_MSG(aspectRatio > 0.0f, "Aspect ratio must be positive");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "SparkEngineCamera::Initialize called. aspectRatio=%f", aspectRatio);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, aspectRatio > 0.0f, "Aspect ratio must be positive");
 
     std::lock_guard<std::mutex> lock(m_stateMutex);
     m_aspectRatio = aspectRatio;
@@ -96,8 +96,8 @@ void SparkEngineCamera::UpdateProjectionMatrix()
 void SparkEngineCamera::Update(float deltaTime)
 {
     // **FIXED: Remove per-frame logging completely**
-    ASSERT_MSG(deltaTime >= 0.0f && std::isfinite(deltaTime),
-               "Camera Update deltaTime must be non-negative and finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, deltaTime >= 0.0f && std::isfinite(deltaTime),
+                      "Camera Update deltaTime must be non-negative and finite");
 
     // Process smooth transition if active
     if (m_isTransitioning)
@@ -128,7 +128,7 @@ void SparkEngineCamera::Update(float deltaTime)
 void SparkEngineCamera::MoveForward(float amount)
 {
     // **FIXED: Remove per-frame logging completely**
-    ASSERT_MSG(std::isfinite(amount), "Move amount must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, std::isfinite(amount), "Move amount must be finite");
 
     std::lock_guard<std::mutex> lock(m_stateMutex);
     XMVECTOR p = XMLoadFloat3(&m_position);
@@ -141,7 +141,7 @@ void SparkEngineCamera::MoveForward(float amount)
 void SparkEngineCamera::MoveRight(float amount)
 {
     // **FIXED: Remove per-frame logging completely**
-    ASSERT_MSG(std::isfinite(amount), "Move amount must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, std::isfinite(amount), "Move amount must be finite");
 
     std::lock_guard<std::mutex> lock(m_stateMutex);
     XMVECTOR p = XMLoadFloat3(&m_position);
@@ -154,7 +154,7 @@ void SparkEngineCamera::MoveRight(float amount)
 void SparkEngineCamera::MoveUp(float amount)
 {
     // **FIXED: Remove per-frame logging completely**
-    ASSERT_MSG(std::isfinite(amount), "Move amount must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, std::isfinite(amount), "Move amount must be finite");
 
     std::lock_guard<std::mutex> lock(m_stateMutex);
     XMVECTOR p = XMLoadFloat3(&m_position);
@@ -167,7 +167,7 @@ void SparkEngineCamera::MoveUp(float amount)
 void SparkEngineCamera::Pitch(float angle)
 {
     // **ENHANCED: Apply mouse sensitivity and Y-inversion from console**
-    ASSERT_MSG(std::isfinite(angle), "Angle must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, std::isfinite(angle), "Angle must be finite");
 
     std::lock_guard<std::mutex> lock(m_stateMutex);
     float adjustedAngle = angle * m_rotationSpeed * m_mouseSensitivity;
@@ -184,7 +184,7 @@ void SparkEngineCamera::Pitch(float angle)
 void SparkEngineCamera::Yaw(float angle)
 {
     // **ENHANCED: Apply mouse sensitivity from console**
-    ASSERT_MSG(std::isfinite(angle), "Angle must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, std::isfinite(angle), "Angle must be finite");
 
     std::lock_guard<std::mutex> lock(m_stateMutex);
     float adjustedAngle = angle * m_rotationSpeed * m_mouseSensitivity;
@@ -201,7 +201,7 @@ void SparkEngineCamera::Yaw(float angle)
 void SparkEngineCamera::Roll(float angle)
 {
     LOG_TO_CONSOLE(std::wstring(L"SparkEngineCamera::Roll called. angle=") + std::to_wstring(angle), L"OPERATION");
-    ASSERT_MSG(std::isfinite(angle), "Roll angle must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, std::isfinite(angle), "Roll angle must be finite");
 
     std::lock_guard<std::mutex> lock(m_stateMutex);
     m_roll += angle * m_rotationSpeed;
@@ -221,7 +221,7 @@ void SparkEngineCamera::SetZoom(bool enabled)
     std::lock_guard<std::mutex> lock(m_stateMutex);
     // Pick FOV
     float fov = enabled ? m_zoomedFov : m_defaultFov;
-    ASSERT_MSG(fov > 0.0f && fov < XM_PI, "Invalid FOV");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, fov > 0.0f && fov < XM_PI, "Invalid FOV");
 
     m_projectionMatrix = XMMatrixPerspectiveFovLH(fov, m_aspectRatio, m_nearPlane, m_farPlane);
     NotifyStateChange();

--- a/SparkEngine/Source/Core/EngineBootstrap.cpp
+++ b/SparkEngine/Source/Core/EngineBootstrap.cpp
@@ -7,6 +7,7 @@
 
 #include "../Utils/LogMacros.h"
 #include "../Utils/Logger.h"
+#include "../Utils/Validate.h"
 
 #include <algorithm>
 #include <queue>
@@ -34,6 +35,8 @@ namespace Spark
 
     bool EngineBootstrap::Register(SubsystemDescriptor descriptor)
     {
+        SPARK_TRACE_ENTER(LogCategory::Core);
+
         if (m_initialized)
         {
             SPARK_LOG_ERROR(LogCategory::Core, "EngineBootstrap::Register called after Initialize() — ignoring '%s'",
@@ -61,6 +64,8 @@ namespace Spark
 
     size_t EngineBootstrap::RegisterAll(std::vector<SubsystemDescriptor> descriptors)
     {
+        SPARK_TRACE_ENTER(LogCategory::Core);
+
         size_t count = 0;
         for (auto& desc : descriptors)
         {
@@ -78,6 +83,8 @@ namespace Spark
 
     bool EngineBootstrap::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Core);
+
         if (m_initialized)
         {
             SPARK_LOG_WARN(LogCategory::Core, "EngineBootstrap::Initialize called more than once — ignoring");
@@ -200,6 +207,8 @@ namespace Spark
 
     void EngineBootstrap::Shutdown()
     {
+        SPARK_TRACE_ENTER(LogCategory::Core);
+
         if (m_shutDown)
         {
             return;

--- a/SparkEngine/Source/Core/EngineContext.cpp
+++ b/SparkEngine/Source/Core/EngineContext.cpp
@@ -8,6 +8,7 @@
 
 #include "EngineContext.h"
 #include "Spark/Version.h"
+#include "../Utils/Validate.h"
 
 #include <algorithm>
 #include <memory>
@@ -158,10 +159,14 @@ bool EngineContext::TopologicalSort(std::vector<SubsystemEntry*>& sorted)
 
 bool EngineContext::InitializeAll()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "EngineContext::InitializeAll — %zu subsystems registered",
+                   m_subsystemEntries.size());
+
     std::vector<SubsystemEntry*> sorted;
     if (!TopologicalSort(sorted))
     {
-        // Dependency cycle detected
+        SPARK_LOG_ERROR(Spark::LogCategory::Core, "EngineContext: dependency cycle detected in subsystem graph");
         return false;
     }
 
@@ -171,8 +176,11 @@ bool EngineContext::InitializeAll()
     {
         if (entry->initFn)
         {
+            SPARK_LOG_DEBUG(Spark::LogCategory::Core, "EngineContext: initializing subsystem (type=%p)", entry->type);
             if (!entry->initFn())
             {
+                SPARK_LOG_ERROR(Spark::LogCategory::Core, "EngineContext: subsystem initialization failed (type=%p)",
+                                entry->type);
                 return false;
             }
         }
@@ -180,11 +188,17 @@ bool EngineContext::InitializeAll()
         m_initOrder.push_back(entry->type);
     }
 
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "EngineContext::InitializeAll — all %zu subsystems initialized",
+                   m_initOrder.size());
     return true;
 }
 
 void EngineContext::ShutdownAll()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "EngineContext::ShutdownAll — shutting down %zu subsystems",
+                   m_initOrder.size());
+
     // Shut down in reverse initialization order
     for (auto it = m_initOrder.rbegin(); it != m_initOrder.rend(); ++it)
     {

--- a/SparkEngine/Source/Core/EngineSettings.cpp
+++ b/SparkEngine/Source/Core/EngineSettings.cpp
@@ -5,6 +5,7 @@
 
 #include "EngineSettings.h"
 #include "Utils/SparkConsole.h"
+#include "Utils/Validate.h"
 #include <filesystem>
 #include <sstream>
 
@@ -53,6 +54,8 @@ std::string EngineSettings::FindSettingsPath() const
 // =============================================================================
 bool EngineSettings::Load(const std::string& path)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+
     m_filePath = path.empty() ? FindSettingsPath() : path;
 
     if (m_config.Load(m_filePath))
@@ -75,6 +78,8 @@ bool EngineSettings::Load(const std::string& path)
 // =============================================================================
 bool EngineSettings::Save() const
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+
     WriteToConfig();
     return m_config.Save(m_filePath);
 }
@@ -90,6 +95,8 @@ bool EngineSettings::SaveAs(const std::string& path) const
 // =============================================================================
 void EngineSettings::ResetToDefaults()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+
     m_graphics = GraphicsSettings{};
     m_audio = AudioSettings{};
     m_controls = ControlsSettings{};

--- a/SparkEngine/Source/Core/GameModuleLoader.cpp
+++ b/SparkEngine/Source/Core/GameModuleLoader.cpp
@@ -5,6 +5,7 @@
 
 #include "GameModuleLoader.h"
 #include "Utils/SparkConsole.h"
+#include "Utils/Validate.h"
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -24,6 +25,10 @@ GameModuleLoader::~GameModuleLoader()
 
 bool GameModuleLoader::Load(const std::string& path)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+    SPARK_VALIDATE_RET(Spark::LogCategory::Core, !path.empty(), false);
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Loading game module: %s", path.c_str());
+
     if (m_libraryHandle)
     {
         Spark::SimpleConsole::GetInstance().LogWarning("Game module already loaded. Unload first.");
@@ -86,6 +91,9 @@ bool GameModuleLoader::Load(const std::string& path)
 
 void GameModuleLoader::Unload()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Unloading game module");
+
     if (m_module && m_destroyFn)
     {
         m_destroyFn(m_module);
@@ -109,6 +117,10 @@ void GameModuleLoader::Unload()
 
 bool GameModuleLoader::Reload()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+    SPARK_VALIDATE_RET(Spark::LogCategory::Core, !m_modulePath.empty(), false);
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Reloading game module");
+
     if (m_modulePath.empty())
     {
         Spark::SimpleConsole::GetInstance().LogError("No module path to reload from");

--- a/SparkEngine/Source/Core/ModuleManager.cpp
+++ b/SparkEngine/Source/Core/ModuleManager.cpp
@@ -8,6 +8,7 @@
 #include "Spark/Version.h"
 #include "Utils/SparkConsole.h"
 #include "Utils/LocalFileCache.h"
+#include "Utils/Validate.h"
 
 #include <algorithm>
 #include <filesystem>
@@ -105,6 +106,10 @@ ModuleManager::~ModuleManager()
 
 bool ModuleManager::LoadModule(const std::string& path)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+    SPARK_VALIDATE_RET(Spark::LogCategory::Core, !path.empty(), false);
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Loading module: %s", path.c_str());
+
     auto& console = Spark::SimpleConsole::GetInstance();
 
     // Load the shared library
@@ -501,6 +506,9 @@ bool ModuleManager::ReloadModule(const std::string& name, Spark::IEngineContext*
 
 void ModuleManager::UnloadAll()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Unloading all modules (%zu loaded)", m_modules.size());
+
     for (auto& entry : m_modules)
         UnloadEntry(entry);
     m_modules.clear();

--- a/SparkEngine/Source/Core/SparkEngine.cpp
+++ b/SparkEngine/Source/Core/SparkEngine.cpp
@@ -21,6 +21,7 @@
 #include "Engine/Events/EventSystem.h"
 #include "Utils/Assert.h"
 #include "Utils/SparkError.h"
+#include "Utils/Validate.h"
 
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <Windows.h>
@@ -226,6 +227,7 @@ static bool LoadGameModules(ModuleManager& manager, LPWSTR cmdLine)
 // ===================================================================================
 int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR lpCmdLine, _In_ int nCmdShow)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
     ASSERT(hInstance != nullptr);
 
     // 1. Crash handler

--- a/SparkEngine/Source/Engine/AI/AIBudgetLimiter.cpp
+++ b/SparkEngine/Source/Engine/AI/AIBudgetLimiter.cpp
@@ -8,6 +8,7 @@
 #include "AIBudgetLimiter.h"
 #include "AISystem.h"
 #include "../ECS/Components.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <cmath>
@@ -21,6 +22,7 @@ namespace Spark::AI
 
     void AIBudgetLimiter::BeginFrame(const DirectX::XMFLOAT3& playerPosition, World& world)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
         m_frameStartTime = std::chrono::high_resolution_clock::now();
         m_frameActive = true;
         m_nextAgentIndex = 0;
@@ -160,6 +162,7 @@ namespace Spark::AI
 
     void AIBudgetLimiter::EndFrame()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
         if (!m_frameActive)
         {
             return;

--- a/SparkEngine/Source/Engine/AI/AIDirector.cpp
+++ b/SparkEngine/Source/Engine/AI/AIDirector.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "AIDirector.h"
+#include "../../Utils/Validate.h"
 
 #include "../ECS/Components/GameplayComponents.h"
 
@@ -21,6 +22,7 @@ namespace Spark::AI
 
     void AIDirector::Update(World& world, float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
         if (!m_enabled)
         {
             return;
@@ -40,6 +42,8 @@ namespace Spark::AI
 
     void AIDirector::SetDesiredIntensityRange(float minIntensity, float maxIntensity)
     {
+        SPARK_WARN_IF(Spark::LogCategory::AI, minIntensity > maxIntensity,
+                      "SetDesiredIntensityRange: minIntensity > maxIntensity, values will be swapped");
         m_minIntensity = std::clamp(minIntensity, 0.0f, 1.0f);
         m_maxIntensity = std::clamp(maxIntensity, 0.0f, 1.0f);
         if (m_minIntensity > m_maxIntensity)

--- a/SparkEngine/Source/Engine/AI/AISystem.cpp
+++ b/SparkEngine/Source/Engine/AI/AISystem.cpp
@@ -10,6 +10,7 @@
 #include "PerceptionSystem.h"
 #include "SteeringBehaviors.h"
 #include "../../Utils/JobSystem.h"
+#include "../../Utils/Validate.h"
 #include <sstream>
 #include <cmath>
 #include <numbers>
@@ -80,6 +81,10 @@ namespace Spark::AI
 
     void AISystem::Update(World& world, float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
+        SPARK_WARN_IF(Spark::LogCategory::AI, deltaTime < 0.0f, "Negative deltaTime in AISystem::Update");
+        SPARK_WARN_IF(Spark::LogCategory::AI, deltaTime > 0.5f, "Large deltaTime (>0.5s) in AISystem::Update");
+
         auto view = world.GetEntitiesWith<Transform, AIComponent>();
 
         // Phase 1 (serial): Collect live agents, handle deaths and lazy initialization.
@@ -112,10 +117,18 @@ namespace Spark::AI
             // Lazily initialize behavior tree instance from template
             if (!ai.behaviorTreeHandle && !ai.behaviorTreeName.empty())
             {
+                SPARK_LOG_DEBUG(Spark::LogCategory::AI, "AISystem: lazy-initializing behavior tree '%s' for entity %u",
+                                ai.behaviorTreeName.c_str(), static_cast<uint32_t>(entity));
                 BehaviorTree* instance = CreateBehaviorInstance(ai.behaviorTreeName);
                 if (instance)
                 {
                     ai.behaviorTreeHandle = Spark::BehaviorTreeHandle(static_cast<void*>(instance));
+                }
+                else
+                {
+                    SPARK_LOG_WARN(Spark::LogCategory::AI,
+                                   "AISystem: failed to create behavior instance '%s' for entity %u",
+                                   ai.behaviorTreeName.c_str(), static_cast<uint32_t>(entity));
                 }
             }
 
@@ -165,14 +178,22 @@ namespace Spark::AI
 
     void AISystem::RegisterBehavior(const std::string& name, std::unique_ptr<BehaviorTree> tree)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::AI, name);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::AI, tree);
+        SPARK_LOG_INFO(Spark::LogCategory::AI, "AISystem: registered behavior template '%s'", name.c_str());
         m_behaviorTemplates[name] = std::move(tree);
     }
 
     BehaviorTree* AISystem::CreateBehaviorInstance(const std::string& templateName)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
         auto it = m_behaviorTemplates.find(templateName);
         if (it == m_behaviorTemplates.end())
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::AI,
+                           "AISystem::CreateBehaviorInstance: no template named '%s' registered", templateName.c_str());
             return nullptr;
+        }
 
         // Clone the template: create a new BehaviorTree with the same name.
         // The tree structure (root node hierarchy) is shared via the template's

--- a/SparkEngine/Source/Engine/AI/NavMesh.cpp
+++ b/SparkEngine/Source/Engine/AI/NavMesh.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "NavMesh.h"
+#include "../../Utils/Validate.h"
 #include <sstream>
 #include <fstream>
 #include <cmath>
@@ -18,7 +19,10 @@ namespace Spark::AI
     // NavMeshQuery
     // ============================================================================
 
-    NavMeshQuery::NavMeshQuery(const NavMeshData* navMesh) : m_navMesh(navMesh) {}
+    NavMeshQuery::NavMeshQuery(const NavMeshData* navMesh) : m_navMesh(navMesh)
+    {
+        SPARK_WARN_IF_NULL(Spark::LogCategory::AI, navMesh);
+    }
 
     NavMeshHit NavMeshQuery::FindNearestPoint(const XMFLOAT3& position, float searchRadius) const
     {
@@ -564,7 +568,8 @@ namespace Spark::AI
                                                        const std::vector<uint32_t>& indices,
                                                        const NavMeshBuildSettings& settings)
     {
-
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
+        SPARK_WARN_IF(Spark::LogCategory::AI, vertices.empty(), "NavMeshBuilder::Build called with empty vertices");
         auto navMesh = std::make_unique<NavMeshData>();
         navMesh->cellSize = settings.cellSize;
         navMesh->cellHeight = settings.cellHeight;
@@ -693,7 +698,7 @@ namespace Spark::AI
                                                                       const XMFLOAT3& origin, float cellSize,
                                                                       const NavMeshBuildSettings& settings)
     {
-
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
         if (!heightData || width <= 0 || height <= 0)
             return std::make_unique<NavMeshData>();
 
@@ -744,6 +749,9 @@ namespace Spark::AI
 
     bool NavMeshManager::LoadNavMesh(const std::string& name, const std::string& filepath)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
+        SPARK_VALIDATE_RET(Spark::LogCategory::AI, !name.empty(), false);
+        SPARK_VALIDATE_RET(Spark::LogCategory::AI, !filepath.empty(), false);
         std::ifstream file(filepath, std::ios::binary);
         if (!file.is_open())
             return false;
@@ -815,6 +823,7 @@ namespace Spark::AI
     bool NavMeshManager::BuildNavMesh(const std::string& name, const std::vector<XMFLOAT3>& vertices,
                                       const std::vector<uint32_t>& indices, const NavMeshBuildSettings& settings)
     {
+        SPARK_VALIDATE_RET(Spark::LogCategory::AI, !name.empty(), false);
         auto navMesh = NavMeshBuilder::Build(vertices, indices, settings);
         if (!navMesh)
             return false;
@@ -830,6 +839,7 @@ namespace Spark::AI
 
     std::unique_ptr<NavMeshQuery> NavMeshManager::CreateQuery(const std::string& name) const
     {
+        SPARK_VALIDATE_RET(Spark::LogCategory::AI, !name.empty(), nullptr);
         const NavMeshData* nm = GetNavMesh(name);
         if (!nm)
             return nullptr;
@@ -843,6 +853,8 @@ namespace Spark::AI
 
     void NavMeshManager::Clear()
     {
+        SPARK_LOG_INFO(Spark::LogCategory::AI, "NavMeshManager::Clear — removing all %zu navmeshes.",
+                       m_navMeshes.size());
         m_navMeshes.clear();
     }
 

--- a/SparkEngine/Source/Engine/AI/NavMeshObstacles.cpp
+++ b/SparkEngine/Source/Engine/AI/NavMeshObstacles.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "NavMeshObstacles.h"
+#include "../../Utils/Validate.h"
 
 #include <cmath>
 #include <sstream>
@@ -30,6 +31,8 @@ namespace Spark::AI
 
     void NavMeshObstacleManager::SetNavMesh(NavMeshData* navMesh)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
+        SPARK_WARN_IF_NULL(Spark::LogCategory::AI, navMesh);
         // Restore all existing carves on the old NavMesh before switching
         if (m_navMesh != nullptr)
         {
@@ -49,6 +52,7 @@ namespace Spark::AI
 
     ObstacleHandle NavMeshObstacleManager::AddObstacle(const ObstacleDesc& desc)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
         if (m_navMesh == nullptr)
         {
             return InvalidObstacleHandle;
@@ -168,6 +172,8 @@ namespace Spark::AI
 
     void NavMeshObstacleManager::Clear()
     {
+        SPARK_LOG_INFO(Spark::LogCategory::AI, "NavMeshObstacleManager::Clear — removing %zu obstacles.",
+                       m_obstacles.size());
         if (m_navMesh != nullptr)
         {
             // Restore all carved triangles

--- a/SparkEngine/Source/Engine/AI/ParallelPerception.cpp
+++ b/SparkEngine/Source/Engine/AI/ParallelPerception.cpp
@@ -8,6 +8,7 @@
 #include "ParallelPerception.h"
 #include "../ECS/Components.h"
 #include "AISystem.h"
+#include "../../Utils/Validate.h"
 
 #include <cmath>
 #include <algorithm>
@@ -22,6 +23,9 @@ namespace Spark::AI
     void ParallelPerceptionSystem::Initialize(const DirectX::XMFLOAT3& worldMin, const DirectX::XMFLOAT3& worldMax,
                                               int octreeMaxDepth)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
+        SPARK_LOG_INFO(Spark::LogCategory::AI, "ParallelPerceptionSystem::Initialize (octreeMaxDepth=%d).",
+                       octreeMaxDepth);
         m_worldMin = worldMin;
         m_worldMax = worldMax;
         m_octreeMaxDepth = octreeMaxDepth;
@@ -38,8 +42,10 @@ namespace Spark::AI
 
     void ParallelPerceptionSystem::RebuildSpatialIndex(World& world)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
         if (!m_initialized)
         {
+            SPARK_WARN_IF(Spark::LogCategory::AI, true, "RebuildSpatialIndex called before Initialize");
             return;
         }
 
@@ -272,6 +278,7 @@ namespace Spark::AI
 
     void ParallelPerceptionSystem::UpdateAllAgents(World& world, float currentTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
         if (!m_initialized)
         {
             return;

--- a/SparkEngine/Source/Engine/Animation/AnimationCompression.cpp
+++ b/SparkEngine/Source/Engine/Animation/AnimationCompression.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "AnimationCompression.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <cmath>
@@ -45,6 +46,8 @@ namespace Spark::Animation
 
     CompressedClip AnimationCompressor::CompressClip(const AnimationClip& clip, const Settings& settings)
     {
+        SPARK_TRACE_ENTER(LogCategory::Animation);
+
         // Work on a copy so we can reduce without modifying the original
         AnimationClip reduced = clip;
         ReduceClip(reduced, settings);
@@ -156,6 +159,8 @@ namespace Spark::Animation
 
     XMFLOAT3 AnimationCompressor::DecompressPosition(const CompressedVectorTrack& track, size_t keyIndex)
     {
+        SPARK_WARN_IF(LogCategory::Animation, track.times.size() != track.values.size(),
+                      "DecompressPosition: track times/values size mismatch");
         if (keyIndex >= track.values.size())
         {
             return {0.0f, 0.0f, 0.0f};

--- a/SparkEngine/Source/Engine/Animation/AnimationSystem.cpp
+++ b/SparkEngine/Source/Engine/Animation/AnimationSystem.cpp
@@ -4,6 +4,7 @@
  */
 #include "../../Core/Platform.h"
 #include "AnimationSystem.h"
+#include "../../Utils/Validate.h"
 #include <sstream>
 #include <cmath>
 #include <fstream>
@@ -140,6 +141,9 @@ namespace Spark::Animation
 
     void AnimationStateMachine::Update(float deltaTime)
     {
+        SPARK_WARN_IF(LogCategory::Animation, deltaTime < 0.0f,
+                      "AnimationStateMachine::Update called with negative deltaTime");
+
         if (m_currentState.empty())
         {
             if (!m_defaultState.empty())
@@ -1194,6 +1198,9 @@ namespace Spark::Animation
 
     void AnimationInstance::Update(float deltaTime)
     {
+        SPARK_WARN_IF(LogCategory::Animation, deltaTime < 0.0f,
+                      "AnimationInstance::Update called with negative deltaTime");
+
         if (!skeleton || skeleton->bones.empty())
             return;
 

--- a/SparkEngine/Source/Engine/Animation/RagdollSystem.cpp
+++ b/SparkEngine/Source/Engine/Animation/RagdollSystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "RagdollSystem.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <sstream>
@@ -36,6 +37,8 @@ namespace Spark::Animation
 
     void RagdollSystem::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Animation);
+
         // Register a default humanoid ragdoll definition
         RagdollDefinition humanoid;
         humanoid.AddBone("Hips", {.shape = RagdollShapeType::Box, .radius = 0.15f, .length = 0.2f, .mass = 10.0f});
@@ -76,6 +79,8 @@ namespace Spark::Animation
 
     void RagdollSystem::Update(float deltaTime)
     {
+        SPARK_WARN_IF(LogCategory::Animation, deltaTime < 0.0f, "RagdollSystem::Update called with negative deltaTime");
+
         for (auto& [entityId, instance] : m_instances)
         {
             if (instance.state == RagdollState::Inactive)
@@ -94,6 +99,8 @@ namespace Spark::Animation
 
     void RagdollSystem::ActivateRagdoll(uint32_t entityId, const std::string& defName, float blendTime)
     {
+        SPARK_TRACE_ENTER(LogCategory::Animation);
+
         auto defIt = m_definitions.find(defName);
         if (defIt == m_definitions.end())
         {
@@ -116,6 +123,8 @@ namespace Spark::Animation
 
     void RagdollSystem::DeactivateRagdoll(uint32_t entityId, float blendTime)
     {
+        SPARK_TRACE_ENTER(LogCategory::Animation);
+
         auto it = m_instances.find(entityId);
         if (it == m_instances.end())
         {

--- a/SparkEngine/Source/Engine/Cinematic/Sequencer.cpp
+++ b/SparkEngine/Source/Engine/Cinematic/Sequencer.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "Sequencer.h"
+#include "../../Utils/Validate.h"
 #include <sstream>
 #include <algorithm>
 #include <cmath>
@@ -507,7 +508,10 @@ namespace Spark::Cinematic
     // Sequence
     // ============================================================================
 
-    Sequence::Sequence(const std::string& name) : m_name(name) {}
+    Sequence::Sequence(const std::string& name) : m_name(name)
+    {
+        SPARK_WARN_IF(Spark::LogCategory::Cinematic, name.empty(), "Sequence created with empty name");
+    }
 
     CameraPathTrack* Sequence::AddCameraTrack(const std::string& trackName)
     {
@@ -579,6 +583,7 @@ namespace Spark::Cinematic
 
     void Sequence::Play()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Cinematic);
         if (m_playState == SequencePlayState::Stopped)
         {
             m_currentTime = 0.0f;
@@ -597,6 +602,7 @@ namespace Spark::Cinematic
 
     void Sequence::Stop()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Cinematic);
         m_playState = SequencePlayState::Stopped;
         m_currentTime = 0.0f;
         m_previousTime = 0.0f;
@@ -623,6 +629,7 @@ namespace Spark::Cinematic
 
     void Sequence::Update(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Cinematic);
         if (m_playState != SequencePlayState::Playing)
             return;
 
@@ -717,6 +724,7 @@ namespace Spark::Cinematic
 
     Sequence* SequencerManager::CreateSequence(const std::string& name)
     {
+        SPARK_VALIDATE_RET(Spark::LogCategory::Cinematic, !name.empty(), nullptr);
         auto seq = std::make_unique<Sequence>(name);
         auto* ptr = seq.get();
         m_sequences[name] = std::move(seq);
@@ -736,6 +744,7 @@ namespace Spark::Cinematic
 
     bool SequencerManager::PlaySequence(const std::string& name)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Cinematic);
         auto* seq = GetSequence(name);
         if (!seq)
             return false;
@@ -759,6 +768,7 @@ namespace Spark::Cinematic
 
     void SequencerManager::StopAll()
     {
+        SPARK_LOG_INFO(Spark::LogCategory::Cinematic, "Stopping all sequences");
         for (auto& [name, seq] : m_sequences)
         {
             seq->Stop();

--- a/SparkEngine/Source/Engine/Destruction/DestructionSystem.cpp
+++ b/SparkEngine/Source/Engine/Destruction/DestructionSystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "DestructionSystem.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <sstream>
@@ -15,6 +16,8 @@ namespace Spark
 
     void DestructionSystem::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
+        SPARK_LOG_INFO(Spark::LogCategory::Physics, "DestructionSystem initializing");
         // Register some default fracture patterns
         FracturePattern woodenCrate;
         woodenCrate.AddPiece({"plank1", "debris_plank", {0.3f, 0, 0}, 0.5f, 8.0f, 3.0f});
@@ -47,6 +50,7 @@ namespace Spark
 
     void DestructionSystem::Update(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
         // Update debris lifetimes
         for (auto& debris : m_debris)
         {
@@ -66,6 +70,7 @@ namespace Spark
 
     void DestructionSystem::RegisterPattern(const std::string& name, const FracturePattern& pattern)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Physics, name);
         m_patterns[name] = pattern;
     }
 
@@ -78,6 +83,8 @@ namespace Spark
     void DestructionSystem::ApplyDamage(uint32_t entityId, float damage, const DirectX::XMFLOAT3& hitPoint,
                                         const DirectX::XMFLOAT3& hitDir)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
+        SPARK_WARN_IF(Spark::LogCategory::Physics, damage < 0.0f, "ApplyDamage called with negative damage value");
         // Damage application is handled via DestructibleComponent::ApplyDamage
         // This method handles the fracturing/debris spawning after destruction
 

--- a/SparkEngine/Source/Engine/Dialogue/DialogueSystem.cpp
+++ b/SparkEngine/Source/Engine/Dialogue/DialogueSystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "DialogueSystem.h"
+#include "../../Utils/Validate.h"
 
 #include <fstream>
 #include <sstream>
@@ -209,6 +210,9 @@ namespace Spark
 
     bool DialogueSystem::LoadTree(const std::string& treeId, const std::string& filePath)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Game, !treeId.empty(), false);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Game, !filePath.empty(), false);
         auto tree = std::make_unique<DialogueTree>();
         if (!tree->LoadFromFile(filePath))
         {
@@ -221,12 +225,15 @@ namespace Spark
 
     void DialogueSystem::RegisterTree(const std::string& treeId, std::unique_ptr<DialogueTree> tree)
     {
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Game, tree);
         tree->SetId(treeId);
         m_trees[treeId] = std::move(tree);
     }
 
     bool DialogueSystem::StartConversation(const std::string& treeId)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Starting conversation with tree '%s'", treeId.c_str());
         auto it = m_trees.find(treeId);
         if (it == m_trees.end())
         {
@@ -251,6 +258,8 @@ namespace Spark
 
     void DialogueSystem::EndConversation()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Ending conversation with tree '%s'", m_state.treeId.c_str());
         std::string treeId = m_state.treeId;
         m_state.isActive = false;
         m_state.currentNodeId.clear();
@@ -264,6 +273,7 @@ namespace Spark
 
     void DialogueSystem::Update(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
         if (!m_state.isActive)
         {
             return;

--- a/SparkEngine/Source/Engine/ECS/Components.h
+++ b/SparkEngine/Source/Engine/ECS/Components.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include "../../Utils/Assert.h"
+#include "../../Utils/Validate.h"
 
 // Core types: EntityID, NameComponent, Transform, MeshRenderer, Camera, Script
 #include "Components/CoreComponents.h"
@@ -89,7 +90,9 @@ class World
     EntityID CreateEntity(const std::string& name = "")
     {
         EntityID entity = m_registry.create();
-        ASSERT_MSG(entity != entt::null, "Failed to create entity — registry returned null entity");
+        SPARK_REQUIRE(Spark::LogCategory::ECS, entity != entt::null);
+        SPARK_LOG_TRACE(Spark::LogCategory::ECS, "Created entity %u%s%s", static_cast<uint32_t>(entity),
+                        name.empty() ? "" : " name=", name.c_str());
         if (!name.empty())
         {
             m_registry.emplace<NameComponent>(entity, NameComponent{name});
@@ -99,38 +102,43 @@ class World
 
     void DestroyEntity(EntityID entity)
     {
-        ASSERT_MSG(m_registry.valid(entity), "DestroyEntity called with invalid entity");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::ECS, m_registry.valid(entity),
+                          "DestroyEntity called with invalid entity");
+        SPARK_LOG_TRACE(Spark::LogCategory::ECS, "Destroying entity %u", static_cast<uint32_t>(entity));
         m_registry.destroy(entity);
     }
 
     template <typename T, typename... Args> T& AddComponent(EntityID entity, Args&&... args)
     {
-        ASSERT_MSG(m_registry.valid(entity), "AddComponent called with invalid entity");
-        ASSERT_MSG(!m_registry.all_of<T>(entity), "Entity already has the requested component");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::ECS, m_registry.valid(entity), "AddComponent called with invalid entity");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::ECS, !m_registry.all_of<T>(entity),
+                          "Entity already has the requested component");
         return m_registry.emplace<T>(entity, std::forward<Args>(args)...);
     }
 
     template <typename T> T* GetComponent(EntityID entity)
     {
-        ASSERT_MSG(m_registry.valid(entity), "GetComponent called with invalid entity");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::ECS, m_registry.valid(entity), "GetComponent called with invalid entity");
         return m_registry.try_get<T>(entity);
     }
     template <typename T> const T* GetComponent(EntityID entity) const
     {
-        ASSERT_MSG(m_registry.valid(entity), "GetComponent called with invalid entity");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::ECS, m_registry.valid(entity), "GetComponent called with invalid entity");
         return m_registry.try_get<T>(entity);
     }
 
     template <typename T> bool HasComponent(EntityID entity) const
     {
-        ASSERT_MSG(m_registry.valid(entity), "HasComponent called with invalid entity");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::ECS, m_registry.valid(entity), "HasComponent called with invalid entity");
         return m_registry.all_of<T>(entity);
     }
 
     template <typename T> void RemoveComponent(EntityID entity)
     {
-        ASSERT_MSG(m_registry.valid(entity), "RemoveComponent called with invalid entity");
-        ASSERT_MSG(m_registry.all_of<T>(entity), "RemoveComponent called but entity does not have the component");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::ECS, m_registry.valid(entity),
+                          "RemoveComponent called with invalid entity");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::ECS, m_registry.all_of<T>(entity),
+                          "RemoveComponent called but entity does not have the component");
         m_registry.remove<T>(entity);
     }
 

--- a/SparkEngine/Source/Engine/ECS/Components/CoreComponents.cpp
+++ b/SparkEngine/Source/Engine/ECS/Components/CoreComponents.cpp
@@ -1,6 +1,7 @@
 // CoreComponents.cpp
 #include "../../../Core/Platform.h"
 #include "CoreComponents.h"
+#include "../../../Utils/Validate.h"
 
 using namespace DirectX;
 
@@ -19,6 +20,7 @@ XMMATRIX Transform::GetLocalMatrix() const
 
 XMMATRIX Transform::GetWorldMatrix(const entt::registry& registry) const
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::ECS);
     XMMATRIX localMtx = GetLocalMatrix();
 
     if (parent == entt::null)

--- a/SparkEngine/Source/Engine/ECS/Systems/ECSystems.cpp
+++ b/SparkEngine/Source/Engine/ECS/Systems/ECSystems.cpp
@@ -8,6 +8,7 @@
 #include "Engine/ECS/Components/FPSComponents.h"
 #include "Engine/ECS/Components/GameplayComponents.h"
 #include "Utils/Cooldown.h"
+#include "Utils/Validate.h"
 #include <sstream>
 #include <cmath>
 
@@ -21,9 +22,9 @@ namespace Spark::ECS
 
     void RenderSystem::Update(World& world, float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::ECS);
         m_renderedCount = 0;
-        if (!m_graphics)
-            return;
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_graphics);
 
         const auto& registry = world.GetRegistry();
         auto view = world.GetEntitiesWith<Transform, MeshRenderer>();
@@ -59,8 +60,10 @@ namespace Spark::ECS
 
     void PhysicsUpdateSystem::Update(World& world, float deltaTime)
     {
-        if (!m_physics)
-            return;
+        SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Physics, m_physics);
+        SPARK_WARN_IF(Spark::LogCategory::Physics, deltaTime > 0.1f,
+                      "Large deltaTime in PhysicsUpdate — possible frame spike");
 
         auto view = world.GetEntitiesWith<Transform, RigidBodyComponent>();
         for (auto entity : view)
@@ -102,8 +105,8 @@ namespace Spark::ECS
 
     void AudioUpdateSystem::Update(World& world, float deltaTime)
     {
-        if (!m_audio)
-            return;
+        SPARK_TRACE_ENTER(Spark::LogCategory::Audio);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Audio, m_audio);
 
         auto view = world.GetEntitiesWith<Transform, AudioSourceComponent>();
         for (auto entity : view)
@@ -138,6 +141,7 @@ namespace Spark::ECS
 
     void LifecycleSystem::Update(World& world, float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::ECS);
         // Collect dead entities first, then fire callbacks to avoid
         // iterator invalidation if the callback destroys the entity.
         std::vector<entt::entity> deadEntities;
@@ -153,12 +157,25 @@ namespace Spark::ECS
             }
         }
 
+        if (!deadEntities.empty())
+        {
+            SPARK_LOG_INFO(Spark::LogCategory::ECS, "LifecycleSystem: %zu entities died this frame",
+                           deadEntities.size());
+        }
+
         if (m_onDeath)
         {
             for (auto entity : deadEntities)
             {
+                SPARK_LOG_DEBUG(Spark::LogCategory::ECS, "LifecycleSystem: firing death callback for entity %u",
+                                static_cast<uint32_t>(entity));
                 m_onDeath(entity);
             }
+        }
+        else
+        {
+            SPARK_WARN_IF(Spark::LogCategory::ECS, !deadEntities.empty(),
+                          "LifecycleSystem: entities died but no death callback is registered");
         }
     }
 
@@ -168,6 +185,8 @@ namespace Spark::ECS
 
     void AnimationUpdateSystem::Update(World& world, float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Animation);
+        SPARK_WARN_IF(Spark::LogCategory::Animation, deltaTime < 0.0f, "Negative deltaTime in AnimationUpdate");
         auto view = world.GetEntitiesWith<Transform, AnimationController>();
         for (auto entity : view)
         {
@@ -206,6 +225,8 @@ namespace Spark::ECS
 
     void AIUpdateSystem::Update(World& world, float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::AI);
+        SPARK_WARN_IF(Spark::LogCategory::AI, deltaTime < 0.0f, "Negative deltaTime in AIUpdate");
         auto view = world.GetEntitiesWith<Transform, AIComponent>();
         for (auto entity : view)
         {
@@ -216,6 +237,8 @@ namespace Spark::ECS
             auto* health = world.GetComponent<HealthComponent>(entity);
             if (health && health->isDead)
             {
+                SPARK_LOG_DEBUG(Spark::LogCategory::AI, "AIUpdateSystem: entity %u marked as dead",
+                                static_cast<uint32_t>(entity));
                 ai.state = AIComponent::State::Dead;
                 continue;
             }
@@ -276,6 +299,7 @@ namespace Spark::ECS
 
     void SplineFollowerSystem::Update(World& world, float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::ECS);
         m_activeFollowerCount = 0;
 
         auto view = world.GetEntitiesWith<Transform, SplineFollowerComponent>();
@@ -372,6 +396,7 @@ namespace Spark::ECS
 
     void ParticleUpdateSystem::Update(World& world, float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::ECS);
         m_activeParticleCount = 0;
         m_activeEmitterCount = 0;
 
@@ -407,6 +432,7 @@ namespace Spark::ECS
 
     void DecalSystem::Update(World& world, float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::ECS);
         m_activeDecalCount = 0;
         std::vector<entt::entity> expiredDecals;
 
@@ -452,6 +478,8 @@ namespace Spark::ECS
 
     void ProjectileSystem::Update(World& world, float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::ECS);
+        SPARK_WARN_IF(Spark::LogCategory::ECS, deltaTime < 0.0f, "Negative deltaTime in ProjectileSystem");
         m_activeProjectileCount = 0;
         std::vector<entt::entity> expiredProjectiles;
 

--- a/SparkEngine/Source/Engine/ECS/Systems/ECSystems.h
+++ b/SparkEngine/Source/Engine/ECS/Systems/ECSystems.h
@@ -56,6 +56,7 @@
 
 #include "../Components.h"
 #include "../../../Utils/Assert.h"
+#include "../../../Utils/Validate.h"
 #include <functional>
 #include <vector>
 #include <string>
@@ -830,6 +831,8 @@ namespace Spark::ECS
         {
             auto system = std::make_unique<T>(std::forward<Args>(args)...);
             T* ptr = system.get();
+            SPARK_LOG_INFO(Spark::LogCategory::ECS, "SystemManager: registering system '%s' (index=%zu)",
+                           ptr->GetName(), m_systems.size());
             m_systems.push_back(std::move(system));
             return ptr;
         }
@@ -846,6 +849,10 @@ namespace Spark::ECS
      */
         void UpdateAll(World& world, float deltaTime)
         {
+            SPARK_WARN_IF(Spark::LogCategory::ECS, deltaTime < 0.0f,
+                          "SystemManager::UpdateAll called with negative deltaTime");
+            SPARK_WARN_IF(Spark::LogCategory::ECS, deltaTime > 1.0f,
+                          "SystemManager::UpdateAll called with deltaTime > 1s — possible frame hang");
             for (auto& system : m_systems)
             {
                 if (system->IsEnabled())

--- a/SparkEngine/Source/Engine/Gameplay/WeaponManager.cpp
+++ b/SparkEngine/Source/Engine/Gameplay/WeaponManager.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "WeaponManager.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <cmath>
@@ -50,6 +51,8 @@ namespace Spark::Gameplay
 
     void WeaponRegistry::RegisterDefaults()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Registering default weapon definitions");
         // Pistol
         {
             WeaponDefinition def;
@@ -208,6 +211,7 @@ namespace Spark::Gameplay
 
     void WeaponSystem::ProcessWeapon(WeaponInventoryComponent& inv, float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
         auto& weapon = inv.GetActiveWeapon();
         if (weapon.definitionID == 0)
             return;
@@ -301,6 +305,7 @@ namespace Spark::Gameplay
 
     void WeaponSystem::HandleFiring(WeaponInstance& weapon, const WeaponDefinition& def, WeaponInventoryComponent& inv)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
         // Semi-auto: prevent firing while trigger is held from previous shot
         if (def.fireMode == FireMode::SemiAuto && weapon.triggerHeld)
             return;

--- a/SparkEngine/Source/Engine/Loading/LoadingScreen.cpp
+++ b/SparkEngine/Source/Engine/Loading/LoadingScreen.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "LoadingScreen.h"
+#include "../../Utils/Validate.h"
 
 #include <sstream>
 #include <random>
@@ -20,6 +21,8 @@ namespace Spark
 
     void LoadingScreen::BeginLoading(const std::string& name)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "Beginning loading session: '%s'", name.c_str());
         std::lock_guard<std::mutex> lock(m_mutex);
         m_sessionName = name;
         m_tasks.clear();
@@ -32,6 +35,8 @@ namespace Spark
 
     void LoadingScreen::AddTask(const std::string& name, float weight, std::function<bool()> execute)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Core, name);
+        SPARK_WARN_IF(Spark::LogCategory::Core, weight <= 0.0f, "Loading task added with non-positive weight");
         std::lock_guard<std::mutex> lock(m_mutex);
         LoadingTask task;
         task.name = name;
@@ -42,6 +47,8 @@ namespace Spark
 
     void LoadingScreen::Execute()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+        SPARK_WARN_IF(Spark::LogCategory::Core, m_tasks.empty(), "Execute called with no loading tasks");
         m_state = LoadingState::Loading;
 
         // Calculate total weight

--- a/SparkEngine/Source/Engine/Localization/LocalizationSystem.cpp
+++ b/SparkEngine/Source/Engine/Localization/LocalizationSystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "LocalizationSystem.h"
+#include "../../Utils/Validate.h"
 
 #include <fstream>
 #include <sstream>
@@ -89,6 +90,9 @@ namespace Spark
 
     bool LocalizationSystem::LoadLanguage(const std::string& languageCode, const std::string& filePath)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "Loading language '%s' from '%s'", languageCode.c_str(),
+                       filePath.c_str());
         std::lock_guard<std::mutex> lock(m_mutex);
         StringTable table;
         if (!table.LoadFromFile(filePath))
@@ -101,6 +105,8 @@ namespace Spark
 
     bool LocalizationSystem::SetCurrentLanguage(const std::string& languageCode)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "Setting current language to '%s'", languageCode.c_str());
         // Copy callbacks under the lock, then invoke outside to prevent deadlocks
         // if callbacks call back into LocalizationSystem.
         std::vector<std::function<void(const std::string&)>> callbacks;

--- a/SparkEngine/Source/Engine/Mobile/MobilePlatform.cpp
+++ b/SparkEngine/Source/Engine/Mobile/MobilePlatform.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "MobilePlatform.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <sstream>
@@ -15,6 +16,8 @@ namespace Spark::Mobile
 
     bool MobilePlatform::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "MobilePlatform initializing");
         m_qualitySettings = GetSettingsForPreset(m_qualityPreset);
         m_initialized = true;
         return true;
@@ -22,6 +25,7 @@ namespace Spark::Mobile
 
     void MobilePlatform::Update(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
         (void)deltaTime;
         RecognizeGestures();
         m_pendingGestures.clear();
@@ -85,6 +89,7 @@ namespace Spark::Mobile
 
     void MobilePlatform::SetQualityPreset(MobileQualityPreset preset)
     {
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "Setting mobile quality preset to %d", static_cast<int>(preset));
         m_qualityPreset = preset;
         m_qualitySettings = GetSettingsForPreset(preset);
     }

--- a/SparkEngine/Source/Engine/Modding/ModSystem.cpp
+++ b/SparkEngine/Source/Engine/Modding/ModSystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "ModSystem.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <filesystem>
@@ -18,6 +19,8 @@ namespace Spark
 
     size_t ModSystem::ScanForMods(const std::string& modsDirectory)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Scanning for mods in '%s'", modsDirectory.c_str());
         m_modsDirectory = modsDirectory;
         size_t found = 0;
 
@@ -105,6 +108,7 @@ namespace Spark
 
     void ModSystem::UnloadAll()
     {
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Unloading all mods");
         for (auto& [id, info] : m_mods)
         {
             if (info.loaded)
@@ -116,6 +120,8 @@ namespace Spark
 
     bool ModSystem::LoadMod(const std::string& modId)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Loading mod '%s'", modId.c_str());
         auto it = m_mods.find(modId);
         if (it == m_mods.end())
         {
@@ -144,6 +150,8 @@ namespace Spark
 
     void ModSystem::UnloadMod(const std::string& modId)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Unloading mod '%s'", modId.c_str());
         auto it = m_mods.find(modId);
         if (it == m_mods.end())
         {

--- a/SparkEngine/Source/Engine/Networking/AreaServer.cpp
+++ b/SparkEngine/Source/Engine/Networking/AreaServer.cpp
@@ -8,6 +8,7 @@
 #ifdef ENABLE_NETWORKING
 
 #include "../../Utils/LogMacros.h"
+#include "../../Utils/Validate.h"
 
 #include <cmath>
 #include <sstream>
@@ -32,6 +33,7 @@ namespace Spark::Net
 
     bool AreaServer::Start(const AreaServerConfig& config)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         if (m_running.load(std::memory_order_acquire))
         {
             SPARK_LOG_WARN("AreaServer", "Already running.");
@@ -52,6 +54,7 @@ namespace Spark::Net
 
     void AreaServer::Stop()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         if (!m_running.load(std::memory_order_acquire))
             return;
 
@@ -68,6 +71,7 @@ namespace Spark::Net
 
     void AreaServer::Tick(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         ProcessClientMessages(deltaTime);
         UpdateSimulation(deltaTime);
         CheckEntityBoundaries();
@@ -83,6 +87,7 @@ namespace Spark::Net
 
     bool AreaServer::AcceptMigratingEntity(const MigratingEntity& entity)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         // Validate networkID
         if (entity.networkID == 0)
         {

--- a/SparkEngine/Source/Engine/Networking/ClientPrediction.cpp
+++ b/SparkEngine/Source/Engine/Networking/ClientPrediction.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "ClientPrediction.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <cmath>
@@ -42,6 +43,7 @@ namespace Spark
 
     void ClientPrediction::Reconcile(const PredictedState& serverState, float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         // Calculate correction magnitude
         float dx = serverState.position.x - m_currentState.position.x;
         float dy = serverState.position.y - m_currentState.position.y;
@@ -76,6 +78,7 @@ namespace Spark
 
     void ClientPrediction::SetMovementSimulator(std::function<void(PredictedState&, const PredictedInput&, float)> func)
     {
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Network, func != nullptr, "Movement simulator function must not be null");
         m_movementSimulator = std::move(func);
     }
 

--- a/SparkEngine/Source/Engine/Networking/DedicatedServer.cpp
+++ b/SparkEngine/Source/Engine/Networking/DedicatedServer.cpp
@@ -17,6 +17,8 @@
 #undef SendMessage
 #endif
 
+#include "../../Utils/Validate.h"
+
 #include <algorithm>
 #include <cstring>
 #include <fstream>
@@ -46,6 +48,7 @@ namespace Spark::Net
 
     bool DedicatedServer::InitializeOnly(const ServerConfig& config)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         if (m_running.load(std::memory_order_acquire))
             return false;
 
@@ -170,6 +173,7 @@ namespace Spark::Net
 
     bool DedicatedServer::Start(const ServerConfig& config)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         if (!InitializeOnly(config))
             return false;
 
@@ -194,6 +198,7 @@ namespace Spark::Net
 
     void DedicatedServer::Stop()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         if (!m_running.load(std::memory_order_acquire))
             return;
 
@@ -407,6 +412,7 @@ namespace Spark::Net
 
     void DedicatedServer::ChangeMap(const std::string& mapName)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Network, mapName);
         if (m_matchInProgress)
             EndMatch();
 
@@ -462,6 +468,7 @@ namespace Spark::Net
 
     void DedicatedServer::KickPlayer(ClientID id, const std::string& reason)
     {
+        SPARK_WARN_IF(Spark::LogCategory::Network, reason.empty(), "KickPlayer called with empty reason");
         NetworkManager::GetInstance().KickClient(id, reason);
         m_stats.currentPlayers = GetPlayerCount();
         Log("Kicked client " + std::to_string(id) + ": " + reason);

--- a/SparkEngine/Source/Engine/Networking/NetworkEncryption.cpp
+++ b/SparkEngine/Source/Engine/Networking/NetworkEncryption.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "NetworkEncryption.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <cstring>
@@ -104,6 +105,7 @@ namespace Spark::Net
 
     std::vector<uint8_t> EncryptPacket(const SessionKey& key, uint64_t sequence, const std::vector<uint8_t>& payload)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         // Output: [nonce 8B] [encrypted payload] [hmac 4B]
         std::vector<uint8_t> packet;
         packet.reserve(NONCE_SIZE + payload.size() + HMAC_SIZE);
@@ -130,6 +132,7 @@ namespace Spark::Net
     bool DecryptPacket(const SessionKey& key, const std::vector<uint8_t>& packet, std::vector<uint8_t>& outPayload,
                        uint64_t& outSequence)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         if (packet.size() < ENCRYPTION_OVERHEAD)
             return false;
 

--- a/SparkEngine/Source/Engine/Networking/NetworkInterpolation.cpp
+++ b/SparkEngine/Source/Engine/Networking/NetworkInterpolation.cpp
@@ -7,6 +7,7 @@
 
 #include "../../Core/Platform.h"
 #include "NetworkInterpolation.h"
+#include "../../Utils/Validate.h"
 
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
@@ -20,6 +21,7 @@ namespace Spark::Net
 
     void NetworkInterpolationBuffer::AddSnapshot(const InterpolationSnapshot& snapshot)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         m_snapshots[m_writeIndex] = snapshot;
         m_writeIndex = (m_writeIndex + 1) % MAX_SNAPSHOTS;
         if (m_count < MAX_SNAPSHOTS)
@@ -96,6 +98,8 @@ namespace Spark::Net
 
     void NetworkInterpolationBuffer::Clear()
     {
+        SPARK_LOG_INFO(Spark::LogCategory::Network, "NetworkInterpolationBuffer::Clear — resetting %zu snapshots.",
+                       m_count);
         m_count = 0;
         m_writeIndex = 0;
     }

--- a/SparkEngine/Source/Engine/Networking/NetworkManager.cpp
+++ b/SparkEngine/Source/Engine/Networking/NetworkManager.cpp
@@ -8,6 +8,7 @@
 
 #include "NetworkManager.h"
 #include "../../Utils/Assert.h"
+#include "../../Utils/Validate.h"
 #include <sstream>
 #include <cstring>
 #include <algorithm>
@@ -78,6 +79,8 @@ namespace Spark::Net
     {
         if (m_error || m_readPos >= m_data.size())
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "NetBuffer::ReadUint8 — buffer overrun at pos %zu (size=%zu)",
+                           m_readPos, m_data.size());
             m_error = true;
             return 0;
         }
@@ -88,6 +91,9 @@ namespace Spark::Net
     {
         if (m_error || m_readPos + 2 > m_data.size())
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Network,
+                           "NetBuffer::ReadUint16 — buffer overrun at pos %zu (need 2, size=%zu)", m_readPos,
+                           m_data.size());
             m_error = true;
             return 0;
         }
@@ -101,6 +107,9 @@ namespace Spark::Net
     {
         if (m_error || m_readPos + 4 > m_data.size())
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Network,
+                           "NetBuffer::ReadUint32 — buffer overrun at pos %zu (need 4, size=%zu)", m_readPos,
+                           m_data.size());
             m_error = true;
             return 0;
         }
@@ -127,6 +136,9 @@ namespace Spark::Net
             return {};
         if (m_readPos + len > m_data.size())
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Network,
+                           "NetBuffer::ReadString — buffer overrun: string len=%u, remaining=%zu", len,
+                           m_data.size() - m_readPos);
             m_error = true;
             return {};
         }
@@ -274,18 +286,26 @@ namespace Spark::Net
 
     bool NetworkManager::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         if (m_initialized)
+        {
+            SPARK_LOG_DEBUG(Spark::LogCategory::Network, "NetworkManager::Initialize — already initialized");
             return true;
+        }
 
 #ifdef ENABLE_NETWORKING
 #ifdef SPARK_PLATFORM_WINDOWS
         WSADATA wsaData{};
         int result = WSAStartup(MAKEWORD(2, 2), &wsaData);
         if (result != 0)
+        {
+            SPARK_LOG_ERROR(Spark::LogCategory::Network, "WSAStartup failed with error: %d", result);
             return false;
+        }
 #endif // SPARK_PLATFORM_WINDOWS
 #endif // ENABLE_NETWORKING
 
+        SPARK_LOG_INFO(Spark::LogCategory::Network, "NetworkManager initialized");
         m_initialized = true;
         m_lastBandwidthSample = std::chrono::steady_clock::now();
         m_bytesSentSinceSample = 0;
@@ -593,8 +613,11 @@ namespace Spark::Net
 
     bool NetworkManager::StartServer(uint16_t port, int maxClients)
     {
-        ASSERT_MSG(port > 0, "NetworkManager::StartServer — port must be greater than 0");
-        ASSERT_MSG(maxClients > 0 && maxClients <= 256, "NetworkManager::StartServer — maxClients must be in [1, 256]");
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Network, port > 0, "port must be greater than 0");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Network, maxClients > 0 && maxClients <= 256,
+                          "maxClients must be in [1, 256]");
+        SPARK_LOG_INFO(Spark::LogCategory::Network, "Starting server on port %u (maxClients=%d)", port, maxClients);
         if (!m_initialized)
         {
             if (!Initialize())
@@ -666,9 +689,12 @@ namespace Spark::Net
 
     bool NetworkManager::Connect(const std::string& address, uint16_t port, const std::string& playerName)
     {
-        ASSERT_MSG(!address.empty(), "NetworkManager::Connect — address must not be empty");
-        ASSERT_MSG(port > 0, "NetworkManager::Connect — port must be greater than 0");
-        ASSERT_MSG(!playerName.empty(), "NetworkManager::Connect — playerName must not be empty");
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Network, !address.empty(), "address must not be empty");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Network, port > 0, "port must be greater than 0");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Network, !playerName.empty(), "playerName must not be empty");
+        SPARK_LOG_INFO(Spark::LogCategory::Network, "Connecting to %s:%u as '%s'", address.c_str(), port,
+                       playerName.c_str());
         if (!m_initialized)
         {
             if (!Initialize())
@@ -759,9 +785,11 @@ namespace Spark::Net
 
     void NetworkManager::Update(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         if (m_role == NetworkRole::None)
             return;
 
+        SPARK_WARN_IF(Spark::LogCategory::Network, deltaTime < 0.0f, "Negative deltaTime in NetworkManager::Update");
         m_serverTime += deltaTime;
 
         // Receive from socket and enqueue

--- a/SparkEngine/Source/Engine/Networking/WorldServer.cpp
+++ b/SparkEngine/Source/Engine/Networking/WorldServer.cpp
@@ -8,6 +8,7 @@
 #ifdef ENABLE_NETWORKING
 
 #include "../../Utils/LogMacros.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <cmath>
@@ -35,6 +36,7 @@ namespace Spark::Net
 
     bool WorldServer::Start(const WorldServerConfig& config)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         if (m_running.load(std::memory_order_acquire))
         {
             SPARK_LOG_WARN("WorldServer", "Already running.");
@@ -54,6 +56,7 @@ namespace Spark::Net
 
     void WorldServer::Stop()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         if (!m_running.load(std::memory_order_acquire))
             return;
 
@@ -79,6 +82,7 @@ namespace Spark::Net
 
     void WorldServer::Tick(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
         ProcessWorldMessages(deltaTime);
         ProcessAreaHeartbeats();
         UpdatePlayerSessions(deltaTime);
@@ -239,6 +243,9 @@ namespace Spark::Net
     AreaID WorldServer::HandlePlayerConnect(ClientID clientId, const std::string& playerName,
                                             const XMFLOAT3& spawnPosition)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Network);
+        SPARK_WARN_IF(Spark::LogCategory::Network, playerName.empty(),
+                      "HandlePlayerConnect called with empty playerName");
         AreaID targetArea = GetAreaForPosition(spawnPosition);
         if (targetArea == INVALID_AREA)
         {

--- a/SparkEngine/Source/Engine/Procedural/ProceduralGeneration.cpp
+++ b/SparkEngine/Source/Engine/Procedural/ProceduralGeneration.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "ProceduralGeneration.h"
+#include "../../Utils/Validate.h"
 #include <sstream>
 #include <cmath>
 #include <algorithm>
@@ -187,6 +188,9 @@ namespace Spark::Procedural
 
     std::vector<float> HeightmapGenerator::Generate(const HeightmapSettings& settings)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Procedural);
+        SPARK_WARN_IF(Spark::LogCategory::Procedural, settings.width <= 0 || settings.height <= 0,
+                      "HeightmapGenerator::Generate called with non-positive dimensions");
         NoiseGenerator noise(settings.seed);
         size_t size = static_cast<size_t>(settings.width) * settings.height;
         std::vector<float> heightmap(size);
@@ -997,6 +1001,8 @@ namespace Spark::Procedural
 
     DungeonLayout DungeonGenerator::GenerateBSP(const DungeonSettings& settings)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Procedural);
+        SPARK_LOG_INFO(Spark::LogCategory::Procedural, "Generating BSP dungeon %dx%d", settings.width, settings.height);
         DungeonLayout layout;
         layout.width = settings.width;
         layout.height = settings.height;

--- a/SparkEngine/Source/Engine/Replay/ReplaySystem.cpp
+++ b/SparkEngine/Source/Engine/Replay/ReplaySystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "ReplaySystem.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <fstream>
@@ -16,6 +17,8 @@ namespace Spark
 
     void ReplaySystem::StartRecording()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Starting replay recording");
         std::lock_guard<std::mutex> lock(m_mutex);
         m_isRecording = true;
         m_recordTimer = 0.0f;
@@ -27,6 +30,8 @@ namespace Spark
 
     void ReplaySystem::StopRecording()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Stopping replay recording");
         std::lock_guard<std::mutex> lock(m_mutex);
         m_isRecording = false;
         if (!m_replayData.frames.empty())
@@ -70,6 +75,8 @@ namespace Spark
 
     void ReplaySystem::StartPlayback()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Starting replay playback");
         std::lock_guard<std::mutex> lock(m_mutex);
         m_playbackState = PlaybackState::Playing;
         m_playbackTime = 0.0f;
@@ -93,6 +100,8 @@ namespace Spark
 
     void ReplaySystem::StopPlayback()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Stopping replay playback");
         std::lock_guard<std::mutex> lock(m_mutex);
         m_playbackState = PlaybackState::Stopped;
         m_playbackTime = 0.0f;
@@ -101,6 +110,7 @@ namespace Spark
 
     void ReplaySystem::UpdatePlayback(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
         std::lock_guard<std::mutex> lock(m_mutex);
         if (m_playbackState != PlaybackState::Playing)
         {
@@ -161,6 +171,9 @@ namespace Spark
 
     void ReplaySystem::StartKillCam(float rewindSeconds, uint32_t focusEntity)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_WARN_IF(Spark::LogCategory::Game, rewindSeconds <= 0.0f,
+                      "StartKillCam called with non-positive rewindSeconds");
         m_killCamActive = true;
         m_killCamFocusEntity = focusEntity;
         m_killCamStartTime = m_replayData.duration - rewindSeconds;
@@ -182,6 +195,8 @@ namespace Spark
 
     bool ReplaySystem::SaveToFile(const std::string& filePath) const
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Saving replay to '%s'", filePath.c_str());
         std::lock_guard<std::mutex> lock(m_mutex);
         std::ofstream file(filePath, std::ios::binary);
         if (!file.is_open())
@@ -240,6 +255,8 @@ namespace Spark
 
     bool ReplaySystem::LoadFromFile(const std::string& filePath)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Loading replay from '%s'", filePath.c_str());
         // Safety limits for deserialization to prevent OOM from malicious/corrupt files
         constexpr uint32_t kMaxStringLength = 4096;
         constexpr uint32_t kMaxFrameCount = 1'000'000;

--- a/SparkEngine/Source/Engine/SaveSystem/SaveSystem.cpp
+++ b/SparkEngine/Source/Engine/SaveSystem/SaveSystem.cpp
@@ -5,6 +5,7 @@
 
 #include "SaveSystem.h"
 #include "../../Utils/Assert.h"
+#include "../../Utils/Validate.h"
 #include "Utils/LocalFileCache.h"
 #include <cstring>
 #include <fstream>
@@ -551,7 +552,10 @@ namespace Spark
 
     bool SaveSystem::Initialize(const std::string& saveDirectory)
     {
-        ASSERT_MSG(!saveDirectory.empty(), "SaveSystem::Initialize — saveDirectory must not be empty");
+        SPARK_TRACE_ENTER(Spark::LogCategory::Save);
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Save, !saveDirectory.empty(),
+                          "SaveSystem::Initialize — saveDirectory must not be empty");
+        SPARK_LOG_INFO(Spark::LogCategory::Save, "SaveSystem initializing with directory '%s'", saveDirectory.c_str());
         m_saveDirectory = saveDirectory;
         try
         {
@@ -567,14 +571,16 @@ namespace Spark
 
     bool SaveSystem::Save(const std::string& slotName, World& world, const SaveMetadata& metadata)
     {
-        ASSERT_MSG(!slotName.empty(), "SaveSystem::Save — slotName must not be empty");
+        SPARK_TRACE_ENTER(Spark::LogCategory::Save);
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Save, !slotName.empty(), "SaveSystem::Save — slotName must not be empty");
         SaveData data = SerializeWorld(world, metadata);
         return WriteToFile(GetSavePath(slotName), data);
     }
 
     bool SaveSystem::Load(const std::string& slotName, World& world)
     {
-        ASSERT_MSG(!slotName.empty(), "SaveSystem::Load — slotName must not be empty");
+        SPARK_TRACE_ENTER(Spark::LogCategory::Save);
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Save, !slotName.empty(), "SaveSystem::Load — slotName must not be empty");
         SaveData data;
         if (!ReadFromFile(GetSavePath(slotName), data))
             return false;
@@ -603,7 +609,9 @@ namespace Spark
 
     bool SaveSystem::DeleteSave(const std::string& slotName)
     {
-        ASSERT_MSG(!slotName.empty(), "SaveSystem::DeleteSave — slotName must not be empty");
+        SPARK_TRACE_ENTER(Spark::LogCategory::Save);
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Save, !slotName.empty(),
+                          "SaveSystem::DeleteSave — slotName must not be empty");
         try
         {
             std::string path = GetSavePath(slotName);

--- a/SparkEngine/Source/Engine/Scripting/AngelScriptEngine.cpp
+++ b/SparkEngine/Source/Engine/Scripting/AngelScriptEngine.cpp
@@ -14,6 +14,7 @@
 #include "../../Core/EngineContext.h"
 #include "../../Utils/LogMacros.h"
 #include "../../Utils/Assert.h"
+#include "../../Utils/Validate.h"
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -265,6 +266,9 @@ bool ASGetKey(const std::string& key)
 
 bool AngelScriptEngine::Initialize()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Scripting);
+    SPARK_LOG_INFO(Spark::LogCategory::Scripting, "AngelScriptEngine initializing...");
+
     if (m_engine)
     {
         LogWarning("Already initialized.");
@@ -292,6 +296,9 @@ bool AngelScriptEngine::Initialize()
 
 void AngelScriptEngine::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Scripting);
+    SPARK_LOG_INFO(Spark::LogCategory::Scripting, "AngelScriptEngine shutting down...");
+
     // Detach and clean up every entity script.
     for (auto& [entityID, instance] : m_entityScripts)
     {
@@ -796,6 +803,8 @@ void AngelScriptEngine::SetLastError(const std::string& error)
 
 bool AngelScriptEngine::Initialize()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Scripting);
+    SPARK_LOG_INFO(Spark::LogCategory::Scripting, "AngelScriptEngine initializing (stub — no AngelScript support)...");
     LogWarning("AngelScript support is not compiled in (SPARK_ANGELSCRIPT_SUPPORT not defined).");
     s_instance = this;
     return true;
@@ -803,6 +812,8 @@ bool AngelScriptEngine::Initialize()
 
 void AngelScriptEngine::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Scripting);
+    SPARK_LOG_INFO(Spark::LogCategory::Scripting, "AngelScriptEngine shutting down (stub)...");
     LogWarning("AngelScript support is not compiled in. Shutdown is a no-op.");
     if (s_instance == this)
     {

--- a/SparkEngine/Source/Engine/Scripting/ScriptHotReload.cpp
+++ b/SparkEngine/Source/Engine/Scripting/ScriptHotReload.cpp
@@ -5,6 +5,7 @@
 
 #include "ScriptHotReload.h"
 #include "../../Utils/Assert.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <sstream>
@@ -30,6 +31,7 @@ namespace Spark::Scripting
     void ScriptHotReloadManager::AddWatchDirectory(const std::string& directory, bool recursive)
     {
         ASSERT_MSG(!directory.empty(), "ScriptHotReloadManager::AddWatchDirectory — directory must not be empty");
+        SPARK_VALIDATE_NOT_EMPTY(LogCategory::Scripting, directory);
         m_watchDirs.push_back(directory);
         if (m_running)
         {
@@ -65,6 +67,8 @@ namespace Spark::Scripting
 
     void ScriptHotReloadManager::Start()
     {
+        SPARK_TRACE_ENTER(LogCategory::Scripting);
+
         if (m_running)
             return;
 
@@ -80,6 +84,8 @@ namespace Spark::Scripting
 
     void ScriptHotReloadManager::Stop()
     {
+        SPARK_TRACE_ENTER(LogCategory::Scripting);
+
         m_running = false;
         m_pendingChanges.clear();
     }
@@ -90,6 +96,8 @@ namespace Spark::Scripting
 
     int ScriptHotReloadManager::PollChanges()
     {
+        SPARK_TRACE_ENTER(LogCategory::Scripting);
+
         if (!m_running)
             return 0;
 

--- a/SparkEngine/Source/Engine/Scripting/VisualScriptSystem.cpp
+++ b/SparkEngine/Source/Engine/Scripting/VisualScriptSystem.cpp
@@ -8,6 +8,7 @@
 #include "VisualScriptSystem.h"
 #include "../../Utils/LogMacros.h"
 #include "../../Utils/Assert.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <cassert>
@@ -1796,6 +1797,8 @@ namespace Spark::Scripting
 
     bool VisualScriptSystem::Initialize()
     {
+        SPARK_TRACE_ENTER(LogCategory::Scripting);
+
         if (m_isInitialized)
         {
             return true;
@@ -1810,6 +1813,8 @@ namespace Spark::Scripting
 
     void VisualScriptSystem::Shutdown()
     {
+        SPARK_TRACE_ENTER(LogCategory::Scripting);
+
         m_graphs.clear();
         m_isInitialized = false;
         SPARK_LOG_INFO("Scripting", "[VisualScriptSystem] Shutdown.");
@@ -1841,6 +1846,8 @@ namespace Spark::Scripting
 
     bool VisualScriptSystem::CompileAndRegister(const std::string& graphName)
     {
+        SPARK_TRACE_ENTER(LogCategory::Scripting);
+
         auto* graph = GetGraph(graphName);
         if (!graph)
         {
@@ -1911,6 +1918,8 @@ namespace Spark::Scripting
 
     bool VisualScriptSystem::LoadGraph(const std::string& filePath)
     {
+        SPARK_TRACE_ENTER(LogCategory::Scripting);
+
         std::ifstream file(filePath);
         if (!file.is_open())
         {

--- a/SparkEngine/Source/Engine/Stats/AchievementSystem.cpp
+++ b/SparkEngine/Source/Engine/Stats/AchievementSystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "AchievementSystem.h"
+#include "../../Utils/Validate.h"
 
 #include <fstream>
 #include <sstream>
@@ -21,6 +22,8 @@ namespace Spark
     void AchievementSystem::DefineAchievement(const std::string& id, const std::string& name,
                                               const std::string& description, bool hidden)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Game, id);
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Game, name);
         std::lock_guard<std::mutex> lock(m_mutex);
         Achievement achievement;
         achievement.id = id;
@@ -44,6 +47,7 @@ namespace Spark
 
     bool AchievementSystem::UnlockAchievement(const std::string& id)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
         std::lock_guard<std::mutex> lock(m_mutex);
         auto it = m_achievements.find(id);
         if (it == m_achievements.end() || it->second.unlocked)
@@ -245,6 +249,8 @@ namespace Spark
 
     bool AchievementSystem::SaveToFile(const std::string& filePath) const
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Saving achievements to '%s'", filePath.c_str());
         std::lock_guard<std::mutex> lock(m_mutex);
         std::ofstream file(filePath);
         if (!file.is_open())
@@ -285,6 +291,8 @@ namespace Spark
 
     bool AchievementSystem::LoadFromFile(const std::string& filePath)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Loading achievements from '%s'", filePath.c_str());
         std::ifstream file(filePath);
         if (!file.is_open())
         {
@@ -362,6 +370,7 @@ namespace Spark
 
     void AchievementSystem::ResetAll()
     {
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Resetting all achievements and statistics");
         std::lock_guard<std::mutex> lock(m_mutex);
         for (auto& [id, achievement] : m_achievements)
         {

--- a/SparkEngine/Source/Engine/Streaming/ContentDelivery.cpp
+++ b/SparkEngine/Source/Engine/Streaming/ContentDelivery.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "ContentDelivery.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <sstream>
@@ -15,6 +16,8 @@ namespace Spark
 
     bool ContentDelivery::CheckForUpdates(const std::string& manifestUrl)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Scene, !manifestUrl.empty(), false);
         // In a real implementation, this would HTTP GET the manifest URL
         // and parse the JSON response. For now, provide the framework.
         (void)manifestUrl;
@@ -38,6 +41,8 @@ namespace Spark
 
     bool ContentDelivery::QueueDownload(const std::string& bundleName, int priority)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Scene, !bundleName.empty(), false);
         std::lock_guard<std::mutex> lock(m_mutex);
         DownloadTask task;
         task.bundleName = bundleName;
@@ -65,6 +70,7 @@ namespace Spark
 
     void ContentDelivery::Update(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
         (void)deltaTime;
         // Process download queue — real implementation would use async HTTP
         // For framework purposes, mark tasks as progressing
@@ -93,12 +99,14 @@ namespace Spark
 
     void ContentDelivery::CancelAll()
     {
+        SPARK_LOG_INFO(Spark::LogCategory::Scene, "ContentDelivery::CancelAll — clearing download queue.");
         std::lock_guard<std::mutex> lock(m_mutex);
         m_downloadQueue.clear();
     }
 
     bool ContentDelivery::VerifyBundle(const std::string& bundleName) const
     {
+        SPARK_VALIDATE_RET(Spark::LogCategory::Scene, !bundleName.empty(), false);
         std::lock_guard<std::mutex> lock(m_mutex);
         auto it = m_localBundles.find(bundleName);
         if (it == m_localBundles.end())
@@ -111,6 +119,7 @@ namespace Spark
 
     void ContentDelivery::DeleteBundle(const std::string& bundleName)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Scene, bundleName);
         std::lock_guard<std::mutex> lock(m_mutex);
         m_localBundles.erase(bundleName);
     }

--- a/SparkEngine/Source/Engine/Streaming/SceneTransitionManager.cpp
+++ b/SparkEngine/Source/Engine/Streaming/SceneTransitionManager.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "SceneTransitionManager.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <sstream>
@@ -21,6 +22,7 @@ namespace Spark::Streaming
 
     void SceneTransitionManager::Update(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
         // Process transition animation
         if (m_transitioning)
         {
@@ -42,6 +44,8 @@ namespace Spark::Streaming
     SceneID SceneTransitionManager::LoadScene(const std::string& filePath, const TransitionConfig& transition,
                                               LoadProgressCallback onProgress, LoadCompleteCallback onComplete)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Scene, !filePath.empty(), INVALID_SCENE);
         std::lock_guard<std::mutex> lock(m_mutex);
 
         SceneID id = AllocateSceneID();
@@ -84,6 +88,8 @@ namespace Spark::Streaming
     SceneID SceneTransitionManager::LoadSceneAdditive(const std::string& filePath, LoadProgressCallback onProgress,
                                                       LoadCompleteCallback onComplete)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Scene, !filePath.empty(), INVALID_SCENE);
         std::lock_guard<std::mutex> lock(m_mutex);
 
         SceneID id = AllocateSceneID();

--- a/SparkEngine/Source/Engine/Streaming/SeamlessAreaManager.cpp
+++ b/SparkEngine/Source/Engine/Streaming/SeamlessAreaManager.cpp
@@ -5,6 +5,7 @@
 
 #include "SeamlessAreaManager.h"
 #include "../../Utils/LogMacros.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <cmath>
@@ -61,6 +62,7 @@ namespace Spark::Streaming
 
     bool SeamlessAreaManager::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
         if (m_initialized)
         {
             SPARK_LOG_WARN("SeamlessArea", "Already initialized.");
@@ -82,6 +84,7 @@ namespace Spark::Streaming
 
     void SeamlessAreaManager::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
         if (!m_initialized)
         {
             return;
@@ -309,6 +312,7 @@ namespace Spark::Streaming
 
     void SeamlessAreaManager::Update(const DirectX::XMFLOAT3& referencePos, float /*deltaTime*/)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
         if (!m_initialized)
         {
             return;

--- a/SparkEngine/Source/Engine/UI/UISystem.cpp
+++ b/SparkEngine/Source/Engine/UI/UISystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "UISystem.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <sstream>
@@ -342,11 +343,17 @@ namespace Spark::UI
 
     void UISystem::Initialize(int screenWidth, int screenHeight)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "UISystem initializing with resolution %dx%d", screenWidth,
+                       screenHeight);
+        SPARK_WARN_IF(Spark::LogCategory::Core, screenWidth <= 0 || screenHeight <= 0,
+                      "UISystem initialized with non-positive screen dimensions");
         m_canvas.Initialize(screenWidth, screenHeight);
     }
 
     void UISystem::Update(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
         if (m_visible)
         {
             m_canvas.Update(deltaTime);
@@ -363,6 +370,7 @@ namespace Spark::UI
 
     void UISystem::OnResize(int width, int height)
     {
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "UISystem resizing to %dx%d", width, height);
         m_canvas.Resize(width, height);
     }
 

--- a/SparkEngine/Source/Engine/VR/VRSystem.cpp
+++ b/SparkEngine/Source/Engine/VR/VRSystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "VRSystem.h"
+#include "../../Utils/Validate.h"
 
 #include <sstream>
 
@@ -21,6 +22,8 @@ namespace Spark::VR
 
     bool VRSystem::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "VRSystem initializing");
         // OpenXR initialization would happen here:
         // 1. xrCreateInstance()
         // 2. xrGetSystem()
@@ -34,12 +37,15 @@ namespace Spark::VR
 
     void VRSystem::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "VRSystem shutting down");
         // Release OpenXR resources
         m_initialized = false;
     }
 
     void VRSystem::UpdateTracking()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
         if (!m_initialized)
         {
             return;
@@ -67,6 +73,8 @@ namespace Spark::VR
 
     void VRSystem::RecenterTracking()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "VR recentering tracking space");
         if (!m_initialized)
         {
             return;

--- a/SparkEngine/Source/Engine/World/WorldOriginSystem.cpp
+++ b/SparkEngine/Source/Engine/World/WorldOriginSystem.cpp
@@ -6,6 +6,7 @@
 #include "WorldOriginSystem.h"
 #include "../ECS/Components/CoreComponents.h"
 #include "../../Utils/LogMacros.h"
+#include "../../Utils/Validate.h"
 
 #include <cmath>
 #include <entt/entt.hpp>
@@ -31,6 +32,7 @@ namespace Spark::World
 
     bool WorldOriginSystem::Update(entt::registry& registry, const DirectX::XMFLOAT3& referencePos)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
         if (!m_enabled)
         {
             return false;
@@ -71,6 +73,7 @@ namespace Spark::World
 
     void WorldOriginSystem::ForceRebase(entt::registry& registry, const DirectX::XMFLOAT3& offset)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
         // Validate offset
         if (!std::isfinite(offset.x) || !std::isfinite(offset.y) || !std::isfinite(offset.z))
         {
@@ -127,6 +130,8 @@ namespace Spark::World
 
     void WorldOriginSystem::Reset()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+        SPARK_LOG_INFO(Spark::LogCategory::Scene, "WorldOriginSystem resetting accumulated offset");
         m_accumulatedOffset = {0.0f, 0.0f, 0.0f};
         m_stats = {};
     }

--- a/SparkEngine/Source/Enums/EnumUtils.cpp
+++ b/SparkEngine/Source/Enums/EnumUtils.cpp
@@ -7,6 +7,7 @@
 
 #include "EnumUtils.h"
 #include "Enums/GameSystemEnums.h"
+#include "../Utils/Validate.h"
 #include <algorithm>
 #include <unordered_map>
 #include <cctype>

--- a/SparkEngine/Source/Game/GameObject.cpp
+++ b/SparkEngine/Source/Game/GameObject.cpp
@@ -11,6 +11,7 @@
 #include "GameObject.h"
 #include "../Utils/MathUtils.h"
 #include "../Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include "../Graphics/GraphicsEngine.h"
 #include "../Core/EngineContext.h"
 #include <iostream>
@@ -36,17 +37,17 @@ GameObject::~GameObject()
 
 HRESULT GameObject::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
-    std::wcout << L"[OPERATION] GameObject::Initialize called. ID=" << m_id << L" Name=" << m_name.c_str() << std::endl;
-    ASSERT_MSG(device != nullptr, "GameObject::Initialize - device is null");
-    ASSERT_MSG(context != nullptr, "GameObject::Initialize - context is null");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, context);
+    SPARK_LOG_INFO(Spark::LogCategory::Game, "GameObject::Initialize called. ID=%u Name=%s", m_id, m_name.c_str());
     m_device = device;
     m_context = context;
     m_mesh = std::make_unique<Mesh>();
-    ASSERT(m_mesh);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, m_mesh);
     HRESULT hr = m_mesh->Initialize(device, context);
-    std::wcout << L"[INFO] Mesh initialized for GameObject ID=" << m_id << L" Name=" << m_name.c_str() << L" HR=0x"
-               << std::hex << hr << std::dec << std::endl;
-    ASSERT_MSG(SUCCEEDED(hr), "Mesh::Initialize failed");
+    SPARK_LOG_INFO(Spark::LogCategory::Game, "Mesh initialized for GameObject ID=%u HR=0x%08X", m_id, hr);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Mesh::Initialize failed");
     if (FAILED(hr))
     {
         std::wcerr << L"[ERROR] Mesh::Initialize failed for GameObject ID=" << m_id << L" Name=" << m_name.c_str()
@@ -54,19 +55,20 @@ HRESULT GameObject::Initialize(ID3D11Device* device, ID3D11DeviceContext* contex
         return hr;
     }
     CreateMesh();
-    std::wcout << L"[INFO] GameObject::Initialize complete. ID=" << m_id << L" Name=" << m_name.c_str() << std::endl;
+    SPARK_LOG_INFO(Spark::LogCategory::Game, "GameObject::Initialize complete. ID=%u Name=%s", m_id, m_name.c_str());
     return S_OK;
 }
 
 void GameObject::Shutdown()
 {
-    std::wcout << L"[OPERATION] GameObject::Shutdown called. ID=" << m_id << L" Name=" << m_name.c_str() << std::endl;
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_LOG_INFO(Spark::LogCategory::Game, "GameObject::Shutdown called. ID=%u Name=%s", m_id, m_name.c_str());
     if (m_mesh)
         m_mesh->Shutdown();
     m_mesh.reset();
     m_device = nullptr;
     m_context = nullptr;
-    std::wcout << L"[INFO] GameObject shutdown complete. ID=" << m_id << L" Name=" << m_name.c_str() << std::endl;
+    SPARK_LOG_INFO(Spark::LogCategory::Game, "GameObject shutdown complete. ID=%u Name=%s", m_id, m_name.c_str());
 }
 
 void GameObject::Update(float dt)
@@ -95,11 +97,11 @@ void GameObject::Render(const XMMATRIX& view, const XMMATRIX& projection)
     if (m_worldMatrixDirty)
         UpdateWorldMatrix();
 
-    ASSERT(m_mesh);
-    ASSERT_MSG(m_device != nullptr, "GameObject::Render - device is null");
-    ASSERT_MSG(m_context != nullptr, "GameObject::Render - context is null");
-    ASSERT_MSG(m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
-               "Mesh has no vertices or indices to render");
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, m_mesh);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, m_device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, m_context);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
+                      "Mesh has no vertices or indices to render");
 
     // Get graphics engine via EngineContext
     GraphicsEngine* graphics = EngineContext::Get() ? EngineContext::Get()->GetGraphics() : nullptr;
@@ -124,28 +126,31 @@ void GameObject::Render(const XMMATRIX& view, const XMMATRIX& projection)
 
 void GameObject::SetPosition(const XMFLOAT3& pos)
 {
-    ASSERT_MSG(std::isfinite(pos.x) && std::isfinite(pos.y) && std::isfinite(pos.z), "Invalid position vector");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, std::isfinite(pos.x) && std::isfinite(pos.y) && std::isfinite(pos.z),
+                      "Invalid position vector");
     m_position = pos;
     m_worldMatrixDirty = true;
 }
 
 void GameObject::SetRotation(const XMFLOAT3& rot)
 {
-    ASSERT_MSG(std::isfinite(rot.x) && std::isfinite(rot.y) && std::isfinite(rot.z), "Invalid rotation vector");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, std::isfinite(rot.x) && std::isfinite(rot.y) && std::isfinite(rot.z),
+                      "Invalid rotation vector");
     m_rotation = rot;
     m_worldMatrixDirty = true;
 }
 
 void GameObject::SetScale(const XMFLOAT3& scl)
 {
-    ASSERT_MSG(scl.x > 0 && scl.y > 0 && scl.z > 0, "Scale must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, scl.x > 0 && scl.y > 0 && scl.z > 0, "Scale must be positive");
     m_scale = scl;
     m_worldMatrixDirty = true;
 }
 
 void GameObject::Translate(const XMFLOAT3& d)
 {
-    ASSERT_MSG(std::isfinite(d.x) && std::isfinite(d.y) && std::isfinite(d.z), "Invalid translation delta");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, std::isfinite(d.x) && std::isfinite(d.y) && std::isfinite(d.z),
+                      "Invalid translation delta");
     m_position.x += d.x;
     m_position.y += d.y;
     m_position.z += d.z;
@@ -154,7 +159,8 @@ void GameObject::Translate(const XMFLOAT3& d)
 
 void GameObject::Rotate(const XMFLOAT3& d)
 {
-    ASSERT_MSG(std::isfinite(d.x) && std::isfinite(d.y) && std::isfinite(d.z), "Invalid rotation delta");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, std::isfinite(d.x) && std::isfinite(d.y) && std::isfinite(d.z),
+                      "Invalid rotation delta");
     m_rotation.x += d.x;
     m_rotation.y += d.y;
     m_rotation.z += d.z;
@@ -163,7 +169,7 @@ void GameObject::Rotate(const XMFLOAT3& d)
 
 void GameObject::Scale(const XMFLOAT3& d)
 {
-    ASSERT_MSG(d.x > 0 && d.y > 0 && d.z > 0, "Scale factors must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, d.x > 0 && d.y > 0 && d.z > 0, "Scale factors must be positive");
     m_scale.x *= d.x;
     m_scale.y *= d.y;
     m_scale.z *= d.z;
@@ -211,8 +217,8 @@ float GameObject::GetDistanceFrom(const GameObject& other) const
 
 float GameObject::GetDistanceFrom(const XMFLOAT3& pos) const
 {
-    ASSERT_MSG(std::isfinite(pos.x) && std::isfinite(pos.y) && std::isfinite(pos.z),
-               "Invalid distance calculation position");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, std::isfinite(pos.x) && std::isfinite(pos.y) && std::isfinite(pos.z),
+                      "Invalid distance calculation position");
     float dx = m_position.x - pos.x;
     float dy = m_position.y - pos.y;
     float dz = m_position.z - pos.z;
@@ -227,7 +233,7 @@ void GameObject::CreateMesh()
         m_mesh = std::make_unique<Mesh>();
     }
     HRESULT hr = m_mesh->Initialize(m_device, m_context);
-    ASSERT_MSG(SUCCEEDED(hr), "Mesh initialization failed");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Mesh initialization failed");
     bool loaded = false;
     if (!m_modelPath.empty())
     {
@@ -244,10 +250,10 @@ void GameObject::CreateMesh()
         {
             hr = m_mesh->CreatePlane(2.0f, 2.0f);
         }
-        ASSERT_MSG(SUCCEEDED(hr), "Failed to create procedural mesh");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Failed to create procedural mesh");
     }
-    ASSERT_MSG(m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
-               "Mesh must have vertices and indices after loading/creation");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
+                      "Mesh must have vertices and indices after loading/creation");
     m_worldMatrixDirty = true;
     m_name = "GameObject_" + std::to_string(m_id);
 
@@ -258,9 +264,9 @@ void GameObject::CreateMesh()
         std::wcout << L"[DEBUG] Created " << meshCreateCount << L" GameObject meshes" << std::endl;
     }
 
-    ASSERT_MSG(!m_name.empty(), "GameObject name unexpected empty");
-    ASSERT_MSG(m_device != nullptr, "GameObject device is null");
-    ASSERT_MSG(m_context != nullptr, "GameObject context is null");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, !m_name.empty(), "GameObject name unexpected empty");
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, m_device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, m_context);
 }
 
 void GameObject::UpdateWorldMatrix()

--- a/SparkEngine/Source/Game/Model.cpp
+++ b/SparkEngine/Source/Game/Model.cpp
@@ -2,6 +2,7 @@
 #include "Model.h"
 #include "ModelVertex.h"
 #include "../Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include "../Graphics/GraphicsEngine.h"
 #include <tiny_obj_loader.h>
 #include <vector>
@@ -20,8 +21,9 @@ HRESULT Model::LoadObj(const std::wstring& filename, ID3D11Device* device)
     // ------------------------------------------------------------------
     //  Argument validation
     // ------------------------------------------------------------------
-    ASSERT_ALWAYS_MSG(!filename.empty(), "Model::LoadObj - filename is empty");
-    ASSERT_ALWAYS_MSG(device != nullptr, "Model::LoadObj - ID3D11Device is null");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, !filename.empty(), "Model::LoadObj - filename is empty");
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, device);
 
     // Convert UTF-16 filename to UTF-8 for tinyobjloader
     std::string fileUtf8(filename.begin(), filename.end());
@@ -39,7 +41,7 @@ HRESULT Model::LoadObj(const std::wstring& filename, ID3D11Device* device)
         OutputDebugStringA(("tinyobj error: " + warn + err + "\n").c_str());
         return E_FAIL;
     }
-    ASSERT_ALWAYS_MSG(!shapes.empty(), "OBJ file contains no shapes");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, !shapes.empty(), "OBJ file contains no shapes");
 
     // ------------------------------------------------------------------
     //  Build vertex / index arrays
@@ -76,7 +78,7 @@ HRESULT Model::LoadObj(const std::wstring& filename, ID3D11Device* device)
     }
 
     m_indexCount = static_cast<UINT>(idxs.size());
-    ASSERT_ALWAYS_MSG(m_indexCount > 0, "OBJ produced zero indices");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, m_indexCount > 0, "OBJ produced zero indices");
 
     // ------------------------------------------------------------------
     //  Create GPU buffers
@@ -92,7 +94,7 @@ HRESULT Model::LoadObj(const std::wstring& filename, ID3D11Device* device)
     sd.pSysMem = verts.data();
 
     HRESULT hr = device->CreateBuffer(&bd, &sd, &m_vb);
-    ASSERT_MSG(SUCCEEDED(hr), "Failed to create vertex buffer");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, SUCCEEDED(hr), "Failed to create vertex buffer");
     if (FAILED(hr))
         return hr;
 
@@ -102,14 +104,14 @@ HRESULT Model::LoadObj(const std::wstring& filename, ID3D11Device* device)
     sd.pSysMem = idxs.data();
 
     hr = device->CreateBuffer(&bd, &sd, &m_ib);
-    ASSERT_MSG(SUCCEEDED(hr), "Failed to create index buffer");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, SUCCEEDED(hr), "Failed to create index buffer");
     return hr;
 }
 
 void Model::Render(ID3D11DeviceContext* ctx, GraphicsEngine* graphics, const DirectX::XMMATRIX* world,
                    const DirectX::XMMATRIX* view, const DirectX::XMMATRIX* proj)
 {
-    ASSERT(ctx != nullptr);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, ctx);
 
     // **SAFETY CHECK: Don't render if model failed to load**
     if (m_vb == nullptr || m_ib == nullptr || m_indexCount == 0)

--- a/SparkEngine/Source/Game/Primitives.cpp
+++ b/SparkEngine/Source/Game/Primitives.cpp
@@ -2,6 +2,7 @@
 // Primitives.cpp
 #include "Primitives.h"
 #include "../Utils/Assert.h"
+#include "../Utils/Validate.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
 #endif // SPARK_PLATFORM_WINDOWS
@@ -12,7 +13,8 @@ using namespace DirectX;
 
 MeshData Primitives::CreateCube(float size)
 {
-    ASSERT_MSG(size > 0.0f, "Cube size must be positive");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, size > 0.0f, "Cube size must be positive");
 
     MeshData m;
     float h = size * 0.5f;
@@ -33,13 +35,15 @@ MeshData Primitives::CreateCube(float size)
         }
     }
 
-    ASSERT_ALWAYS_MSG(!m.vertices.empty() && !m.indices.empty(), "CreateCube produced empty mesh");
+    SPARK_ENSURE_MSG(Spark::LogCategory::Graphics, !m.vertices.empty() && !m.indices.empty(),
+                     "CreateCube produced empty mesh");
     return m;
 }
 
 MeshData Primitives::CreatePlane(float width, float depth)
 {
-    ASSERT_MSG(width > 0.0f && depth > 0.0f, "Plane dimensions must be positive");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, width > 0.0f && depth > 0.0f, "Plane dimensions must be positive");
 
     MeshData m;
     float hw = width * 0.5f, hd = depth * 0.5f;
@@ -53,14 +57,16 @@ MeshData Primitives::CreatePlane(float width, float depth)
         m.indices.push_back(static_cast<unsigned int>(m.indices.size()));
     }
 
-    ASSERT_ALWAYS_MSG(!m.vertices.empty() && !m.indices.empty(), "CreatePlane produced empty mesh");
+    SPARK_ENSURE_MSG(Spark::LogCategory::Graphics, !m.vertices.empty() && !m.indices.empty(),
+                     "CreatePlane produced empty mesh");
     return m;
 }
 
 MeshData Primitives::CreateSphere(float radius, int slices, int stacks)
 {
-    ASSERT_MSG(radius > 0.0f, "Sphere radius must be positive");
-    ASSERT_MSG(slices >= 3 && stacks >= 2, "Sphere slices/stacks must be >=3/2");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, radius > 0.0f, "Sphere radius must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, slices >= 3 && stacks >= 2, "Sphere slices/stacks must be >=3/2");
 
     MeshData m;
     for (int i = 0; i <= stacks; ++i)
@@ -90,6 +96,7 @@ MeshData Primitives::CreateSphere(float radius, int slices, int stacks)
         }
     }
 
-    ASSERT_ALWAYS_MSG(!m.vertices.empty() && !m.indices.empty(), "CreateSphere produced empty mesh");
+    SPARK_ENSURE_MSG(Spark::LogCategory::Graphics, !m.vertices.empty() && !m.indices.empty(),
+                     "CreateSphere produced empty mesh");
     return m;
 }

--- a/SparkEngine/Source/Graphics/AssetPipeline.cpp
+++ b/SparkEngine/Source/Graphics/AssetPipeline.cpp
@@ -9,6 +9,7 @@
 
 #include "AssetPipeline.h"
 #include "Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
 #include <iostream>
 #include <fstream>
@@ -535,7 +536,9 @@ AssetPipeline::~AssetPipeline()
 
 HRESULT AssetPipeline::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
-    ASSERT(device && context);
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, context);
 
     m_device = device;
     m_context = context;
@@ -549,12 +552,14 @@ HRESULT AssetPipeline::Initialize(ID3D11Device* device, ID3D11DeviceContext* con
     // Start loading threads
     SetStreamingThreadCount(2);
 
-    Spark::SimpleConsole::GetInstance().LogSuccess("AssetPipeline initialized successfully");
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "AssetPipeline initialized successfully");
     return S_OK;
 }
 
 void AssetPipeline::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "AssetPipeline shutting down");
     // Stop loading threads
     m_shouldStop = true;
     m_queueCondition.notify_all();
@@ -1267,6 +1272,7 @@ std::string LoadingPriorityToString(LoadingPriority priority)
 #else // !SPARK_PLATFORM_WINDOWS
 
 #include "AssetPipeline.h"
+#include "../Utils/Validate.h"
 #include <sstream>
 #include <algorithm>
 #include <filesystem>

--- a/SparkEngine/Source/Graphics/DecalSystem.cpp
+++ b/SparkEngine/Source/Graphics/DecalSystem.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "DecalSystem.h"
+#include "../Utils/Validate.h"
 #include <sstream>
 #include <cmath>
 #include <cstdlib>
@@ -70,6 +71,9 @@ namespace Spark::Graphics
 
     void DecalSystem::Initialize(uint32_t maxDecals)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_WARN_IF(Spark::LogCategory::Graphics, maxDecals == 0, "DecalSystem initialized with maxDecals=0");
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "DecalSystem initializing with maxDecals=%u", maxDecals);
         m_maxDecals = maxDecals;
         m_decals.reserve(maxDecals);
 
@@ -119,6 +123,9 @@ namespace Spark::Graphics
 
     void DecalSystem::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "DecalSystem shutting down (%u active decals)",
+                       GetActiveDecalCount());
         m_decals.clear();
         m_materials.clear();
         m_surfaceMappings.clear();
@@ -127,6 +134,7 @@ namespace Spark::Graphics
     Decal* DecalSystem::SpawnDecal(const XMFLOAT3& position, const XMFLOAT3& normal, DecalType type,
                                    SurfaceType surface, float size)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
         // Find appropriate material from surface mapping
         std::string materialName;
         XMFLOAT2 sizeRange = {0.05f, 0.2f};
@@ -208,12 +216,16 @@ namespace Spark::Graphics
 
     void DecalSystem::RegisterMaterial(const DecalMaterial& material)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Graphics, material.name);
+        SPARK_LOG_DEBUG(Spark::LogCategory::Graphics, "Registering decal material '%s'", material.name.c_str());
         m_materials[material.name] = material;
     }
 
     const DecalMaterial* DecalSystem::GetMaterial(const std::string& name) const
     {
         auto it = m_materials.find(name);
+        SPARK_WARN_IF(Spark::LogCategory::Graphics, it == m_materials.end() && !name.empty(),
+                      "Decal material not found");
         return (it != m_materials.end()) ? &it->second : nullptr;
     }
 
@@ -224,6 +236,7 @@ namespace Spark::Graphics
 
     void DecalSystem::ClearAllDecals()
     {
+        SPARK_LOG_DEBUG(Spark::LogCategory::Graphics, "Clearing all decals (%u active)", GetActiveDecalCount());
         for (auto& d : m_decals)
             d.active = false;
     }
@@ -317,6 +330,7 @@ namespace Spark::Graphics
 #else // !SPARK_PLATFORM_WINDOWS
 
 #include "DecalSystem.h"
+#include "../Utils/Validate.h"
 #include <sstream>
 #include <cmath>
 #include <cstdlib>

--- a/SparkEngine/Source/Graphics/GraphicsConsoleCommands.cpp
+++ b/SparkEngine/Source/Graphics/GraphicsConsoleCommands.cpp
@@ -11,6 +11,7 @@
 #include "GraphicsConsoleCommands.h"
 #include "GraphicsEngine.h"
 #include "../Utils/SparkConsole.h"
+#include "../Utils/Validate.h"
 #include <sstream>
 #include <string>
 #include <vector>
@@ -20,6 +21,8 @@ namespace Spark::Graphics
 
     void RegisterGraphicsConsoleCommands(GraphicsEngine& engine)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "Registering graphics console commands");
         auto& console = Spark::SimpleConsole::GetInstance();
 
         console.RegisterCommand(

--- a/SparkEngine/Source/Graphics/GraphicsEngine.cpp
+++ b/SparkEngine/Source/Graphics/GraphicsEngine.cpp
@@ -5,6 +5,7 @@
 #include "../Utils/Assert.h"
 #include "../Utils/SparkError.h"
 #include "../Utils/SparkConsole.h"
+#include "../Utils/Validate.h"
 
 // **CRITICAL FIX: Add missing system includes**
 #include "TextureSystem.h"
@@ -330,6 +331,8 @@ HRESULT GraphicsEngine::Initialize(Spark::NativeWindowHandle hWnd)
 
 void GraphicsEngine::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "GraphicsEngine::Shutdown — beginning graphics subsystem teardown");
     LOG_TO_CONSOLE_IMMEDIATE(L"GraphicsEngine::Shutdown called.", L"INFO");
 
     // Shutdown advanced systems
@@ -419,11 +422,11 @@ void GraphicsEngine::Shutdown()
 
 void GraphicsEngine::BeginFrame()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
     bool expected = false;
     if (!m_frameInProgress.compare_exchange_strong(expected, true))
     {
-        LOG_TO_CONSOLE_RATE_LIMITED(L"Warning: BeginFrame called while frame already in progress - skipping",
-                                    L"WARNING");
+        SPARK_LOG_WARN(Spark::LogCategory::Graphics, "BeginFrame called while frame already in progress — skipping");
         return;
     }
 
@@ -465,10 +468,11 @@ void GraphicsEngine::BeginFrame()
 
 void GraphicsEngine::EndFrame()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
     bool expected = true;
     if (!m_frameInProgress.compare_exchange_strong(expected, false))
     {
-        LOG_TO_CONSOLE_RATE_LIMITED(L"Warning: EndFrame called without matching BeginFrame - skipping", L"WARNING");
+        SPARK_LOG_WARN(Spark::LogCategory::Graphics, "EndFrame called without matching BeginFrame — skipping");
         return;
     }
 
@@ -541,6 +545,8 @@ void GraphicsEngine::EndFrame()
 void GraphicsEngine::SubmitMeshForRendering(const std::string& meshPath, const std::string& materialPath,
                                             const DirectX::XMMATRIX& worldMatrix, bool castShadows)
 {
+    SPARK_WARN_IF(Spark::LogCategory::Graphics, meshPath.empty(), "SubmitMeshForRendering: empty meshPath");
+    SPARK_WARN_IF(Spark::LogCategory::Graphics, materialPath.empty(), "SubmitMeshForRendering: empty materialPath");
     MeshDrawCommand cmd;
     cmd.meshPath = meshPath;
     cmd.materialPath = materialPath;
@@ -2924,6 +2930,7 @@ using Spark::Graphics::PostProcessingPipeline;
 #include "../Physics/PhysicsSystem.h"
 #include "../Game/GameObject.h"
 #include "RHI/RHI.h"
+#include "../Utils/Validate.h"
 #include <iostream>
 #include <sstream>
 #include <chrono>
@@ -3030,6 +3037,7 @@ HRESULT GraphicsEngine::Initialize(Spark::NativeWindowHandle hWnd)
 
 void GraphicsEngine::Shutdown()
 {
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "GraphicsEngine::Shutdown (RHI path) — beginning teardown");
     auto& rhi = GetRHI();
     if (!rhi.initialized)
         return;

--- a/SparkEngine/Source/Graphics/LightingSystem.cpp
+++ b/SparkEngine/Source/Graphics/LightingSystem.cpp
@@ -7,6 +7,7 @@
 
 #include "LightingSystem.h"
 #include "Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
 #include <sstream>
 #include <algorithm>
@@ -162,7 +163,9 @@ LightingSystem::~LightingSystem()
 
 HRESULT LightingSystem::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
-    ASSERT(device && context);
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, context);
 
     m_device = device;
     m_context = context;
@@ -171,7 +174,7 @@ HRESULT LightingSystem::Initialize(ID3D11Device* device, ID3D11DeviceContext* co
     HRESULT hr = CreateConstantBuffers();
     if (FAILED(hr))
     {
-        Spark::SimpleConsole::GetInstance().LogError("Failed to create constant buffers");
+        SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "Failed to create lighting constant buffers");
         return hr;
     }
 
@@ -179,15 +182,18 @@ HRESULT LightingSystem::Initialize(ID3D11Device* device, ID3D11DeviceContext* co
     hr = CreateDefaultEnvironment();
     if (FAILED(hr))
     {
-        Spark::SimpleConsole::GetInstance().LogWarning("Failed to create default environment");
+        SPARK_LOG_WARN(Spark::LogCategory::Graphics, "Failed to create default environment");
     }
 
-    Spark::SimpleConsole::GetInstance().LogSuccess("LightingSystem initialized successfully");
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "LightingSystem initialized with %zu lights", m_lights.size());
     return S_OK;
 }
 
 void LightingSystem::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "LightingSystem shutting down (%zu lights, %zu shadow maps)",
+                   m_lights.size(), m_shadowMaps.size());
     // Clear lights
     m_lights.clear();
     m_lightDataArray.clear();
@@ -217,6 +223,9 @@ void LightingSystem::Shutdown()
 
 void LightingSystem::Update(float deltaTime, const XMMATRIX& viewMatrix, const XMMATRIX& projMatrix)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_WARN_IF(Spark::LogCategory::Graphics, deltaTime < 0.0f,
+                  "LightingSystem::Update called with negative deltaTime");
     // Update metrics
     m_metrics.activeLights = static_cast<uint32_t>(m_lights.size());
     m_metrics.shadowCastingLights = 0;
@@ -533,6 +542,7 @@ LightingSystem::LightingMetrics LightingSystem::Console_GetMetrics() const
 
 std::shared_ptr<Light> LightingSystem::CreateLight(LightType type)
 {
+    SPARK_LOG_DEBUG(Spark::LogCategory::Graphics, "Creating light of type %d", static_cast<int>(type));
     auto light = std::make_shared<Light>(type);
     m_lights.push_back(light);
 
@@ -552,6 +562,7 @@ std::shared_ptr<Light> LightingSystem::CreateLight(LightType type)
 
 void LightingSystem::AddLight(std::shared_ptr<Light> light)
 {
+    SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, light);
     if (light)
     {
         m_lights.push_back(light);
@@ -570,6 +581,7 @@ void LightingSystem::AddLight(std::shared_ptr<Light> light)
 
 void LightingSystem::RemoveLight(std::shared_ptr<Light> light)
 {
+    SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, light);
     if (light)
     {
         // Remove shadow map
@@ -586,6 +598,7 @@ void LightingSystem::RemoveLight(std::shared_ptr<Light> light)
 
 void LightingSystem::RemoveAllLights()
 {
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "Removing all lights (%zu total)", m_lights.size());
     m_shadowMaps.clear();
     m_lights.clear();
 
@@ -1697,6 +1710,7 @@ ShadowTechnique StringToShadowTechnique(const std::string& str)
 #else // !SPARK_PLATFORM_WINDOWS
 
 #include "LightingSystem.h"
+#include "../Utils/Validate.h"
 #include <sstream>
 #include <algorithm>
 #include <cmath>
@@ -1819,15 +1833,19 @@ LightingSystem::~LightingSystem()
 
 HRESULT LightingSystem::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
     m_device = device;
     m_context = context;
     m_environmentLighting.skyColor = {0.5f, 0.7f, 1.0f};
     m_environmentLighting.skyIntensity = 1.0f;
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "LightingSystem (Linux) initialized");
     return S_OK;
 }
 
 void LightingSystem::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "LightingSystem (Linux) shutting down");
     m_lights.clear();
     m_lightDataArray.clear();
     m_shadowMaps.clear();

--- a/SparkEngine/Source/Graphics/MaterialSystem.cpp
+++ b/SparkEngine/Source/Graphics/MaterialSystem.cpp
@@ -9,6 +9,7 @@
 
 #include "MaterialSystem.h"
 #include "../Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
 #include "Utils/LocalFileCache.h"
 #include <iostream>
@@ -1384,20 +1385,29 @@ MaterialSystem::~MaterialSystem()
 
 HRESULT MaterialSystem::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
-    ASSERT(device && context);
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, context);
     m_device = device;
     m_context = context;
 
     HRESULT hr = CreateDefaultMaterials();
     if (SUCCEEDED(hr))
     {
-        Spark::SimpleConsole::GetInstance().Log("MaterialSystem initialized successfully", "SUCCESS");
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "MaterialSystem initialized successfully");
+    }
+    else
+    {
+        SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "MaterialSystem failed to create default materials");
     }
     return hr;
 }
 
 void MaterialSystem::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "MaterialSystem shutting down (%zu materials, %zu cached textures)",
+                   m_materials.size(), m_textureCache.size());
     m_materials.clear();
     m_textureCache.clear();
     m_samplerCache.clear();
@@ -1409,6 +1419,8 @@ void MaterialSystem::Shutdown()
 
 std::shared_ptr<Material> MaterialSystem::CreateMaterial(const std::string& name)
 {
+    SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Graphics, name);
+    SPARK_LOG_DEBUG(Spark::LogCategory::Graphics, "Creating material '%s'", name.c_str());
     auto material = std::make_shared<Material>(name);
     m_materials[name] = material;
     return material;
@@ -1416,6 +1428,8 @@ std::shared_ptr<Material> MaterialSystem::CreateMaterial(const std::string& name
 
 std::shared_ptr<Material> MaterialSystem::LoadMaterial(const std::string& filePath)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Graphics, filePath);
     // Check if already loaded
     auto it = m_materials.find(filePath);
     if (it != m_materials.end())
@@ -1434,21 +1448,25 @@ std::shared_ptr<Material> MaterialSystem::LoadMaterial(const std::string& filePa
             m_fileTimestamps[filePath] = GetFileTimestamp(filePath);
         }
 
+        SPARK_LOG_DEBUG(Spark::LogCategory::Graphics, "Loaded material from '%s'", filePath.c_str());
         return material;
     }
 
-    Spark::SimpleConsole::GetInstance().LogError("Failed to load material: " + filePath);
+    SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "Failed to load material: %s", filePath.c_str());
     return m_errorMaterial;
 }
 
 std::shared_ptr<Material> MaterialSystem::GetMaterial(const std::string& name) const
 {
     auto it = m_materials.find(name);
+    SPARK_WARN_IF(Spark::LogCategory::Graphics, it == m_materials.end() && !name.empty(),
+                  "Material not found, returning default");
     return (it != m_materials.end()) ? it->second : m_defaultMaterial;
 }
 
 void MaterialSystem::UnloadMaterial(const std::string& name)
 {
+    SPARK_LOG_DEBUG(Spark::LogCategory::Graphics, "Unloading material '%s'", name.c_str());
     auto it = m_materials.find(name);
     if (it != m_materials.end())
     {
@@ -1459,6 +1477,7 @@ void MaterialSystem::UnloadMaterial(const std::string& name)
 
 void MaterialSystem::UnloadAllMaterials()
 {
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "Unloading all materials (%zu total)", m_materials.size());
     m_materials.clear();
     m_fileTimestamps.clear();
 }
@@ -2961,6 +2980,7 @@ std::string MaterialSystem::Console_ListMaterialVariants(const std::string& mate
 
 #include "MaterialSystem.h"
 #include "RHI/RHI.h"
+#include "../Utils/Validate.h"
 #include <sstream>
 #include <algorithm>
 #include <cmath>
@@ -3452,6 +3472,7 @@ MaterialSystem::~MaterialSystem()
 
 HRESULT MaterialSystem::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
     m_device = device;
     m_context = context;
     memset(&m_metrics, 0, sizeof(m_metrics));
@@ -3460,11 +3481,15 @@ HRESULT MaterialSystem::Initialize(ID3D11Device* device, ID3D11DeviceContext* co
     CreateDefaultMaterials();
 
     UpdateMetrics();
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "MaterialSystem (Linux) initialized");
     return S_OK;
 }
 
 void MaterialSystem::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "MaterialSystem (Linux) shutting down (%zu materials)",
+                   m_materials.size());
     m_materials.clear();
     m_textureCache.clear();
     m_samplerCache.clear();

--- a/SparkEngine/Source/Graphics/MaterialSystem.cpp
+++ b/SparkEngine/Source/Graphics/MaterialSystem.cpp
@@ -1419,7 +1419,7 @@ void MaterialSystem::Shutdown()
 
 std::shared_ptr<Material> MaterialSystem::CreateMaterial(const std::string& name)
 {
-    SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Graphics, name);
+    SPARK_VALIDATE_RET(Spark::LogCategory::Graphics, !name.empty(), nullptr);
     SPARK_LOG_DEBUG(Spark::LogCategory::Graphics, "Creating material '%s'", name.c_str());
     auto material = std::make_shared<Material>(name);
     m_materials[name] = material;
@@ -1429,7 +1429,7 @@ std::shared_ptr<Material> MaterialSystem::CreateMaterial(const std::string& name
 std::shared_ptr<Material> MaterialSystem::LoadMaterial(const std::string& filePath)
 {
     SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
-    SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Graphics, filePath);
+    SPARK_VALIDATE_RET(Spark::LogCategory::Graphics, !filePath.empty(), nullptr);
     // Check if already loaded
     auto it = m_materials.find(filePath);
     if (it != m_materials.end())

--- a/SparkEngine/Source/Graphics/Mesh.cpp
+++ b/SparkEngine/Source/Graphics/Mesh.cpp
@@ -2,6 +2,7 @@
 // Mesh.cpp
 #include "Mesh.h"
 #include "Utils/Assert.h"
+#include "../Utils/Validate.h"
 //#include "Utils/Debug.h"
 #include <tiny_obj_loader.h>
 #ifdef SPARK_PLATFORM_WINDOWS
@@ -28,11 +29,12 @@ Mesh::~Mesh()
 
 HRESULT Mesh::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
-    std::wcout << L"[OPERATION] Mesh::Initialize called." << std::endl;
-    ASSERT(device && context);
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, context);
     m_device = device;
     m_context = context;
-    std::wcout << L"[INFO] Mesh initialized with device/context." << std::endl;
+    SPARK_LOG_DEBUG(Spark::LogCategory::Graphics, "Mesh initialized with device/context");
     return S_OK;
 }
 
@@ -59,8 +61,8 @@ void Mesh::Shutdown()
 
 bool Mesh::LoadFromFile(const std::wstring& path)
 {
-    std::wcout << L"[OPERATION] Mesh::LoadFromFile called. path=" << path << std::endl;
-    ASSERT_ALWAYS_MSG(!path.empty(), "Mesh::LoadFromFile – empty path");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, !path.empty(), "Mesh::LoadFromFile — empty path");
 
     // Convert wide path to UTF-8 for tinyobjloader
     auto u8path_u8 = std::filesystem::path(path).u8string(); // basic_string<char8_t>
@@ -172,9 +174,9 @@ bool Mesh::LoadFromFile(const std::wstring& path)
 
 HRESULT Mesh::CreateFromVertices(const std::vector<Vertex>& verts, const std::vector<unsigned int>& inds)
 {
-    std::wcout << L"[OPERATION] Mesh::CreateFromVertices called. verts=" << verts.size() << L" inds=" << inds.size()
-               << std::endl;
-    ASSERT(!verts.empty() && !inds.empty());
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, !verts.empty() && !inds.empty(),
+                      "CreateFromVertices — empty vertex or index data");
 
     m_vertices = verts;
     m_indices = inds;
@@ -187,8 +189,8 @@ HRESULT Mesh::CreateFromVertices(const std::vector<Vertex>& verts, const std::ve
 
 HRESULT Mesh::CreateCube(float size)
 {
-    std::wcout << L"[OPERATION] Mesh::CreateCube called. size=" << size << std::endl;
-    ASSERT(size > 0.0f);
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, size > 0.0f, "Cube size must be positive");
 
     // Clear existing data
     m_vertices.clear();
@@ -270,9 +272,8 @@ HRESULT Mesh::CreateCube(float size)
 
 HRESULT Mesh::CreateTriangle(float size)
 {
-    ASSERT(size > 0.0f);
-
-    std::wcout << L"[OPERATION] Mesh::CreateTriangle called. size=" << size << std::endl;
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, size > 0.0f, "Triangle size must be positive");
 
     std::vector<Vertex> vertices;
     std::vector<unsigned int> indices;
@@ -307,9 +308,8 @@ HRESULT Mesh::CreateTriangle(float size)
 
 HRESULT Mesh::CreatePlane(float width, float depth)
 {
-    ASSERT(width > 0.0f && depth > 0.0f);
-
-    std::wcout << L"[OPERATION] Mesh::CreatePlane called. width=" << width << L" depth=" << depth << std::endl;
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, width > 0.0f && depth > 0.0f, "Plane dimensions must be positive");
 
     MeshData md;
     float hw = width * 0.5f, hd = depth * 0.5f;
@@ -332,11 +332,10 @@ HRESULT Mesh::CreatePlane(float width, float depth)
 
 HRESULT Mesh::CreateSphere(float radius, int slices, int stacks)
 {
-    ASSERT(radius > 0.0f);
-    ASSERT(slices >= 3 && stacks >= 2);
-
-    std::wcout << L"[OPERATION] Mesh::CreateSphere called. radius=" << radius << L" slices=" << slices << L" stacks="
-               << stacks << std::endl;
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, radius > 0.0f, "Sphere radius must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, slices >= 3 && stacks >= 2,
+                      "Sphere needs at least 3 slices and 2 stacks");
 
     MeshData md;
     for (int i = 0; i <= stacks; ++i)
@@ -378,9 +377,9 @@ HRESULT Mesh::CreateSphere(float radius, int slices, int stacks)
 
 HRESULT Mesh::CreatePyramid(float size, float height)
 {
-    ASSERT(size > 0.0f && height > 0.0f);
-
-    std::wcout << L"[OPERATION] Mesh::CreatePyramid called. size=" << size << L" height=" << height << std::endl;
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, size > 0.0f && height > 0.0f,
+                      "Pyramid size and height must be positive");
 
     // Clear existing data
     m_vertices.clear();
@@ -535,8 +534,8 @@ HRESULT Mesh::CreateBuffers()
 
 void Mesh::Render(ID3D11DeviceContext* ctx)
 {
-    // **FIXED: Removed per-frame logging that was causing severe performance issues**
-    ASSERT(ctx && m_vb && m_ib && m_indexCount > 0);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, ctx && m_vb && m_ib && m_indexCount > 0,
+                      "Mesh::Render — invalid render state");
 
     UINT stride = sizeof(Vertex), offset = 0;
     ctx->IASetVertexBuffers(0, 1, &m_vb, &stride, &offset);
@@ -561,6 +560,7 @@ void Mesh::Render(ID3D11DeviceContext* ctx)
 // Linux implementation using RHI abstraction
 // ============================================================================
 #include "Mesh.h"
+#include "../Utils/Validate.h"
 #include <iostream>
 #include <cstring>
 #include <unordered_map>

--- a/SparkEngine/Source/Graphics/MeshLOD.cpp
+++ b/SparkEngine/Source/Graphics/MeshLOD.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "MeshLOD.h"
+#include "../Utils/Validate.h"
 #include <sstream>
 #include <algorithm>
 #include <cmath>
@@ -58,6 +59,11 @@ namespace Spark::Graphics
                                                   const uint32_t* indices, uint32_t indexCount,
                                                   uint32_t targetIndexCount, float maxError)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, vertices);
+        SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, indices);
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, vertexCount > 0, "Simplify called with 0 vertices");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, indexCount >= 3, "Simplify called with < 3 indices");
 
         SimplificationResult result;
 
@@ -199,6 +205,11 @@ namespace Spark::Graphics
                                           uint32_t vertexCount, const uint32_t* indices, uint32_t indexCount,
                                           const LODGenerationSettings& settings)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, vertices);
+        SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, indices);
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "Generating LOD chain for '%s' (%u verts, %u indices)",
+                       meshName.c_str(), vertexCount, indexCount);
         LODChain chain;
         chain.meshName = meshName;
         chain.totalVertices = 0;
@@ -328,6 +339,7 @@ namespace Spark::Graphics
 #else // !SPARK_PLATFORM_WINDOWS
 
 #include "MeshLOD.h"
+#include "../Utils/Validate.h"
 #include <sstream>
 #include <algorithm>
 #include <cmath>

--- a/SparkEngine/Source/Graphics/ParticleSystem.cpp
+++ b/SparkEngine/Source/Graphics/ParticleSystem.cpp
@@ -3,6 +3,7 @@
 // ParticleSystem.cpp
 #include "ParticleSystem.h"
 #include "Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include <algorithm>
 #include <random>
 #include <cmath>
@@ -388,16 +389,20 @@ ParticleSystem::~ParticleSystem()
 
 HRESULT ParticleSystem::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
-    ASSERT_MSG(device != nullptr, "ParticleSystem::Initialize device is null");
-    ASSERT_MSG(context != nullptr, "ParticleSystem::Initialize context is null");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, context);
 
     m_device = device;
     m_context = context;
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "ParticleSystem initialized");
     return S_OK;
 }
 
 void ParticleSystem::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "ParticleSystem shutting down (%zu emitters)", m_emitters.size());
     m_emitters.clear();
     m_device = nullptr;
     m_context = nullptr;
@@ -405,6 +410,9 @@ void ParticleSystem::Shutdown()
 
 void ParticleSystem::Update(float deltaTime)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_WARN_IF(Spark::LogCategory::Graphics, deltaTime < 0.0f,
+                  "ParticleSystem::Update called with negative deltaTime");
     // Update all emitters and remove dead one-shot emitters
     for (auto it = m_emitters.begin(); it != m_emitters.end();)
     {
@@ -652,6 +660,7 @@ void ParticleSystem::Console_SpawnEffect(const std::string& effectType, float x,
 #else // !SPARK_PLATFORM_WINDOWS
 
 #include "ParticleSystem.h"
+#include "../Utils/Validate.h"
 #include <algorithm>
 #include <random>
 #include <cmath>

--- a/SparkEngine/Source/Graphics/RHI/D3D11/D3D11Device.cpp
+++ b/SparkEngine/Source/Graphics/RHI/D3D11/D3D11Device.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "D3D11Device.h"
+#include "../../../Utils/Validate.h"
 #include <algorithm>
 #include <cassert>
 
@@ -495,6 +496,8 @@ namespace Spark
 
             bool D3D11Device::Initialize(const RHIDeviceDesc& desc)
             {
+                SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+                SPARK_LOG_INFO(Spark::LogCategory::Graphics, "D3D11Device::Initialize starting");
                 m_debugEnabled = desc.enableDebugLayer;
 
                 UINT createFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
@@ -556,6 +559,8 @@ namespace Spark
 
             void D3D11Device::Shutdown()
             {
+                SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+                SPARK_LOG_INFO(Spark::LogCategory::Graphics, "D3D11Device::Shutdown");
                 m_immediateCommandList.reset();
                 m_immediateContext.Reset();
                 m_dxgiFactory.Reset();

--- a/SparkEngine/Source/Graphics/RHI/D3D12/D3D12Device.cpp
+++ b/SparkEngine/Source/Graphics/RHI/D3D12/D3D12Device.cpp
@@ -14,6 +14,7 @@
 #include "D3D12Device.h"
 #include "../RHIFactory.h"
 #include "../../../Utils/LogMacros.h"
+#include "../../../Utils/Validate.h"
 
 #include <algorithm>
 #include <cassert>
@@ -573,6 +574,8 @@ namespace Spark
 
             bool D3D12Device::Initialize(const RHIDeviceDesc& desc)
             {
+                SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+                SPARK_LOG_INFO(Spark::LogCategory::Graphics, "D3D12Device::Initialize starting");
                 m_debugEnabled = desc.enableDebugLayer;
                 if (!CreateDevice(desc))
                     return false;
@@ -595,6 +598,8 @@ namespace Spark
 
             void D3D12Device::Shutdown()
             {
+                SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+                SPARK_LOG_INFO(Spark::LogCategory::Graphics, "D3D12Device::Shutdown");
                 WaitForIdle();
                 ProcessDeferredReleases();
                 m_immediateCommandList.reset();

--- a/SparkEngine/Source/Graphics/RHI/DXRSupport.cpp
+++ b/SparkEngine/Source/Graphics/RHI/DXRSupport.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "DXRSupport.h"
+#include "../../Utils/Validate.h"
 #include <sstream>
 #include <iostream>
 #include <cstring>
@@ -495,8 +496,11 @@ namespace Spark::Graphics
 
     bool DXRManager::Initialize(void* d3d12Device)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "DXRManager::Initialize starting");
         if (!d3d12Device)
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Graphics, "DXRManager::Initialize called with null device");
             m_isAvailable = false;
             m_isInitialized = false;
             return false;
@@ -591,6 +595,8 @@ namespace Spark::Graphics
 
     void DXRManager::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "DXRManager::Shutdown");
 #ifdef SPARK_PLATFORM_WINDOWS
         if (s_dxrState)
         {

--- a/SparkEngine/Source/Graphics/RHI/OpenGL/OpenGLDevice.cpp
+++ b/SparkEngine/Source/Graphics/RHI/OpenGL/OpenGLDevice.cpp
@@ -11,6 +11,7 @@
 #ifdef SPARK_OPENGL_SUPPORT
 
 #include "OpenGLDevice.h"
+#include "../../../Utils/Validate.h"
 #include <cassert>
 #include <cstring>
 #include <iostream>
@@ -644,6 +645,8 @@ namespace Spark
 
             bool GLDevice::Initialize(const RHIDeviceDesc& desc)
             {
+                SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+                SPARK_LOG_INFO(Spark::LogCategory::Graphics, "GLDevice::Initialize starting");
                 m_debugEnabled = desc.enableDebugLayer;
 
                 // GLAD must be loaded before any GL calls
@@ -668,6 +671,8 @@ namespace Spark
 
             void GLDevice::Shutdown()
             {
+                SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+                SPARK_LOG_INFO(Spark::LogCategory::Graphics, "GLDevice::Shutdown");
                 m_immediateCommandList.reset();
             }
 

--- a/SparkEngine/Source/Graphics/RHI/RHIAdapter.cpp
+++ b/SparkEngine/Source/Graphics/RHI/RHIAdapter.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "RHIAdapter.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <cassert>
@@ -27,7 +28,8 @@ namespace Spark::RHI
 
     bool RHIAdapter::Initialize(IRHIDevice* device)
     {
-        assert(device && "RHIAdapter::Initialize -- device must not be null");
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, device);
         if (!device)
         {
             return false;
@@ -40,6 +42,8 @@ namespace Spark::RHI
 
     void RHIAdapter::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "RHIAdapter::Shutdown");
         if (!m_device)
         {
             return;
@@ -87,8 +91,10 @@ namespace Spark::RHI
 
     void RHIAdapter::BeginFrame()
     {
-        assert(m_device && "RHIAdapter::BeginFrame -- not initialized");
-        assert(!m_frameActive && "RHIAdapter::BeginFrame -- frame already in progress");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, m_device != nullptr,
+                          "RHIAdapter::BeginFrame -- not initialized");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, !m_frameActive,
+                          "RHIAdapter::BeginFrame -- frame already in progress");
 
         m_device->BeginFrame();
         m_commandList = m_device->GetImmediateCommandList();
@@ -98,7 +104,7 @@ namespace Spark::RHI
 
     void RHIAdapter::EndFrame()
     {
-        assert(m_frameActive && "RHIAdapter::EndFrame -- no frame in progress");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, m_frameActive, "RHIAdapter::EndFrame -- no frame in progress");
 
         m_commandList->End();
         m_device->EndFrame();

--- a/SparkEngine/Source/Graphics/RHI/RHIBridge.cpp
+++ b/SparkEngine/Source/Graphics/RHI/RHIBridge.cpp
@@ -7,6 +7,7 @@
 
 #include "RHIBridge.h"
 #include "RHIFactory.h"
+#include "../../Utils/Validate.h"
 #include <cassert>
 #include <fstream>
 #include <algorithm>
@@ -137,6 +138,8 @@ namespace Spark
         bool RHIBridge::Initialize(void* windowHandle, uint32_t width, uint32_t height, GraphicsBackend backend,
                                    bool enableDebug)
         {
+            SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+            SPARK_LOG_INFO(Spark::LogCategory::Graphics, "RHIBridge::Initialize %ux%u", width, height);
             if (m_initialized)
                 Shutdown();
 
@@ -199,6 +202,8 @@ namespace Spark
 
         void RHIBridge::Shutdown()
         {
+            SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+            SPARK_LOG_INFO(Spark::LogCategory::Graphics, "RHIBridge::Shutdown");
             if (!m_initialized)
                 return;
 

--- a/SparkEngine/Source/Graphics/RHI/RHIFactory.cpp
+++ b/SparkEngine/Source/Graphics/RHI/RHIFactory.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "RHIFactory.h"
+#include "../../Utils/Validate.h"
 #include <iostream>
 #include <fstream>
 #include <algorithm>
@@ -82,6 +83,7 @@ namespace Spark
 
         std::unique_ptr<IRHIDevice> CreateDevice(GraphicsBackend backend)
         {
+            SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
             if (backend == GraphicsBackend::Auto)
                 backend = GetRecommendedBackend();
 

--- a/SparkEngine/Source/Graphics/RHI/Vulkan/VulkanDevice.cpp
+++ b/SparkEngine/Source/Graphics/RHI/Vulkan/VulkanDevice.cpp
@@ -12,6 +12,7 @@
 #ifdef SPARK_VULKAN_SUPPORT
 
 #include "VulkanDevice.h"
+#include "../../../Utils/Validate.h"
 #include <algorithm>
 #include <cassert>
 #include <cstring>
@@ -685,6 +686,8 @@ namespace Spark
 
             bool VulkanDevice::Initialize(const RHIDeviceDesc& desc)
             {
+                SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+                SPARK_LOG_INFO(Spark::LogCategory::Graphics, "VulkanDevice::Initialize starting");
                 m_validationEnabled = desc.enableDebugLayer;
 
                 if (!CreateInstance(desc))
@@ -1063,6 +1066,8 @@ namespace Spark
 
             void VulkanDevice::Shutdown()
             {
+                SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+                SPARK_LOG_INFO(Spark::LogCategory::Graphics, "VulkanDevice::Shutdown");
                 if (m_device != VK_NULL_HANDLE)
                     vkDeviceWaitIdle(m_device);
 

--- a/SparkEngine/Source/Graphics/RenderDevice.cpp
+++ b/SparkEngine/Source/Graphics/RenderDevice.cpp
@@ -4,6 +4,7 @@
 #include "RenderDevice.h"
 #include "RHI/RHIFactory.h"
 #include "../Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include <d3d11.h>
 
 namespace Spark::Graphics
@@ -17,8 +18,12 @@ namespace Spark::Graphics
     bool RenderDevice::Initialize(Spark::NativeWindowHandle hwnd, uint32_t width, uint32_t height, bool fullscreen,
                                   RHI::GraphicsBackend backend)
     {
-        ASSERT_MSG(hwnd != nullptr, "RenderDevice::Initialize — null window handle");
-        ASSERT_MSG(width > 0 && height > 0, "RenderDevice::Initialize — width and height must be positive");
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, hwnd);
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, width > 0 && height > 0,
+                          "RenderDevice::Initialize — width and height must be positive");
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "RenderDevice initializing (%ux%u, fullscreen=%d)", width, height,
+                       fullscreen);
 
         m_width = width;
         m_height = height;
@@ -55,6 +60,8 @@ namespace Spark::Graphics
 
     void RenderDevice::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "RenderDevice shutting down");
 #ifdef SPARK_PLATFORM_WINDOWS
         m_backBufferRTV.Reset();
         m_depthStencilView.Reset();

--- a/SparkEngine/Source/Graphics/RenderGraph/RenderGraphBuilder.cpp
+++ b/SparkEngine/Source/Graphics/RenderGraph/RenderGraphBuilder.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "RenderGraphBuilder.h"
+#include "../../Utils/Validate.h"
 
 #include <cassert>
 #include <sstream>
@@ -89,6 +90,7 @@ namespace Spark::Graphics
 
     void StandardPipelineBuilder::Build(RenderGraph& graph)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
         // Passes are added in dependency order.  The RenderGraph compiler
         // will verify and reorder if needed, but adding them in the natural
         // order makes the setup lambdas straightforward.

--- a/SparkEngine/Source/Graphics/RenderPipeline.cpp
+++ b/SparkEngine/Source/Graphics/RenderPipeline.cpp
@@ -2,6 +2,7 @@
 #ifdef SPARK_PLATFORM_WINDOWS
 
 #include "RenderPipeline.h"
+#include "../Utils/Validate.h"
 #include <algorithm>
 
 namespace Spark::Graphics
@@ -9,14 +10,20 @@ namespace Spark::Graphics
 
     bool RenderPipeline::Initialize(RenderDevice* device)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, device, false);
         m_device = device;
         m_renderGraph = std::make_unique<RenderGraph>("MainPipeline");
         BuildDefaultPasses();
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "RenderPipeline initialized with %zu default passes",
+                       m_passes.size());
         return true;
     }
 
     void RenderPipeline::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "RenderPipeline shutting down (%zu passes)", m_passes.size());
         m_passes.clear();
         m_renderGraph.reset();
         m_device = nullptr;
@@ -25,7 +32,9 @@ namespace Spark::Graphics
     void RenderPipeline::ExecuteFrame(const DirectX::XMMATRIX& viewMatrix, const DirectX::XMMATRIX& projMatrix,
                                       const DirectX::XMFLOAT3& cameraPos)
     {
-        if (!m_device || !m_renderGraph)
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_device);
+        if (!m_renderGraph)
             return;
 
         // Sort passes if registrations changed
@@ -55,6 +64,8 @@ namespace Spark::Graphics
 
     void RenderPipeline::RegisterPass(const std::string& name, PassPhase phase, PassSetupFn setupFn)
     {
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Graphics, name);
+        SPARK_LOG_DEBUG(Spark::LogCategory::Graphics, "Registering render pass '%s'", name.c_str());
         // Remove existing pass with same name
         RemovePass(name);
 

--- a/SparkEngine/Source/Graphics/RenderTarget.cpp
+++ b/SparkEngine/Source/Graphics/RenderTarget.cpp
@@ -9,6 +9,7 @@
 
 #include "RenderTarget.h"
 #include "Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
 
 #ifdef SPARK_PLATFORM_WINDOWS
@@ -26,7 +27,10 @@ RenderTarget::~RenderTarget()
 
 HRESULT RenderTarget::Create(ID3D11Device* device)
 {
-    ASSERT(device);
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, device);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, m_desc.width > 0 && m_desc.height > 0,
+                      "RenderTarget dimensions must be positive");
 
     DXGI_FORMAT dxgiFormat = GetDXGIFormat(m_desc.format);
 
@@ -1013,6 +1017,7 @@ RenderTargetFormat RenderTargetManager::StringToFormat(const std::string& str) c
 #else // !SPARK_PLATFORM_WINDOWS
 
 #include "RenderTarget.h"
+#include "../Utils/Validate.h"
 #include <sstream>
 #include <cmath>
 #include <cstring>

--- a/SparkEngine/Source/Graphics/SceneRenderer.cpp
+++ b/SparkEngine/Source/Graphics/SceneRenderer.cpp
@@ -2,6 +2,7 @@
 #ifdef SPARK_PLATFORM_WINDOWS
 
 #include "SceneRenderer.h"
+#include "../Utils/Validate.h"
 #include <algorithm>
 
 namespace Spark::Graphics
@@ -11,6 +12,10 @@ namespace Spark::Graphics
 
     bool SceneRenderer::Initialize(uint32_t maxDrawCommands)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Graphics, maxDrawCommands > 0, false);
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "SceneRenderer initializing with maxDrawCommands=%u",
+                       maxDrawCommands);
         m_maxDrawCommands = maxDrawCommands;
         m_drawCommands.reserve(maxDrawCommands);
         m_visibleCommands.reserve(maxDrawCommands);
@@ -19,6 +24,9 @@ namespace Spark::Graphics
 
     void SceneRenderer::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "SceneRenderer shutting down (%zu draw commands in flight)",
+                       m_drawCommands.size());
         m_drawCommands.clear();
         m_visibleCommands.clear();
         m_pathLookup.clear();

--- a/SparkEngine/Source/Graphics/Shader.cpp
+++ b/SparkEngine/Source/Graphics/Shader.cpp
@@ -3,6 +3,7 @@
 // Shader.cpp - Enhanced shader system implementation with AAA features (C++14 compatible)
 #include "Shader.h"
 #include "Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <d3dcompiler.h>
@@ -108,9 +109,9 @@ Shader::~Shader()
 
 HRESULT Shader::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
-    LOG_TO_CONSOLE_IMMEDIATE(L"Enhanced Shader::Initialize started with AAA features.", L"INFO");
-    ASSERT_MSG(device != nullptr, "Shader::Initialize device is null");
-    ASSERT_MSG(context != nullptr, "Shader::Initialize context is null");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, context);
 
     m_device = device;
     m_context = context;
@@ -118,8 +119,8 @@ HRESULT Shader::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
     HRESULT hr = CreateConstantBuffers();
     if (FAILED(hr))
     {
-        std::wstring errorMsg = L"Enhanced Shader constant buffer creation failed with HR=0x" + std::to_wstring(hr);
-        LOG_TO_CONSOLE_IMMEDIATE(errorMsg, L"ERROR");
+        SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "Shader constant buffer creation failed with HR=0x%08lX",
+                        static_cast<long>(hr));
         return hr;
     }
 
@@ -127,13 +128,15 @@ HRESULT Shader::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
     m_vertexShader = std::unique_ptr<VertexShaderResource>(new VertexShaderResource());
     m_pixelShader = std::unique_ptr<PixelShaderResource>(new PixelShaderResource());
 
-    LOG_TO_CONSOLE_IMMEDIATE(L"Enhanced Shader system initialized with comprehensive features.", L"SUCCESS");
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "Shader system initialized");
     return S_OK;
 }
 
 void Shader::Shutdown()
 {
-    LOG_TO_CONSOLE_IMMEDIATE(L"Enhanced Shader::Shutdown called.", L"INFO");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "Shader system shutting down (%zu cached, %zu variants)",
+                   m_shaderCache.size(), m_shaderVariants.size());
 
     // Clear shader cache
     m_shaderCache.clear();
@@ -157,12 +160,11 @@ void Shader::Shutdown()
 
 HRESULT Shader::LoadVertexShader(const std::wstring& filename, const ShaderCompilationFlags& flags)
 {
-    LOG_TO_CONSOLE_IMMEDIATE(std::wstring(L"Loading enhanced vertex shader: ") + filename, L"INFO");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, !filename.empty(), "LoadVertexShader: filename empty");
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, m_device);
 
     auto startTime = std::chrono::high_resolution_clock::now();
-
-    ASSERT_MSG(!filename.empty(), "LoadVertexShader: filename empty");
-    ASSERT_MSG(m_device != nullptr, "LoadVertexShader: device is null");
 
     ComPtr<ID3DBlob> vsBlob;
 
@@ -1292,6 +1294,7 @@ bool Shader::CompileWithRHI(const std::string& sourceFile, ShaderType type, int 
 
 #include "Shader.h"
 #include "RHI/RHIFactory.h"
+#include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
 #include "Utils/LocalFileCache.h"
 #include <iostream>

--- a/SparkEngine/Source/Graphics/TextureSystem.cpp
+++ b/SparkEngine/Source/Graphics/TextureSystem.cpp
@@ -7,6 +7,7 @@
 
 #include "TextureSystem.h"
 #include "Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <d3d11.h>
@@ -384,8 +385,9 @@ TextureSystem::~TextureSystem()
 
 HRESULT TextureSystem::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
-    ASSERT_NOT_NULL(device);
-    ASSERT_NOT_NULL(context);
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, context);
 
     m_device = device;
     m_context = context;
@@ -397,19 +399,21 @@ HRESULT TextureSystem::Initialize(ID3D11Device* device, ID3D11DeviceContext* con
     HRESULT hr = CreateDefaultTextures();
     if (FAILED(hr))
     {
-        Spark::SimpleConsole::GetInstance().LogError("Failed to create default textures");
+        SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "Failed to create default textures");
         return hr;
     }
 
     // Start streaming threads
     SetStreamingThreadCount(2);
 
-    Spark::SimpleConsole::GetInstance().LogSuccess("TextureSystem initialized successfully");
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "TextureSystem initialized successfully");
     return S_OK;
 }
 
 void TextureSystem::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "TextureSystem shutting down");
     // Stop streaming threads
     m_shouldStop = true;
     m_streamingCondition.notify_all();
@@ -436,7 +440,7 @@ void TextureSystem::Shutdown()
     m_device = nullptr;
     m_context = nullptr;
 
-    Spark::SimpleConsole::GetInstance().LogInfo("TextureSystem shutdown complete");
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "TextureSystem shutdown complete");
 }
 
 void TextureSystem::Update(float deltaTime)
@@ -1127,6 +1131,7 @@ uint32_t GetFormatBytesPerPixel(TextureFormat format)
 #else // !SPARK_PLATFORM_WINDOWS
 
 #include "TextureSystem.h"
+#include "../Utils/Validate.h"
 #include <sstream>
 #include <algorithm>
 #include <filesystem>

--- a/SparkEngine/Source/Graphics/UpscalingSystem.cpp
+++ b/SparkEngine/Source/Graphics/UpscalingSystem.cpp
@@ -18,6 +18,7 @@
 
 #include "../Core/Platform.h"
 #include "UpscalingSystem.h"
+#include "../Utils/Validate.h"
 
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <d3d11.h>
@@ -795,6 +796,11 @@ namespace Spark
             bool CompileComputeShader(ID3D11Device* device, const char* hlslSource, const char* entryPoint,
                                       ID3D11ComputeShader** outShader)
             {
+                SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+                SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, device, false);
+                SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, hlslSource, false);
+                SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, entryPoint, false);
+                SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, outShader, false);
                 if (!device || !hlslSource || !entryPoint || !outShader)
                 {
                     return false;
@@ -838,6 +844,10 @@ namespace Spark
  */
             bool CreateFSR1Shaders(ID3D11Device* device, ID3D11ComputeShader** outEASU, ID3D11ComputeShader** outRCAS)
             {
+                SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+                SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, device, false);
+                SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, outEASU, false);
+                SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, outRCAS, false);
                 if (!device || !outEASU || !outRCAS)
                 {
                     return false;

--- a/SparkEngine/Source/Input/GamepadInput.cpp
+++ b/SparkEngine/Source/Input/GamepadInput.cpp
@@ -1,6 +1,7 @@
 #include "Core/Platform.h"
 // GamepadInput.cpp
 #include "GamepadInput.h"
+#include "../Utils/Validate.h"
 #include <sstream>
 #include <cmath>
 #include <algorithm>
@@ -14,6 +15,7 @@ GamepadInput::~GamepadInput()
 
 void GamepadInput::Update(float deltaTime)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Input);
     m_connectionPollTimer += deltaTime;
 
     for (int i = 0; i < MAX_CONTROLLERS; ++i)
@@ -182,6 +184,8 @@ bool GamepadInput::IsTriggerDown(GamepadTrigger trigger, float threshold, int co
 
 void GamepadInput::SetVibration(float leftMotor, float rightMotor, float duration, int controllerIndex)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+    SPARK_VALIDATE_RANGE(Spark::LogCategory::Input, controllerIndex, 0, MAX_CONTROLLERS - 1);
     if (controllerIndex < 0 || controllerIndex >= MAX_CONTROLLERS)
         return;
 
@@ -198,6 +202,8 @@ void GamepadInput::SetVibration(float leftMotor, float rightMotor, float duratio
 
 void GamepadInput::StopVibration(int controllerIndex)
 {
+    SPARK_WARN_IF(Spark::LogCategory::Input, controllerIndex < 0 || controllerIndex >= MAX_CONTROLLERS,
+                  "StopVibration called with out-of-range controller index");
     if (controllerIndex < 0 || controllerIndex >= MAX_CONTROLLERS)
         return;
 
@@ -212,6 +218,7 @@ void GamepadInput::StopVibration(int controllerIndex)
 
 void GamepadInput::StopAllVibrations()
 {
+    SPARK_LOG_INFO(Spark::LogCategory::Input, "Stopping all gamepad vibrations");
     for (int i = 0; i < MAX_CONTROLLERS; ++i)
         StopVibration(i);
 }
@@ -222,6 +229,9 @@ void GamepadInput::StopAllVibrations()
 
 void GamepadInput::SetDeadZone(GamepadStick stick, float deadZone)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+    SPARK_WARN_IF(Spark::LogCategory::Input, deadZone < 0.0f || deadZone > 1.0f,
+                  "Dead zone value out of [0,1] range, will be clamped");
     deadZone = std::clamp(deadZone, 0.0f, 1.0f);
     if (stick == GamepadStick::Left)
         m_leftStickDeadZone = deadZone;
@@ -240,6 +250,8 @@ float GamepadInput::GetDeadZone(GamepadStick stick) const
 
 void GamepadInput::BindAction(const std::string& action, GamepadButton button)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+    SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Input, action);
     ActionBinding binding;
     binding.type = ActionBinding::Type::Button;
     binding.button = button;
@@ -250,6 +262,8 @@ void GamepadInput::BindAction(const std::string& action, GamepadButton button)
 
 void GamepadInput::BindAction(const std::string& action, GamepadTrigger trigger, float threshold)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+    SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Input, action);
     ActionBinding binding;
     binding.type = ActionBinding::Type::Trigger;
     binding.button = GamepadButton::A;

--- a/SparkEngine/Source/Input/InputBindings.cpp
+++ b/SparkEngine/Source/Input/InputBindings.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "InputBindings.h"
+#include "../Utils/Validate.h"
 
 #include <fstream>
 #include <sstream>
@@ -19,11 +20,14 @@ namespace Spark
 
     InputBindingManager::InputBindingManager()
     {
+        SPARK_LOG_INFO(Spark::LogCategory::Input, "InputBindingManager initializing");
         CreateDefaultPresets();
     }
 
     void InputBindingManager::SetBinding(const std::string& action, const InputBinding& binding)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Input, action);
         m_bindings[action] = binding;
         for (const auto& callback : m_bindingChangedCallbacks)
         {
@@ -43,6 +47,8 @@ namespace Spark
 
     void InputBindingManager::RemoveBinding(const std::string& action)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+        SPARK_WARN_IF(Spark::LogCategory::Input, action.empty(), "RemoveBinding called with empty action name");
         m_bindings.erase(action);
     }
 
@@ -81,6 +87,8 @@ namespace Spark
 
     bool InputBindingManager::ApplyPreset(const std::string& presetName)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Input, !presetName.empty(), false);
         for (const auto& preset : m_presets)
         {
             if (preset.name == presetName)
@@ -147,9 +155,12 @@ namespace Spark
 
     bool InputBindingManager::SaveToFile(const std::string& filePath) const
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Input, !filePath.empty(), false);
         std::ofstream file(filePath);
         if (!file.is_open())
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Input, "Failed to open file for saving bindings: %s", filePath.c_str());
             return false;
         }
 
@@ -176,9 +187,12 @@ namespace Spark
 
     bool InputBindingManager::LoadFromFile(const std::string& filePath)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+        SPARK_VALIDATE_RET(Spark::LogCategory::Input, !filePath.empty(), false);
         std::ifstream file(filePath);
         if (!file.is_open())
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Input, "Failed to open file for loading bindings: %s", filePath.c_str());
             return false;
         }
 
@@ -214,6 +228,7 @@ namespace Spark
 
     void InputBindingManager::OnBindingChanged(std::function<void(const std::string&, const InputBinding&)> callback)
     {
+        SPARK_WARN_IF(Spark::LogCategory::Input, !callback, "OnBindingChanged called with null callback");
         m_bindingChangedCallbacks.push_back(std::move(callback));
     }
 

--- a/SparkEngine/Source/Input/InputManager.cpp
+++ b/SparkEngine/Source/Input/InputManager.cpp
@@ -3,6 +3,7 @@
 #ifdef SPARK_PLATFORM_WINDOWS
 #include "InputManager.h"
 #include "Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
 #include <Windows.h>
 #include <windowsx.h> // GET_X_LPARAM, GET_Y_LPARAM
@@ -28,11 +29,13 @@ InputManager::InputManager()
     // Reserve space for recent events
     m_recentInputEvents.reserve(100);
 
+    SPARK_LOG_INFO(Spark::LogCategory::Input, "InputManager constructed (Windows)");
     Spark::SimpleConsole::GetInstance().Log("InputManager constructed with console integration.", "INFO");
 }
 
 InputManager::~InputManager()
 {
+    SPARK_LOG_INFO(Spark::LogCategory::Input, "InputManager shutting down");
     Spark::SimpleConsole::GetInstance().Log("InputManager destructor called.", "INFO");
     if (m_mouseCaptured)
         CaptureMouse(false);
@@ -50,7 +53,8 @@ InputManager::~InputManager()
 
 void InputManager::Initialize(HWND hwnd)
 {
-    ASSERT_MSG(hwnd != nullptr, "InputManager::Initialize - hwnd is null");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Input, hwnd);
     m_hwnd = hwnd;
 
     RECT rect;
@@ -62,6 +66,7 @@ void InputManager::Initialize(HWND hwnd)
     m_mouseX = m_prevMouseX = center.x;
     m_mouseY = m_prevMouseY = center.y;
 
+    SPARK_LOG_INFO(Spark::LogCategory::Input, "InputManager initialized (Windows)");
     Spark::SimpleConsole::GetInstance().Log("InputManager initialized with console integration.", "SUCCESS");
 }
 
@@ -75,7 +80,7 @@ void InputManager::Update()
         firstFrame = false;
     }
 
-    ASSERT_MSG(m_hwnd != nullptr, "InputManager::Update - hwnd not initialized");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, m_hwnd != nullptr, "InputManager::Update - hwnd not initialized");
 
     m_prevKeyStates = m_keyStates;
     memcpy(m_prevMouseButtons, m_mouseButtons, sizeof(m_mouseButtons));
@@ -193,7 +198,7 @@ void InputManager::HandleMessage(UINT message, WPARAM wParam, LPARAM lParam)
 
 bool InputManager::IsKeyDown(int key) const
 {
-    ASSERT_MSG(key >= 0, "IsKeyDown - invalid key code");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, key >= 0, "IsKeyDown - invalid key code");
     auto it = m_keyStates.find(key);
     return it != m_keyStates.end() && it->second;
 }
@@ -205,7 +210,7 @@ bool InputManager::IsKeyUp(int key) const
 
 bool InputManager::WasKeyPressed(int key) const
 {
-    ASSERT_MSG(key >= 0, "WasKeyPressed - invalid key code");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, key >= 0, "WasKeyPressed - invalid key code");
     bool curr = IsKeyDown(key);
     bool prev = m_prevKeyStates.count(key) ? m_prevKeyStates.at(key) : false;
     return curr && !prev;
@@ -213,7 +218,7 @@ bool InputManager::WasKeyPressed(int key) const
 
 bool InputManager::WasKeyReleased(int key) const
 {
-    ASSERT_MSG(key >= 0, "WasKeyReleased - invalid key code");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, key >= 0, "WasKeyReleased - invalid key code");
     bool curr = IsKeyDown(key);
     bool prev = m_prevKeyStates.count(key) ? m_prevKeyStates.at(key) : false;
     return !curr && prev;
@@ -221,19 +226,19 @@ bool InputManager::WasKeyReleased(int key) const
 
 bool InputManager::IsMouseButtonDown(int button) const
 {
-    ASSERT_MSG(button >= 0 && button < 3, "IsMouseButtonDown - invalid button");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, button >= 0 && button < 3, "IsMouseButtonDown - invalid button");
     return m_mouseButtons[button];
 }
 
 bool InputManager::WasMouseButtonPressed(int button) const
 {
-    ASSERT_MSG(button >= 0 && button < 3, "WasMouseButtonPressed - invalid button");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, button >= 0 && button < 3, "WasMouseButtonPressed - invalid button");
     return m_mouseButtons[button] && !m_prevMouseButtons[button];
 }
 
 bool InputManager::WasMouseButtonReleased(int button) const
 {
-    ASSERT_MSG(button >= 0 && button < 3, "WasMouseButtonReleased - invalid button");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, button >= 0 && button < 3, "WasMouseButtonReleased - invalid button");
     return !m_mouseButtons[button] && m_prevMouseButtons[button];
 }
 
@@ -628,7 +633,7 @@ void InputManager::Console_RefreshInput()
 
 void InputManager::UpdateKeyState(int key, bool isDown)
 {
-    ASSERT_MSG(key >= 0, "UpdateKeyState - invalid key code");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, key >= 0, "UpdateKeyState - invalid key code");
     m_keyStates[key] = isDown;
     if (key == VK_ESCAPE && !isDown && m_mouseCaptured)
         CaptureMouse(false);
@@ -636,7 +641,7 @@ void InputManager::UpdateKeyState(int key, bool isDown)
 
 void InputManager::UpdateMouseButton(int button, bool isDown)
 {
-    ASSERT_MSG(button >= 0 && button < 3, "UpdateMouseButton - invalid button");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, button >= 0 && button < 3, "UpdateMouseButton - invalid button");
     m_mouseButtons[button] = isDown;
 }
 
@@ -800,6 +805,7 @@ InputManager::InputMetrics InputManager::GetMetricsThreadSafe() const
 
 #include "InputManager.h"
 #include "Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
 #include <cstring>
 #include <cmath>
@@ -819,10 +825,12 @@ InputManager::InputManager()
     memset(m_mouseButtons, 0, sizeof(m_mouseButtons));
     memset(m_prevMouseButtons, 0, sizeof(m_prevMouseButtons));
     m_recentInputEvents.reserve(100);
+    SPARK_LOG_INFO(Spark::LogCategory::Input, "InputManager constructed (Linux/macOS)");
 }
 
 InputManager::~InputManager()
 {
+    SPARK_LOG_INFO(Spark::LogCategory::Input, "InputManager shutting down");
     for (auto& t : m_pendingTimedThreads)
     {
         if (t.joinable())
@@ -833,7 +841,9 @@ InputManager::~InputManager()
 
 void InputManager::Initialize(HWND hwnd)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Input);
     m_hwnd = hwnd;
+    SPARK_LOG_INFO(Spark::LogCategory::Input, "InputManager initialized (Linux/SDL2 backend)");
     Spark::SimpleConsole::GetInstance().Log("InputManager initialized (Linux/SDL2 backend).", "INFO");
 }
 
@@ -951,6 +961,7 @@ void InputManager::CaptureMouse(bool capture)
 
 void InputManager::UpdateKeyState(int key, bool isDown)
 {
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, key >= 0, "UpdateKeyState - invalid key code");
     m_keyStates[key] = isDown;
     if (isDown)
         ++m_keyPressCount;
@@ -961,6 +972,7 @@ void InputManager::UpdateKeyState(int key, bool isDown)
 
 void InputManager::UpdateMouseButton(int button, bool isDown)
 {
+    SPARK_WARN_IF(Spark::LogCategory::Input, button < 0 || button >= 3, "UpdateMouseButton - invalid button index");
     if (button >= 0 && button < 3)
     {
         m_mouseButtons[button] = isDown;

--- a/SparkEngine/Source/Input/PlatformInput.cpp
+++ b/SparkEngine/Source/Input/PlatformInput.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "PlatformInput.h"
+#include "../Utils/Validate.h"
 #include <sstream>
 #include <algorithm>
 #include <cmath>
@@ -118,14 +119,18 @@ namespace Spark::Input
 
     bool Win32InputBackend::Initialize(void* windowHandle)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Input, windowHandle, false);
         m_windowHandle = windowHandle;
         m_keyStates.fill(false);
         m_prevKeyStates.fill(false);
+        SPARK_LOG_INFO(Spark::LogCategory::Input, "Win32InputBackend initialized");
         return true;
     }
 
     void Win32InputBackend::Shutdown()
     {
+        SPARK_LOG_INFO(Spark::LogCategory::Input, "Win32InputBackend shutting down");
         if (m_mouseCaptured)
         {
             SetMouseCapture(false);
@@ -134,6 +139,7 @@ namespace Spark::Input
 
     void Win32InputBackend::PollEvents()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
         // Save previous states
         m_prevKeyStates = m_keyStates;
         for (auto& gp : m_gamepads)
@@ -452,8 +458,10 @@ namespace Spark::Input
 
     bool SDL2InputBackend::Initialize(void* windowHandle)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
         if (SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC) < 0)
         {
+            SPARK_LOG_ERROR(Spark::LogCategory::Input, "SDL2 initialization failed");
             return false;
         }
         m_window = windowHandle;
@@ -479,6 +487,7 @@ namespace Spark::Input
 
     void SDL2InputBackend::Shutdown()
     {
+        SPARK_LOG_INFO(Spark::LogCategory::Input, "SDL2InputBackend shutting down");
         for (int i = 0; i < MAX_GAMEPADS; ++i)
         {
             if (m_sdlControllers[i])
@@ -780,6 +789,8 @@ namespace Spark::Input
 
     bool PlatformInputManager::Initialize(void* windowHandle, const std::string& preferredBackend)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Input, windowHandle, false);
 #ifdef SPARK_SDL2_AVAILABLE
         if (preferredBackend == "sdl2" || preferredBackend == "SDL2")
         {
@@ -808,6 +819,7 @@ namespace Spark::Input
 
     void PlatformInputManager::Shutdown()
     {
+        SPARK_LOG_INFO(Spark::LogCategory::Input, "PlatformInputManager shutting down");
         if (m_backend)
             m_backend->Shutdown();
         m_backend.reset();
@@ -815,6 +827,7 @@ namespace Spark::Input
 
     void PlatformInputManager::Update()
     {
+        SPARK_WARN_IF(Spark::LogCategory::Input, !m_backend, "PlatformInputManager::Update called with no backend");
         if (!m_backend)
             return;
         m_backend->PollEvents();
@@ -1043,6 +1056,8 @@ namespace Spark::Input
 
     void PlatformInputManager::BindAction(const std::string& name, KeyCode key, ActionTrigger trigger)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Input, name);
         ActionBinding binding;
         binding.actionName = name;
         binding.key = key;
@@ -1053,6 +1068,8 @@ namespace Spark::Input
 
     void PlatformInputManager::BindAction(const std::string& name, GamepadBtn button, ActionTrigger trigger)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Input, name);
         ActionBinding binding;
         binding.actionName = name;
         binding.gamepadButton = button;
@@ -1063,6 +1080,8 @@ namespace Spark::Input
 
     void PlatformInputManager::BindAxis(const std::string& name, KeyCode positiveKey, KeyCode negativeKey, float scale)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Input, name);
         AxisBinding binding;
         binding.axisName = name;
         binding.positiveKey = positiveKey;
@@ -1074,6 +1093,8 @@ namespace Spark::Input
 
     void PlatformInputManager::BindAxis(const std::string& name, GamepadAxis axis, float scale, float deadZone)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+        SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Input, name);
         AxisBinding binding;
         binding.axisName = name;
         binding.gamepadAxis = axis;
@@ -1168,6 +1189,8 @@ namespace Spark::Input
 
     void PlatformInputManager::RemoveAction(const std::string& name)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+        SPARK_WARN_IF(Spark::LogCategory::Input, name.empty(), "RemoveAction called with empty name");
         m_actionBindings.erase(std::remove_if(m_actionBindings.begin(), m_actionBindings.end(),
                                               [&](const ActionBinding& b) { return b.actionName == name; }),
                                m_actionBindings.end());
@@ -1296,6 +1319,7 @@ namespace Spark::Input
 
     void PlatformInputManager::RegisterEventCallback(InputEventCallback callback)
     {
+        SPARK_WARN_IF(Spark::LogCategory::Input, !callback, "RegisterEventCallback called with null callback");
         m_eventCallbacks.push_back(std::move(callback));
     }
 

--- a/SparkEngine/Source/Physics/ClothSimulation.cpp
+++ b/SparkEngine/Source/Physics/ClothSimulation.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "ClothSimulation.h"
+#include "../Utils/Validate.h"
 
 #include <algorithm>
 #include <cmath>
@@ -18,6 +19,10 @@ namespace Spark::Physics
 
     uint32_t ClothSimulation::CreateCloth(const ClothDescriptor& desc)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
+        SPARK_WARN_IF(Spark::LogCategory::Physics, desc.width <= 0 || desc.height <= 0,
+                      "ClothDescriptor has non-positive dimensions");
+        SPARK_WARN_IF(Spark::LogCategory::Physics, desc.mass <= 0.0f, "ClothDescriptor has non-positive mass");
         uint32_t id = m_nextId++;
         ClothInstance cloth;
         cloth.id = id;
@@ -161,6 +166,9 @@ namespace Spark::Physics
 
     void ClothSimulation::Update(float deltaTime)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
+        SPARK_WARN_IF(Spark::LogCategory::Physics, deltaTime < 0.0f,
+                      "ClothSimulation::Update called with negative deltaTime");
         for (auto& [id, cloth] : m_clothInstances)
         {
             if (cloth.enabled)
@@ -192,6 +200,8 @@ namespace Spark::Physics
 
     void ClothSimulation::SimulateCloth(ClothInstance& cloth, float deltaTime)
     {
+        SPARK_WARN_IF(Spark::LogCategory::Physics, deltaTime <= 0.0f,
+                      "ClothSimulation::SimulateCloth called with non-positive deltaTime");
         ApplyForces(cloth, deltaTime);
         IntegratePositions(cloth, deltaTime);
 

--- a/SparkEngine/Source/Physics/CollisionSystem.cpp
+++ b/SparkEngine/Source/Physics/CollisionSystem.cpp
@@ -2,6 +2,7 @@
 // CollisionSystem.cpp
 #include "CollisionSystem.h"
 #include "Utils/Assert.h"
+#include "../Utils/Validate.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
 #endif // SPARK_PLATFORM_WINDOWS
@@ -25,7 +26,7 @@ XMFLOAT3 BoundingBox::GetExtents() const
 
 void BoundingBox::Transform(const XMMATRIX& transform)
 {
-    ASSERT_MSG(std::isfinite(transform.r[0].m128_f32[0]), "Invalid transform matrix");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
 
     XMFLOAT3 corners[8] = {{Min.x, Min.y, Min.z}, {Max.x, Min.y, Min.z}, {Min.x, Max.y, Min.z}, {Max.x, Max.y, Min.z},
                            {Min.x, Min.y, Max.z}, {Max.x, Min.y, Max.z}, {Min.x, Max.y, Max.z}, {Max.x, Max.y, Max.z}};
@@ -52,7 +53,7 @@ void BoundingBox::Transform(const XMMATRIX& transform)
 // BoundingSphere methods
 void BoundingSphere::Transform(const XMMATRIX& transform)
 {
-    ASSERT_MSG(std::isfinite(transform.r[0].m128_f32[0]), "Invalid transform matrix");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
 
     XMVECTOR c = XMLoadFloat3(&Center);
     c = XMVector3Transform(c, transform);
@@ -62,14 +63,14 @@ void BoundingSphere::Transform(const XMMATRIX& transform)
     float sy = XMVectorGetX(XMVector3Length(transform.r[1]));
     float sz = XMVectorGetX(XMVector3Length(transform.r[2]));
     float scale = std::max({sx, sy, sz});
-    ASSERT_MSG(scale > 0.0f, "Non-positive scale");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Physics, scale > 0.0f, "Non-positive scale");
     Radius *= scale;
 }
 
 // Ray methods
 XMFLOAT3 Ray::GetPoint(float t) const
 {
-    ASSERT_MSG(std::isfinite(t), "Invalid ray parameter");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Physics, std::isfinite(t), "Invalid ray parameter");
     return XMFLOAT3(Origin.x + Direction.x * t, Origin.y + Direction.y * t, Origin.z + Direction.z * t);
 }
 

--- a/SparkEngine/Source/Physics/PhysicsSystem.cpp
+++ b/SparkEngine/Source/Physics/PhysicsSystem.cpp
@@ -8,6 +8,7 @@
 
 #include "PhysicsSystem.h"
 #include "Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
 
 #include <btBulletDynamicsCommon.h>
@@ -709,6 +710,8 @@ PhysicsSystem::~PhysicsSystem()
 
 HRESULT PhysicsSystem::Initialize()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
+    SPARK_LOG_INFO(Spark::LogCategory::Physics, "PhysicsSystem initializing (Bullet Physics)");
     // Initialize default material
     m_defaultMaterial.friction = 0.5f;
     m_defaultMaterial.restitution = 0.1f;
@@ -737,9 +740,12 @@ HRESULT PhysicsSystem::Initialize()
 
 void PhysicsSystem::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
     // Guard against double shutdown (destructor also calls Shutdown)
     if (!m_dynamicsWorld && m_bodies.empty() && m_constraints.empty())
         return;
+
+    SPARK_LOG_INFO(Spark::LogCategory::Physics, "PhysicsSystem shutting down");
 
     // Remove all constraints from the world first
     if (m_dynamicsWorld)
@@ -796,6 +802,9 @@ void PhysicsSystem::Shutdown()
 
 void PhysicsSystem::Update(float deltaTime)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
+    SPARK_WARN_IF(Spark::LogCategory::Physics, deltaTime < 0.0f,
+                  "PhysicsSystem::Update called with negative deltaTime");
     if (m_paused || deltaTime <= 0.0f)
     {
         return;
@@ -1009,8 +1018,8 @@ XMFLOAT3 PhysicsSystem::GetGravity() const
 
 std::shared_ptr<PhysicsBody> PhysicsSystem::CreateBody(const PhysicsBodyDesc& desc)
 {
-    if (!m_dynamicsWorld)
-        return nullptr;
+    SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
+    SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Physics, m_dynamicsWorld, nullptr);
 
     // Create collision shape
     btCollisionShape* shape = CreateCollisionShape(desc.shape);

--- a/SparkEngine/Source/Physics/PhysicsSystemStub.cpp
+++ b/SparkEngine/Source/Physics/PhysicsSystemStub.cpp
@@ -10,6 +10,7 @@
 #include "Core/Platform.h"
 #include "PhysicsSystem.h"
 #include "Utils/LogMacros.h"
+#include "Utils/Validate.h"
 #include <sstream>
 
 // ============================================================================
@@ -309,12 +310,15 @@ PhysicsSystem::~PhysicsSystem()
 
 HRESULT PhysicsSystem::Initialize()
 {
-    SPARK_LOG_WARN("Physics", "Bullet Physics not available — physics simulation disabled");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
+    SPARK_LOG_WARN(Spark::LogCategory::Physics, "Bullet Physics not available — physics simulation disabled");
     return S_OK;
 }
 
 void PhysicsSystem::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Physics);
+    SPARK_LOG_INFO(Spark::LogCategory::Physics, "PhysicsSystem stub shutting down");
     m_bodies.clear();
     m_constraints.clear();
     m_namedBodies.clear();
@@ -344,8 +348,8 @@ std::shared_ptr<PhysicsBody> PhysicsSystem::CreateBody(const PhysicsBodyDesc& de
 
 void PhysicsSystem::RemoveBody(std::shared_ptr<PhysicsBody> body)
 {
-    if (!body)
-        return;
+    SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Physics, body);
+
     if (!body->GetName().empty())
     {
         m_namedBodies.erase(body->GetName());

--- a/SparkEngine/Source/SceneManager/SceneManager.cpp
+++ b/SparkEngine/Source/SceneManager/SceneManager.cpp
@@ -10,6 +10,7 @@
 #include "Game/WallObject.h"
 #include "Graphics/GraphicsEngine.h"
 #include "Utils/Assert.h"
+#include "../Utils/Validate.h"
 #include "../Utils/ConsoleProcessManager.h"
 #include "Utils/LocalFileCache.h"
 
@@ -36,9 +37,9 @@ static std::string WideToNarrow(const std::wstring& wide)
 
 SceneManager::SceneManager(GraphicsEngine* graphics, InputManager* input) : m_graphics(graphics), m_input(input)
 {
-    LOG_TO_CONSOLE_IMMEDIATE(L"SceneManager constructed.", L"INFO");
-    ASSERT_MSG(graphics != nullptr, "SceneManager: graphics is null");
-    ASSERT_MSG(input != nullptr, "SceneManager: input is null");
+    SPARK_LOG_INFO(Spark::LogCategory::Scene, "SceneManager constructed");
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Scene, graphics);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Scene, input);
 }
 
 SceneManager::~SceneManager()
@@ -61,7 +62,9 @@ const std::vector<std::unique_ptr<GameObject>>& SceneManager::GetObjects() const
 
 bool SceneManager::LoadScene(const std::wstring& filepath)
 {
-    ASSERT_MSG(!filepath.empty(), "SceneManager::LoadScene — filepath must not be empty");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Scene, !filepath.empty(),
+                      "SceneManager::LoadScene — filepath must not be empty");
     LOG_TO_CONSOLE_IMMEDIATE(L"SceneManager::LoadScene called. filepath=" + filepath, L"OPERATION");
 
     auto ext = std::filesystem::path(filepath).extension();
@@ -94,7 +97,9 @@ bool SceneManager::LoadScene(const std::wstring& filepath)
 
 bool SceneManager::SaveScene(const std::wstring& filepath) const
 {
-    ASSERT_MSG(!filepath.empty(), "SceneManager::SaveScene — filepath must not be empty");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Scene, !filepath.empty(),
+                      "SceneManager::SaveScene — filepath must not be empty");
     LOG_TO_CONSOLE_IMMEDIATE(L"SceneManager::SaveScene called. filepath=" + filepath, L"OPERATION");
     bool saved = SaveJSON(filepath);
     if (saved)
@@ -107,8 +112,10 @@ bool SceneManager::SaveScene(const std::wstring& filepath) const
 
 void SceneManager::LoadSceneAsync(const std::wstring& filepath, SceneLoadCallback callback)
 {
-    ASSERT_MSG(!filepath.empty(), "SceneManager::LoadSceneAsync — filepath must not be empty");
-    ASSERT_MSG(callback != nullptr, "SceneManager::LoadSceneAsync — callback must not be null");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Scene);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Scene, !filepath.empty(),
+                      "SceneManager::LoadSceneAsync — filepath must not be empty");
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Scene, callback);
     // Join any previous async load before starting a new one
     if (m_asyncLoadThread.joinable())
     {
@@ -130,7 +137,8 @@ void SceneManager::LoadSceneAsync(const std::wstring& filepath, SceneLoadCallbac
 
 int SceneManager::AddNode(const SceneNode& node)
 {
-    ASSERT_MSG(!node.name.empty(), "SceneManager::AddNode — node name must not be empty");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Scene, !node.name.empty(),
+                      "SceneManager::AddNode — node name must not be empty");
     int index = static_cast<int>(m_sceneNodes.size());
     m_sceneNodes.push_back(node);
 
@@ -574,7 +582,7 @@ bool SceneManager::LoadCustom(const std::wstring& path)
     LOG_TO_CONSOLE_IMMEDIATE(L"SceneManager::LoadCustom called. path=" + path, L"OPERATION");
     if (!m_graphics || !m_graphics->GetDevice() || !m_graphics->GetContext())
     {
-        ASSERT_MSG(false, "SceneManager: Graphics device/context is null");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Scene, false, "SceneManager: Graphics device/context is null");
         return false;
     }
 
@@ -830,7 +838,8 @@ bool SceneManager::Console_MoveNode(int index, float x, float y, float z)
 
 bool SceneManager::Console_RenameNode(int index, const std::string& newName)
 {
-    ASSERT_MSG(!newName.empty(), "SceneManager::Console_RenameNode — newName must not be empty");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Scene, !newName.empty(),
+                      "SceneManager::Console_RenameNode — newName must not be empty");
     auto* node = GetNode(index);
     if (!node)
         return false;

--- a/SparkEngine/Source/SceneManager/SceneManager.cpp
+++ b/SparkEngine/Source/SceneManager/SceneManager.cpp
@@ -11,6 +11,7 @@
 #include "Graphics/GraphicsEngine.h"
 #include "Utils/Assert.h"
 #include "../Utils/Validate.h"
+#include "../Utils/SparkConsole.h"
 #include "../Utils/ConsoleProcessManager.h"
 #include "Utils/LocalFileCache.h"
 

--- a/SparkEngine/Source/Utils/Assert.h
+++ b/SparkEngine/Source/Utils/Assert.h
@@ -81,6 +81,9 @@
 #ifdef GetCurrentTime
 #undef GetCurrentTime
 #endif
+#ifdef GetClassName
+#undef GetClassName
+#endif
 #endif
 
 // Forward declarations

--- a/SparkEngine/Source/Utils/Assert.h
+++ b/SparkEngine/Source/Utils/Assert.h
@@ -65,6 +65,22 @@
 #include <windows.h>
 #include <dbghelp.h>
 #pragma comment(lib, "dbghelp.lib")
+// Undefine Windows macros that collide with our enum members and method names
+#ifdef ERROR
+#undef ERROR
+#endif
+#ifdef OPAQUE
+#undef OPAQUE
+#endif
+#ifdef TRANSPARENT
+#undef TRANSPARENT
+#endif
+#ifdef GetTickCount
+#undef GetTickCount
+#endif
+#ifdef GetCurrentTime
+#undef GetCurrentTime
+#endif
 #endif
 
 // Forward declarations

--- a/SparkEngine/Source/Utils/ConfigParser.cpp
+++ b/SparkEngine/Source/Utils/ConfigParser.cpp
@@ -5,20 +5,26 @@
 
 #include "ConfigParser.h"
 #include "LocalFileCache.h"
+#include "Validate.h"
 
 namespace Spark
 {
 
     bool ConfigParser::Load(const std::string& path, LocalFileCache& cache)
     {
+        SPARK_VALIDATE_RET(Spark::LogCategory::Core, !path.empty(), false);
         auto result = cache.ReadText(path);
         if (result.IsErr())
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Core, "ConfigParser::Load failed to read '%s'", path.c_str());
             return false;
+        }
         return LoadFromString(result.Value());
     }
 
     bool ConfigParser::Save(const std::string& path, LocalFileCache& cache) const
     {
+        SPARK_VALIDATE_RET(Spark::LogCategory::Core, !path.empty(), false);
         std::string content = SaveToString();
         auto result = cache.WriteText(path, content);
         return result.IsOk();

--- a/SparkEngine/Source/Utils/ConsoleProcessManager.cpp
+++ b/SparkEngine/Source/Utils/ConsoleProcessManager.cpp
@@ -2,6 +2,7 @@
 #include "ConsoleProcessManager.h"
 #include "Utils/Assert.h"
 #include "Utils/CrashHandler.h"
+#include "Validate.h"
 #include <iostream>
 #include <sstream>
 #include <filesystem>
@@ -55,6 +56,7 @@ namespace Spark
     ConsoleProcessManager::ConsoleProcessManager()
         : m_commandRegistry(std::make_unique<CommandRegistry>()), m_consoleThread(), m_shouldStopThread(false)
     {
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "ConsoleProcessManager constructed");
 
         // Register default commands
         m_commandRegistry->RegisterCommand(
@@ -95,7 +97,7 @@ namespace Spark
             "assert_test",
             [](const std::vector<std::string>& args) -> std::string
             {
-                ASSERT_MSG(false, "Test assertion triggered from console command");
+                SPARK_REQUIRE_MSG(Spark::LogCategory::Core, false, "Test assertion triggered from console command");
                 return "This should not be reached";
             },
             "Trigger a test assertion", "assert_test");
@@ -148,13 +150,14 @@ namespace Spark
 
     bool ConsoleProcessManager::Initialize(const std::wstring& consolePath)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
         if (m_initialized)
         {
-            OutputDebugStringW(L"ConsoleProcessManager already initialized\n");
+            SPARK_LOG_WARN(Spark::LogCategory::Core, "ConsoleProcessManager already initialized");
             return true;
         }
 
-        OutputDebugStringW(L"ConsoleProcessManager::Initialize starting...\n");
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "ConsoleProcessManager::Initialize starting");
 
         wchar_t currentDir[MAX_PATH];
         GetModuleFileNameW(NULL, currentDir, MAX_PATH);
@@ -209,9 +212,11 @@ namespace Spark
 
     void ConsoleProcessManager::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
         if (!m_initialized)
             return;
 
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "ConsoleProcessManager shutting down");
         m_shouldStopThread = true;
         if (m_consoleThread.joinable())
             m_consoleThread.join();
@@ -427,8 +432,11 @@ namespace Spark
 
     bool ConsoleProcessManager::Initialize(const std::wstring& consolePath)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
         if (m_initialized)
             return true;
+
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "ConsoleProcessManager::Initialize starting (Linux)");
 
         // Get the executable directory
         char exePath[PATH_MAX];
@@ -488,9 +496,11 @@ namespace Spark
 
     void ConsoleProcessManager::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
         if (!m_initialized)
             return;
 
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "ConsoleProcessManager shutting down (Linux)");
         m_shouldStopThread = true;
         if (m_consoleThread.joinable())
             m_consoleThread.join();

--- a/SparkEngine/Source/Utils/ConsoleSink.cpp
+++ b/SparkEngine/Source/Utils/ConsoleSink.cpp
@@ -7,6 +7,7 @@
 
 #include "ConsoleSink.h"
 #include "SparkConsole.h"
+#include "Validate.h"
 
 #include <cstring>
 
@@ -17,6 +18,7 @@ namespace Spark
 
     void ConsoleSink::Write(const LogMessage& msg)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
         // Build the message: [Category] message (file:line)
         std::string formatted;
         formatted.reserve(msg.message.size() + 64);

--- a/SparkEngine/Source/Utils/CrashHandler.cpp
+++ b/SparkEngine/Source/Utils/CrashHandler.cpp
@@ -3,6 +3,7 @@
 #include "Utils/Assert.h"
 #include "Utils/SparkError.h"
 #include "Utils/ConsoleProcessManager.h"
+#include "Validate.h"
 
 // Only include CURL when networking is enabled
 #ifdef NETWORKING_ENABLED
@@ -464,6 +465,7 @@ static void ZipFiles(const std::wstring& zip, const std::vector<std::wstring>& f
 
 void InstallCrashHandler(const CrashConfig& cfg)
 {
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Installing crash handler (Windows)");
     g_cfg = cfg;
     g_triggerCrashOnAssert = cfg.triggerCrashOnAssert;
 
@@ -472,6 +474,7 @@ void InstallCrashHandler(const CrashConfig& cfg)
 #endif
 
     SetUnhandledExceptionFilter(CrashFilter);
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Crash handler installed successfully");
 }
 
 void TriggerCrashHandler(const char* assertMsg)
@@ -1213,6 +1216,7 @@ static void HandleLinuxCrash(int sig, siginfo_t* info, void* context)
 
 void InstallCrashHandler(const CrashConfig& cfg)
 {
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Installing crash handler (Linux)");
     g_cfg = cfg;
     g_triggerCrashOnAssert = cfg.triggerCrashOnAssert;
 
@@ -1309,6 +1313,7 @@ void SetAssertCrashBehavior(bool shouldCrash)
 // Unsupported platform stubs
 void InstallCrashHandler(const CrashConfig& cfg)
 {
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Installing crash handler (stub - unsupported platform)");
     g_cfg = cfg;
     g_triggerCrashOnAssert = cfg.triggerCrashOnAssert;
 }

--- a/SparkEngine/Source/Utils/CrashHandlerHelpers.cpp
+++ b/SparkEngine/Source/Utils/CrashHandlerHelpers.cpp
@@ -4,6 +4,7 @@
 // CrashHandlerHelpers.cpp
 #include "Utils/CrashHandler.h"
 #include "Utils/Assert.h"
+#include "Validate.h"
 
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <windows.h>
@@ -524,6 +525,7 @@ static bool Upload(const std::string&, const std::wstring&, const std::string&);
 #endif
 static LONG WINAPI CrashFilter(EXCEPTION_POINTERS* ep)
 {
+    // NOTE: Minimal instrumentation here — we are inside a crash handler
     HandleCrashInternal(ep, nullptr);
     return EXCEPTION_EXECUTE_HANDLER;
 }

--- a/SparkEngine/Source/Utils/CrashHandlerStub.cpp
+++ b/SparkEngine/Source/Utils/CrashHandlerStub.cpp
@@ -8,11 +8,12 @@
  */
 
 #include "CrashHandler.h"
+#include "Validate.h"
 #include <cstdio>
 
 void InstallCrashHandler(const CrashConfig& /*cfg*/)
 {
-    // No crash handler available without miniz
+    SPARK_LOG_WARN(Spark::LogCategory::Core, "CrashHandler stub: no crash handler available (miniz not found)");
 }
 
 void TriggerCrashHandler(const char* assertMsg)

--- a/SparkEngine/Source/Utils/D3DUtils.cpp
+++ b/SparkEngine/Source/Utils/D3DUtils.cpp
@@ -1,4 +1,5 @@
 #include "Core/Platform.h"
+#include "Validate.h"
 
 #ifdef SPARK_PLATFORM_WINDOWS
 
@@ -18,6 +19,7 @@ ID3D11DeviceContext* g_D3DContext = nullptr;
 static GraphicsEngine* GetGraphicsFromContext()
 {
     auto* ctx = EngineContext::Get();
+    SPARK_WARN_IF_NULL(Spark::LogCategory::Graphics, ctx);
     return ctx ? ctx->GetGraphics() : nullptr;
 }
 

--- a/SparkEngine/Source/Utils/FileUtils.cpp
+++ b/SparkEngine/Source/Utils/FileUtils.cpp
@@ -1,2 +1,3 @@
+#include "Validate.h"
 #include <iostream>
 // Remove all FileUtils:: member function implementations (no class FileUtils declared in headers)

--- a/SparkEngine/Source/Utils/LogMacros.h
+++ b/SparkEngine/Source/Utils/LogMacros.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include "Logger.h"
-#include "SparkConsole.h"
 #include <chrono>
 #include <cstdio>
 #include <string>

--- a/SparkEngine/Source/Utils/MathUtils.cpp
+++ b/SparkEngine/Source/Utils/MathUtils.cpp
@@ -2,6 +2,7 @@
 // MathUtils.cpp
 #include "MathUtils.h"
 #include "Utils/Assert.h"
+#include "Validate.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
 #endif // SPARK_PLATFORM_WINDOWS
@@ -29,19 +30,19 @@ static bool s_randomInitialized = false;
 
 float MathUtils::DegreesToRadians(float degrees)
 {
-    ASSERT_MSG(std::isfinite(degrees), "Degrees must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(degrees), "Degrees must be finite");
     return degrees * DEG_TO_RAD;
 }
 
 float MathUtils::RadiansToDegrees(float radians)
 {
-    ASSERT_MSG(std::isfinite(radians), "Radians must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(radians), "Radians must be finite");
     return radians * RAD_TO_DEG;
 }
 
 float MathUtils::WrapAngle(float angle)
 {
-    ASSERT_MSG(std::isfinite(angle), "Angle must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(angle), "Angle must be finite");
     while (angle > PI)
         angle -= TWO_PI;
     while (angle < -PI)
@@ -51,7 +52,7 @@ float MathUtils::WrapAngle(float angle)
 
 float MathUtils::NormalizeAngle(float angle)
 {
-    ASSERT_MSG(std::isfinite(angle), "Angle must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(angle), "Angle must be finite");
     while (angle < 0.0f)
         angle += TWO_PI;
     while (angle >= TWO_PI)
@@ -65,19 +66,21 @@ float MathUtils::NormalizeAngle(float angle)
 
 float MathUtils::Lerp(float a, float b, float t)
 {
-    ASSERT_MSG(std::isfinite(a) && std::isfinite(b) && std::isfinite(t), "Lerp inputs must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(a) && std::isfinite(b) && std::isfinite(t),
+                      "Lerp inputs must be finite");
     return a + t * (b - a);
 }
 
 XMFLOAT3 MathUtils::Lerp(const XMFLOAT3& a, const XMFLOAT3& b, float t)
 {
-    ASSERT_MSG(std::isfinite(t), "Lerp t must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(t), "Lerp t must be finite");
     return XMFLOAT3(Lerp(a.x, b.x, t), Lerp(a.y, b.y, t), Lerp(a.z, b.z, t));
 }
 
 float MathUtils::SmoothStep(float a, float b, float t)
 {
-    ASSERT_MSG(std::isfinite(a) && std::isfinite(b) && std::isfinite(t), "SmoothStep inputs must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(a) && std::isfinite(b) && std::isfinite(t),
+                      "SmoothStep inputs must be finite");
     t = Clamp(t, 0.0f, 1.0f);
     t = t * t * (3.0f - 2.0f * t);
     return Lerp(a, b, t);
@@ -89,8 +92,10 @@ float MathUtils::SmoothStep(float a, float b, float t)
 
 float MathUtils::Distance(const XMFLOAT3& a, const XMFLOAT3& b)
 {
-    ASSERT_MSG(std::isfinite(a.x) && std::isfinite(a.y) && std::isfinite(a.z), "Distance a must be finite");
-    ASSERT_MSG(std::isfinite(b.x) && std::isfinite(b.y) && std::isfinite(b.z), "Distance b must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(a.x) && std::isfinite(a.y) && std::isfinite(a.z),
+                      "Distance a must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(b.x) && std::isfinite(b.y) && std::isfinite(b.z),
+                      "Distance b must be finite");
     float dx = b.x - a.x;
     float dy = b.y - a.y;
     float dz = b.z - a.z;
@@ -99,8 +104,10 @@ float MathUtils::Distance(const XMFLOAT3& a, const XMFLOAT3& b)
 
 float MathUtils::DistanceSquared(const XMFLOAT3& a, const XMFLOAT3& b)
 {
-    ASSERT_MSG(std::isfinite(a.x) && std::isfinite(a.y) && std::isfinite(a.z), "DistanceSquared a must be finite");
-    ASSERT_MSG(std::isfinite(b.x) && std::isfinite(b.y) && std::isfinite(b.z), "DistanceSquared b must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(a.x) && std::isfinite(a.y) && std::isfinite(a.z),
+                      "DistanceSquared a must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(b.x) && std::isfinite(b.y) && std::isfinite(b.z),
+                      "DistanceSquared b must be finite");
     float dx = b.x - a.x;
     float dy = b.y - a.y;
     float dz = b.z - a.z;
@@ -119,6 +126,7 @@ XMFLOAT3 MathUtils::Direction(const XMFLOAT3& from, const XMFLOAT3& to)
 
 void MathUtils::InitializeRandom()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
     if (!s_randomInitialized)
     {
         s_randomGenerator.seed(s_randomDevice());
@@ -136,7 +144,7 @@ float MathUtils::RandomFloat(float min, float max)
 
 int MathUtils::RandomInt(int min, int max)
 {
-    ASSERT_MSG(min <= max, "RandomInt min must be <= max");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, min <= max, "RandomInt min must be <= max");
     InitializeRandom();
     std::uniform_int_distribution<int> distribution(min, max);
     return distribution(s_randomGenerator);
@@ -153,7 +161,7 @@ XMFLOAT3 MathUtils::RandomDirection()
 
 XMFLOAT3 MathUtils::RandomPointInSphere(float radius)
 {
-    ASSERT_MSG(radius >= 0.0f, "Sphere radius must be non-negative");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, radius >= 0.0f, "Sphere radius must be non-negative");
     XMFLOAT3 point{};
     float lengthSq;
     do
@@ -172,7 +180,7 @@ XMFLOAT3 MathUtils::RandomPointInSphere(float radius)
 
 float MathUtils::Clamp(float value, float min, float max)
 {
-    ASSERT_MSG(min <= max, "Clamp min must be <= max");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, min <= max, "Clamp min must be <= max");
     if (value < min)
         return min;
     if (value > max)
@@ -182,7 +190,7 @@ float MathUtils::Clamp(float value, float min, float max)
 
 int MathUtils::Clamp(int value, int min, int max)
 {
-    ASSERT_MSG(min <= max, "Clamp min must be <= max");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, min <= max, "Clamp min must be <= max");
     if (value < min)
         return min;
     if (value > max)
@@ -206,13 +214,15 @@ XMMATRIX MathUtils::CreateLookAt(const XMFLOAT3& eye, const XMFLOAT3& target, co
 
 XMMATRIX MathUtils::CreatePerspective(float fovY, float aspectRatio, float nearPlane, float farPlane)
 {
-    ASSERT_MSG(fovY > 0 && aspectRatio > 0 && nearPlane > 0 && farPlane > nearPlane, "Invalid perspective parameters");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, fovY > 0 && aspectRatio > 0 && nearPlane > 0 && farPlane > nearPlane,
+                      "Invalid perspective parameters");
     return XMMatrixPerspectiveFovLH(fovY, aspectRatio, nearPlane, farPlane);
 }
 
 XMMATRIX MathUtils::CreateOrthographic(float width, float height, float nearPlane, float farPlane)
 {
-    ASSERT_MSG(width > 0 && height > 0 && farPlane > nearPlane, "Invalid orthographic parameters");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, width > 0 && height > 0 && farPlane > nearPlane,
+                      "Invalid orthographic parameters");
     return XMMatrixOrthographicLH(width, height, nearPlane, farPlane);
 }
 
@@ -232,13 +242,13 @@ XMFLOAT3 MathUtils::Subtract(const XMFLOAT3& a, const XMFLOAT3& b)
 
 XMFLOAT3 MathUtils::Multiply(const XMFLOAT3& v, float scalar)
 {
-    ASSERT_MSG(std::isfinite(scalar), "Multiply scalar must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(scalar), "Multiply scalar must be finite");
     return XMFLOAT3(v.x * scalar, v.y * scalar, v.z * scalar);
 }
 
 XMFLOAT3 MathUtils::Divide(const XMFLOAT3& v, float scalar)
 {
-    ASSERT_MSG(scalar != 0.0f, "Divide by zero");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, scalar != 0.0f, "Divide by zero");
     float inv = 1.0f / scalar;
     return XMFLOAT3(v.x * inv, v.y * inv, v.z * inv);
 }
@@ -255,9 +265,10 @@ XMFLOAT3 MathUtils::Cross(const XMFLOAT3& a, const XMFLOAT3& b)
 
 XMFLOAT3 MathUtils::Normalize(const XMFLOAT3& v)
 {
-    ASSERT_MSG(std::isfinite(v.x) && std::isfinite(v.y) && std::isfinite(v.z), "Normalize input must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(v.x) && std::isfinite(v.y) && std::isfinite(v.z),
+                      "Normalize input must be finite");
     float len = Length(v);
-    ASSERT_MSG(len >= 0.0f, "Length must be non-negative");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, len >= 0.0f, "Length must be non-negative");
     return len > 0.0f ? Divide(v, len) : XMFLOAT3(0, 0, 0);
 }
 
@@ -277,19 +288,19 @@ float MathUtils::LengthSquared(const XMFLOAT3& v)
 
 float MathUtils::EaseInQuad(float t)
 {
-    ASSERT_MSG(std::isfinite(t), "EaseInQuad t must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(t), "EaseInQuad t must be finite");
     return t * t;
 }
 
 float MathUtils::EaseOutQuad(float t)
 {
-    ASSERT_MSG(std::isfinite(t), "EaseOutQuad t must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(t), "EaseOutQuad t must be finite");
     return 1.0f - (1.0f - t) * (1.0f - t);
 }
 
 float MathUtils::EaseInOutQuad(float t)
 {
-    ASSERT_MSG(std::isfinite(t), "EaseInOutQuad t must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(t), "EaseInOutQuad t must be finite");
     if (t < 0.5f)
         return 2.0f * t * t;
     else
@@ -301,20 +312,20 @@ float MathUtils::EaseInOutQuad(float t)
 
 float MathUtils::EaseInCubic(float t)
 {
-    ASSERT_MSG(std::isfinite(t), "EaseInCubic t must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(t), "EaseInCubic t must be finite");
     return t * t * t;
 }
 
 float MathUtils::EaseOutCubic(float t)
 {
-    ASSERT_MSG(std::isfinite(t), "EaseOutCubic t must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(t), "EaseOutCubic t must be finite");
     float f = (1.0f - t);
     return 1.0f - f * f * f;
 }
 
 float MathUtils::EaseInOutCubic(float t)
 {
-    ASSERT_MSG(std::isfinite(t), "EaseInOutCubic t must be finite");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, std::isfinite(t), "EaseInOutCubic t must be finite");
     if (t < 0.5f)
         return 4.0f * t * t * t;
     else

--- a/SparkEngine/Source/Utils/Profiler.cpp
+++ b/SparkEngine/Source/Utils/Profiler.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "Profiler.h"
+#include "Validate.h"
 #include <sstream>
 #include <iomanip>
 #include <algorithm>
@@ -36,6 +37,9 @@ ScopedProfileTimer::~ScopedProfileTimer()
 #ifdef SPARK_PLATFORM_WINDOWS
 HRESULT Profiler::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+    SPARK_WARN_IF_NULL(Spark::LogCategory::Core, device);
+    SPARK_WARN_IF_NULL(Spark::LogCategory::Core, context);
     m_device = device;
     m_context = context;
     m_enabled = true;
@@ -47,6 +51,8 @@ HRESULT Profiler::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 
 void Profiler::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Profiler shutting down");
     m_enabled = false;
     m_currentFrameSamples.clear();
     m_activeSections.clear();

--- a/SparkEngine/Source/Utils/SparkConsole.cpp
+++ b/SparkEngine/Source/Utils/SparkConsole.cpp
@@ -1,6 +1,7 @@
 #include "../Core/Platform.h"
 #include "SparkConsole.h"
 #include "ConsoleVariable.h"
+#include "Validate.h"
 #include <iostream>
 #include <sstream>
 #include <iomanip>
@@ -448,10 +449,13 @@ namespace Spark
 
     bool SimpleConsole::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
         if (m_initialized)
         {
             return true;
         }
+
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "SimpleConsole initializing");
 
         if (!CreateConsoleWindow())
         {
@@ -519,11 +523,13 @@ namespace Spark
 
     void SimpleConsole::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
         if (!m_initialized)
         {
             return;
         }
 
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "SimpleConsole shutting down");
         LogInfo("Console shutdown initiated");
 
         // Persist command history before shutdown
@@ -4395,7 +4401,8 @@ namespace Spark
             "debug_assert_test",
             [](const std::vector<std::string>& args) -> std::string
             {
-                ASSERT_MSG(false, "Test assertion triggered from console command 'debug_assert_test'");
+                SPARK_REQUIRE_MSG(Spark::LogCategory::Core, false,
+                                  "Test assertion triggered from console command 'debug_assert_test'");
                 return "Assertion was non-fatal or handled";
             },
             "Trigger a test assertion for debugging", "Debug");
@@ -5584,7 +5591,8 @@ namespace Spark
                 }
 
                 LogWarning("Triggering test assertion from console...");
-                ASSERT_MSG(false, "Test assertion triggered from console command 'crash_test_assert'");
+                SPARK_REQUIRE_MSG(Spark::LogCategory::Core, false,
+                                  "Test assertion triggered from console command 'crash_test_assert'");
                 return "Assertion fired (non-fatal mode - engine continues)";
             },
             "Trigger a test assertion to verify error handling", "Crash/Diagnostics");
@@ -6224,6 +6232,7 @@ namespace Spark
 #ifndef SPARK_PLATFORM_WINDOWS
 #include "../Core/Platform.h"
 #include "SparkConsole.h"
+#include "Validate.h"
 #include <iostream>
 #include <sstream>
 #include <fstream>
@@ -6439,8 +6448,10 @@ namespace Spark
 
     bool SimpleConsole::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
         if (m_initialized)
             return true;
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "SimpleConsole initializing (Linux)");
         CreateConsoleWindow();
         SetupConsoleHandles();
         RegisterDefaultCommands();
@@ -6452,6 +6463,8 @@ namespace Spark
     }
     void SimpleConsole::Shutdown()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Core);
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "SimpleConsole shutting down (Linux)");
         m_initialized = false;
         m_commands.clear();
         m_logHistory.clear();

--- a/SparkEngine/Source/Utils/SplineMath.cpp
+++ b/SparkEngine/Source/Utils/SplineMath.cpp
@@ -6,6 +6,7 @@
 #include "../Core/Platform.h"
 #include "SplineMath.h"
 #include "Utils/Assert.h"
+#include "Validate.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
 #endif // SPARK_PLATFORM_WINDOWS
@@ -107,7 +108,7 @@ static float PointDistance(const XMFLOAT3& a, const XMFLOAT3& b)
 float SplineMath::CatmullRomSegmentLength(const XMFLOAT3& p0, const XMFLOAT3& p1, const XMFLOAT3& p2,
                                           const XMFLOAT3& p3, int subdivisions)
 {
-    ASSERT_MSG(subdivisions > 0, "Subdivisions must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, subdivisions > 0, "Subdivisions must be positive");
 
     float totalLength = 0.0f;
     XMFLOAT3 prev = p1; // At t=0 the segment starts at p1
@@ -124,7 +125,7 @@ float SplineMath::CatmullRomSegmentLength(const XMFLOAT3& p0, const XMFLOAT3& p1
 float SplineMath::CubicBezierSegmentLength(const XMFLOAT3& p0, const XMFLOAT3& p1, const XMFLOAT3& p2,
                                            const XMFLOAT3& p3, int subdivisions)
 {
-    ASSERT_MSG(subdivisions > 0, "Subdivisions must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, subdivisions > 0, "Subdivisions must be positive");
 
     float totalLength = 0.0f;
     XMFLOAT3 prev = p0; // At t=0 the Bezier starts at p0

--- a/SparkEngine/Source/Utils/SplinePath.cpp
+++ b/SparkEngine/Source/Utils/SplinePath.cpp
@@ -7,6 +7,7 @@
 #include "SplinePath.h"
 #include "SplineMath.h"
 #include "Utils/Assert.h"
+#include "Validate.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
 #endif // SPARK_PLATFORM_WINDOWS
@@ -29,28 +30,32 @@ void SplinePath::AddPoint(const XMFLOAT3& point)
 
 void SplinePath::InsertPoint(int index, const XMFLOAT3& point)
 {
-    ASSERT_MSG(index >= 0 && index <= static_cast<int>(m_points.size()), "InsertPoint index out of range");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, index >= 0 && index <= static_cast<int>(m_points.size()),
+                      "InsertPoint index out of range");
     m_points.insert(m_points.begin() + index, point);
     MarkDirty();
 }
 
 void SplinePath::RemovePoint(int index)
 {
-    ASSERT_MSG(index >= 0 && index < static_cast<int>(m_points.size()), "RemovePoint index out of range");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, index >= 0 && index < static_cast<int>(m_points.size()),
+                      "RemovePoint index out of range");
     m_points.erase(m_points.begin() + index);
     MarkDirty();
 }
 
 void SplinePath::SetPoint(int index, const XMFLOAT3& point)
 {
-    ASSERT_MSG(index >= 0 && index < static_cast<int>(m_points.size()), "SetPoint index out of range");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, index >= 0 && index < static_cast<int>(m_points.size()),
+                      "SetPoint index out of range");
     m_points[index] = point;
     MarkDirty();
 }
 
 const XMFLOAT3& SplinePath::GetPoint(int index) const
 {
-    ASSERT_MSG(index >= 0 && index < static_cast<int>(m_points.size()), "GetPoint index out of range");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, index >= 0 && index < static_cast<int>(m_points.size()),
+                      "GetPoint index out of range");
     return m_points[index];
 }
 

--- a/SparkEngine/Source/Utils/Timer.cpp
+++ b/SparkEngine/Source/Utils/Timer.cpp
@@ -1,16 +1,17 @@
 // Timer.cpp
 #include "Timer.h"
+#include "Validate.h"
 #include <iostream>
 
 Timer::Timer() : m_deltaTime(0.0f), m_totalTime(0.0f), m_paused(false)
 {
     m_lastTime = std::chrono::high_resolution_clock::now();
-    std::wcout << L"[INFO] Timer constructed." << std::endl;
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Timer constructed");
 }
 
 Timer::~Timer()
 {
-    std::wcout << L"[INFO] Timer destructor called." << std::endl;
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Timer destructor called");
 }
 
 void Timer::Start()
@@ -19,14 +20,14 @@ void Timer::Start()
     {
         m_lastTime = std::chrono::high_resolution_clock::now();
         m_paused = false;
-        std::wcout << L"[INFO] Timer started." << std::endl;
+        SPARK_LOG_INFO(Spark::LogCategory::Core, "Timer started");
     }
 }
 
 void Timer::Stop()
 {
     m_paused = true;
-    std::wcout << L"[INFO] Timer stopped." << std::endl;
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Timer stopped");
 }
 
 void Timer::Reset()
@@ -35,7 +36,7 @@ void Timer::Reset()
     m_deltaTime = 0.0f;
     m_totalTime = 0.0f;
     m_paused = false;
-    std::wcout << L"[INFO] Timer reset." << std::endl;
+    SPARK_LOG_INFO(Spark::LogCategory::Core, "Timer reset");
 }
 
 float Timer::GetDeltaTime()
@@ -44,7 +45,7 @@ float Timer::GetDeltaTime()
     {
         UpdateTime();
     }
-    ASSERT_MSG(m_deltaTime >= 0.0f, "Delta time should never be negative");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, m_deltaTime >= 0.0f, "Delta time should never be negative");
     return m_deltaTime;
 }
 
@@ -53,7 +54,7 @@ void Timer::UpdateTime()
     auto currentTime = std::chrono::high_resolution_clock::now();
     std::chrono::duration<float> diff = currentTime - m_lastTime;
 
-    ASSERT_MSG(diff.count() >= 0.0f, "Time difference must be non-negative");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, diff.count() >= 0.0f, "Time difference must be non-negative");
     m_deltaTime = diff.count();
 
     // Cap delta time to prevent large jumps
@@ -65,5 +66,5 @@ void Timer::UpdateTime()
     m_lastTime += std::chrono::duration_cast<std::chrono::high_resolution_clock::duration>(diff);
     m_totalTime += m_deltaTime;
 
-    ASSERT_MSG(m_totalTime >= 0.0f, "Total time should never be negative");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Core, m_totalTime >= 0.0f, "Total time should never be negative");
 }

--- a/SparkEngine/Source/Utils/Validate.h
+++ b/SparkEngine/Source/Utils/Validate.h
@@ -1,0 +1,507 @@
+/**
+ * @file Validate.h
+ * @brief Project-wide validation, defensive programming, and diagnostic logging utilities
+ * @author Spark Engine Team
+ * @date 2026
+ *
+ * Provides a unified validation framework combining:
+ *
+ * ## Defensive Programming (fail-safe with logging)
+ * - SPARK_VALIDATE / SPARK_VALIDATE_MSG        — soft checks that log + return on failure
+ * - SPARK_VALIDATE_NOT_NULL                     — null pointer guard with early return
+ * - SPARK_VALIDATE_RANGE                        — numeric range guard
+ * - SPARK_VALIDATE_ENUM                         — enum range guard
+ * - SPARK_VALIDATE_NOT_EMPTY                    — string/container non-empty guard
+ *
+ * ## Offensive Programming (fail-fast with abort)
+ * - SPARK_REQUIRE / SPARK_REQUIRE_MSG           — precondition checks (abort on failure)
+ * - SPARK_REQUIRE_NOT_NULL                      — non-null precondition
+ * - SPARK_ENSURE / SPARK_ENSURE_MSG             — postcondition checks (abort on failure)
+ * - SPARK_UNREACHABLE                           — marks impossible code paths
+ *
+ * ## Diagnostic Logging Utilities
+ * - SPARK_TRACE_ENTER / SPARK_TRACE_EXIT        — function entry/exit tracing
+ * - SPARK_TRACE_SCOPE                           — RAII scope tracing
+ * - SPARK_TRACE_VALUE                           — log named variable value
+ * - SPARK_DIAGNOSTIC_CONTEXT                    — scoped breadcrumb for crash reports
+ *
+ * ## Contract Logging (structured validation reports)
+ * - SPARK_CONTRACT_LOG_PRE                      — log precondition check result
+ * - SPARK_CONTRACT_LOG_POST                     — log postcondition check result
+ * - SPARK_CONTRACT_LOG_INVARIANT                — log invariant check result
+ *
+ * All macros integrate with the unified Logger system (LogMacros.h) and the
+ * Assert system (Assert.h). Defensive macros log errors and continue; offensive
+ * macros log fatal errors and abort via ASSERT_ALWAYS.
+ *
+ * @see Assert.h, LogMacros.h, SparkError.h, Result.h
+ */
+
+#pragma once
+
+#include "Assert.h"
+#include "LogMacros.h"
+#include <string>
+#include <type_traits>
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+namespace Spark::Validation
+{
+
+    /**
+     * @brief Log a validation failure through the unified logger
+     *
+     * @param level     Severity level for the log message
+     * @param category  Log category (subsystem that triggered the validation)
+     * @param kind      Validation kind label ("PRECONDITION", "POSTCONDITION", etc.)
+     * @param expr      The stringified expression that was checked
+     * @param file      Source file (__FILE__)
+     * @param line      Source line (__LINE__)
+     * @param func      Function name (__FUNCTION__)
+     * @param msg       Optional human-readable message (may be nullptr)
+     */
+    inline void LogValidationFailure(Spark::LogLevel level, Spark::LogCategory category, const char* kind,
+                                     const char* expr, const char* file, int line, const char* func,
+                                     const char* msg = nullptr)
+    {
+        auto& logger = Spark::Logger::Get();
+        if (!logger.IsInitialized())
+        {
+            // Fallback to stderr before logger is ready
+            if (msg && msg[0])
+            {
+                std::fprintf(stderr, "[%s] VALIDATION FAILED: %s — %s  (%s:%d in %s)\n", kind, expr, msg, file, line,
+                             func ? func : "?");
+            }
+            else
+            {
+                std::fprintf(stderr, "[%s] VALIDATION FAILED: %s  (%s:%d in %s)\n", kind, expr, file, line,
+                             func ? func : "?");
+            }
+            std::fflush(stderr);
+            return;
+        }
+
+        char buf[1024];
+        if (msg && msg[0])
+        {
+            std::snprintf(buf, sizeof(buf), "[%s] VALIDATION FAILED: %s — %s", kind, expr, msg);
+        }
+        else
+        {
+            std::snprintf(buf, sizeof(buf), "[%s] VALIDATION FAILED: %s", kind, expr);
+        }
+        logger.Log(level, category, file, line, func, std::string(buf));
+    }
+
+    /**
+     * @brief Log a validation success (trace level) for contract auditing
+     */
+    inline void LogValidationSuccess(Spark::LogCategory category, const char* kind, const char* expr, const char* file,
+                                     int line, const char* func)
+    {
+        auto& logger = Spark::Logger::Get();
+        if (!logger.IsInitialized() || !logger.ShouldLog(Spark::LogLevel::Trace, category))
+            return;
+
+        char buf[512];
+        std::snprintf(buf, sizeof(buf), "[%s] OK: %s", kind, expr);
+        logger.Log(Spark::LogLevel::Trace, category, file, line, func, std::string(buf));
+    }
+
+    /**
+     * @brief RAII scope tracer that logs function/scope entry and exit
+     */
+    class ScopeTracer
+    {
+      public:
+        ScopeTracer(Spark::LogCategory category, const char* scopeName, const char* file, int line)
+            : m_category(category), m_scopeName(scopeName), m_file(file), m_line(line)
+        {
+            SPARK_LOG_TRACE(category, ">> ENTER: %s", scopeName);
+        }
+
+        ~ScopeTracer() { SPARK_LOG_TRACE(m_category, "<< EXIT:  %s", m_scopeName); }
+
+        ScopeTracer(const ScopeTracer&) = delete;
+        ScopeTracer& operator=(const ScopeTracer&) = delete;
+
+      private:
+        Spark::LogCategory m_category;
+        const char* m_scopeName;
+        const char* m_file;
+        int m_line;
+    };
+
+} // namespace Spark::Validation
+
+// ============================================================================
+// Defensive Programming — Soft checks (log + return, never abort)
+// ============================================================================
+
+/**
+ * @def SPARK_VALIDATE(category, expr)
+ * @brief Soft validation: logs an error and returns (void) if expr is false
+ *
+ * Use for recoverable conditions at system boundaries. The expression is always
+ * evaluated. On failure, logs at Error level and returns from the calling function.
+ */
+#define SPARK_VALIDATE(category, expr)                                                                                 \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (!(expr))                                                                                                   \
+        {                                                                                                              \
+            Spark::Validation::LogValidationFailure(Spark::LogLevel::Error, category, "VALIDATE", #expr, __FILE__,     \
+                                                    __LINE__, __FUNCTION__);                                           \
+            return;                                                                                                    \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_VALIDATE_MSG(category, expr, msg)
+ * @brief Soft validation with a human-readable message
+ */
+#define SPARK_VALIDATE_MSG(category, expr, msg)                                                                        \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (!(expr))                                                                                                   \
+        {                                                                                                              \
+            Spark::Validation::LogValidationFailure(Spark::LogLevel::Error, category, "VALIDATE", #expr, __FILE__,     \
+                                                    __LINE__, __FUNCTION__, msg);                                      \
+            return;                                                                                                    \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_VALIDATE_RET(category, expr, retval)
+ * @brief Soft validation that returns a specific value on failure
+ */
+#define SPARK_VALIDATE_RET(category, expr, retval)                                                                     \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (!(expr))                                                                                                   \
+        {                                                                                                              \
+            Spark::Validation::LogValidationFailure(Spark::LogLevel::Error, category, "VALIDATE", #expr, __FILE__,     \
+                                                    __LINE__, __FUNCTION__);                                           \
+            return (retval);                                                                                           \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_VALIDATE_NOT_NULL(category, ptr)
+ * @brief Null-pointer guard: logs error and returns (void) if ptr is null
+ */
+#define SPARK_VALIDATE_NOT_NULL(category, ptr)                                                                         \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if ((ptr) == nullptr)                                                                                          \
+        {                                                                                                              \
+            Spark::Validation::LogValidationFailure(Spark::LogLevel::Error, category, "NULL_CHECK",                    \
+                                                    "'" #ptr "' must not be null", __FILE__, __LINE__, __FUNCTION__);  \
+            return;                                                                                                    \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_VALIDATE_NOT_NULL_RET(category, ptr, retval)
+ * @brief Null-pointer guard that returns a specific value on failure
+ */
+#define SPARK_VALIDATE_NOT_NULL_RET(category, ptr, retval)                                                             \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if ((ptr) == nullptr)                                                                                          \
+        {                                                                                                              \
+            Spark::Validation::LogValidationFailure(Spark::LogLevel::Error, category, "NULL_CHECK",                    \
+                                                    "'" #ptr "' must not be null", __FILE__, __LINE__, __FUNCTION__);  \
+            return (retval);                                                                                           \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_VALIDATE_RANGE(category, val, minVal, maxVal)
+ * @brief Range guard: logs error and returns if val is outside [minVal, maxVal]
+ */
+#define SPARK_VALIDATE_RANGE(category, val, minVal, maxVal)                                                            \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if ((val) < (minVal) || (val) > (maxVal))                                                                      \
+        {                                                                                                              \
+            SPARK_LOG_ERROR(category, "RANGE VALIDATION FAILED: %s = %g, valid range [%g, %g]", #val,                  \
+                            static_cast<double>(val), static_cast<double>(minVal), static_cast<double>(maxVal));       \
+            return;                                                                                                    \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_VALIDATE_ENUM(category, val, maxVal)
+ * @brief Enum range guard: logs error and returns if enum val is outside [0, maxVal)
+ */
+#define SPARK_VALIDATE_ENUM(category, val, maxVal)                                                                     \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (static_cast<int>(val) < 0 || static_cast<int>(val) >= static_cast<int>(maxVal))                            \
+        {                                                                                                              \
+            SPARK_LOG_ERROR(category, "ENUM VALIDATION FAILED: %s = %d, valid range [0, %d)", #val,                    \
+                            static_cast<int>(val), static_cast<int>(maxVal));                                          \
+            return;                                                                                                    \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_VALIDATE_NOT_EMPTY(category, container)
+ * @brief Non-empty guard for strings and containers: logs error and returns if empty
+ */
+#define SPARK_VALIDATE_NOT_EMPTY(category, container)                                                                  \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if ((container).empty())                                                                                       \
+        {                                                                                                              \
+            Spark::Validation::LogValidationFailure(Spark::LogLevel::Error, category, "EMPTY_CHECK",                   \
+                                                    "'" #container "' must not be empty", __FILE__, __LINE__,          \
+                                                    __FUNCTION__);                                                     \
+            return;                                                                                                    \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_VALIDATE_POSITIVE(category, val)
+ * @brief Positive-value guard: logs error and returns if val <= 0
+ */
+#define SPARK_VALIDATE_POSITIVE(category, val)                                                                         \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if ((val) <= 0)                                                                                                \
+        {                                                                                                              \
+            SPARK_LOG_ERROR(category, "POSITIVE VALIDATION FAILED: %s = %g, must be > 0", #val,                        \
+                            static_cast<double>(val));                                                                 \
+            return;                                                                                                    \
+        }                                                                                                              \
+    } while (0)
+
+// ============================================================================
+// Offensive Programming — Hard checks (log + abort, never returns)
+// ============================================================================
+
+/**
+ * @def SPARK_REQUIRE(category, expr)
+ * @brief Precondition check: logs fatal error and aborts if expr is false
+ *
+ * Use for invariants that indicate a programming error if violated.
+ * Active in all builds (debug and release).
+ */
+#define SPARK_REQUIRE(category, expr)                                                                                  \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (!(expr))                                                                                                   \
+        {                                                                                                              \
+            Spark::Validation::LogValidationFailure(Spark::LogLevel::Fatal, category, "PRECONDITION", #expr, __FILE__, \
+                                                    __LINE__, __FUNCTION__);                                           \
+            ASSERT_ALWAYS(expr);                                                                                       \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_REQUIRE_MSG(category, expr, msg)
+ * @brief Precondition check with a diagnostic message
+ */
+#define SPARK_REQUIRE_MSG(category, expr, msg)                                                                         \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (!(expr))                                                                                                   \
+        {                                                                                                              \
+            Spark::Validation::LogValidationFailure(Spark::LogLevel::Fatal, category, "PRECONDITION", #expr, __FILE__, \
+                                                    __LINE__, __FUNCTION__, msg);                                      \
+            ASSERT_ALWAYS_MSG(expr, "%s", msg);                                                                        \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_REQUIRE_NOT_NULL(category, ptr)
+ * @brief Non-null precondition: logs fatal error and aborts if ptr is null
+ */
+#define SPARK_REQUIRE_NOT_NULL(category, ptr)                                                                          \
+    SPARK_REQUIRE_MSG(category, (ptr) != nullptr, "Pointer '" #ptr "' must not be null")
+
+/**
+ * @def SPARK_ENSURE(category, expr)
+ * @brief Postcondition check: logs fatal error and aborts if expr is false
+ */
+#define SPARK_ENSURE(category, expr)                                                                                   \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (!(expr))                                                                                                   \
+        {                                                                                                              \
+            Spark::Validation::LogValidationFailure(Spark::LogLevel::Fatal, category, "POSTCONDITION", #expr,          \
+                                                    __FILE__, __LINE__, __FUNCTION__);                                 \
+            ASSERT_ALWAYS(expr);                                                                                       \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_ENSURE_MSG(category, expr, msg)
+ * @brief Postcondition check with a diagnostic message
+ */
+#define SPARK_ENSURE_MSG(category, expr, msg)                                                                          \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (!(expr))                                                                                                   \
+        {                                                                                                              \
+            Spark::Validation::LogValidationFailure(Spark::LogLevel::Fatal, category, "POSTCONDITION", #expr,          \
+                                                    __FILE__, __LINE__, __FUNCTION__, msg);                            \
+            ASSERT_ALWAYS_MSG(expr, "%s", msg);                                                                        \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_UNREACHABLE(category, msg)
+ * @brief Marks code paths that should never be reached — aborts if executed
+ */
+#define SPARK_UNREACHABLE(category, msg)                                                                               \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        Spark::Validation::LogValidationFailure(Spark::LogLevel::Fatal, category, "UNREACHABLE",                       \
+                                                "Reached unreachable code", __FILE__, __LINE__, __FUNCTION__, msg);    \
+        ASSERT_ALWAYS_MSG(false, "UNREACHABLE: %s", msg);                                                              \
+    } while (0)
+
+// ============================================================================
+// Diagnostic Logging — Function/scope tracing
+// ============================================================================
+
+/**
+ * @def SPARK_TRACE_ENTER(category)
+ * @brief Log function entry at Trace level (compiled out in Release)
+ */
+#ifndef NDEBUG
+#define SPARK_TRACE_ENTER(category) SPARK_LOG_TRACE(category, ">> ENTER: %s", __FUNCTION__)
+#else
+#define SPARK_TRACE_ENTER(category) ((void)0)
+#endif
+
+/**
+ * @def SPARK_TRACE_EXIT(category)
+ * @brief Log function exit at Trace level (compiled out in Release)
+ */
+#ifndef NDEBUG
+#define SPARK_TRACE_EXIT(category) SPARK_LOG_TRACE(category, "<< EXIT:  %s", __FUNCTION__)
+#else
+#define SPARK_TRACE_EXIT(category) ((void)0)
+#endif
+
+/**
+ * @def SPARK_TRACE_SCOPE(category, name)
+ * @brief RAII scope tracer: logs entry and exit of a named scope
+ */
+#ifndef NDEBUG
+#define SPARK_TRACE_SCOPE(category, name)                                                                              \
+    Spark::Validation::ScopeTracer _sparkScopeTracer_##__LINE__(category, name, __FILE__, __LINE__)
+#else
+#define SPARK_TRACE_SCOPE(category, name) ((void)0)
+#endif
+
+/**
+ * @def SPARK_TRACE_VALUE(category, name, val)
+ * @brief Log a named value at Trace level for diagnostics
+ */
+#ifndef NDEBUG
+#define SPARK_TRACE_VALUE(category, name, val) SPARK_LOG_TRACE(category, "  %s = %s", name, std::to_string(val).c_str())
+#else
+#define SPARK_TRACE_VALUE(category, name, val) ((void)0)
+#endif
+
+/**
+ * @def SPARK_DIAGNOSTIC_CONTEXT(name)
+ * @brief Scoped breadcrumb for crash reports (delegates to SparkError ScopedContext)
+ */
+#define SPARK_DIAGNOSTIC_CONTEXT(name) SPARK_SCOPED_CONTEXT(name)
+
+// ============================================================================
+// Contract Logging — Structured validation audit trail
+// ============================================================================
+
+/**
+ * @def SPARK_CONTRACT_LOG_PRE(category, expr)
+ * @brief Log a precondition check result (pass or fail) at appropriate level
+ */
+#define SPARK_CONTRACT_LOG_PRE(category, expr)                                                                         \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (!(expr))                                                                                                   \
+        {                                                                                                              \
+            Spark::Validation::LogValidationFailure(Spark::LogLevel::Warn, category, "PRE", #expr, __FILE__, __LINE__, \
+                                                    __FUNCTION__);                                                     \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+            Spark::Validation::LogValidationSuccess(category, "PRE", #expr, __FILE__, __LINE__, __FUNCTION__);         \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_CONTRACT_LOG_POST(category, expr)
+ * @brief Log a postcondition check result (pass or fail) at appropriate level
+ */
+#define SPARK_CONTRACT_LOG_POST(category, expr)                                                                        \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (!(expr))                                                                                                   \
+        {                                                                                                              \
+            Spark::Validation::LogValidationFailure(Spark::LogLevel::Warn, category, "POST", #expr, __FILE__,          \
+                                                    __LINE__, __FUNCTION__);                                           \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+            Spark::Validation::LogValidationSuccess(category, "POST", #expr, __FILE__, __LINE__, __FUNCTION__);        \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_CONTRACT_LOG_INVARIANT(category, expr)
+ * @brief Log an invariant check result (pass or fail) at appropriate level
+ */
+#define SPARK_CONTRACT_LOG_INVARIANT(category, expr)                                                                   \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (!(expr))                                                                                                   \
+        {                                                                                                              \
+            Spark::Validation::LogValidationFailure(Spark::LogLevel::Warn, category, "INVARIANT", #expr, __FILE__,     \
+                                                    __LINE__, __FUNCTION__);                                           \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+            Spark::Validation::LogValidationSuccess(category, "INVARIANT", #expr, __FILE__, __LINE__, __FUNCTION__);   \
+        }                                                                                                              \
+    } while (0)
+
+// ============================================================================
+// Warn-only validation — Log but never return or abort
+// ============================================================================
+
+/**
+ * @def SPARK_WARN_IF(category, cond, msg)
+ * @brief Log a warning if condition is true (does not return or abort)
+ */
+#define SPARK_WARN_IF(category, cond, msg)                                                                             \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (cond)                                                                                                      \
+        {                                                                                                              \
+            SPARK_LOG_WARN(category, "%s", msg);                                                                       \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * @def SPARK_WARN_IF_NULL(category, ptr)
+ * @brief Log a warning if pointer is null (does not return or abort)
+ */
+#define SPARK_WARN_IF_NULL(category, ptr)                                                                              \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if ((ptr) == nullptr)                                                                                          \
+        {                                                                                                              \
+            SPARK_LOG_WARN(category, "Pointer '%s' is null (non-fatal)", #ptr);                                        \
+        }                                                                                                              \
+    } while (0)

--- a/SparkGame/Source/Console/AdvancedConsoleCommands.cpp
+++ b/SparkGame/Source/Console/AdvancedConsoleCommands.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "Utils/SparkConsole.h"
+#include "Utils/Validate.h"
 #include "Game/Game.h"
 #include "Graphics/GraphicsEngine.h"
 #include "Graphics/Shader.h"
@@ -32,6 +33,10 @@ namespace SparkConsole
  */
     void RegisterAdvancedCommands(Game* game, GraphicsEngine* graphics)
     {
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Game, graphics);
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Registering advanced console commands");
+
         auto& console = Spark::SimpleConsole::GetInstance();
 
         // ========================================================================

--- a/SparkGame/Source/Core/Main.cpp
+++ b/SparkGame/Source/Core/Main.cpp
@@ -20,6 +20,7 @@
 #include "Core/EngineContext.h"
 #include "Engine/Events/EventSystem.h"
 #include "Utils/SparkConsole.h"
+#include "Utils/Validate.h"
 
 // Global game pointer used by SparkConsole (in SparkEngineLib) to call into
 // game systems.  Owned by SparkGameModule; set during Initialize, cleared
@@ -73,6 +74,8 @@ Spark::ModuleInfo SparkGameModule::GetModuleInfo() const
 
 bool SparkGameModule::OnLoad(Spark::IEngineContext* context)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Game, context, false);
     m_context = context;
 
     // Delegate to the shared Initialize logic using the context's subsystems
@@ -138,11 +141,16 @@ const char* SparkGameModule::GetGameVersion() const
 
 bool SparkGameModule::Initialize(GraphicsEngine* graphics, InputManager* input)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     if (m_initialized)
         return true; // Prevent double-init
 
+    SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Game, graphics, false);
+    SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Game, input, false);
+
     auto& console = Spark::SimpleConsole::GetInstance();
     console.LogInfo("Initializing SparkGame module...");
+    SPARK_LOG_INFO(Spark::LogCategory::Game, "Initializing SparkGame module");
 
     g_game = std::make_unique<Game>();
     HRESULT hr = g_game->Initialize(graphics, input);
@@ -166,8 +174,11 @@ bool SparkGameModule::Initialize(GraphicsEngine* graphics, InputManager* input)
 
 void SparkGameModule::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     if (!m_initialized)
         return;
+
+    SPARK_LOG_INFO(Spark::LogCategory::Game, "Shutting down SparkGame module");
 
     if (g_game)
     {

--- a/SparkGame/Source/Game/ClassSystem.cpp
+++ b/SparkGame/Source/Game/ClassSystem.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "ClassSystem.h"
+#include "Utils/Validate.h"
 #include <algorithm>
 #include <cmath>
 
@@ -99,6 +100,8 @@ namespace Spark
 
     bool ClassSystem::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Initializing ClassSystem with 6 classes");
         InitScout();
         InitMedic();
         InitEngineer();
@@ -550,6 +553,9 @@ namespace Spark
 
     int ClassSystem::PlaceDeployable(Deployable::Type type, const DirectX::XMFLOAT3& position, int ownerID)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_WARN_IF(Spark::LogCategory::Game, static_cast<int>(m_deployables.size()) >= MAX_DEPLOYABLES - 1,
+                      "Deployable count near maximum capacity");
         if (static_cast<int>(m_deployables.size()) >= MAX_DEPLOYABLES)
             return -1;
 

--- a/SparkGame/Source/Game/Console.cpp
+++ b/SparkGame/Source/Game/Console.cpp
@@ -2,6 +2,7 @@
 // Console.cpp
 #include "Console.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 #include <iostream>
 #include <sstream>
 #include <algorithm>
@@ -9,7 +10,8 @@
 // -----------------------------------------------------------------------------
 void Console::Initialize(int screenW, int screenH)
 {
-    ASSERT(screenW > 0 && screenH > 0);
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, screenW > 0 && screenH > 0, "Screen dimensions must be positive");
     width = screenW;
     height = screenH;
 
@@ -87,7 +89,7 @@ bool Console::HandleChar(wchar_t c)
     if (!visible)
         return false;
 
-    ASSERT_MSG(c >= 0, "Invalid character code");
+    SPARK_WARN_IF(Spark::LogCategory::Game, c < 0, "Invalid character code received");
     if (c >= L' ' && c <= L'~') // printable ASCII
         inputLine.push_back(c);
 
@@ -193,7 +195,7 @@ void Console::Log(const std::wstring& msg)
 // -----------------------------------------------------------------------------
 void Console::ExecuteCommand(const std::wstring& line)
 {
-    ASSERT_ALWAYS(!line.empty());
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, !line.empty(), "Console command line must not be empty");
     Log(L"> " + line);
 
     std::wistringstream iss(line);
@@ -229,7 +231,7 @@ void Console::Render(ID3D11DeviceContext* ctx)
 {
     if (!visible)
         return;
-    ASSERT(ctx != nullptr);
+    SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Game, ctx);
 
     constexpr float lineH = 18.0f;
     constexpr float scale = 1.0f;

--- a/SparkGame/Source/Game/CubeObject.cpp
+++ b/SparkGame/Source/Game/CubeObject.cpp
@@ -1,6 +1,7 @@
 #include "Core/Platform.h"
 #include "CubeObject.h"
-#include "Utils/Assert.h"         // custom assert
+#include "Utils/Assert.h" // custom assert
+#include "Utils/Validate.h"
 #include "Game/PlaceholderMesh.h" // Add this include for LoadOrPlaceholderMesh
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
@@ -14,20 +15,22 @@ using DirectX::XMMATRIX;
 CubeObject::CubeObject(float size) : m_size(size)
 {
     std::wcout << L"[INFO] CubeObject constructed. size=" << size << std::endl;
-    ASSERT_MSG(size > 0.0f, "Cube size must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, size > 0.0f, "Cube size must be positive");
     SetName("Cube_" + std::to_string(GetID()));
 }
 
 HRESULT CubeObject::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     std::wcout << L"[OPERATION] CubeObject::Initialize called. size=" << m_size << std::endl;
-    ASSERT(device != nullptr);
-    ASSERT(context != nullptr);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, context);
     return GameObject::Initialize(device, context);
 }
 
 void CubeObject::CreateMesh()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     std::wcout << L"[OPERATION] CubeObject::CreateMesh called. size=" << m_size << std::endl;
     if (!m_mesh)
     {
@@ -36,7 +39,7 @@ void CubeObject::CreateMesh()
     }
     HRESULT hr = m_mesh->Initialize(m_device, m_context);
     std::wcout << L"[INFO] Mesh initialized for CubeObject. HR=0x" << std::hex << hr << std::dec << std::endl;
-    ASSERT_MSG(SUCCEEDED(hr), "Mesh initialization failed");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Mesh initialization failed");
     bool loaded = false;
     if (!m_modelPath.empty())
     {
@@ -55,8 +58,8 @@ void CubeObject::CreateMesh()
             hr = m_mesh->CreatePlane(m_size, m_size);
         }
         std::wcout << L"[INFO] Procedural cube mesh created. HR=0x" << std::hex << hr << std::dec << std::endl;
-        ASSERT_MSG(SUCCEEDED(hr), "Failed to create procedural cube mesh");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Failed to create procedural cube mesh");
     }
-    ASSERT_MSG(m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
-               "Cube mesh must have vertices and indices after loading/creation");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
+                      "Cube mesh must have vertices and indices after loading/creation");
 }

--- a/SparkGame/Source/Game/Game.cpp
+++ b/SparkGame/Source/Game/Game.cpp
@@ -12,6 +12,7 @@
 #include "ClassSystem.h"
 #include "Utils/Assert.h"
 #include "Utils/SparkError.h"
+#include "Utils/Validate.h"
 
 #include "Graphics/GraphicsEngine.h"
 #include "Graphics/TextureSystem.h"
@@ -60,10 +61,12 @@ Game::~Game()
 --------------------------------------------------------------*/
 HRESULT Game::Initialize(GraphicsEngine* graphics, InputManager* input)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_LOG_INFO(Spark::LogCategory::Game, "Game::Initialize called");
     LOG_TO_CONSOLE_IMMEDIATE(L"Game::Initialize called.", L"INFO");
 
-    ASSERT(graphics != nullptr);
-    ASSERT(input != nullptr);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, graphics);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, input);
 
     m_graphics = graphics;
     m_input = input;

--- a/SparkGame/Source/Game/Game.cpp
+++ b/SparkGame/Source/Game/Game.cpp
@@ -13,6 +13,7 @@
 #include "Utils/Assert.h"
 #include "Utils/SparkError.h"
 #include "Utils/Validate.h"
+#include "Utils/SparkConsole.h"
 
 #include "Graphics/GraphicsEngine.h"
 #include "Graphics/TextureSystem.h"

--- a/SparkGame/Source/Game/GameMechanics.cpp
+++ b/SparkGame/Source/Game/GameMechanics.cpp
@@ -2,6 +2,7 @@
 #include "GameMechanics.h"
 #include "Player.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 #include <algorithm>
 #include <cmath>
 #include <sstream>
@@ -32,6 +33,8 @@ namespace Spark
 
     bool DamageZoneSystem::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Initializing DamageZoneSystem");
         m_zones.clear();
         m_damageTickTimer = 0.0f;
         return true;
@@ -39,6 +42,7 @@ namespace Spark
 
     void DamageZoneSystem::Update(float deltaTime, Player* player)
     {
+        SPARK_WARN_IF(Spark::LogCategory::Game, !player, "DamageZoneSystem::Update called with null player");
         if (!player || !player->IsAlive())
             return;
 
@@ -231,6 +235,8 @@ namespace Spark
 
     bool RespawnSystem::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Initializing RespawnSystem");
         m_spawnPoints.clear();
         m_killHistory.clear();
         m_respawnTimer = 0.0f;
@@ -306,6 +312,7 @@ namespace Spark
     void RespawnSystem::OnPlayerDeath(Player* player, const std::string& killerName, const std::string& weapon,
                                       bool headshot)
     {
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Game, player);
         if (!player)
             return;
 
@@ -323,6 +330,7 @@ namespace Spark
 
     void RespawnSystem::RespawnPlayer(Player* player)
     {
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Game, player);
         if (!player)
             return;
 

--- a/SparkGame/Source/Game/GameMode.cpp
+++ b/SparkGame/Source/Game/GameMode.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "GameMode.h"
+#include "Utils/Validate.h"
 #include <algorithm>
 #include <cmath>
 
@@ -16,6 +17,8 @@ namespace Spark
 
     bool GameMode::Initialize(const GameModeRules& rules)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Initializing GameMode: %s", rules.modeName.c_str());
         m_rules = rules;
         m_roundState = RoundState::WaitingForPlayers;
         m_matchActive = false;
@@ -60,6 +63,8 @@ namespace Spark
 
     void GameMode::StartMatch()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Starting match");
         m_matchActive = true;
         m_currentRound = 0;
         m_alphaScore = 0;
@@ -86,6 +91,8 @@ namespace Spark
 
     void GameMode::EndMatch()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Ending match");
         m_matchActive = false;
         m_roundState = RoundState::MatchEnd;
 

--- a/SparkGame/Source/Game/GravitySystem.cpp
+++ b/SparkGame/Source/Game/GravitySystem.cpp
@@ -1,4 +1,5 @@
 #include "GravitySystem.h"
+#include "Utils/Validate.h"
 #include <algorithm>
 #include <cmath>
 #include <sstream>
@@ -84,6 +85,8 @@ namespace Spark
 
     bool GravitySystem::Initialize(const XMFLOAT3& worldGravity)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Initializing GravitySystem");
         m_worldGravity = worldGravity;
         m_zones.clear();
         return true;

--- a/SparkGame/Source/Game/HUDSystem.cpp
+++ b/SparkGame/Source/Game/HUDSystem.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "HUDSystem.h"
+#include "Utils/Validate.h"
 #include "Player.h"
 #include <cmath>
 #include <algorithm>
@@ -18,6 +19,8 @@ namespace Spark
 
     bool HUDSystem::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Initializing HUDSystem");
         m_damageIndicators.reserve(MAX_DAMAGE_INDICATORS);
         m_objectives.reserve(16);
         m_minimapBlips.reserve(64);

--- a/SparkGame/Source/Game/InteractiveObject.cpp
+++ b/SparkGame/Source/Game/InteractiveObject.cpp
@@ -3,6 +3,7 @@
 #include "Player.h"
 #include "Input/InputManager.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 #include <algorithm>
 #include <cmath>
 #include <sstream>
@@ -47,6 +48,7 @@ namespace Spark
 
     bool InteractiveObject::Interact(Player* player)
     {
+        SPARK_WARN_IF(Spark::LogCategory::Game, !player, "Interact called with null player");
         if (!m_isInteractable || !player)
             return false;
         if (m_interactionCallback)
@@ -724,6 +726,8 @@ namespace Spark
 
     bool InteractionSystem::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Initializing InteractionSystem");
         m_objects.clear();
         m_highlightedObject = nullptr;
         return true;

--- a/SparkGame/Source/Game/ModelObject.cpp
+++ b/SparkGame/Source/Game/ModelObject.cpp
@@ -8,6 +8,7 @@
 
 #include "ModelObject.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 #include <iostream>
 
 ModelObject::ModelObject(const std::wstring& modelPath) : m_modelPath(modelPath), m_model(std::make_unique<Model>())
@@ -17,8 +18,9 @@ ModelObject::ModelObject(const std::wstring& modelPath) : m_modelPath(modelPath)
 
 HRESULT ModelObject::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
-    ASSERT(device != nullptr);
-    ASSERT(context != nullptr);
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, context);
 
     // Load the model
     HRESULT hr = m_model->LoadObj(m_modelPath, device);
@@ -41,7 +43,7 @@ void ModelObject::Render(const DirectX::XMMATRIX& view, const DirectX::XMMATRIX&
         return;
     }
 
-    ASSERT(m_context != nullptr);
+    SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Game, m_context);
 
     // Build full world matrix with scale, rotation, and translation
     DirectX::XMFLOAT3 pos = GetPosition();
@@ -82,7 +84,7 @@ void ModelObject::OnHit(GameObject* target)
 {
     // Handle collision with another game object
     // For now, just do nothing - override in derived classes for specific behavior
-    ASSERT(target != nullptr);
+    SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Game, target);
 }
 
 void ModelObject::OnHitWorld(const DirectX::XMFLOAT3& hitPoint, const DirectX::XMFLOAT3& normal)

--- a/SparkGame/Source/Game/PlaneObject.cpp
+++ b/SparkGame/Source/Game/PlaneObject.cpp
@@ -1,27 +1,30 @@
 #include "Core/Platform.h"
 #include "PlaneObject.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 #include <string>
 #include <iostream>
 
 PlaneObject::PlaneObject(float width, float depth) : m_width(width), m_depth(depth)
 {
     std::wcout << L"[INFO] PlaneObject constructed. width=" << width << L" depth=" << depth << std::endl;
-    ASSERT_MSG(width > 0.f && depth > 0.f, "Plane dimensions must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, width > 0.f && depth > 0.f, "Plane dimensions must be positive");
     SetName("Plane_" + std::to_string(GetID()));
 }
 
 HRESULT PlaneObject::Initialize(ID3D11Device* d, ID3D11DeviceContext* c)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     std::wcout << L"[OPERATION] PlaneObject::Initialize called. width=" << m_width << L" depth=" << m_depth
                << std::endl;
-    ASSERT(d != nullptr);
-    ASSERT(c != nullptr);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, d);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, c);
     return GameObject::Initialize(d, c);
 }
 
 void PlaneObject::CreateMesh()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     std::wcout << L"[OPERATION] PlaneObject::CreateMesh called. width=" << m_width << L" depth=" << m_depth
                << std::endl;
     if (!m_mesh)
@@ -31,7 +34,7 @@ void PlaneObject::CreateMesh()
     }
     HRESULT hr = m_mesh->Initialize(m_device, m_context);
     std::wcout << L"[INFO] Mesh initialized for PlaneObject. HR=0x" << std::hex << hr << std::dec << std::endl;
-    ASSERT_MSG(SUCCEEDED(hr), "Mesh initialization failed");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Mesh initialization failed");
     bool loaded = false;
     if (!m_modelPath.empty())
     {
@@ -50,8 +53,8 @@ void PlaneObject::CreateMesh()
             hr = m_mesh->CreateTriangle(m_width);
         }
         std::wcout << L"[INFO] Procedural plane mesh created. HR=0x" << std::hex << hr << std::dec << std::endl;
-        ASSERT_MSG(SUCCEEDED(hr), "Failed to create procedural plane mesh");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Failed to create procedural plane mesh");
     }
-    ASSERT_MSG(m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
-               "Plane mesh must have vertices and indices after loading/creation");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
+                      "Plane mesh must have vertices and indices after loading/creation");
 }

--- a/SparkGame/Source/Game/Player.cpp
+++ b/SparkGame/Source/Game/Player.cpp
@@ -4,6 +4,7 @@
 #include "InteractiveObject.h"
 #include "Utils/Assert.h"
 #include "Utils/Validate.h"
+#include "Utils/SparkConsole.h"
 #include "Camera/SparkEngineCamera.h"
 #include "Input/InputManager.h"
 #include "Projectiles/WeaponStats.h"

--- a/SparkGame/Source/Game/Player.cpp
+++ b/SparkGame/Source/Game/Player.cpp
@@ -3,6 +3,7 @@
 #include "VehicleSystem.h"
 #include "InteractiveObject.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 #include "Camera/SparkEngineCamera.h"
 #include "Input/InputManager.h"
 #include "Projectiles/WeaponStats.h"
@@ -55,6 +56,8 @@ Player::~Player() = default;
 // Constructor
 Player::Player() : m_currentWeapon(GetWeaponStats(WeaponType::PISTOL)), m_collisionSphere(GetPosition(), 0.5f)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_LOG_INFO(Spark::LogCategory::Game, "Player constructed");
     LOG_TO_CONSOLE_IMMEDIATE(L"Player constructed.", L"INFO");
     SetName("Player");
     m_currentAmmo = m_currentWeapon.MagazineSize;

--- a/SparkGame/Source/Game/PyramidObject.cpp
+++ b/SparkGame/Source/Game/PyramidObject.cpp
@@ -1,24 +1,28 @@
 #include "Core/Platform.h"
 #include "PyramidObject.h"
+#include "Utils/Validate.h"
 #include <string>
 #include <iostream>
 
 PyramidObject::PyramidObject(float size) : m_size(size)
 {
     std::wcout << L"[INFO] PyramidObject constructed. size=" << size << std::endl;
-    ASSERT_MSG(size > 0.f, "Pyramid size must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, size > 0.f, "Pyramid size must be positive");
     SetName("Pyramid_" + std::to_string(GetID()));
 }
 
 HRESULT PyramidObject::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     std::wcout << L"[OPERATION] PyramidObject::Initialize called. size=" << m_size << std::endl;
-    ASSERT(device != nullptr && context != nullptr);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, context);
     return GameObject::Initialize(device, context);
 }
 
 void PyramidObject::CreateMesh()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     std::wcout << L"[OPERATION] PyramidObject::CreateMesh called. size=" << m_size << std::endl;
     if (!m_mesh)
     {
@@ -27,7 +31,7 @@ void PyramidObject::CreateMesh()
     }
     HRESULT hr = m_mesh->Initialize(m_device, m_context);
     std::wcout << L"[INFO] Mesh initialized for PyramidObject. HR=0x" << std::hex << hr << std::dec << std::endl;
-    ASSERT_MSG(SUCCEEDED(hr), "Mesh initialization failed");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Mesh initialization failed");
 
     bool loaded = false;
     if (!m_modelPath.empty())
@@ -56,9 +60,9 @@ void PyramidObject::CreateMesh()
             hr = m_mesh->CreatePlane(m_size, m_size);
         }
         std::wcout << L"[INFO] Procedural pyramid mesh created. HR=0x" << std::hex << hr << std::dec << std::endl;
-        ASSERT_MSG(SUCCEEDED(hr), "Failed to create procedural pyramid mesh");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Failed to create procedural pyramid mesh");
     }
 
-    ASSERT_MSG(m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
-               "Pyramid mesh must have vertices and indices after loading/creation");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
+                      "Pyramid mesh must have vertices and indices after loading/creation");
 }

--- a/SparkGame/Source/Game/RampObject.cpp
+++ b/SparkGame/Source/Game/RampObject.cpp
@@ -1,5 +1,6 @@
 #include "Core/Platform.h"
 #include "RampObject.h"
+#include "Utils/Validate.h"
 #include <string>
 #include <iostream>
 
@@ -8,20 +9,23 @@ using namespace std;
 RampObject::RampObject(float length, float height) : m_length(length), m_height(height)
 {
     std::wcout << L"[INFO] RampObject constructed. length=" << length << L" height=" << height << std::endl;
-    ASSERT_MSG(length > 0.f && height > 0.f, "Ramp dimensions must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, length > 0.f && height > 0.f, "Ramp dimensions must be positive");
     SetName("Ramp_" + std::to_string(GetID()));
 }
 
 HRESULT RampObject::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     std::wcout << L"[OPERATION] RampObject::Initialize called. length=" << m_length << L" height=" << m_height
                << std::endl;
-    ASSERT(device != nullptr && context != nullptr);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, context);
     return GameObject::Initialize(device, context);
 }
 
 void RampObject::CreateMesh()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     std::wcout << L"[OPERATION] RampObject::CreateMesh called. length=" << m_length << L" height=" << m_height
                << std::endl;
     if (!m_mesh)
@@ -31,7 +35,7 @@ void RampObject::CreateMesh()
     }
     HRESULT hr = m_mesh->Initialize(m_device, m_context);
     std::wcout << L"[INFO] Mesh initialized for RampObject. HR=0x" << std::hex << hr << std::dec << std::endl;
-    ASSERT_MSG(SUCCEEDED(hr), "Mesh initialization failed");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Mesh initialization failed");
     bool loaded = false;
     if (!m_modelPath.empty())
     {
@@ -50,8 +54,8 @@ void RampObject::CreateMesh()
             hr = m_mesh->CreatePlane(m_length, m_height);
         }
         std::wcout << L"[INFO] Procedural ramp mesh created. HR=0x" << std::hex << hr << std::dec << std::endl;
-        ASSERT_MSG(SUCCEEDED(hr), "Failed to create procedural ramp mesh");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Failed to create procedural ramp mesh");
     }
-    ASSERT_MSG(m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
-               "Ramp mesh must have vertices and indices after loading/creation");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
+                      "Ramp mesh must have vertices and indices after loading/creation");
 }

--- a/SparkGame/Source/Game/SphereObject.cpp
+++ b/SparkGame/Source/Game/SphereObject.cpp
@@ -2,29 +2,32 @@
 // SphereObject.cpp
 #include "SphereObject.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 #include <iostream>
 
 SphereObject::SphereObject(float radius, int slices, int stacks) : m_radius(radius), m_slices(slices), m_stacks(stacks)
 {
     std::wcout << L"[INFO] SphereObject constructed. radius=" << radius << L" slices=" << slices << L" stacks="
                << stacks << std::endl;
-    ASSERT_MSG(radius > 0.0f, "Sphere radius must be positive");
-    ASSERT_MSG(slices >= 3, "Sphere slices must be >= 3");
-    ASSERT_MSG(stacks >= 2, "Sphere stacks must be >= 2");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, radius > 0.0f, "Sphere radius must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, slices >= 3, "Sphere slices must be >= 3");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, stacks >= 2, "Sphere stacks must be >= 2");
     SetName("Sphere_" + std::to_string(GetID()));
 }
 
 HRESULT SphereObject::Initialize(ID3D11Device* d, ID3D11DeviceContext* c)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     std::wcout << L"[OPERATION] SphereObject::Initialize called. radius=" << m_radius << L" slices=" << m_slices
                << L" stacks=" << m_stacks << std::endl;
-    ASSERT(d != nullptr);
-    ASSERT(c != nullptr);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, d);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, c);
     return GameObject::Initialize(d, c);
 }
 
 void SphereObject::CreateMesh()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     std::wcout << L"[OPERATION] SphereObject::CreateMesh called. radius=" << m_radius << L" slices=" << m_slices
                << L" stacks=" << m_stacks << std::endl;
     if (!m_mesh)
@@ -34,7 +37,7 @@ void SphereObject::CreateMesh()
     }
     HRESULT hr = m_mesh->Initialize(m_device, m_context);
     std::wcout << L"[INFO] Mesh initialized for SphereObject. HR=0x" << std::hex << hr << std::dec << std::endl;
-    ASSERT_MSG(SUCCEEDED(hr), "Mesh initialization failed");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Mesh initialization failed");
     bool loaded = false;
     if (!m_modelPath.empty())
     {
@@ -53,8 +56,8 @@ void SphereObject::CreateMesh()
             hr = m_mesh->CreatePlane(m_radius, m_radius);
         }
         std::wcout << L"[INFO] Procedural sphere mesh created. HR=0x" << std::hex << hr << std::dec << std::endl;
-        ASSERT_MSG(SUCCEEDED(hr), "Failed to create procedural sphere mesh");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Failed to create procedural sphere mesh");
     }
-    ASSERT_MSG(m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
-               "Sphere mesh must have vertices and indices after loading/creation");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
+                      "Sphere mesh must have vertices and indices after loading/creation");
 }

--- a/SparkGame/Source/Game/Terrain.cpp
+++ b/SparkGame/Source/Game/Terrain.cpp
@@ -2,6 +2,7 @@
 // Terrain.cpp
 #include "Terrain.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 #include <fstream>
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
@@ -15,11 +16,12 @@ using namespace DirectX;
 HRESULT Terrain::Initialize(ID3D11Device* device, ID3D11DeviceContext* ctx, const wchar_t* file, UINT w, UINT h,
                             float s)
 {
-    ASSERT(device != nullptr);
-    ASSERT(ctx != nullptr);
-    ASSERT_MSG(file != nullptr, "Heightmap file path null");
-    ASSERT_MSG(w > 1 && h > 1, "Terrain dimensions must be >1");
-    ASSERT_MSG(s > 0, "Cell spacing must be positive");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, ctx);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, file != nullptr, "Heightmap file path null");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, w > 1 && h > 1, "Terrain dimensions must be >1");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, s > 0, "Cell spacing must be positive");
 
     // 1) Read raw 8-bit BMP after 54-byte header
     std::vector<uint8_t> data(w * h);
@@ -35,8 +37,8 @@ HRESULT Terrain::Initialize(ID3D11Device* device, ID3D11DeviceContext* ctx, cons
     CalculateNormals();
 
     // Ensure we have vertices and indices
-    ASSERT_ALWAYS_MSG(!m_vertices.empty(), "No terrain vertices generated");
-    ASSERT_ALWAYS_MSG(!m_indices.empty(), "No terrain indices generated");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, !m_vertices.empty(), "No terrain vertices generated");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, !m_indices.empty(), "No terrain indices generated");
 
     // 3) Create VB
     D3D11_BUFFER_DESC bd{};
@@ -48,7 +50,7 @@ HRESULT Terrain::Initialize(ID3D11Device* device, ID3D11DeviceContext* ctx, cons
     sd.pSysMem = m_vertices.data();
 
     HRESULT hr = device->CreateBuffer(&bd, &sd, &m_vb);
-    ASSERT_MSG(SUCCEEDED(hr), "Terrain vertex buffer creation failed");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Terrain vertex buffer creation failed");
     if (FAILED(hr))
         return hr;
 
@@ -59,14 +61,14 @@ HRESULT Terrain::Initialize(ID3D11Device* device, ID3D11DeviceContext* ctx, cons
     sd.pSysMem = m_indices.data();
 
     hr = device->CreateBuffer(&bd, &sd, &m_ib);
-    ASSERT_MSG(SUCCEEDED(hr), "Terrain index buffer creation failed");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Terrain index buffer creation failed");
     m_indexCount = UINT(m_indices.size());
     return hr;
 }
 
 void Terrain::BuildMesh(const std::vector<uint8_t>& h, UINT w, UINT hgt, float s)
 {
-    ASSERT_MSG(h.size() == w * hgt, "Height data size mismatch");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, h.size() == w * hgt, "Height data size mismatch");
 
     m_vertices.resize(static_cast<std::vector<TerrainVertex, std::allocator<TerrainVertex>>::size_type>(w) * hgt);
     m_indices.clear();
@@ -96,13 +98,14 @@ void Terrain::BuildMesh(const std::vector<uint8_t>& h, UINT w, UINT hgt, float s
         }
     }
 
-    ASSERT_ALWAYS_MSG(!m_vertices.empty(), "BuildMesh: no vertices");
-    ASSERT_ALWAYS_MSG(!m_indices.empty(), "BuildMesh: no indices");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, !m_vertices.empty(), "BuildMesh: no vertices");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, !m_indices.empty(), "BuildMesh: no indices");
 }
 
 void Terrain::CalculateNormals()
 {
-    ASSERT(!m_vertices.empty() && !m_indices.empty());
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, !m_vertices.empty() && !m_indices.empty(),
+                      "Cannot calculate normals without vertices and indices");
 
     // Zero normals
     for (auto& v : m_vertices)
@@ -146,10 +149,10 @@ void Terrain::CalculateNormals()
 
 void Terrain::Render(ID3D11DeviceContext* ctx)
 {
-    ASSERT(ctx != nullptr);
-    ASSERT(m_vb != nullptr);
-    ASSERT(m_ib != nullptr);
-    ASSERT(m_indexCount > 0);
+    SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Game, ctx);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, m_vb.Get());
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, m_ib.Get());
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, m_indexCount > 0, "Terrain has no indices to render");
 
     UINT stride = sizeof(TerrainVertex), offset = 0;
     ctx->IASetVertexBuffers(0, 1, m_vb.GetAddressOf(), &stride, &offset);

--- a/SparkGame/Source/Game/VehicleSystem.cpp
+++ b/SparkGame/Source/Game/VehicleSystem.cpp
@@ -4,6 +4,7 @@
 #include "Input/InputManager.h"
 #include "Utils/MathUtils.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 #include <algorithm>
 #include <cmath>
 #include <sstream>
@@ -134,6 +135,7 @@ namespace Spark
 
     bool Vehicle::EnterSeat(Player* player, int seatIndex)
     {
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Game, player, false);
         if (!player || IsDestroyed())
             return false;
 
@@ -467,6 +469,8 @@ namespace Spark
 
     bool VehicleSystem::Initialize()
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_LOG_INFO(Spark::LogCategory::Game, "Initializing VehicleSystem");
         InitVehicleDefinitions();
         return true;
     }
@@ -500,6 +504,9 @@ namespace Spark
     Vehicle* VehicleSystem::SpawnVehicle(VehicleType type, const XMFLOAT3& position, ID3D11Device* device,
                                          ID3D11DeviceContext* context)
     {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+        SPARK_WARN_IF(Spark::LogCategory::Game, (int)m_vehicles.size() >= MAX_VEHICLES - 1,
+                      "Vehicle count near maximum capacity");
         if ((int)m_vehicles.size() >= MAX_VEHICLES)
             return nullptr;
 

--- a/SparkGame/Source/Game/WallObject.cpp
+++ b/SparkGame/Source/Game/WallObject.cpp
@@ -1,25 +1,29 @@
 #include "Core/Platform.h"
 #include "WallObject.h"
+#include "Utils/Validate.h"
 #include <string>
 #include <iostream>
 
 WallObject::WallObject(float width, float height) : m_width(width), m_height(height)
 {
     std::wcout << L"[INFO] WallObject constructed. width=" << width << L" height=" << height << std::endl;
-    ASSERT_MSG(width > 0.f && height > 0.f, "Wall dimensions must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, width > 0.f && height > 0.f, "Wall dimensions must be positive");
     SetName("Wall_" + std::to_string(GetID()));
 }
 
 HRESULT WallObject::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     std::wcout << L"[OPERATION] WallObject::Initialize called. width=" << m_width << L" height=" << m_height
                << std::endl;
-    ASSERT(device != nullptr && context != nullptr);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, context);
     return GameObject::Initialize(device, context);
 }
 
 void WallObject::CreateMesh()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     std::wcout << L"[OPERATION] WallObject::CreateMesh called. width=" << m_width << L" height=" << m_height
                << std::endl;
     if (!m_mesh)
@@ -29,7 +33,7 @@ void WallObject::CreateMesh()
     }
     HRESULT hr = m_mesh->Initialize(m_device, m_context);
     std::wcout << L"[INFO] Mesh initialized for WallObject. HR=0x" << std::hex << hr << std::dec << std::endl;
-    ASSERT_MSG(SUCCEEDED(hr), "Mesh initialization failed");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Mesh initialization failed");
     bool loaded = false;
     if (!m_modelPath.empty())
     {
@@ -40,8 +44,8 @@ void WallObject::CreateMesh()
     {
         hr = m_mesh->CreatePlane(m_width, m_height);
         std::wcout << L"[INFO] Procedural wall mesh created. HR=0x" << std::hex << hr << std::dec << std::endl;
-        ASSERT_MSG(SUCCEEDED(hr), "Failed to create procedural wall mesh");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Failed to create procedural wall mesh");
     }
-    ASSERT_MSG(m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
-               "Wall mesh must have vertices and indices after loading");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, m_mesh && m_mesh->GetVertexCount() > 0 && m_mesh->GetIndexCount() > 0,
+                      "Wall mesh must have vertices and indices after loading");
 }

--- a/SparkGame/Source/Projectiles/Bullet.cpp
+++ b/SparkGame/Source/Projectiles/Bullet.cpp
@@ -2,6 +2,7 @@
 // Bullet.cpp
 #include "Bullet.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 
 using DirectX::XMFLOAT3;
 using DirectX::XMMATRIX;
@@ -13,26 +14,29 @@ Bullet::Bullet()
     m_speed = 100.0f;
     m_maxLifeTime = 3.0f;
 
-    // Assert scale values are positive
+    // Validate scale values are positive
     XMFLOAT3 scale = {0.05f, 0.05f, 0.2f};
-    ASSERT_MSG(scale.x > 0 && scale.y > 0 && scale.z > 0, "Bullet scale must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, scale.x > 0 && scale.y > 0 && scale.z > 0,
+                      "Bullet scale must be positive");
     SetScale(scale);
 }
 
 HRESULT Bullet::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
-    ASSERT_MSG(device != nullptr, "Bullet::Initialize - device is null");
-    ASSERT_MSG(context != nullptr, "Bullet::Initialize - context is null");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, context);
 
     // Base initialization sets up mesh and transforms
     HRESULT hr = Projectile::Initialize(device, context);
-    ASSERT_MSG(SUCCEEDED(hr), "Projectile::Initialize failed in Bullet");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Projectile::Initialize failed in Bullet");
     return hr;
 }
 
 void Bullet::Update(float deltaTime)
 {
-    ASSERT_MSG(deltaTime >= 0.0f && std::isfinite(deltaTime), "Invalid deltaTime in Bullet::Update");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, deltaTime >= 0.0f && std::isfinite(deltaTime),
+                      "Invalid deltaTime in Bullet::Update");
     // Use base physics/lifetime/collision
     Projectile::Update(deltaTime);
 }
@@ -41,6 +45,6 @@ void Bullet::Render(const XMMATRIX& view, const XMMATRIX& projection)
 {
     if (!m_active)
         return;
-    ASSERT_MSG(m_mesh != nullptr, "Bullet mesh not initialized");
+    SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Game, m_mesh);
     Projectile::Render(view, projection);
 }

--- a/SparkGame/Source/Projectiles/Grenade.cpp
+++ b/SparkGame/Source/Projectiles/Grenade.cpp
@@ -2,6 +2,7 @@
 // Grenade.cpp
 #include "Grenade.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 #include "Physics/PhysicsSystem.h"
 
 using DirectX::XMFLOAT3;
@@ -11,8 +12,8 @@ using DirectX::XMMATRIX;
 Grenade::Grenade() : m_fuseTime(3.0f), m_explosionRadius(8.0f), m_hasExploded(false)
 {
     // Validate parameters
-    ASSERT_MSG(m_fuseTime > 0.0f, "Grenade fuse time must be positive");
-    ASSERT_MSG(m_explosionRadius > 0.0f, "Grenade explosion radius must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, m_fuseTime > 0.0f, "Grenade fuse time must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, m_explosionRadius > 0.0f, "Grenade explosion radius must be positive");
 
     m_damage = 100.0f;
     m_speed = 15.0f;
@@ -23,23 +24,26 @@ Grenade::Grenade() : m_fuseTime(3.0f), m_explosionRadius(8.0f), m_hasExploded(fa
 
     // Scale grenade
     XMFLOAT3 scale{0.3f, 0.3f, 0.3f};
-    ASSERT_MSG(scale.x > 0.0f && scale.y > 0.0f && scale.z > 0.0f, "Grenade scale must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, scale.x > 0.0f && scale.y > 0.0f && scale.z > 0.0f,
+                      "Grenade scale must be positive");
     SetScale(scale);
 }
 
 HRESULT Grenade::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
-    ASSERT_MSG(device != nullptr, "Grenade::Initialize device is null");
-    ASSERT_MSG(context != nullptr, "Grenade::Initialize context is null");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, context);
 
     HRESULT hr = Projectile::Initialize(device, context);
-    ASSERT_MSG(SUCCEEDED(hr), "Projectile::Initialize failed in Grenade");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Projectile::Initialize failed in Grenade");
     return hr;
 }
 
 void Grenade::Update(float deltaTime)
 {
-    ASSERT_MSG(deltaTime >= 0.0f && std::isfinite(deltaTime), "Invalid deltaTime in Grenade::Update");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, deltaTime >= 0.0f && std::isfinite(deltaTime),
+                      "Invalid deltaTime in Grenade::Update");
 
     if (!m_active)
         return;
@@ -59,12 +63,13 @@ void Grenade::Render(const XMMATRIX& view, const XMMATRIX& projection)
 {
     if (!m_active)
         return;
-    ASSERT_MSG(m_mesh != nullptr, "Grenade mesh not initialized");
+    SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Game, m_mesh);
     Projectile::Render(view, projection);
 }
 
 void Grenade::Fire(const XMFLOAT3& startPosition, const XMFLOAT3& direction, float speed)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     m_hasExploded = false;
     Projectile::Fire(startPosition, direction, speed);
 }

--- a/SparkGame/Source/Projectiles/Projectile.cpp
+++ b/SparkGame/Source/Projectiles/Projectile.cpp
@@ -2,6 +2,7 @@
 // Projectile.cpp
 #include "Projectile.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 #include "Utils/MathUtils.h"
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
@@ -15,7 +16,7 @@ Projectile::Projectile()
 {
     // Base GameObject scale
     XMFLOAT3 scale{0.1f, 0.1f, 0.3f};
-    ASSERT_MSG(scale.x > 0 && scale.y > 0 && scale.z > 0, "Scale must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, scale.x > 0 && scale.y > 0 && scale.z > 0, "Scale must be positive");
     SetScale(scale);
 }
 
@@ -23,11 +24,12 @@ Projectile::~Projectile() = default;
 
 HRESULT Projectile::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
-    ASSERT_MSG(device != nullptr, "Device is null");
-    ASSERT_MSG(context != nullptr, "Context is null");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, context);
 
     HRESULT hr = GameObject::Initialize(device, context);
-    ASSERT_MSG(SUCCEEDED(hr), "GameObject::Initialize failed in Projectile");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "GameObject::Initialize failed in Projectile");
     if (FAILED(hr))
         return hr;
 
@@ -37,7 +39,7 @@ HRESULT Projectile::Initialize(ID3D11Device* device, ID3D11DeviceContext* contex
 
 void Projectile::Update(float deltaTime)
 {
-    ASSERT_MSG(deltaTime >= 0 && std::isfinite(deltaTime), "Invalid deltaTime");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, deltaTime >= 0 && std::isfinite(deltaTime), "Invalid deltaTime");
     if (!m_active)
         return;
 
@@ -75,7 +77,8 @@ void Projectile::Render(const XMMATRIX& view, const XMMATRIX& projection)
 
 void Projectile::Fire(const XMFLOAT3& startPosition, const XMFLOAT3& direction, float speed)
 {
-    ASSERT_MSG(speed >= 0, "Speed must be non-negative");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, speed >= 0, "Speed must be non-negative");
     SetPosition(startPosition);
     m_speed = speed;
 
@@ -109,7 +112,7 @@ void Projectile::Reset()
 
 void Projectile::OnHit(GameObject* target)
 {
-    ASSERT_MSG(target != nullptr, "OnHit target null");
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, target);
     Deactivate();
 }
 
@@ -121,7 +124,7 @@ void Projectile::OnHitWorld(const XMFLOAT3& hitPoint, const XMFLOAT3& normal)
 
 void Projectile::SetGravity(bool enabled, float scale)
 {
-    ASSERT_MSG(scale >= 0, "Gravity scale must be non-negative");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, scale >= 0, "Gravity scale must be non-negative");
     m_hasGravity = enabled;
     m_gravityScale = scale;
 }

--- a/SparkGame/Source/Projectiles/ProjectilePool.cpp
+++ b/SparkGame/Source/Projectiles/ProjectilePool.cpp
@@ -5,6 +5,7 @@
 #include "Rocket.h"
 #include "Grenade.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 #include "Utils/ConsoleProcessManager.h"
 #include <algorithm>
 #include <iostream>
@@ -42,7 +43,7 @@ using namespace DirectX;
 ProjectilePool::ProjectilePool(size_t poolSize) : m_poolSize(poolSize)
 {
     LOG_TO_CONSOLE_IMMEDIATE(L"ProjectilePool constructed with size " + std::to_wstring(poolSize), L"INFO");
-    ASSERT_MSG(poolSize > 0, "ProjectilePool size must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, poolSize > 0, "ProjectilePool size must be positive");
     m_projectiles.reserve(poolSize);
 }
 
@@ -54,9 +55,10 @@ ProjectilePool::~ProjectilePool()
 
 HRESULT ProjectilePool::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     LOG_TO_CONSOLE_IMMEDIATE(L"ProjectilePool::Initialize called.", L"OPERATION");
-    ASSERT(device != nullptr);
-    ASSERT(context != nullptr);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, context);
 
     m_device = device;
     m_context = context;
@@ -72,7 +74,7 @@ HRESULT ProjectilePool::Initialize(ID3D11Device* device, ID3D11DeviceContext* co
         for (size_t i = 0; i < count; ++i)
         {
             auto p = TypeFactory();
-            ASSERT_MSG(p != nullptr, "Failed to create projectile");
+            SPARK_REQUIRE_MSG(Spark::LogCategory::Game, p != nullptr, "Failed to create projectile");
             if (SUCCEEDED(p->Initialize(m_device, m_context)))
             {
                 m_availableProjectiles.push(p.get());
@@ -85,7 +87,8 @@ HRESULT ProjectilePool::Initialize(ID3D11Device* device, ID3D11DeviceContext* co
     makeAndStore([] { return std::make_unique<Rocket>(); }, rocketsCount);
     makeAndStore([] { return std::make_unique<Grenade>(); }, grenadesCount);
 
-    ASSERT_MSG(m_projectiles.size() == m_poolSize, "Some projectiles failed to initialize");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, m_projectiles.size() == m_poolSize,
+                      "Some projectiles failed to initialize");
 
     LOG_TO_CONSOLE_IMMEDIATE(L"ProjectilePool created " + std::to_wstring(m_projectiles.size()) + L" projectiles.",
                              L"INFO");
@@ -95,7 +98,8 @@ HRESULT ProjectilePool::Initialize(ID3D11Device* device, ID3D11DeviceContext* co
 void ProjectilePool::Update(float deltaTime)
 {
     // **FIXED: Remove per-frame logging completely**
-    ASSERT_MSG(deltaTime >= 0.0f && std::isfinite(deltaTime), "Invalid deltaTime in ProjectilePool::Update");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, deltaTime >= 0.0f && std::isfinite(deltaTime),
+                      "Invalid deltaTime in ProjectilePool::Update");
 
     for (auto& up : m_projectiles)
     {
@@ -120,6 +124,8 @@ void ProjectilePool::Render(const DirectX::XMMATRIX& view, const DirectX::XMMATR
 
 void ProjectilePool::Shutdown()
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_LOG_INFO(Spark::LogCategory::Game, "ProjectilePool shutting down");
     LOG_TO_CONSOLE_IMMEDIATE(L"ProjectilePool::Shutdown called.", L"OPERATION");
 
     m_projectiles.clear();
@@ -147,7 +153,7 @@ void ProjectilePool::ReturnProjectile(Projectile* p)
 {
     // **FIXED: Rate-limited logging for projectile return**
     LOG_TO_CONSOLE(L"ProjectilePool::ReturnProjectile called.", L"OPERATION");
-    ASSERT(p != nullptr);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, p);
     if (p)
     {
         p->SetActive(false);
@@ -158,7 +164,7 @@ void ProjectilePool::ReturnProjectile(Projectile* p)
 void ProjectilePool::FireBullet(const XMFLOAT3& pos, const XMFLOAT3& dir, float speed)
 {
     LOG_TO_CONSOLE(L"ProjectilePool::FireBullet called. speed=" + std::to_wstring(speed), L"OPERATION");
-    ASSERT_MSG(speed >= 0.0f, "Speed must be non-negative in FireBullet");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, speed >= 0.0f, "Speed must be non-negative in FireBullet");
     if (auto p = GetProjectile())
     {
         p->Fire(pos, dir, speed);
@@ -168,7 +174,7 @@ void ProjectilePool::FireBullet(const XMFLOAT3& pos, const XMFLOAT3& dir, float 
 void ProjectilePool::FireRocket(const XMFLOAT3& pos, const XMFLOAT3& dir, float speed)
 {
     LOG_TO_CONSOLE(L"ProjectilePool::FireRocket called. speed=" + std::to_wstring(speed), L"OPERATION");
-    ASSERT_MSG(speed >= 0.0f, "Speed must be non-negative in FireRocket");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, speed >= 0.0f, "Speed must be non-negative in FireRocket");
     if (auto p = GetProjectile())
     {
         p->Fire(pos, dir, speed);
@@ -178,7 +184,7 @@ void ProjectilePool::FireRocket(const XMFLOAT3& pos, const XMFLOAT3& dir, float 
 void ProjectilePool::FireGrenade(const XMFLOAT3& pos, const XMFLOAT3& dir, float speed)
 {
     LOG_TO_CONSOLE(L"ProjectilePool::FireGrenade called. speed=" + std::to_wstring(speed), L"OPERATION");
-    ASSERT_MSG(speed >= 0.0f, "Speed must be non-negative in FireGrenade");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, speed >= 0.0f, "Speed must be non-negative in FireGrenade");
     if (auto p = GetProjectile())
     {
         p->SetGravity(true, 1.0f);
@@ -206,7 +212,7 @@ void ProjectilePool::FireProjectile(ProjectileType type, const XMFLOAT3& pos, co
         break;
     default:
         LOG_TO_CONSOLE_IMMEDIATE(L"Unknown ProjectileType in FireProjectile", L"ERROR");
-        ASSERT_MSG(false, "Unknown ProjectileType in FireProjectile");
+        SPARK_REQUIRE_MSG(Spark::LogCategory::Game, false, "Unknown ProjectileType in FireProjectile");
     }
 
     // Only log firing every 3 seconds to avoid spam

--- a/SparkGame/Source/Projectiles/ProjectilePool.cpp
+++ b/SparkGame/Source/Projectiles/ProjectilePool.cpp
@@ -6,6 +6,7 @@
 #include "Grenade.h"
 #include "Utils/Assert.h"
 #include "Utils/Validate.h"
+#include "Utils/SparkConsole.h"
 #include "Utils/ConsoleProcessManager.h"
 #include <algorithm>
 #include <iostream>

--- a/SparkGame/Source/Projectiles/Rocket.cpp
+++ b/SparkGame/Source/Projectiles/Rocket.cpp
@@ -2,6 +2,7 @@
 // Rocket.cpp
 #include "Rocket.h"
 #include "Utils/Assert.h"
+#include "Utils/Validate.h"
 #include "Utils/MathUtils.h"
 #include "Physics/PhysicsSystem.h"
 
@@ -11,7 +12,7 @@ using DirectX::XMMATRIX;
 
 Rocket::Rocket() : m_explosionRadius(5.0f), m_hasExploded(false), m_trailTimer(0.0f)
 {
-    ASSERT_MSG(m_explosionRadius > 0.0f, "Rocket explosion radius must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, m_explosionRadius > 0.0f, "Rocket explosion radius must be positive");
 
     m_damage = 75.0f;
     m_speed = 30.0f;
@@ -21,23 +22,26 @@ Rocket::Rocket() : m_explosionRadius(5.0f), m_hasExploded(false), m_trailTimer(0
     SetGravity(true, 0.3f);
 
     XMFLOAT3 scale{0.2f, 0.2f, 0.8f};
-    ASSERT_MSG(scale.x > 0 && scale.y > 0 && scale.z > 0, "Rocket scale must be positive");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, scale.x > 0 && scale.y > 0 && scale.z > 0,
+                      "Rocket scale must be positive");
     SetScale(scale);
 }
 
 HRESULT Rocket::Initialize(ID3D11Device* device, ID3D11DeviceContext* context)
 {
-    ASSERT_MSG(device != nullptr, "Rocket::Initialize device is null");
-    ASSERT_MSG(context != nullptr, "Rocket::Initialize context is null");
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, device);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, context);
 
     HRESULT hr = Projectile::Initialize(device, context);
-    ASSERT_MSG(SUCCEEDED(hr), "Projectile::Initialize failed in Rocket");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, SUCCEEDED(hr), "Projectile::Initialize failed in Rocket");
     return hr;
 }
 
 void Rocket::Update(float deltaTime)
 {
-    ASSERT_MSG(deltaTime >= 0.0f && std::isfinite(deltaTime), "Invalid deltaTime in Rocket::Update");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, deltaTime >= 0.0f && std::isfinite(deltaTime),
+                      "Invalid deltaTime in Rocket::Update");
     Projectile::Update(deltaTime);
 
     // Trail effect: record positions at intervals for visual trail rendering
@@ -59,12 +63,13 @@ void Rocket::Render(const XMMATRIX& view, const XMMATRIX& projection)
 {
     if (!m_active)
         return;
-    ASSERT_MSG(m_mesh != nullptr, "Rocket mesh not initialized");
+    SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Game, m_mesh);
     Projectile::Render(view, projection);
 }
 
 void Rocket::Fire(const XMFLOAT3& startPosition, const XMFLOAT3& direction, float speed)
 {
+    SPARK_TRACE_ENTER(Spark::LogCategory::Game);
     m_hasExploded = false;
     m_trailPositions.clear();
     m_trailTimer = 0.0f;
@@ -73,22 +78,23 @@ void Rocket::Fire(const XMFLOAT3& startPosition, const XMFLOAT3& direction, floa
 
 void Rocket::OnHit(GameObject* target)
 {
-    ASSERT_MSG(target != nullptr, "Rocket::OnHit target is null");
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Game, target);
     if (!m_hasExploded)
         Explode(GetPosition());
 }
 
 void Rocket::OnHitWorld(const XMFLOAT3& hitPoint, const XMFLOAT3& normal)
 {
-    ASSERT_MSG(std::isfinite(hitPoint.x) && std::isfinite(hitPoint.y) && std::isfinite(hitPoint.z),
-               "Invalid hitPoint in Rocket::OnHitWorld");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game,
+                      std::isfinite(hitPoint.x) && std::isfinite(hitPoint.y) && std::isfinite(hitPoint.z),
+                      "Invalid hitPoint in Rocket::OnHitWorld");
     if (!m_hasExploded)
         Explode(hitPoint);
 }
 
 void Rocket::Explode(const XMFLOAT3& position)
 {
-    ASSERT_MSG(!m_hasExploded, "Rocket exploded multiple times");
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Game, !m_hasExploded, "Rocket exploded multiple times");
     m_hasExploded = true;
 
     // Apply area damage to all physics bodies within explosion radius

--- a/SparkGame/Source/Projectiles/WeaponStats.cpp
+++ b/SparkGame/Source/Projectiles/WeaponStats.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "WeaponStats.h"
+#include "Utils/Validate.h"
 #include <unordered_map>
 #include <string>
 #include <algorithm>

--- a/SparkShaderCompiler/CMakeLists.txt
+++ b/SparkShaderCompiler/CMakeLists.txt
@@ -17,6 +17,7 @@ set(COMPILER_SOURCES
 # RHI sources needed for shader compilation
 set(RHI_SOURCES
     "${CMAKE_SOURCE_DIR}/SparkEngine/Source/Graphics/RHI/RHIFactory.cpp"
+    "${CMAKE_SOURCE_DIR}/SparkEngine/Source/Utils/Logger.cpp"
 )
 
 # Backend implementation files (needed by RHIFactory::CreateDevice)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -130,5 +130,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 75 |
 | Test cases | 917+ |
 | Wiki pages | 53 |
-| *Last synced* | *2026-03-13 15:31* |
+| *Last synced* | *2026-03-13 16:17* |
 <!-- /AUTO:stats -->

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -123,12 +123,12 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 <!-- AUTO:stats -->
 | Metric | Count |
 |--------|-------|
-| Header files | 351 |
+| Header files | 352 |
 | ECS Components | 39 |
 | ECS Systems | 49 |
 | Editor Panels | 32 |
 | Test files | 75 |
 | Test cases | 917+ |
 | Wiki pages | 53 |
-| *Last synced* | *2026-03-13 14:44* |
+| *Last synced* | *2026-03-13 15:31* |
 <!-- /AUTO:stats -->

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -130,5 +130,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 75 |
 | Test cases | 917+ |
 | Wiki pages | 53 |
-| *Last synced* | *2026-03-13 16:17* |
+| *Last synced* | *2026-03-13 16:41* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
…gnostic logging

Introduce Validate.h — a comprehensive validation framework providing:
- Defensive macros (SPARK_VALIDATE, SPARK_VALIDATE_NOT_NULL, SPARK_VALIDATE_RANGE, SPARK_VALIDATE_ENUM, SPARK_VALIDATE_NOT_EMPTY, SPARK_VALIDATE_POSITIVE) that log errors and return gracefully on failure
- Offensive macros (SPARK_REQUIRE, SPARK_ENSURE, SPARK_UNREACHABLE) that log fatal errors and abort on invariant violations
- Diagnostic tracing (SPARK_TRACE_ENTER, SPARK_TRACE_EXIT, SPARK_TRACE_SCOPE, SPARK_TRACE_VALUE) for function entry/exit and value inspection
- Contract logging (SPARK_CONTRACT_LOG_PRE/POST/INVARIANT) for structured audit trails
- Warning-only checks (SPARK_WARN_IF, SPARK_WARN_IF_NULL) for non-fatal diagnostics

Apply validation and logging across all major subsystems:
- ECS: World entity operations use SPARK_REQUIRE for invalid entity detection; SystemManager logs system registration and validates deltaTime bounds
- All ECS systems (Render, Physics, Audio, AI, Animation, Lifecycle, Particle, Decal, Projectile, SplineFollower) now trace entry and validate preconditions
- AISystem: validates behavior registration, logs lazy initialization, warns on missing templates and large deltaTime values
- NetworkManager: validates initialization, connection parameters, and logs buffer overrun warnings in NetBuffer read operations for security
- EngineContext: logs subsystem initialization order, dependency cycle detection, and shutdown sequence
- GraphicsEngine: traces frame lifecycle (BeginFrame/EndFrame), warns on empty mesh/material paths, logs shutdown sequence (both DX11 and RHI paths)

https://claude.ai/code/session_01A4gpnnrDv9XpYRTXpfeGSM