### PR TITLE
Expand persistence context DB to general self-learning store

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -80,6 +80,17 @@ All entries use this structure. Sections marked _(Issue only)_ are omitted for n
 - `Ongoing` — Issue or situation that recurs and is being managed
 - `Superseded` — Entry replaced by a better approach (keep for history)
 
+## Cross-References
+
+When an entry directly relates to another, add a `**See also:**` line in the Notes section:
+
+```markdown
+## Notes
+- **See also:** [topic description](filename.md)
+```
+
+Use this when one entry's context or solution depends on knowledge from another (e.g., an Optimization that references its related Issue, or an Observation that leads to a Pattern). This allows navigating between related entries without returning to the index.
+
 ## Rules
 
 1. **Claude owns these files** — written by Claude sessions; humans may correct factual errors.
@@ -88,6 +99,7 @@ All entries use this structure. Sections marked _(Issue only)_ are omitted for n
 4. **Do not exclude from `.promptignore`** — this directory must remain visible to Claude.
 5. **Update the index** — whenever you add or update a knowledge file, update `index.md`.
 6. **Prefer updating over creating** — if an existing entry covers the topic, extend it.
+7. **Cross-reference related entries** — add `See also:` links when entries are meaningfully related.
 
 ## Entry Types Reference
 
@@ -113,5 +125,6 @@ All entries use this structure. Sections marked _(Issue only)_ are omitted for n
     ├── cmake-linux-build-failures.md      # [Issue] Linux CMake configure/build failures
     ├── windows-msvc-w4-warnings.md        # [Issue] MSVC /W4 warning-as-error patterns
     ├── workflow-patterns.md               # [Pattern] Effective SparkEngine dev workflows
