### PR TITLE
Add anti-bloat rules, debloat targets, and AI bloat countermeasures

### DIFF
--- a/.claude/index.md
+++ b/.claude/index.md
@@ -15,6 +15,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 | Effective dev workflows | [knowledge/workflow-patterns.md](knowledge/workflow-patterns.md) | Pattern | Active | 2026-03-14 |
 | Codebase non-obvious facts | [knowledge/codebase-observations.md](knowledge/codebase-observations.md) | Observation | Active | 2026-03-14 |
 | Build and CI workflow speedups | [knowledge/build-optimizations.md](knowledge/build-optimizations.md) | Optimization | Active | 2026-03-14 |
+| AI bloat pattern and countermeasures | [knowledge/ai-bloat-pattern.md](knowledge/ai-bloat-pattern.md) | Observation | Active | 2026-03-14 |
 
 ## Quick Reference by Topic
 
@@ -33,6 +34,12 @@ _Read this at every session start (after git sync). Each row links to a detailed
 **Windows CI fails but Linux passes** → MSVC `/W4` warnings. Use fix table. See [windows-msvc-w4-warnings.md](knowledge/windows-msvc-w4-warnings.md).
 
 ### Doing things well (Patterns & Optimizations)
+
+**BEFORE writing any code** → Check file size. If over 400 lines (.cpp) or 200 lines (.h), trim first. See [ai-bloat-pattern.md](knowledge/ai-bloat-pattern.md).
+
+**BEFORE adding a new method/class** → Search for existing one. Remove a duplicate if adding. See [workflow-patterns.md](knowledge/workflow-patterns.md).
+
+**System is built but Initialize() is never called** → Either wire it in immediately or delete it. See [ai-bloat-pattern.md](knowledge/ai-bloat-pattern.md).
 
 **Starting a task involving multiple codebase areas** → Launch parallel Explore agents. See [workflow-patterns.md](knowledge/workflow-patterns.md).
 

--- a/.claude/knowledge/ai-bloat-pattern.md
+++ b/.claude/knowledge/ai-bloat-pattern.md
@@ -1,0 +1,81 @@
+# AI-Assisted Development — Bloat Pattern and Countermeasures
+
+**Last updated:** 2026-03-14
+**Type:** Observation
+**Status:** Active
+
+## Description
+
+AI-assisted development has a structural, unavoidable tendency toward bloat. This is not a bug in any single session — it is a systemic property. Understanding why it happens is required to prevent it.
+
+## Context
+
+Discovered through full audit of SparkEngine codebase in March 2026. The engine had been AI-assisted for multiple months. The cumulative result: `SparkConsole.cpp` grew to 261KB, `ConsoleProcessManager` was built but never wired in, `SimpleConsole` accumulated 25+ command registration functions, and `SimpleConsole::Initialize()` was called 5 times in different code paths.
+
+## Details
+
+### Why AI Creates Bloat
+
+**1. No pain from complexity**
+A human developer feels the cost of a 261KB file when they spend 3 hours debugging it. AI never feels that. Each session starts fresh; the accumulated mess is invisible until it's catastrophic.
+
+**2. Addition feels productive; removal does not**
+Every new feature, method, or class looks like forward progress. Deleting code looks like going backwards. AI has no natural counter-pressure.
+
+**3. "What if we need this later?" thinking**
+AI defaults to comprehensive solutions. A simple logging function becomes a full logging system with severity enums, color coding, history persistence, tab completion, and watch variables — because "it might be needed."
+
+**4. Systems built but not integrated**
+AI builds things. AI may not always wire them in. ConsoleProcessManager: fully implemented pipes, process launching, command queuing — never initialized. Pure overhead with zero functionality.
+
+**5. Parallel duplication**
+Two systems doing overlapping things get built independently and neither gets removed. SimpleConsole and ConsoleProcessManager both exist with overlapping command registration. Neither is cleaned up because "we might need both."
+
+**6. Each session sees a small change**
+No single session adds an outrageous amount. 50 lines here, a new method there. After 20 sessions: 261KB files and systems nobody can understand.
+
+### Confirmed Bloat Instances Found in SparkEngine
+
+| Location | Bloat Type | Estimated Waste |
+|----------|-----------|-----------------|
+| `SparkConsole.cpp` | Embedded console UI never used (cursor, ANSI, Win32 handles) | ~150 lines |
+| `SparkConsole.h` | 25+ `Register*()` methods, could be 3 | ~20 method declarations |
+| `ConsoleProcessManager` | Fully implemented, zero call sites for `Initialize()` | Entire file is dead |
+| `SparkEngine.cpp` | `SimpleConsole::Initialize()` called 5x | 4 redundant call sites |
+| `SimpleConsole::WatchEntry` system | Built, no callers outside the class | Entire subsystem |
+| `SimpleConsole` tab completion state | 3 members, never used externally | Dead state |
+
+### The Compounding Effect
+
+Bloat compounds. A bloated file is harder to read, so the next session adds another helper function instead of understanding the existing code. That makes it more bloated. After N sessions, the file is incomprehensible and nobody touches it — it just accumulates more wrappers.
+
+## Solution / Summary
+
+### Per-Session Rules (enforced in CLAUDE.md)
+
+1. **Hard line limits**: `.cpp` max 400 lines, `.h` max 200 lines
+2. **Removal mandate**: every PR that adds code must also remove code
+3. **Wire-in requirement**: if a system has `Initialize()`, it must be called, or delete the system
+4. **No orphaned code**: dead code is deleted immediately, not commented out
+5. **Bloat check at session start**: `find ... | xargs wc -l | sort -rn | head -15`
+
+### When You Notice Bloat Mid-Task
+
+Do not defer. If the file you're editing is over the limit:
+1. Trim it first — delete dead code, consolidate duplicate methods, remove unused members
+2. Then make your actual change
+3. The PR should show a net negative line count or small positive
+
+### What "Minimal" Means Here
+
+The SparkConsole fix is the canonical example:
+- **Wrong**: Add 20 lines wrapping `Initialize()` in a helper class with retry logic and callbacks
+- **Right**: Add 2 lines — `Initialize()` in startup, `ProcessCommands()` in main loop
+
+If the fix is more than 10 lines, ask: "What am I adding that I don't need?"
+
+## Notes
+
+- This problem is not fixable with AI alone — human review focused on *removal* is the real safeguard
+- The CLAUDE.md Anti-Bloat Rules section is the living enforcement mechanism; update it when new patterns are found
+- "Looks good, simplify it" is a valid and important review comment — it should be used often

