### PR TITLE
Fix CI build failures — remove missed GLEW references

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
       if: matrix.language == 'c-cpp'
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake libgl-dev libvulkan-dev libsdl2-dev libglew-dev
+        sudo apt-get install -y build-essential cmake libgl-dev libvulkan-dev libsdl2-dev
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake libgl-dev libvulkan-dev libsdl2-dev libglew-dev
+        sudo apt-get install -y build-essential cmake libgl-dev libvulkan-dev libsdl2-dev
 
     - name: Configure CMake
       run: |

--- a/SparkEditor/Source/Core/EditorApplication.cpp
+++ b/SparkEditor/Source/Core/EditorApplication.cpp
@@ -32,7 +32,7 @@ extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg
 #include <imgui_impl_sdl2.h>
 #include <imgui_impl_opengl3.h>
 #include <SDL.h>
-#include <GL/gl.h>
+#include <SDL_opengl.h>
 #endif
 
 #include <chrono>

--- a/ThirdParty/CMakeLists.txt
+++ b/ThirdParty/CMakeLists.txt
@@ -38,12 +38,11 @@ if(EXISTS "${IMGUI_DIR}/imgui.cpp")
         endif()
         message(STATUS "ThirdParty: Dear ImGui configured (Win32+DX11)")
     else()
-        # Linux: SDL2 + OpenGL3 backends
+        # Linux: SDL2 + OpenGL3 backends (ImGui ships its own GL loader)
         find_package(SDL2 QUIET)
         find_package(OpenGL QUIET)
-        find_package(GLEW QUIET)
 
-        if(SDL2_FOUND AND OpenGL_FOUND AND GLEW_FOUND)
+        if(SDL2_FOUND AND OpenGL_FOUND)
             add_library(imgui STATIC
                 ${IMGUI_CORE_SOURCES}
                 ${IMGUI_DIR}/backends/imgui_impl_sdl2.cpp
@@ -57,13 +56,13 @@ if(EXISTS "${IMGUI_DIR}/imgui.cpp")
                 target_include_directories(imgui PUBLIC ${SDL2_INCLUDE_DIRS})
                 target_link_libraries(imgui PUBLIC ${SDL2_LIBRARIES})
             endif()
-            target_link_libraries(imgui PUBLIC OpenGL::GL GLEW::GLEW)
+            target_link_libraries(imgui PUBLIC OpenGL::GL)
             message(STATUS "ThirdParty: Dear ImGui configured (SDL2+OpenGL3)")
         else()
             # Fallback: core only without platform backends
             add_library(imgui STATIC ${IMGUI_CORE_SOURCES})
             target_include_directories(imgui PUBLIC ${IMGUI_DIR})
-            message(STATUS "ThirdParty: Dear ImGui configured (core only, install SDL2/GLEW for full editor support)")
+            message(STATUS "ThirdParty: Dear ImGui configured (core only, install SDL2 for full editor support)")
         endif()
     endif()
 else()


### PR DESCRIPTION
ThirdParty/CMakeLists.txt still required GLEW for the Linux imgui target, causing the SDL2+OpenGL3 backend to fall through to core-only mode when libglew-dev was no longer installed in CI. This broke both the Linux Clang and Windows VS2022 builds.

- Remove find_package(GLEW) and GLEW::GLEW link from ThirdParty/CMakeLists.txt
- Use SDL_opengl.h instead of GL/gl.h in EditorApplication.cpp
- Remove libglew-dev from codeql.yml and release.yml workflows

https://claude.ai/code/session_013WaPbBPE2wafCsmNFJn8Zn