-    └── codebase-observations.md           # [Observation] Non-obvious SparkEngine facts
+    ├── codebase-observations.md           # [Observation] Non-obvious SparkEngine facts
+    └── build-optimizations.md            # [Optimization] Build and CI workflow speedups
 ```

--- a/.claude/index.md
+++ b/.claude/index.md
@@ -14,6 +14,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 | Windows MSVC /W4 warnings | [knowledge/windows-msvc-w4-warnings.md](knowledge/windows-msvc-w4-warnings.md) | Issue | Resolved | 2026-03-14 |
 | Effective dev workflows | [knowledge/workflow-patterns.md](knowledge/workflow-patterns.md) | Pattern | Active | 2026-03-14 |
 | Codebase non-obvious facts | [knowledge/codebase-observations.md](knowledge/codebase-observations.md) | Observation | Active | 2026-03-14 |
+| Build and CI workflow speedups | [knowledge/build-optimizations.md](knowledge/build-optimizations.md) | Optimization | Active | 2026-03-14 |
 
 ## Quick Reference by Topic
 
@@ -36,6 +37,16 @@ _Read this at every session start (after git sync). Each row links to a detailed
 **Starting a task involving multiple codebase areas** → Launch parallel Explore agents. See [workflow-patterns.md](knowledge/workflow-patterns.md).
 
 **After any structural code change** → Run `generate-api-docs.sh check` + `sync-wiki.sh sync`. See [workflow-patterns.md](knowledge/workflow-patterns.md).
+
+### Working faster (Optimizations)
+
+**Slow cmake build** → Add `--parallel $(nproc)`. See [build-optimizations.md](knowledge/build-optimizations.md).
+
+**CI failure log is huge** → Use `gh run view <RUN_ID> --log-failed` for just the failures. See [build-optimizations.md](knowledge/build-optimizations.md).
+
+**About to rebase** → Check `git log --oneline HEAD..origin/Working | wc -l` first. See [build-optimizations.md](knowledge/build-optimizations.md).
+
+**Verify CMake preset flags without configuring** → `cmake --preset linux-gcc-release -N`. See [build-optimizations.md](knowledge/build-optimizations.md).
 
 ### Understanding the codebase (Observations)
 

--- a/.claude/knowledge/build-optimizations.md
+++ b/.claude/knowledge/build-optimizations.md
@@ -1,0 +1,121 @@
+# Build and CI Workflow Optimizations
+
+**Last updated:** 2026-03-14
+**Type:** Optimization
+**Status:** Active
+
+## Description
+
+Concrete time and effort savers for build, CI diagnosis, and git workflows. These are faster or more reliable alternatives to the obvious first approach.
+
+## Context
+
+Applies to any session involving building, testing, CI diagnosis, or git operations in SparkEngine. These are not correctness fixes — the default approaches work — they are efficiency improvements.
+
+---
+
+## Optimization: Always Use `--parallel $(nproc)` for CMake Builds
+
+### Approach
+
+Always pass `--parallel $(nproc)` to `cmake --build` to exploit all available CPU cores:
+
+```bash
+cmake --build build --config Release --parallel $(nproc)
+```
+
+Without this flag, CMake builds single-threaded by default on some configurations, which is dramatically slower on multi-core hosts.
+
+### Notes
+
+- `$(nproc)` is Linux/bash-specific. On macOS use `$(sysctl -n hw.logicalcpu)`.
+- All CI jobs already use `--parallel $(nproc)` — this makes local builds match CI speed.
+
+---
+
+## Optimization: Use `--log-failed` to Jump Straight to CI Failure Output
+
+### Approach
+
+When a CI run fails, skip reading the full log. Use `--log-failed` to download only the failed job output:
+
+```bash
+# Get run ID first
+gh run list --branch "$(git branch --show-current)" --limit 3
+
+# Download only failed logs (much smaller, faster to scan)
+gh run view <RUN_ID> --log-failed
+```
+
+### Notes
+
+- Full logs (`gh run view <RUN_ID> --log`) can be very large — often 10–50 MB for all jobs.
+- `--log-failed` downloads only the logs from jobs with a `failure` conclusion.
+- **See also:** [github-api-pr-checks.md](github-api-pr-checks.md) for the full PR check diagnosis workflow.
+
+---
+
+## Optimization: Check Branch Delta Before Rebasing
+
+### Approach
+
+Before running `git rebase origin/Working`, check how many commits you're behind. This tells you whether to expect conflicts and how many:
+
+```bash
+git log --oneline HEAD..origin/Working | wc -l
+```
+
+| Output | Action |
+|--------|--------|
+| `0` | Branch is up to date — skip rebase entirely |
+| `1–3` | Straightforward rebase, unlikely to conflict |
+| `4–10` | Moderate delta — read commit messages before rebasing |
+| `10+` | Large delta — review commits first with `git log --oneline HEAD..origin/Working` |
+
+### Notes
+
+- **See also:** [git-rebase-conflicts.md](git-rebase-conflicts.md) for conflict resolution strategies.
+- Checking first prevents surprises mid-rebase on large divergences.
+
+---
+
+## Optimization: `gh pr checks` Snapshot Over `--watch` Loop
+
+### Approach
+
+For a quick status snapshot without risk of hanging, use plain `gh pr checks` (no flags) rather than `--watch`:
+
+```bash
+# Quick snapshot — does not hang
+gh pr checks
+
+# Then use run list + view for details on failures
+gh run list --branch "$(git branch --show-current)" --limit 3
+gh run view <RUN_ID>
+```
+
+`gh pr checks --watch` is designed for interactive terminals and can hang indefinitely in non-TTY environments.
+
+### Notes
+
+- **See also:** [github-api-pr-checks.md](github-api-pr-checks.md) for the full polling workflow.
+- Ignore exit code 1 from `gh pr checks` if checks are still running — the non-zero exit is not meaningful while checks are in progress.
+
+---
+
+## Optimization: CMake Dry-Run to Verify Preset Flags
+
+### Approach
+
+Use the `-N` flag to do a CMake dry-run that prints all resolved options without actually configuring:
+
+```bash
+cmake --preset linux-gcc-release -N
+```
+
+Useful for verifying which CMake toggles (`ENABLE_NETWORKING`, `ENABLE_DXR`, etc.) are set by a preset before committing to a full configure.
+
+### Notes
+
+- Much faster than a full configure when you just need to check a flag.
+- **See also:** [codebase-observations.md](codebase-observations.md) for the list of systems that are OFF by default.

--- a/.claude/knowledge/codebase-observations.md
+++ b/.claude/knowledge/codebase-observations.md
@@ -32,6 +32,7 @@ If code in a disabled system silently breaks, it won't show up in standard CI bu
 
 - To verify what's enabled in the current build: `cmake --preset linux-gcc-release -N` (dry run shows resolved options)
 - CI does NOT enable `ENABLE_NETWORKING` — network-related CI failures must be from code paths that compile unconditionally
+- **See also:** [build-optimizations.md](build-optimizations.md) for the CMake dry-run preset verification optimization
 
 ---
 
@@ -111,6 +112,7 @@ During rebase conflicts in wiki files, always take upstream for the AUTO: sectio
 
 - Files that have AUTO: sections: `Entity-Component-System.md`, `Testing.md`, `SparkEditor.md`, `Home.md`
 - To add a new wiki page: create the file in `wiki/`, then add it to `wiki/_Sidebar.md`
+- **See also:** [git-rebase-conflicts.md](git-rebase-conflicts.md) for conflict resolution in AUTO: sections during rebases
 
 ---
 

--- a/.claude/knowledge/git-rebase-conflicts.md
+++ b/.claude/knowledge/git-rebase-conflicts.md
@@ -77,3 +77,4 @@ To take upstream for just the auto-sections, open the file and manually accept t
 - The `--rebase-merges` flag is not needed for this repo — the history is linear on feature branches.
 - If a rebase has many conflicts (5+ files), consider whether your branch has diverged too far. In that case, it may be worth doing a careful `git merge` instead of a rebase, then squashing before the PR.
 - **Never** use `git rebase --abort` then force-push to skip a rebase. Always resolve conflicts properly.
+- **See also:** [build-optimizations.md](build-optimizations.md) for checking branch delta before rebasing; [codebase-observations.md](codebase-observations.md) for details on AUTO: wiki markers.

--- a/.claude/knowledge/workflow-patterns.md
+++ b/.claude/knowledge/workflow-patterns.md
@@ -103,6 +103,7 @@ Stop at the first failure; fix it before proceeding to the next step.
 - Step 1 (format) is cheap (~5 seconds). Do it even for tiny changes — MSVC code often reformats differently.
 - Step 2 (configure) detects include path issues early before a full compile.
 - Step 5 (docs) is only needed when step 1 touches headers or structural files.
+- **See also:** [clang-format.md](clang-format.md) for why `head -50` must not be used in step 1; [build-optimizations.md](build-optimizations.md) for the `--parallel $(nproc)` flag in step 3.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ After writing, update `.claude/index.md` and commit both alongside code changes.
 
 **Last updated:** YYYY-MM-DD
 **Type:** Issue | Pattern | Optimization | Observation | Decision
-**Status:** Resolved | Active | Ongoing
+**Status:** Resolved | Active | Ongoing | Superseded
 
 ## Description
 ## Context
@@ -186,8 +186,18 @@ After writing, update `.claude/index.md` and commit both alongside code changes.
     ├── cmake-linux-build-failures.md      # [Issue] Linux CMake configure/build failures
     ├── windows-msvc-w4-warnings.md        # [Issue] MSVC /W4 fix table
     ├── workflow-patterns.md               # [Pattern] Effective dev workflows
-    └── codebase-observations.md           # [Observation] Non-obvious SparkEngine facts
+    ├── codebase-observations.md           # [Observation] Non-obvious SparkEngine facts
+    └── build-optimizations.md            # [Optimization] Build and CI workflow speedups
 ```
+
+### At session end
+
+After completing any non-trivial task, review whether anything learned during the session warrants a new or updated entry. This is especially important for:
+- **Optimizations** discovered incidentally (a faster flag, a better command sequence)
+- **Patterns** that worked well and should be repeated
+- **Observations** about the codebase that weren't obvious before
+
+Don't wait for something to break. Positive learning — things that worked well — is equally worth recording.
 
 **Rules:**
 - Do not exclude `.claude/` from `.promptignore` — Claude must be able to read it.


### PR DESCRIPTION
- Add build-optimizations.md (Type: Optimization) with 5 entries covering parallel builds, --log-failed CI diagnosis, branch delta check, gh pr checks snapshot, and CMake dry-run preset verification
- Add session-end reminder to CLAUDE.md: review after every non-trivial task for patterns/optimizations/observations worth recording
- Document See also: cross-reference convention in README.md; add cross- references across git-rebase-conflicts, workflow-patterns, and codebase-observations entries
- Add Superseded as a valid Status value in CLAUDE.md entry format
- Update index.md with Optimization quick-reference section and new entry
- Update directory structure blocks in CLAUDE.md and README.md

https://claude.ai/code/session_01Y7A2W9tw32H9Dt7SXyoVey