### PR TITLE
Remove GLEW dependency — use ImGui's built-in GL loader instead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake libgl-dev libvulkan-dev libsdl2-dev 
+        sudo apt-get install -y build-essential cmake libgl-dev libvulkan-dev libsdl2-dev
+
     - name: Configure CMake (ASan + UBSan)
       run: |
         cmake -B build \
@@ -201,7 +202,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake libgl-dev libvulkan-dev libsdl2-dev 
+        sudo apt-get install -y build-essential cmake libgl-dev libvulkan-dev libsdl2-dev
+
     - name: Configure CMake
       run: |
         cmake -B build \
@@ -253,7 +255,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y clang cmake libgl-dev libvulkan-dev libsdl2-dev 
+        sudo apt-get install -y clang cmake libgl-dev libvulkan-dev libsdl2-dev
+
     - name: Configure CMake
       run: |
         cmake -B build \
@@ -300,7 +303,8 @@ jobs:
         with:
           submodules: recursive
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y lcov libgl-dev libsdl2-dev       - name: Configure
+        run: sudo apt-get update && sudo apt-get install -y lcov libgl-dev libsdl2-dev
+      - name: Configure
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
@@ -336,7 +340,8 @@ jobs:
         with:
           submodules: recursive
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang-tidy libgl-dev libsdl2-dev       - name: Configure
+        run: sudo apt-get update && sudo apt-get install -y clang-tidy libgl-dev libsdl2-dev
+      - name: Configure
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,8 +58,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake libgl-dev libvulkan-dev libsdl2-dev libglew-dev
-
+        sudo apt-get install -y build-essential cmake libgl-dev libvulkan-dev libsdl2-dev 
     - name: Configure CMake (ASan + UBSan)
       run: |
         cmake -B build \
@@ -202,8 +201,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake libgl-dev libvulkan-dev libsdl2-dev libglew-dev
-
+        sudo apt-get install -y build-essential cmake libgl-dev libvulkan-dev libsdl2-dev 
     - name: Configure CMake
       run: |
         cmake -B build \
@@ -255,8 +253,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y clang cmake libgl-dev libvulkan-dev libsdl2-dev libglew-dev
-
+        sudo apt-get install -y clang cmake libgl-dev libvulkan-dev libsdl2-dev 
     - name: Configure CMake
       run: |
         cmake -B build \
@@ -303,8 +300,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y lcov libgl-dev libsdl2-dev libglew-dev
-      - name: Configure
+        run: sudo apt-get update && sudo apt-get install -y lcov libgl-dev libsdl2-dev       - name: Configure
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
@@ -340,8 +336,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang-tidy libgl-dev libsdl2-dev libglew-dev
-      - name: Configure
+        run: sudo apt-get update && sudo apt-get install -y clang-tidy libgl-dev libsdl2-dev       - name: Configure
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,11 +562,28 @@ endif()
 # ---------------------------------------------------------------------
 # 9.6) Build SparkEditor if enabled and exists
 # ---------------------------------------------------------------------
-if(ENABLE_EDITOR AND EXISTS "${CMAKE_SOURCE_DIR}/SparkEditor/CMakeLists.txt" AND EXISTS "${CMAKE_SOURCE_DIR}/ThirdParty/UI/imgui/imgui.h")
+set(SPARK_EDITOR_DEPS_OK TRUE)
+if(NOT EXISTS "${CMAKE_SOURCE_DIR}/ThirdParty/UI/imgui/imgui.h")
+    set(SPARK_EDITOR_DEPS_OK FALSE)
+    set(SPARK_EDITOR_SKIP_REASON "Dear ImGui not found (initialize submodule)")
+elseif(NOT WIN32)
+    # Linux editor requires SDL2 and OpenGL — check before adding subdirectory
+    find_package(SDL2 QUIET)
+    find_package(OpenGL QUIET)
+    if(NOT SDL2_FOUND)
+        set(SPARK_EDITOR_DEPS_OK FALSE)
+        set(SPARK_EDITOR_SKIP_REASON "SDL2 not found (install libsdl2-dev)")
+    elseif(NOT OpenGL_FOUND)
+        set(SPARK_EDITOR_DEPS_OK FALSE)
+        set(SPARK_EDITOR_SKIP_REASON "OpenGL not found (install libgl-dev)")
+    endif()
+endif()
+
+if(ENABLE_EDITOR AND EXISTS "${CMAKE_SOURCE_DIR}/SparkEditor/CMakeLists.txt" AND SPARK_EDITOR_DEPS_OK)
     message(STATUS "Adding SparkEditor to build...")
     add_subdirectory(SparkEditor)