--- a/.claude/knowledge/workflow-patterns.md
+++ b/.claude/knowledge/workflow-patterns.md
@@ -130,6 +130,46 @@ cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_NETWORKING=O
 
 ---
 
+## Pattern: Removal Before Addition
+
+### Approach
+
+Before writing any new code in a file, check its size. If it is over the limit (400 lines for `.cpp`, 200 for `.h`), trim it first:
+
+```bash
+# Check size of a file before editing
+wc -l SparkEngine/Source/Utils/SparkConsole.cpp
+
+# If over limit:
+# 1. Find dead methods (no callers outside the class)
+grep -n "void SimpleConsole::" SparkEngine/Source/Utils/SparkConsole.cpp | head -30
+# 2. Delete them
+# 3. Then make your actual change
+```
+
+For any new public method being added:
+1. Search for existing methods that do something similar
+2. If one exists, extend it — don't add a new one
+3. If there are now 2 similar methods after your change, remove the older one
+
+For any new system/class being added:
+1. Search for an existing class that could be extended
+2. If adding, remove something of equivalent complexity
+
+### When to apply
+
+- Every time you open a file to edit it
+- Before every PR — check net line delta: should be ≤ 0 for refactors, minimal positive for features
+- When a file starts feeling hard to navigate
+
+### Notes
+
+- Removal is not "going backwards" — it is the primary maintenance activity
+- The goal is a codebase that shrinks toward its essential minimum, not grows toward "comprehensive"
+- If a feature isn't used by something running today, delete it
+
+---
+
 ## Pattern: Session Start Checklist Order
 
 ### Approach
@@ -141,11 +181,18 @@ Every session should start in this exact order before doing anything else:
 3. Resolve any rebase conflicts (see [git-rebase-conflicts.md](git-rebase-conflicts.md))
 4. `cat .claude/index.md` — load persistent context
 5. Read any knowledge files relevant to the current task
-6. **Then** start reading code or planning
+6. **Bloat check** — run before touching anything:
+   ```bash
+   find SparkEngine/Source SparkEditor/Source SparkConsole/src SparkGame/Source \
+     -name '*.cpp' | xargs wc -l | sort -rn | head -15
+   ```
+7. **Then** start reading code or planning
 
