### PR TITLE
Integrate utility headers deeper across the codebase

### DIFF
--- a/SparkEngine/Source/Engine/AI/AIDirector.cpp
+++ b/SparkEngine/Source/Engine/AI/AIDirector.cpp
@@ -18,6 +18,78 @@ namespace Spark::AI
     AIDirector::AIDirector()
     {
         m_baseDifficultyParams = DifficultyParameters{};
+
+        // --- Phase FSM setup ---
+        m_phaseFSM.AddState(
+            DirectorPhase::BuildUp,
+            [this]()
+            {
+                m_currentPhase = DirectorPhase::BuildUp;
+                m_phaseTimer = 0.0f;
+            },
+            [this](float dt)
+            {
+                m_phaseTimer += dt;
+                float progress = m_phaseTimer / m_buildUpDuration;
+                m_targetIntensity = m_minIntensity + (m_maxIntensity - m_minIntensity) * progress;
+            });
+
+        m_phaseFSM.AddState(
+            DirectorPhase::Peak,
+            [this]()
+            {
+                m_currentPhase = DirectorPhase::Peak;
+                m_phaseTimer = 0.0f;
+            },
+            [this](float dt)
+            {
+                m_phaseTimer += dt;
+                m_targetIntensity = m_maxIntensity;
+            });
+
+        m_phaseFSM.AddState(
+            DirectorPhase::Relax,
+            [this]()
+            {
+                m_currentPhase = DirectorPhase::Relax;
+                m_phaseTimer = 0.0f;
+            },
+            [this](float dt)
+            {
+                m_phaseTimer += dt;
+                float progress = m_phaseTimer / m_relaxDuration;
+                m_targetIntensity = m_maxIntensity - (m_maxIntensity - m_minIntensity) * progress;
+            });
+
+        m_phaseFSM.AddState(
+            DirectorPhase::Transition,
+            [this]()
+            {
+                m_currentPhase = DirectorPhase::Transition;
+                m_phaseTimer = 0.0f;
+            },
+            [this](float dt) { m_phaseTimer += dt; });
+
+        // Transitions
+        m_phaseFSM.AddTransition(DirectorPhase::BuildUp, DirectorPhase::Peak,
+                                 [this]() { return m_phaseTimer >= m_buildUpDuration; });
+
+        m_phaseFSM.AddTransition(DirectorPhase::Peak, DirectorPhase::Relax,
+                                 [this]()
+                                 {
+                                     float earlyExitThreshold = m_peakDuration * 0.5f;
+                                     bool playerStruggling = m_playerMetrics.healthPercent < 0.2f;
+                                     return m_phaseTimer >= m_peakDuration ||
+                                            (m_phaseTimer >= earlyExitThreshold && playerStruggling);
+                                 });
+
+        m_phaseFSM.AddTransition(DirectorPhase::Relax, DirectorPhase::BuildUp,
+                                 [this]() { return m_phaseTimer >= m_relaxDuration; });
+
+        m_phaseFSM.AddTransition(DirectorPhase::Transition, DirectorPhase::BuildUp,
+                                 [this]() { return m_phaseTimer >= 2.0f; });
+
+        m_phaseFSM.Start(DirectorPhase::BuildUp);
     }
 
     void AIDirector::Update(World& world, float deltaTime)
@@ -79,60 +151,7 @@ namespace Spark::AI
 
     void AIDirector::UpdateIntensity(float deltaTime)
     {
-        m_phaseTimer += deltaTime;
-
-        switch (m_currentPhase)
-        {
-        case DirectorPhase::BuildUp:
-        {
-            float progress = m_phaseTimer / m_buildUpDuration;
-            m_targetIntensity = m_minIntensity + (m_maxIntensity - m_minIntensity) * progress;
-
-            if (m_phaseTimer >= m_buildUpDuration)
-            {
-                m_currentPhase = DirectorPhase::Peak;
-                m_phaseTimer = 0.0f;
-            }
-            break;
-        }
-        case DirectorPhase::Peak:
-        {
-            m_targetIntensity = m_maxIntensity;
-
-            // End peak early if player is struggling
-            float earlyExitThreshold = m_peakDuration * 0.5f;
-            bool playerStruggling = m_playerMetrics.healthPercent < 0.2f;
-
-            if (m_phaseTimer >= m_peakDuration || (m_phaseTimer >= earlyExitThreshold && playerStruggling))
-            {
-                m_currentPhase = DirectorPhase::Relax;
-                m_phaseTimer = 0.0f;
-            }
-            break;
-        }
-        case DirectorPhase::Relax:
-        {
-            float progress = m_phaseTimer / m_relaxDuration;
-            m_targetIntensity = m_maxIntensity - (m_maxIntensity - m_minIntensity) * progress;
-
-            if (m_phaseTimer >= m_relaxDuration)
-            {
-                m_currentPhase = DirectorPhase::BuildUp;
-                m_phaseTimer = 0.0f;
-            }
-            break;
-        }
-        case DirectorPhase::Transition:
-        {
-            // Smooth transition between phases
-            if (m_phaseTimer >= 2.0f)
-            {
-                m_currentPhase = DirectorPhase::BuildUp;
-                m_phaseTimer = 0.0f;
-            }
-            break;
-        }
-        }
+        m_phaseFSM.Tick(deltaTime);
 
         // Adjust target intensity based on player skill
         float skillAdjustment = (m_playerSkillEstimate - 0.5f) * 0.2f;
@@ -222,8 +241,7 @@ namespace Spark::AI
 
     void AIDirector::Console_ForcePhase(DirectorPhase phase)
     {
-        m_currentPhase = phase;
-        m_phaseTimer = 0.0f;
+        m_phaseFSM.TransitionTo(phase);
     }
 
     void AIDirector::Console_SetIntensity(float intensity)

--- a/SparkEngine/Source/Engine/AI/AIDirector.h
+++ b/SparkEngine/Source/Engine/AI/AIDirector.h
@@ -40,6 +40,7 @@
 #pragma once
 
 #include "../ECS/Systems/ECSystems.h"
+#include "../../Utils/StateMachine.h"
 
 #include <string>
 #include <vector>
@@ -199,6 +200,7 @@ namespace Spark::AI
 
         // Phase timing
         DirectorPhase m_currentPhase = DirectorPhase::BuildUp;
+        Spark::StateMachine<DirectorPhase> m_phaseFSM; ///< Drives phase cycling lifecycle
         float m_phaseTimer = 0.0f;
         float m_buildUpDuration = 60.0f;
         float m_peakDuration = 20.0f;

--- a/SparkEngine/Source/Engine/Cinematic/Sequencer.cpp
+++ b/SparkEngine/Source/Engine/Cinematic/Sequencer.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "Sequencer.h"
+#include "../../Utils/MathUtils.h"
 #include "../../Utils/Validate.h"
 #include <sstream>
 #include <algorithm>
@@ -14,17 +15,17 @@ namespace Spark::Cinematic
 {
 
     // ============================================================================
-    // Helper: Linear interpolation for float
+    // Helper: Linear interpolation — delegates to MathUtils
     // ============================================================================
 
     static float LerpF(float a, float b, float t)
     {
-        return a + (b - a) * t;
+        return MathUtils::Lerp(a, b, t);
     }
 
     static XMFLOAT3 LerpFloat3(const XMFLOAT3& a, const XMFLOAT3& b, float t)
     {
-        return {a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t};
+        return MathUtils::Lerp(a, b, t);
     }
 
     // ============================================================================

--- a/SparkEngine/Source/Engine/Dialogue/DialogueSystem.cpp
+++ b/SparkEngine/Source/Engine/Dialogue/DialogueSystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "DialogueSystem.h"
+#include "../../Utils/Hash.h"
 #include "../../Utils/Validate.h"
 
 #include <fstream>
@@ -99,25 +100,27 @@ namespace Spark
                 static_cast<size_t>(it->position()),
                 (std::min)(static_cast<size_t>(500), content.size() - static_cast<size_t>(it->position())));
 
-            // Parse node type
+            // Parse node type using compile-time hash dispatch
             if (std::regex_search(nodeContext, match, typeRegex))
             {
+                using namespace Spark::HashLiterals;
                 const std::string& typeStr = match[1].str();
-                if (typeStr == "Choice")
+                switch (Spark::FNV1a64(typeStr))
                 {
+                case "Choice"_hash64:
                     node.type = DialogueNodeType::Choice;
-                }
-                else if (typeStr == "Branch")
-                {
+                    break;
+                case "Branch"_hash64:
                     node.type = DialogueNodeType::Branch;
-                }
-                else if (typeStr == "Event")
-                {
+                    break;
+                case "Event"_hash64:
                     node.type = DialogueNodeType::Event;
-                }
-                else if (typeStr == "End")
-                {
+                    break;
+                case "End"_hash64:
                     node.type = DialogueNodeType::End;
+                    break;
+                default:
+                    break; // Stays as DialogueNodeType::Text
                 }
             }
 

--- a/SparkEngine/Source/Engine/Replay/ReplaySystem.cpp
+++ b/SparkEngine/Source/Engine/Replay/ReplaySystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "ReplaySystem.h"
+#include "../../Utils/Serializer.h"
 #include "../../Utils/Validate.h"
 
 #include <algorithm>
@@ -204,52 +205,43 @@ namespace Spark
             return false;
         }
 