-elseif(ENABLE_EDITOR AND NOT EXISTS "${CMAKE_SOURCE_DIR}/ThirdParty/UI/imgui/imgui.h")
-    message(STATUS "SparkEditor skipped — Dear ImGui not found (initialize submodule)")
+elseif(ENABLE_EDITOR AND NOT SPARK_EDITOR_DEPS_OK)
+    message(STATUS "SparkEditor skipped — ${SPARK_EDITOR_SKIP_REASON}")
 
     if(TARGET SparkEngine AND TARGET SparkEditor)
         add_dependencies(SparkEditor SparkEngine)

--- a/SparkEditor/CMakeLists.txt
+++ b/SparkEditor/CMakeLists.txt
@@ -47,10 +47,9 @@ if(IMGUI_INCLUDE_DIR)
                 d3d11 dxgi user32 gdi32 shell32 ole32 oleaut32 uuid comdlg32 advapi32
             )
         else()
-            # Linux: SDL2 + OpenGL3 backends
+            # Linux: SDL2 + OpenGL3 backends (ImGui ships its own GL loader)
             find_package(SDL2 REQUIRED)
             find_package(OpenGL REQUIRED)
-            find_package(GLEW REQUIRED)
 
             add_library(imgui STATIC
                 ${IMGUI_CORE_SOURCES}
@@ -65,7 +64,7 @@ if(IMGUI_INCLUDE_DIR)
                 target_link_libraries(imgui PUBLIC ${SDL2_LIBRARIES})
             endif()
 
-            target_link_libraries(imgui PUBLIC OpenGL::GL GLEW::GLEW)
+            target_link_libraries(imgui PUBLIC OpenGL::GL)
         endif()
 
         target_include_directories(imgui PUBLIC
@@ -208,10 +207,9 @@ if(WIN32)
         odbc32 odbccp32 winmm shlwapi comctl32 version
     )
 else()
-    # Linux libraries
+    # Linux libraries (ImGui ships its own GL loader — no GLEW needed)
     find_package(SDL2 REQUIRED)
     find_package(OpenGL REQUIRED)
-    find_package(GLEW REQUIRED)
 
     if(TARGET SDL2::SDL2)
         target_link_libraries(SparkEditor PRIVATE SDL2::SDL2)
@@ -220,7 +218,7 @@ else()
         target_link_libraries(SparkEditor PRIVATE ${SDL2_LIBRARIES})
     endif()
 
-    target_link_libraries(SparkEditor PRIVATE OpenGL::GL GLEW::GLEW)
+    target_link_libraries(SparkEditor PRIVATE OpenGL::GL)
     target_link_libraries(SparkEditor PRIVATE pthread dl)
 endif()
 

--- a/SparkEditor/Source/Core/EditorApplication.cpp
+++ b/SparkEditor/Source/Core/EditorApplication.cpp
@@ -32,7 +32,7 @@ extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg
 #include <imgui_impl_sdl2.h>
 #include <imgui_impl_opengl3.h>
 #include <SDL.h>
-#include <GL/glew.h>
+#include <GL/gl.h>
 #endif
 
 #include <chrono>
@@ -555,15 +555,6 @@ namespace SparkEditor
 
         SDL_GL_MakeCurrent(m_window, m_glContext);
         SDL_GL_SetSwapInterval(1); // VSync
-
-        // Initialize GLEW
-        GLenum glewErr = glewInit();
-        if (glewErr != GLEW_OK)
-        {
-            console.LogError("Failed to initialize GLEW: " +
-                             std::string(reinterpret_cast<const char*>(glewGetErrorString(glewErr))));
-            return false;
-        }
 
         std::cout << "OpenGL initialized: " << glGetString(GL_VERSION) << "\n";
         std::cout << "GLSL version: " << glGetString(GL_SHADING_LANGUAGE_VERSION) << "\n";

--- a/Tests/TestLocalizationSystem.cpp
+++ b/Tests/TestLocalizationSystem.cpp
@@ -25,7 +25,7 @@ TEST(StringTable_SetAndGet)
 TEST(StringTable_MissingKeyReturnsSelf)
 {
     Spark::StringTable table;
-    const std::string& result = table.GetEntry("missing.key");
+    std::string result = table.GetEntry("missing.key");
     EXPECT_EQ(result, std::string("missing.key"));
 }
 


### PR DESCRIPTION
ImGui ships imgui_impl_opengl3_loader.h which handles all OpenGL extension loading internally. GLEW was an unnecessary system dependency that caused CMake configure failures on fresh Linux clones.

- Remove find_package(GLEW) from SparkEditor/CMakeLists.txt
- Replace #include <GL/glew.h> with <GL/gl.h> in EditorApplication.cpp
- Remove glewInit() call (ImGui handles GL loading)
- Gate SparkEditor on SDL2/OpenGL availability in root CMakeLists.txt so missing deps produce a skip message instead of a fatal error

https://claude.ai/code/session_015AACjDLuZLVvQueRCeHkkh