-Skipping step 4–5 means starting each session without the accumulated knowledge from prior sessions.
+Skipping step 4–5 means starting each session without accumulated knowledge. Skipping step 6 means walking into a bloated file blind.
 
 ### Notes
 
 - If `wc -l` output is 0 in step 1, the branch is up to date — skip the rebase.
 - Never start reading or editing code before completing the git sync. Stale code leads to conflicts on push.
+- The bloat check takes 2 seconds. Files over 400 lines must be trimmed before adding to them.
+- **See also:** [ai-bloat-pattern.md](ai-bloat-pattern.md) for why this problem exists and how to prevent it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,68 @@ cd build && ctest --output-on-failure
 
 CMake 3.16+, C++20 required. Key toggles: `ENABLE_EDITOR`, `ENABLE_GRAPHICS`, `ENABLE_PHYSX`, `ENABLE_AI`, `ENABLE_ANIMATION`, `ENABLE_NETWORKING` (OFF by default), `ENABLE_VULKAN`, `ENABLE_OPENGL`, `ENABLE_SAVE_SYSTEM`, `ENABLE_PROCEDURAL`, `ENABLE_CINEMATIC`, `ENABLE_EVENT_SYSTEM`, `ENABLE_DECALS`, `ENABLE_MESH_LOD`, `ENABLE_DXR` (OFF by default), `BUILD_TESTS`.
 
+## Anti-Bloat Rules — HIGHEST PRIORITY
+
+These rules exist because AI-assisted development has a structural bias toward complexity. Every session, without active enforcement, will add more than it removes. These rules are non-negotiable and override every other instinct.
+
+### The Core Problem
+
+AI defaults to:
+- Adding features "just in case" → dead code accumulates
+- Creating helper classes for single uses → pointless abstraction
+- Over-engineering simple problems → 261KB files that nobody can debug
+- Building systems without wiring them in → ConsoleProcessManager-style orphans
+- Scattering related logic → 25 command registration functions instead of 1
+
+### Hard Limits
+
+| Thing | Limit | Action if exceeded |
+|-------|-------|--------------------|
+| `.cpp` file size | 400 lines | Refactor before touching anything else |
+| `.h` file size | 200 lines | Split or consolidate before adding anything |
+| Public methods per class | 15 | Justify each one or remove it |
+| Private helper methods per class | 10 | Extract to free function or delete |
+| Command registration functions | 1 per subsystem | Consolidate before adding commands |
+| Parallel singleton systems doing the same thing | 0 | Remove the duplicate |
+
+### Before Writing Any Code — Ask These Questions
+
+1. **Does this already exist?** Search before writing. If yes, use the existing one.
+2. **Will this be called?** If you can't name the caller right now, don't write it.
+3. **Can the existing code do this with a small change?** Prefer editing over adding.
+4. **Is this a one-time use?** If yes, inline it — no helper function, no new class.
+5. **Am I future-proofing?** Stop. Write only what is needed today.
+
+### Mandatory Removal Before Addition
+
+- Adding a new class → remove or consolidate an existing one if the total count grows
+- Adding a new `.cpp` file → justify why it can't live in an existing file
+- Adding a new public method → check if a private or existing method can be extended
+- Adding new command registrations → they go in ONE place per subsystem, not scattered
+
+### Dead Code Is Actively Harmful
+
+- Unused public methods → delete immediately, don't comment out
+- Uninitialized systems (built but never called) → either wire them in or delete them
+- Features built but not integrated → count as bugs, not WIP
+- Commented-out code → delete it, git history exists for a reason
+- "Stub" implementations → either implement fully or remove entirely
+
+### Signs You Are Creating Bloat — Stop Immediately
+
+- Writing a function longer than 50 lines
+- A class has more `Register*` methods than actual logic
+- You're adding a 6th logging method when 3 exist
+- A new `*Manager` or `*System` class when the existing one can be extended
+- Duplicating member variables that exist in a related class
+- Creating an abstraction for something used in exactly one place
+
+### The Removal Mandate
+
+Every PR that adds code **must** also remove code. If a PR adds 50 lines and removes 0, that is a bloat PR and should be rejected. Aim for negative line counts on refactor tasks. The codebase should shrink over time, not grow.
+
+---
+
 ## Coding Standards
 
 - **C++20**: `constexpr`, `enum class`, structured bindings, `std::format`, concepts