+        Spark::BinaryWriter writer;
+
         // Write header
-        uint32_t magic = 0x52504C59; // "RPLY"
-        file.write(reinterpret_cast<const char*>(&magic), sizeof(magic));
-        file.write(reinterpret_cast<const char*>(&m_replayData.version), sizeof(uint32_t));
+        writer.Write<uint32_t>(0x52504C59); // "RPLY"
+        writer.Write<uint32_t>(m_replayData.version);
 
         // Write metadata
-        uint32_t mapLen = static_cast<uint32_t>(m_replayData.mapName.size());
-        file.write(reinterpret_cast<const char*>(&mapLen), sizeof(mapLen));
-        file.write(m_replayData.mapName.data(), mapLen);
+        writer.WriteString(m_replayData.mapName);
+        writer.WriteString(m_replayData.gameMode);
+        writer.Write<float>(m_replayData.duration);
 
-        uint32_t modeLen = static_cast<uint32_t>(m_replayData.gameMode.size());
-        file.write(reinterpret_cast<const char*>(&modeLen), sizeof(modeLen));
-        file.write(m_replayData.gameMode.data(), modeLen);
-
-        file.write(reinterpret_cast<const char*>(&m_replayData.duration), sizeof(float));
-
-        // Write frame count and frames
-        uint32_t frameCount = static_cast<uint32_t>(m_replayData.frames.size());
-        file.write(reinterpret_cast<const char*>(&frameCount), sizeof(frameCount));
-
+        // Write frames
+        writer.Write<uint32_t>(static_cast<uint32_t>(m_replayData.frames.size()));
         for (const auto& frame : m_replayData.frames)
         {
-            file.write(reinterpret_cast<const char*>(&frame.timestamp), sizeof(float));
-            file.write(reinterpret_cast<const char*>(&frame.frameNumber), sizeof(uint32_t));
-            uint32_t entityCount = static_cast<uint32_t>(frame.entities.size());
-            file.write(reinterpret_cast<const char*>(&entityCount), sizeof(entityCount));
+            writer.Write<float>(frame.timestamp);
+            writer.Write<uint32_t>(frame.frameNumber);
+            writer.Write<uint32_t>(static_cast<uint32_t>(frame.entities.size()));
             for (const auto& entity : frame.entities)
             {
-                file.write(reinterpret_cast<const char*>(&entity), sizeof(ReplayEntityState));
+                writer.WriteBytes(&entity, sizeof(ReplayEntityState));
             }
         }
 
         // Write events
-        uint32_t eventCount = static_cast<uint32_t>(m_replayData.events.size());
-        file.write(reinterpret_cast<const char*>(&eventCount), sizeof(eventCount));
+        writer.Write<uint32_t>(static_cast<uint32_t>(m_replayData.events.size()));
         for (const auto& event : m_replayData.events)
         {
-            file.write(reinterpret_cast<const char*>(&event.timestamp), sizeof(float));
-            uint32_t typeLen = static_cast<uint32_t>(event.type.size());
-            file.write(reinterpret_cast<const char*>(&typeLen), sizeof(typeLen));
-            file.write(event.type.data(), typeLen);
-            file.write(reinterpret_cast<const char*>(&event.sourceEntity), sizeof(uint32_t));
-            file.write(reinterpret_cast<const char*>(&event.targetEntity), sizeof(uint32_t));
-            file.write(reinterpret_cast<const char*>(&event.position), sizeof(DirectX::XMFLOAT3));
+            writer.Write<float>(event.timestamp);
+            writer.WriteString(event.type);
+            writer.Write<uint32_t>(event.sourceEntity);
+            writer.Write<uint32_t>(event.targetEntity);
+            writer.WriteBytes(&event.position, sizeof(DirectX::XMFLOAT3));
         }
 
