### PR TITLE
feat: add stack traces to assertion and validation failure output

### DIFF
--- a/SparkEngine/Source/Utils/Assert.h
+++ b/SparkEngine/Source/Utils/Assert.h
@@ -40,6 +40,8 @@
 #include <ctime>
 #include <string>
 
+#include "StackTrace.h"
+
 /**
  * @def DEBUG_BREAK()
  * @brief Trigger a debugger breakpoint
@@ -131,22 +133,27 @@ namespace Assert
             va_end(args);
         }
 
+        // Capture stack trace before building the message
+        auto stackTrace = Spark::StackTrace::Capture(2); // skip Fail + macro wrapper
+        std::string traceStr = stackTrace.ToString("    ");
+
         // Build the full assertion text
-        char fullMsg[2048];
+        char fullMsg[4096];
         std::snprintf(fullMsg, sizeof(fullMsg),
                       "===== ASSERTION FAILED =====\n"
                       "Time       : %s\n"
                       "Expression : %s\n"
                       "Location   : %s(%d)\n"
                       "Message    : %s\n"
-                      "Thread ID  : 0x%08X\n",
+                      "Thread ID  : 0x%08X\n"
+                      "Stack Trace:\n%s",
                       timeBuf, expr, file, line, userMsg[0] ? userMsg : "(none)",
 #ifdef _WIN32
-                      static_cast<unsigned>(GetCurrentThreadId())
+                      static_cast<unsigned>(GetCurrentThreadId()),
 #else
-                      0u
+                      0u,
 #endif
-        );
+                      traceStr.c_str());
 
         // Print immediately
         std::fprintf(stderr, "%s", fullMsg);
@@ -185,20 +192,25 @@ namespace Assert
             va_end(args);
         }
 
-        char fullMsg[2048];
+        // Capture stack trace
+        auto stackTrace = Spark::StackTrace::Capture(2);
+        std::string traceStr = stackTrace.ToString("    ");
+
+        char fullMsg[4096];
         std::snprintf(fullMsg, sizeof(fullMsg),
                       "===== HRESULT FAILED =====\n"
                       "Expression : %s returned 0x%08lX\n"
                       "Location   : %s(%d)\n"
                       "Message    : %s\n"
-                      "Thread ID  : 0x%08X\n",
+                      "Thread ID  : 0x%08X\n"
+                      "Stack Trace:\n%s",
                       expr, hr, file, line, userMsg[0] ? userMsg : "(none)",
 #ifdef _WIN32
-                      static_cast<unsigned>(GetCurrentThreadId())
+                      static_cast<unsigned>(GetCurrentThreadId()),
 #else
-                      0u
+                      0u,
 #endif
-        );
+                      traceStr.c_str());
 
         std::fprintf(stderr, "%s", fullMsg);
         std::fflush(stderr);

--- a/SparkEngine/Source/Utils/SparkError.h
+++ b/SparkEngine/Source/Utils/SparkError.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "Utils/Assert.h" // existing ASSERT / ASSERT_MSG
+#include "Utils/StackTrace.h"
 #include <cstdio>
 #include <cstdarg>
 #include <cstdlib>
@@ -116,6 +117,12 @@ namespace SparkError
         {
             LogMessage(Severity::Error, "Check", file, line, func, "CHECK FAILED: %s", expr);
         }
+        auto stackTrace = Spark::StackTrace::Capture(2);
+        std::string traceStr = stackTrace.ToString("    ");
+        if (!traceStr.empty())
+        {
+            LogMessage(Severity::Error, "Check", file, line, func, "Stack Trace:\n%s", traceStr.c_str());
+        }
         return false; // always returns false for use in conditionals
     }
 
@@ -125,6 +132,12 @@ namespace SparkError
     {
         LogMessage(Severity::Error, "Bounds", file, line, func, "BOUNDS CHECK FAILED: %s = %lld, valid range [0, %lld)",
                    indexExpr, index, size);
+        auto stackTrace = Spark::StackTrace::Capture(2);
+        std::string traceStr = stackTrace.ToString("    ");
+        if (!traceStr.empty())
+        {
+            LogMessage(Severity::Error, "Bounds", file, line, func, "Stack Trace:\n%s", traceStr.c_str());
+        }
         return false;
     }
 
@@ -152,6 +165,12 @@ namespace SparkError
         {
             LogMessage(Severity::Error, "HRESULT", file, line, func, "HR FAILED: %s returned 0x%08lX (%s)", expr, hr,
                        sysMsg);
+        }
+        auto stackTrace = Spark::StackTrace::Capture(2);
+        std::string traceStr = stackTrace.ToString("    ");
+        if (!traceStr.empty())
+        {
+            LogMessage(Severity::Error, "HRESULT", file, line, func, "Stack Trace:\n%s", traceStr.c_str());
         }
         return false;
     }

--- a/SparkEngine/Source/Utils/Validate.h
+++ b/SparkEngine/Source/Utils/Validate.h
@@ -81,6 +81,12 @@ namespace Spark::Validation
                 std::fprintf(stderr, "[%s] VALIDATION FAILED: %s  (%s:%d in %s)\n", kind, expr, file, line,
                              func ? func : "?");
             }
+            auto earlyTrace = Spark::StackTrace::Capture(2);
+            std::string earlyTraceStr = earlyTrace.ToString("    ");
+            if (!earlyTraceStr.empty())
+            {
+                std::fprintf(stderr, "Stack Trace:\n%s", earlyTraceStr.c_str());
+            }
             std::fflush(stderr);
             return;
         }
@@ -95,6 +101,14 @@ namespace Spark::Validation
             std::snprintf(buf, sizeof(buf), "[%s] VALIDATION FAILED: %s", kind, expr);
         }
         logger.Log(level, category, file, line, func, std::string(buf));
+
+        // Append stack trace for diagnostic context
+        auto stackTrace = Spark::StackTrace::Capture(2);
+        std::string traceStr = stackTrace.ToString("    ");
+        if (!traceStr.empty())
+        {
+            logger.Log(level, category, file, line, func, std::string("Stack Trace:\n") + traceStr);
+        }
     }
 
     /**

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -130,5 +130,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 75 |
 | Test cases | 917+ |
 | Wiki pages | 53 |
-| *Last synced* | *2026-03-13 16:41* |
+| *Last synced* | *2026-03-13 19:48* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
All assertion failures (Assert::Fail, Assert::FailHResult), soft check failures (SparkError::CheckFailed, BoundsCheckFailed, HResultFailed), and validation failures (Spark::Validation::LogValidationFailure) now capture and display a full stack trace using the existing Spark::StackTrace utility, making it much easier to diagnose where failures originate from.

https://claude.ai/code/session_01WwG5DXgXjDnZQTK1axUbgB