@@ -124,7 +186,13 @@ After the git sync, **read `.claude/index.md`** to load session context (step 5 
 ```bash
 # 5. Load persistent context
 cat .claude/index.md
+
+# 6. Bloat check — identify the worst files before touching anything
+find SparkEngine/Source SparkEditor/Source SparkConsole/src SparkGame/Source \
+  -name '*.cpp' | xargs wc -l | sort -rn | head -15
 ```
+
+Step 6 takes 2 seconds and tells you immediately what is over the line-count limit. If the task involves any of those files, the first job is to trim them, not add to them.
 
 ## Persistence Context Database
 
@@ -412,6 +480,37 @@ Whenever code is **added**, **modified**, or **deleted**, update the correspondi
 
 Skipping documentation is **not acceptable** — treat docs as part of the deliverable, not an afterthought.
 
+## Wiring Things In — Functionality Is Not Optional
+
+A system that exists but is never initialized, called, or connected is **worse than not existing**. It adds confusion, maintenance burden, and false confidence. The rule is simple:
+
+- **Every system must be initialized.** If `Initialize()` exists, it must be called somewhere in the startup path.
+- **Every update loop must be called.** If `Update()` or `ProcessCommands()` exists, it must appear in the main loop.
+- **Every sink must have a source.** If a system receives data (commands, logs, events), something must be sending it.
+
+When wiring a system in, use the absolute minimum code:
+```cpp
+// CORRECT — minimal, direct, explicit
+ConsoleProcessManager::GetInstance().Initialize();  // in startup
+ConsoleProcessManager::GetInstance().ProcessCommands();  // in main loop
+
+// WRONG — wrapping in another layer of abstraction before it even works
+class ConsoleInitHelper { ... };  // NO. Just call Initialize().
+```
+
+If you discover a system that is built but not wired in: **either wire it in immediately, or delete it**. It cannot stay in a half-built state.
+
+## Known Debloat Targets (address these before adding anything new)
+
+These are confirmed bloat problems discovered during audit. They must be fixed before new features are added in the relevant areas.
+
+| File | Problem | Action Required |
+|------|---------|-----------------|
+| `SparkEngine/Source/Utils/SparkConsole.cpp` | 261KB — embedded console UI that's no longer used (cursor handling, ANSI colors, tab state, Win32 console) | Strip all local UI code; keep only Log(), severity helpers |
+| `SparkEngine/Source/Utils/SparkConsole.h` | 25+ `Register*()` methods scattered across subsystems | Consolidate into ≤3: Engine, Game, Debug |
+| `SparkEngine/Source/Utils/ConsoleProcessManager` | Built but never initialized; `ProcessCommands()` never called | Wire into startup and main loop |
+| `SparkEngine/Source/Core/SparkEngine.cpp` | `SimpleConsole::Initialize()` called 5 times in different code paths | Call it once, correctly |
+
 ## Things to know
 
 - Use `EngineContext` service locator, not deprecated `g_graphics`/`g_input` globals
@@ -422,3 +521,5 @@ Skipping documentation is **not acceptable** — treat docs as part of the deliv
 - `.clang-tidy` checks for bugprone, modernize, performance, and readability issues
 - Doxygen config lives in `docs/Doxyfile.txt`; wiki pages in `wiki/`
 - 82+ unit tests in `Tests/`; always run `ctest` after changes
+- **SparkConsole communicates with the engine via stdin/stdout pipes.** ConsoleProcessManager launches the subprocess and owns the pipe. SimpleConsole is the engine-side log sink only — it is not an IPC layer.
+- **ConsoleProcessManager must be initialized at engine startup** and `ProcessCommands()` must be called each frame. Without this, SparkConsole.exe never launches and commands are never executed.


### PR DESCRIPTION
- Add prominent Anti-Bloat Rules section to CLAUDE.md with hard file size limits, removal mandate, and pre-addition checklist
- Add Wiring Things In section documenting that uninitialized systems must be wired or deleted (addresses ConsoleProcessManager disconnect)
- Add Known Debloat Targets table documenting confirmed bloat problems to fix before adding new features in those areas
- Add bloat check step to session start procedure (wc -l sorted by size)
- Add ai-bloat-pattern.md knowledge entry documenting why AI creates bloat and concrete countermeasures
- Add Removal Before Addition workflow pattern to workflow-patterns.md
- Update session start checklist to include bloat check as step 6
- Update index.md with new knowledge file and priority quick-reference entries

https://claude.ai/code/session_01U5Y1H4t5YANyDV887GV5Ai