+        const auto& buffer = writer.GetBuffer();
+        file.write(reinterpret_cast<const char*>(buffer.data()), static_cast<std::streamsize>(buffer.size()));
         return true;
     }
 
@@ -258,68 +250,49 @@ namespace Spark
         SPARK_TRACE_ENTER(Spark::LogCategory::Game);
         SPARK_LOG_INFO(Spark::LogCategory::Game, "Loading replay from '%s'", filePath.c_str());
         // Safety limits for deserialization to prevent OOM from malicious/corrupt files
-        constexpr uint32_t kMaxStringLength = 4096;
         constexpr uint32_t kMaxFrameCount = 1'000'000;
         constexpr uint32_t kMaxEntityCount = 100'000;
         constexpr uint32_t kMaxEventCount = 1'000'000;
 
         std::lock_guard<std::mutex> lock(m_mutex);
-        std::ifstream file(filePath, std::ios::binary);
+        std::ifstream file(filePath, std::ios::binary | std::ios::ate);
         if (!file.is_open())
         {
             return false;
         }
 
-        uint32_t magic = 0;
-        file.read(reinterpret_cast<char*>(&magic), sizeof(magic));
-        if (!file || magic != 0x52504C59)
-        {
-            return false;
-        }
-
-        file.read(reinterpret_cast<char*>(&m_replayData.version), sizeof(uint32_t));
+        auto fileSize = file.tellg();
+        file.seekg(0, std::ios::beg);
+        std::vector<uint8_t> fileData(static_cast<size_t>(fileSize));
+        file.read(reinterpret_cast<char*>(fileData.data()), fileSize);
         if (!file)
         {
             return false;
         }
 
-        // Read metadata with bounds-checked string lengths
-        uint32_t mapLen = 0;
-        file.read(reinterpret_cast<char*>(&mapLen), sizeof(mapLen));
-        if (!file || mapLen > kMaxStringLength)
-        {
-            return false;
-        }
-        m_replayData.mapName.resize(mapLen);
-        file.read(m_replayData.mapName.data(), mapLen);
-        if (!file)
+        Spark::BinaryReader reader(fileData);
+
+        // Read and verify header
+        uint32_t magic = reader.Read<uint32_t>();
+        if (reader.HasError() || magic != 0x52504C59)
         {
             return false;
         }
 
-        uint32_t modeLen = 0;
-        file.read(reinterpret_cast<char*>(&modeLen), sizeof(modeLen));
-        if (!file || modeLen > kMaxStringLength)
-        {
-            return false;
-        }
-        m_replayData.gameMode.resize(modeLen);
-        file.read(m_replayData.gameMode.data(), modeLen);
-        if (!file)
-        {
-            return false;
-        }
+        m_replayData.version = reader.Read<uint32_t>();
 
-        file.read(reinterpret_cast<char*>(&m_replayData.duration), sizeof(float));
-        if (!file)
+        // Read metadata
+        m_replayData.mapName = reader.ReadString();
+        m_replayData.gameMode = reader.ReadString();
+        m_replayData.duration = reader.Read<float>();
+        if (reader.HasError())
         {
             return false;
         }
 
         // Read frames with bounds checking
-        uint32_t frameCount = 0;
-        file.read(reinterpret_cast<char*>(&frameCount), sizeof(frameCount));
-        if (!file || frameCount > kMaxFrameCount)
+        uint32_t frameCount = reader.Read<uint32_t>();
+        if (reader.HasError() || frameCount > kMaxFrameCount)
         {
             return false;
         }
@@ -327,29 +300,27 @@ namespace Spark
 
         for (auto& frame : m_replayData.frames)
         {
-            file.read(reinterpret_cast<char*>(&frame.timestamp), sizeof(float));
-            file.read(reinterpret_cast<char*>(&frame.frameNumber), sizeof(uint32_t));
-            uint32_t entityCount = 0;
-            file.read(reinterpret_cast<char*>(&entityCount), sizeof(entityCount));
-            if (!file || entityCount > kMaxEntityCount)
+            frame.timestamp = reader.Read<float>();
+            frame.frameNumber = reader.Read<uint32_t>();
+            uint32_t entityCount = reader.Read<uint32_t>();
+            if (reader.HasError() || entityCount > kMaxEntityCount)
             {
                 return false;
             }
             frame.entities.resize(entityCount);
             for (auto& entity : frame.entities)
             {
-                file.read(reinterpret_cast<char*>(&entity), sizeof(ReplayEntityState));
+                reader.ReadBytes(&entity, sizeof(ReplayEntityState));
             }
-            if (!file)
+            if (reader.HasError())
             {
                 return false;
             }
         }
 
         // Read events with bounds checking
-        uint32_t eventCount = 0;
-        file.read(reinterpret_cast<char*>(&eventCount), sizeof(eventCount));
-        if (!file || eventCount > kMaxEventCount)
+        uint32_t eventCount = reader.Read<uint32_t>();
+        if (reader.HasError() || eventCount > kMaxEventCount)
         {
             return false;
         }
@@ -357,19 +328,12 @@ namespace Spark
 
         for (auto& event : m_replayData.events)
         {
-            file.read(reinterpret_cast<char*>(&event.timestamp), sizeof(float));
-            uint32_t typeLen = 0;
-            file.read(reinterpret_cast<char*>(&typeLen), sizeof(typeLen));
-            if (!file || typeLen > kMaxStringLength)
-            {
-                return false;
-            }
-            event.type.resize(typeLen);
-            file.read(event.type.data(), typeLen);
-            file.read(reinterpret_cast<char*>(&event.sourceEntity), sizeof(uint32_t));
-            file.read(reinterpret_cast<char*>(&event.targetEntity), sizeof(uint32_t));
-            file.read(reinterpret_cast<char*>(&event.position), sizeof(DirectX::XMFLOAT3));
-            if (!file)
+            event.timestamp = reader.Read<float>();
+            event.type = reader.ReadString();
+            event.sourceEntity = reader.Read<uint32_t>();
+            event.targetEntity = reader.Read<uint32_t>();
+            reader.ReadBytes(&event.position, sizeof(DirectX::XMFLOAT3));
+            if (reader.HasError())
             {
                 return false;
             }

--- a/SparkEngine/Source/Enums/EnumUtils.h
+++ b/SparkEngine/Source/Enums/EnumUtils.h
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <stdexcept>
 #include <chrono>
+#include "Utils/TypeTraits.h"
 
 namespace SparkEditor
 {
@@ -28,7 +29,7 @@ namespace SparkEditor
  * Provides common functionality for enum validation and conversion.
  * Specialized for specific enum types to provide custom behavior.
  */
-    template <typename EnumType> class EnumUtils
+    template <Spark::Enum EnumType> class EnumUtils
     {
       public:
         /**
@@ -36,11 +37,7 @@ namespace SparkEditor
      * @param value Enum value to validate
      * @return true if the value is within valid range
      */
-        static bool IsValid(EnumType value)
-        {
-            static_assert(std::is_enum_v<EnumType>, "EnumType must be an enumeration");
-            return IsValidImpl(value);
-        }
+        static bool IsValid(EnumType value) { return IsValidImpl(value); }
 
         /**
      * @brief Convert enum to string representation
@@ -163,7 +160,7 @@ namespace SparkEditor
  * Provides range-based for loop support for enums.
  * Usage: for (auto value : EnumIterator<MyEnum>()) { ... }
  */
-    template <typename EnumType> class EnumIterator
+    template <Spark::Enum EnumType> class EnumIterator
     {
       public:
         class Iterator
@@ -200,9 +197,8 @@ namespace SparkEditor
  * 
  * Provides bitwise operations for enum flags with type safety.
  */
-    template <typename EnumType> class EnumFlags
+    template <Spark::Enum EnumType> class EnumFlags
     {
-        static_assert(std::is_enum_v<EnumType>, "EnumType must be an enumeration");
 
       public:
         using UnderlyingType = std::underlying_type_t<EnumType>;
@@ -281,7 +277,7 @@ namespace SparkEditor
  * 
  * Provides runtime validation for enum values with detailed error reporting.
  */
-    template <typename EnumType> class EnumValidator
+    template <Spark::Enum EnumType> class EnumValidator
     {
       public:
         struct ValidationResult

--- a/SparkEngine/Source/Graphics/LightingSystem.cpp
+++ b/SparkEngine/Source/Graphics/LightingSystem.cpp
@@ -7,6 +7,7 @@
 
 #include "LightingSystem.h"
 #include "Utils/Assert.h"
+#include "../Utils/Hash.h"
 #include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
 #include <sstream>
@@ -1654,17 +1655,22 @@ std::string LightTypeToString(LightType type)
 
 LightType StringToLightType(const std::string& str)
 {
-    if (str == "directional")
+    using namespace Spark::HashLiterals;
+    switch (Spark::FNV1a64(str))
+    {
+    case "directional"_hash64:
         return LightType::Directional;
-    if (str == "point")
+    case "point"_hash64:
         return LightType::Point;
-    if (str == "spot")
+    case "spot"_hash64:
         return LightType::Spot;
-    if (str == "area")
+    case "area"_hash64:
         return LightType::Area;
-    if (str == "environment")
+    case "environment"_hash64:
         return LightType::Environment;
-    return LightType::Directional; // Default
+    default:
+        return LightType::Directional;
+    }
 }
 
 std::string ShadowTechniqueToString(ShadowTechnique technique)
@@ -1690,19 +1696,24 @@ std::string ShadowTechniqueToString(ShadowTechnique technique)
 
 ShadowTechnique StringToShadowTechnique(const std::string& str)
 {
-    if (str == "none")
+    using namespace Spark::HashLiterals;
+    switch (Spark::FNV1a64(str))
+    {
+    case "none"_hash64:
         return ShadowTechnique::None;
-    if (str == "basic")
+    case "basic"_hash64:
         return ShadowTechnique::Basic;
-    if (str == "pcf")
+    case "pcf"_hash64:
         return ShadowTechnique::PCF;
-    if (str == "vsm")
+    case "vsm"_hash64:
         return ShadowTechnique::VSM;
-    if (str == "csm")
+    case "csm"_hash64:
         return ShadowTechnique::CSM;
-    if (str == "pcss")
+    case "pcss"_hash64:
         return ShadowTechnique::PCSS;
-    return ShadowTechnique::PCF; // Default
+    default:
+        return ShadowTechnique::PCF;
+    }
 }
 
 #endif // inner SPARK_PLATFORM_WINDOWS
@@ -1710,6 +1721,7 @@ ShadowTechnique StringToShadowTechnique(const std::string& str)
 #else // !SPARK_PLATFORM_WINDOWS
 
 #include "LightingSystem.h"
+#include "../Utils/Hash.h"
 #include "../Utils/Validate.h"
 #include <sstream>
 #include <algorithm>
@@ -2155,17 +2167,22 @@ std::string LightTypeToString(LightType type)
 
 LightType StringToLightType(const std::string& str)
 {
-    if (str == "directional")
+    using namespace Spark::HashLiterals;
+    switch (Spark::FNV1a64(str))
+    {
+    case "directional"_hash64:
         return LightType::Directional;
-    if (str == "point")
+    case "point"_hash64:
         return LightType::Point;
-    if (str == "spot")
+    case "spot"_hash64:
         return LightType::Spot;
-    if (str == "area")
+    case "area"_hash64:
         return LightType::Area;
-    if (str == "environment")
+    case "environment"_hash64:
         return LightType::Environment;
-    return LightType::Directional;
+    default:
+        return LightType::Directional;
+    }
 }
 
 std::string ShadowTechniqueToString(ShadowTechnique technique)
@@ -2191,19 +2208,24 @@ std::string ShadowTechniqueToString(ShadowTechnique technique)
 
 ShadowTechnique StringToShadowTechnique(const std::string& str)
 {
-    if (str == "none")
+    using namespace Spark::HashLiterals;
+    switch (Spark::FNV1a64(str))
+    {
+    case "none"_hash64:
         return ShadowTechnique::None;
-    if (str == "basic")
+    case "basic"_hash64:
         return ShadowTechnique::Basic;
-    if (str == "pcf")
+    case "pcf"_hash64:
         return ShadowTechnique::PCF;
-    if (str == "vsm")
+    case "vsm"_hash64:
         return ShadowTechnique::VSM;
-    if (str == "csm")
+    case "csm"_hash64:
         return ShadowTechnique::CSM;
-    if (str == "pcss")
+    case "pcss"_hash64:
         return ShadowTechnique::PCSS;
-    return ShadowTechnique::PCF;
+    default:
+        return ShadowTechnique::PCF;
+    }
 }
 
 #endif // SPARK_PLATFORM_WINDOWS

--- a/SparkEngine/Source/Graphics/MaterialSystem.cpp
+++ b/SparkEngine/Source/Graphics/MaterialSystem.cpp
@@ -9,6 +9,7 @@
 
 #include "MaterialSystem.h"
 #include "../Utils/Assert.h"
+#include "../Utils/Hash.h"
 #include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
 #include "Utils/LocalFileCache.h"
@@ -2686,43 +2687,48 @@ std::string MaterialSystem::TextureTypeToString(MaterialTextureType type) const
 
 MaterialTextureType MaterialSystem::StringToTextureType(const std::string& str) const
 {
-    if (str == "Albedo")
+    using namespace Spark::HashLiterals;
+    switch (Spark::FNV1a64(str))
+    {
+    case "Albedo"_hash64:
         return MaterialTextureType::Albedo;
-    if (str == "Normal")
+    case "Normal"_hash64:
         return MaterialTextureType::Normal;
-    if (str == "Metallic")
+    case "Metallic"_hash64:
         return MaterialTextureType::Metallic;
-    if (str == "Roughness")
+    case "Roughness"_hash64:
         return MaterialTextureType::Roughness;
-    if (str == "Occlusion")
+    case "Occlusion"_hash64:
         return MaterialTextureType::Occlusion;
-    if (str == "Emissive")
+    case "Emissive"_hash64:
         return MaterialTextureType::Emissive;
-    if (str == "Height")
+    case "Height"_hash64:
         return MaterialTextureType::Height;
-    if (str == "DetailAlbedo")
+    case "DetailAlbedo"_hash64:
         return MaterialTextureType::DetailAlbedo;
-    if (str == "DetailNormal")
+    case "DetailNormal"_hash64:
         return MaterialTextureType::DetailNormal;
-    if (str == "Subsurface")
+    case "Subsurface"_hash64:
         return MaterialTextureType::Subsurface;
-    if (str == "Transmission")
+    case "Transmission"_hash64:
         return MaterialTextureType::Transmission;
-    if (str == "Clearcoat")
+    case "Clearcoat"_hash64:
         return MaterialTextureType::Clearcoat;
-    if (str == "ClearcoatRoughness")
+    case "ClearcoatRoughness"_hash64:
         return MaterialTextureType::ClearcoatRoughness;
-    if (str == "Anisotropy")
+    case "Anisotropy"_hash64:
         return MaterialTextureType::Anisotropy;
-    if (str == "Custom0")
+    case "Custom0"_hash64:
         return MaterialTextureType::Custom0;
-    if (str == "Custom1")
+    case "Custom1"_hash64:
         return MaterialTextureType::Custom1;
-    if (str == "Custom2")
+    case "Custom2"_hash64:
         return MaterialTextureType::Custom2;
-    if (str == "Custom3")
+    case "Custom3"_hash64:
         return MaterialTextureType::Custom3;
-    return MaterialTextureType::Albedo; // Default fallback
+    default:
+        return MaterialTextureType::Albedo;
+    }
 }
 
 std::string MaterialSystem::Console_DumpMaterialDetails(const std::string& materialName) const
@@ -2980,6 +2986,7 @@ std::string MaterialSystem::Console_ListMaterialVariants(const std::string& mate
 
 #include "MaterialSystem.h"
 #include "RHI/RHI.h"
+#include "../Utils/Hash.h"
 #include "../Utils/Validate.h"
 #include <sstream>
 #include <algorithm>
@@ -4272,43 +4279,48 @@ MaterialTextureType MaterialSystem::StringToTextureType(const std::string& str) 
     std::string lower = str;
     std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
 
-    if (lower == "albedo")
+    using namespace Spark::HashLiterals;
+    switch (Spark::FNV1a64(lower))
+    {
+    case "albedo"_hash64:
         return MaterialTextureType::Albedo;
-    if (lower == "normal")
+    case "normal"_hash64:
         return MaterialTextureType::Normal;
-    if (lower == "metallic")
+    case "metallic"_hash64:
         return MaterialTextureType::Metallic;
-    if (lower == "roughness")
+    case "roughness"_hash64:
         return MaterialTextureType::Roughness;
-    if (lower == "occlusion")
+    case "occlusion"_hash64:
         return MaterialTextureType::Occlusion;
-    if (lower == "emissive")
+    case "emissive"_hash64:
         return MaterialTextureType::Emissive;
-    if (lower == "height")
+    case "height"_hash64:
         return MaterialTextureType::Height;
-    if (lower == "detailalbedo")
+    case "detailalbedo"_hash64:
         return MaterialTextureType::DetailAlbedo;
-    if (lower == "detailnormal")
+    case "detailnormal"_hash64:
         return MaterialTextureType::DetailNormal;
-    if (lower == "subsurface")
+    case "subsurface"_hash64:
         return MaterialTextureType::Subsurface;
-    if (lower == "transmission")
+    case "transmission"_hash64:
         return MaterialTextureType::Transmission;
-    if (lower == "clearcoat")
+    case "clearcoat"_hash64:
         return MaterialTextureType::Clearcoat;
-    if (lower == "clearcoatroughness")
+    case "clearcoatroughness"_hash64:
         return MaterialTextureType::ClearcoatRoughness;
-    if (lower == "anisotropy")
+    case "anisotropy"_hash64:
         return MaterialTextureType::Anisotropy;
-    if (lower == "custom0")
+    case "custom0"_hash64:
         return MaterialTextureType::Custom0;
-    if (lower == "custom1")
+    case "custom1"_hash64:
         return MaterialTextureType::Custom1;
-    if (lower == "custom2")
+    case "custom2"_hash64:
         return MaterialTextureType::Custom2;
-    if (lower == "custom3")
+    case "custom3"_hash64:
         return MaterialTextureType::Custom3;
-    return MaterialTextureType::Albedo;
+    default:
+        return MaterialTextureType::Albedo;
+    }
 }
 
 #endif // SPARK_PLATFORM_WINDOWS

--- a/SparkEngine/Source/Physics/PhysicsSystem.cpp
+++ b/SparkEngine/Source/Physics/PhysicsSystem.cpp
@@ -8,6 +8,7 @@
 
 #include "PhysicsSystem.h"
 #include "Utils/Assert.h"
+#include "../Utils/Hash.h"
 #include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
 
@@ -180,16 +181,14 @@ size_t PhysicsSystem::HashShape(const CollisionShapeDesc& desc)
 {
     size_t hash = std::hash<int>()(static_cast<int>(desc.type));
 
-    auto hashCombine = [](size_t& seed, size_t value) { seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2); };
-
-    hashCombine(hash, std::hash<float>()(desc.dimensions.x));
-    hashCombine(hash, std::hash<float>()(desc.dimensions.y));
-    hashCombine(hash, std::hash<float>()(desc.dimensions.z));
-    hashCombine(hash, std::hash<float>()(desc.radius));
-    hashCombine(hash, std::hash<float>()(desc.height));
-    hashCombine(hash, std::hash<std::string>()(desc.meshPath));
-    hashCombine(hash, std::hash<size_t>()(desc.vertices.size()));
-    hashCombine(hash, std::hash<size_t>()(desc.indices.size()));
+    Spark::CombineHash(hash, std::hash<float>()(desc.dimensions.x));
+    Spark::CombineHash(hash, std::hash<float>()(desc.dimensions.y));
+    Spark::CombineHash(hash, std::hash<float>()(desc.dimensions.z));
+    Spark::CombineHash(hash, std::hash<float>()(desc.radius));
+    Spark::CombineHash(hash, std::hash<float>()(desc.height));
+    Spark::CombineHash(hash, std::hash<std::string>()(desc.meshPath));
+    Spark::CombineHash(hash, std::hash<size_t>()(desc.vertices.size()));
+    Spark::CombineHash(hash, std::hash<size_t>()(desc.indices.size()));
 
     return hash;
 }

--- a/SparkEngine/Source/Physics/PhysicsSystemStub.cpp
+++ b/SparkEngine/Source/Physics/PhysicsSystemStub.cpp
@@ -10,6 +10,7 @@
 #include "Core/Platform.h"
 #include "PhysicsSystem.h"
 #include "Utils/LogMacros.h"
+#include "Utils/Hash.h"
 #include "Utils/Validate.h"
 #include <sstream>
 
@@ -33,11 +34,16 @@ std::string PhysicsBodyTypeToString(PhysicsBodyType type)
 
 PhysicsBodyType StringToPhysicsBodyType(const std::string& str)
 {
-    if (str == "Static")
+    using namespace Spark::HashLiterals;
+    switch (Spark::FNV1a64(str))
+    {
+    case "Static"_hash64:
         return PhysicsBodyType::Static;
-    if (str == "Kinematic")
+    case "Kinematic"_hash64:
         return PhysicsBodyType::Kinematic;
-    return PhysicsBodyType::Dynamic;
+    default:
+        return PhysicsBodyType::Dynamic;
+    }
 }
 
 std::string CollisionShapeTypeToString(CollisionShapeType type)
@@ -68,23 +74,28 @@ std::string CollisionShapeTypeToString(CollisionShapeType type)
 
 CollisionShapeType StringToCollisionShapeType(const std::string& str)
 {
-    if (str == "Sphere")
+    using namespace Spark::HashLiterals;
+    switch (Spark::FNV1a64(str))
+    {
+    case "Sphere"_hash64:
         return CollisionShapeType::Sphere;
-    if (str == "Capsule")
+    case "Capsule"_hash64:
         return CollisionShapeType::Capsule;
-    if (str == "Cylinder")
+    case "Cylinder"_hash64:
         return CollisionShapeType::Cylinder;
-    if (str == "Cone")
+    case "Cone"_hash64:
         return CollisionShapeType::Cone;
-    if (str == "Mesh")
+    case "Mesh"_hash64:
         return CollisionShapeType::Mesh;
-    if (str == "ConvexHull")
+    case "ConvexHull"_hash64:
         return CollisionShapeType::ConvexHull;
-    if (str == "Heightfield")
+    case "Heightfield"_hash64:
         return CollisionShapeType::Heightfield;
-    if (str == "Compound")
+    case "Compound"_hash64:
         return CollisionShapeType::Compound;
-    return CollisionShapeType::Box;
+    default:
+        return CollisionShapeType::Box;
+    }
 }
 
 std::string ConstraintTypeToString(ConstraintType type)
@@ -109,17 +120,22 @@ std::string ConstraintTypeToString(ConstraintType type)
 
 ConstraintType StringToConstraintType(const std::string& str)
 {
-    if (str == "Hinge")
+    using namespace Spark::HashLiterals;
+    switch (Spark::FNV1a64(str))
+    {
+    case "Hinge"_hash64:
         return ConstraintType::Hinge;
-    if (str == "Slider")
+    case "Slider"_hash64:
         return ConstraintType::Slider;
-    if (str == "ConeTwist")
+    case "ConeTwist"_hash64:
         return ConstraintType::ConeTwist;
-    if (str == "Generic6DOF")
+    case "Generic6DOF"_hash64:
         return ConstraintType::Generic6DOF;
-    if (str == "Fixed")
+    case "Fixed"_hash64:
         return ConstraintType::Fixed;
-    return ConstraintType::Point2Point;
+    default:
+        return ConstraintType::Point2Point;
+    }
 }
 
 // ============================================================================
@@ -622,10 +638,10 @@ void PhysicsSystem::ProcessCollisions() {}
 size_t PhysicsSystem::HashShape(const CollisionShapeDesc& desc)
 {
     size_t hash = std::hash<int>{}(static_cast<int>(desc.type));
-    hash ^= std::hash<float>{}(desc.dimensions.x) << 1;
-    hash ^= std::hash<float>{}(desc.dimensions.y) << 2;
-    hash ^= std::hash<float>{}(desc.dimensions.z) << 3;
-    hash ^= std::hash<float>{}(desc.radius) << 4;
-    hash ^= std::hash<float>{}(desc.height) << 5;
+    Spark::CombineHash(hash, std::hash<float>{}(desc.dimensions.x));
+    Spark::CombineHash(hash, std::hash<float>{}(desc.dimensions.y));
+    Spark::CombineHash(hash, std::hash<float>{}(desc.dimensions.z));
+    Spark::CombineHash(hash, std::hash<float>{}(desc.radius));
+    Spark::CombineHash(hash, std::hash<float>{}(desc.height));
     return hash;
 }

--- a/SparkEngine/Source/Utils/BitFlags.h
+++ b/SparkEngine/Source/Utils/BitFlags.h
@@ -37,6 +37,7 @@
 
 #include <cstdint>
 #include <type_traits>
+#include "TypeTraits.h"
 
 // =============================================================================
 // Free operator overloads for enum class bitmasks
@@ -97,9 +98,8 @@ namespace Spark
      *
      * @tparam E  Enum class type with power-of-two values.
      */
-    template <typename E> class BitFlags
+    template <Spark::Enum E> class BitFlags
     {
-        static_assert(std::is_enum_v<E>, "BitFlags requires an enum type");
         using Underlying = std::underlying_type_t<E>;
 
       public:

--- a/SparkEngine/Source/Utils/ConsoleVariable.h
+++ b/SparkEngine/Source/Utils/ConsoleVariable.h
@@ -37,6 +37,7 @@
 #include <sstream>
 #include <algorithm>
 #include <concepts>
+#include "TypeTraits.h"
 #include <type_traits>
 #include <cstdint>
 
@@ -256,7 +257,7 @@ namespace Spark
         /**
          * @brief Construct with range clamping (numeric types only)
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_arithmetic_v<U>>>
+        template <Spark::Arithmetic U = T>
         CVar(std::string name, T defaultVal, CVarFlags flags, std::string description, T minVal, T maxVal)
             : m_name(std::move(name)), m_description(std::move(description)), m_flags(flags), m_value(defaultVal),
               m_defaultValue(defaultVal), m_hasRange(true), m_min(minVal), m_max(maxVal)

--- a/SparkEngine/Source/Utils/Serializer.h
+++ b/SparkEngine/Source/Utils/Serializer.h
@@ -47,6 +47,7 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+#include "TypeTraits.h"
 
 namespace Spark
 {
@@ -66,9 +67,8 @@ namespace Spark
 #endif
         }
 
-        template <typename T> [[nodiscard]] inline T ByteSwap(T value) noexcept
+        template <Spark::TriviallyCopyable T> [[nodiscard]] inline T ByteSwap(T value) noexcept
         {
-            static_assert(std::is_trivially_copyable_v<T>, "ByteSwap requires a trivially copyable type");
             uint8_t bytes[sizeof(T)];
             std::memcpy(bytes, &value, sizeof(T));
             for (size_t i = 0; i < sizeof(T) / 2; ++i)
@@ -121,10 +121,10 @@ namespace Spark
          * @tparam T    A trivially-copyable, non-pointer type.
          * @param value  Value to serialise.
          */
-        template <typename T> void Write(const T& value)
+        template <Spark::TriviallyCopyable T>
+            requires(!std::is_pointer_v<T>)
+        void Write(const T& value)
         {
-            static_assert(std::is_trivially_copyable_v<T>, "BinaryWriter::Write requires a trivially copyable type");
-            static_assert(!std::is_pointer_v<T>, "BinaryWriter::Write does not accept raw pointers");
 
             T leValue = Detail::ToLittleEndian(value);
             const auto* bytes = reinterpret_cast<const uint8_t*>(&leValue);
@@ -239,10 +239,10 @@ namespace Spark
          * @tparam T  A trivially-copyable, non-pointer type.
          * @return    The deserialised value, or a zero-initialised T on error.
          */
-        template <typename T> T Read()
+        template <Spark::TriviallyCopyable T>
+            requires(!std::is_pointer_v<T>)
+        T Read()
         {
-            static_assert(std::is_trivially_copyable_v<T>, "BinaryReader::Read requires a trivially copyable type");
-            static_assert(!std::is_pointer_v<T>, "BinaryReader::Read does not return raw pointers");
 
             T value{};
             if (!Consume(sizeof(T)))

--- a/SparkEngine/Source/Utils/SparkConsole.cpp
+++ b/SparkEngine/Source/Utils/SparkConsole.cpp
@@ -1,6 +1,7 @@
 #include "../Core/Platform.h"
 #include "SparkConsole.h"
 #include "ConsoleVariable.h"
+#include "Hash.h"
 #include "Validate.h"
 #include <iostream>
 #include <sstream>
@@ -106,21 +107,26 @@ namespace Spark
 
     ConsoleSeverity StringToConsoleSeverity(const std::string& str)
     {
-        if (str == "TRACE")
+        using namespace Spark::HashLiterals;
+        switch (Spark::FNV1a64(str))
+        {
+        case "TRACE"_hash64:
             return ConsoleSeverity::Trace;
-        if (str == "DEBUG")
+        case "DEBUG"_hash64:
             return ConsoleSeverity::Debug;
-        if (str == "INFO")
+        case "INFO"_hash64:
             return ConsoleSeverity::Info;
-        if (str == "SUCCESS")
+        case "SUCCESS"_hash64:
             return ConsoleSeverity::Success;
-        if (str == "WARNING")
+        case "WARNING"_hash64:
             return ConsoleSeverity::Warning;
-        if (str == "ERROR")
+        case "ERROR"_hash64:
             return ConsoleSeverity::Error;
-        if (str == "CRITICAL")
+        case "CRITICAL"_hash64:
             return ConsoleSeverity::Critical;
-        return ConsoleSeverity::Info;
+        default:
+            return ConsoleSeverity::Info;
+        }
     }
 
     // ============================================================================
@@ -6279,21 +6285,26 @@ namespace Spark
 
     ConsoleSeverity StringToConsoleSeverity(const std::string& str)
     {
-        if (str == "TRACE")
+        using namespace Spark::HashLiterals;
+        switch (Spark::FNV1a64(str))
+        {
+        case "TRACE"_hash64:
             return ConsoleSeverity::Trace;
-        if (str == "DEBUG")
+        case "DEBUG"_hash64:
             return ConsoleSeverity::Debug;
-        if (str == "INFO")
+        case "INFO"_hash64:
             return ConsoleSeverity::Info;
-        if (str == "SUCCESS")
+        case "SUCCESS"_hash64:
             return ConsoleSeverity::Success;
-        if (str == "WARNING")
+        case "WARNING"_hash64:
             return ConsoleSeverity::Warning;
-        if (str == "ERROR")
+        case "ERROR"_hash64:
             return ConsoleSeverity::Error;
-        if (str == "CRITICAL")
+        case "CRITICAL"_hash64:
             return ConsoleSeverity::Critical;
-        return ConsoleSeverity::Info;
+        default:
+            return ConsoleSeverity::Info;
+        }
     }
 
     SimpleConsole::Color SimpleConsole::SeverityToColor(ConsoleSeverity severity)

--- a/SparkGame/Source/Game/InteractiveObject.cpp
+++ b/SparkGame/Source/Game/InteractiveObject.cpp
@@ -292,46 +292,55 @@ namespace Spark
         m_objectType = InteractiveObjectType::ELEVATOR;
         SetName("Elevator");
         m_interactionRange = 3.0f;
+
+        // Set up elevator state FSM — callbacks keep m_state in sync for external queries.
+        m_elevatorFSM.AddState(ElevatorState::AtBottom, [this]() { m_state = ElevatorState::AtBottom; });
+
+        m_elevatorFSM.AddState(
+            ElevatorState::MovingUp, [this]() { m_state = ElevatorState::MovingUp; },
+            [this](float dt)
+            {
+                m_moveProgress += m_moveSpeed * dt / GetDistanceFrom(m_topPosition);
+                if (m_moveProgress > 1.0f)
+                    m_moveProgress = 1.0f;
+            });
+
+        m_elevatorFSM.AddState(
+            ElevatorState::AtTop,
+            [this]()
+            {
+                m_state = ElevatorState::AtTop;
+                m_waitTimer = 0.0f;
+            },
+            [this](float dt)
+            {
+                if (m_autoReturn)
+                    m_waitTimer += dt;
+            });
+
+        m_elevatorFSM.AddState(
+            ElevatorState::MovingDown, [this]() { m_state = ElevatorState::MovingDown; },
+            [this](float dt)
+            {
+                m_moveProgress -= m_moveSpeed * dt / GetDistanceFrom(m_bottomPosition);
+                if (m_moveProgress < 0.0f)
+                    m_moveProgress = 0.0f;
+            });
+
+        // Automatic transitions
+        m_elevatorFSM.AddTransition(ElevatorState::MovingUp, ElevatorState::AtTop,
+                                    [this]() { return m_moveProgress >= 1.0f; });
+        m_elevatorFSM.AddTransition(ElevatorState::MovingDown, ElevatorState::AtBottom,
+                                    [this]() { return m_moveProgress <= 0.0f; });
+        m_elevatorFSM.AddTransition(ElevatorState::AtTop, ElevatorState::MovingDown,
+                                    [this]() { return m_autoReturn && m_waitTimer >= m_waitTime; });
+
+        m_elevatorFSM.Start(ElevatorState::AtBottom);
     }
 
     void ElevatorObject::Update(float deltaTime)
     {
-        switch (m_state)
-        {
-        case ElevatorState::MovingUp:
-            m_moveProgress += m_moveSpeed * deltaTime / GetDistanceFrom(m_topPosition);
-            if (m_moveProgress >= 1.0f)
-            {
-                m_moveProgress = 1.0f;
-                m_state = ElevatorState::AtTop;
-                m_waitTimer = 0.0f;
-            }
-            break;
-
-        case ElevatorState::MovingDown:
-            m_moveProgress -= m_moveSpeed * deltaTime / GetDistanceFrom(m_bottomPosition);
-            if (m_moveProgress <= 0.0f)
-            {
-                m_moveProgress = 0.0f;
-                m_state = ElevatorState::AtBottom;
-                m_waitTimer = 0.0f;
-            }
-            break;
-
-        case ElevatorState::AtTop:
-            if (m_autoReturn)
-            {
-                m_waitTimer += deltaTime;
-                if (m_waitTimer >= m_waitTime)
-                {
-                    m_state = ElevatorState::MovingDown;
-                }
-            }
-            break;
-
-        case ElevatorState::AtBottom:
-            break;
-        }
+        m_elevatorFSM.Tick(deltaTime);
 
         // Interpolate position
         XMFLOAT3 pos = {m_bottomPosition.x + (m_topPosition.x - m_bottomPosition.x) * m_moveProgress,
@@ -354,12 +363,12 @@ namespace Spark
     {
         if (m_state == ElevatorState::AtBottom)
         {
-            m_state = ElevatorState::MovingUp;
+            m_elevatorFSM.TransitionTo(ElevatorState::MovingUp);
             m_ridingPlayer = player;
         }
         else if (m_state == ElevatorState::AtTop)
         {
-            m_state = ElevatorState::MovingDown;
+            m_elevatorFSM.TransitionTo(ElevatorState::MovingDown);
             m_ridingPlayer = player;
         }
         return InteractiveObject::Interact(player);

--- a/SparkGame/Source/Game/InteractiveObject.h
+++ b/SparkGame/Source/Game/InteractiveObject.h
@@ -264,6 +264,7 @@ namespace Spark
 
       private:
         ElevatorState m_state = ElevatorState::AtBottom;
+        Spark::StateMachine<ElevatorState> m_elevatorFSM; ///< Drives elevator movement lifecycle
         XMFLOAT3 m_bottomPosition = {0, 0, 0};
         XMFLOAT3 m_topPosition = {0, 10, 0};
         float m_moveSpeed = 5.0f;

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -130,5 +130,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 81 |
 | Test cases | 1007+ |
 | Wiki pages | 54 |
-| *Last synced* | *2026-03-14 01:21* |
+| *Last synced* | *2026-03-14 02:29* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
Extend the use of Hash.h, TypeTraits.h, StateMachine.h, Serializer.h, and MathUtils.h into additional engine subsystems:

- Hash: Convert 7 string-to-enum functions (52 comparisons) to FNV1a64 switch dispatch in SparkConsole, PhysicsSystemStub, LightingSystem, and MaterialSystem (both Windows and non-Windows paths)
- Hash CombineHash: Replace manual hash-combining lambdas/XOR shifts in PhysicsSystem.cpp and PhysicsSystemStub.cpp HashShape()
- TypeTraits: Apply Spark::Arithmetic concept in ConsoleVariable.h, Spark::Enum concept in EnumUtils.h and BitFlags.h (replacing static_asserts), Spark::TriviallyCopyable concept in Serializer.h
- StateMachine: Convert AIDirector phase cycling (BuildUp/Peak/Relax/ Transition) and ElevatorObject movement to Spark::StateMachine FSM
- Serializer: Rewrite ReplaySystem SaveToFile/LoadFromFile with BinaryWriter/BinaryReader
- MathUtils: Replace duplicate Lerp functions in Sequencer.cpp
- Hash: Convert DialogueSystem node type parsing to hash switch

https://claude.ai/code/session_01WLKBcrhb9t2yFS8qfAQWpv