### PR TITLE
Fix GNU extension warnings: replace ##__VA_ARGS__ with __VA_OPT__(,)

### DIFF
--- a/SparkEngine/Source/Engine/Destruction/DestructionSystem.h
+++ b/SparkEngine/Source/Engine/Destruction/DestructionSystem.h
@@ -39,6 +39,7 @@
 #include <DirectXMath.h>
 #endif
 
+#include <algorithm>
 #include <string>
 #include <vector>
 #include <unordered_map>

--- a/SparkEngine/Source/Graphics/RHI/D3D12/D3D12Device.cpp
+++ b/SparkEngine/Source/Graphics/RHI/D3D12/D3D12Device.cpp
@@ -31,8 +31,10 @@ using Microsoft::WRL::ComPtr;
 // ---------------------------------------------------------------------------
 // Compatibility logging macros — bridge std::format syntax to SPARK_LOG_*
 // ---------------------------------------------------------------------------
-#define LOG_ERROR(fmt, ...) SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "%s", std::format(fmt, ##__VA_ARGS__).c_str())
-#define LOG_INFO(fmt, ...) SPARK_LOG_INFO(Spark::LogCategory::Graphics, "%s", std::format(fmt, ##__VA_ARGS__).c_str())
+#define LOG_ERROR(fmt, ...)                                                                                            \
+    SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "%s", std::format(fmt __VA_OPT__(, ) __VA_ARGS__).c_str())
+#define LOG_INFO(fmt, ...)                                                                                             \
+    SPARK_LOG_INFO(Spark::LogCategory::Graphics, "%s", std::format(fmt __VA_OPT__(, ) __VA_ARGS__).c_str())
 
 // ---------------------------------------------------------------------------
 // D3D12CalcSubresource — normally provided by d3dx12.h helper header

--- a/SparkEngine/Source/Utils/Assert.h
+++ b/SparkEngine/Source/Utils/Assert.h
@@ -243,7 +243,8 @@ namespace Assert
  * @param fmt  Printf-style format string
  */
 #if defined(_DEBUG) || defined(DEBUG)
-#define ASSERT_MSG(expr, fmt, ...) ((expr) ? (void)0 : Assert::Fail(#expr, __FILE__, __LINE__, fmt, ##__VA_ARGS__))
+#define ASSERT_MSG(expr, fmt, ...)                                                                                     \
+    ((expr) ? (void)0 : Assert::Fail(#expr, __FILE__, __LINE__, fmt __VA_OPT__(, ) __VA_ARGS__))
 #else
 #define ASSERT_MSG(expr, fmt, ...) ((void)0)
 #endif
@@ -271,7 +272,7 @@ namespace Assert
 #if !defined(DISABLE_ALWAYS_ASSERTS)
 #define ASSERT_ALWAYS(expr) ((expr) ? (void)0 : Assert::Fail(#expr, __FILE__, __LINE__))
 #define ASSERT_ALWAYS_MSG(expr, fmt, ...)                                                                              \
-    ((expr) ? (void)0 : Assert::Fail(#expr, __FILE__, __LINE__, fmt, ##__VA_ARGS__))
+    ((expr) ? (void)0 : Assert::Fail(#expr, __FILE__, __LINE__, fmt __VA_OPT__(, ) __VA_ARGS__))
 #else
 #define ASSERT_ALWAYS(expr) ((void)0)
 #define ASSERT_ALWAYS_MSG(expr, fmt, ...) ((void)0)
@@ -311,7 +312,7 @@ namespace Assert
     {                                                                                                                  \
         long _hr = static_cast<long>(hrExpr);                                                                          \
         if (FAILED(_hr))                                                                                               \
-            Assert::FailHResult(#hrExpr, __FILE__, __LINE__, _hr, fmt, ##__VA_ARGS__);                                 \
+            Assert::FailHResult(#hrExpr, __FILE__, __LINE__, _hr, fmt __VA_OPT__(, ) __VA_ARGS__);                     \
     } while (0)
 #else
 #define ASSERT_HR(hrExpr) ((void)(hrExpr))
@@ -367,7 +368,8 @@ namespace Assert
  * @param expr Boolean expression to check
  * @param fmt  Printf-style format string
  */
-#define VERIFY_MSG(expr, fmt, ...) ((expr) ? (void)0 : Assert::Fail(#expr, __FILE__, __LINE__, fmt, ##__VA_ARGS__))
+#define VERIFY_MSG(expr, fmt, ...)                                                                                     \
+    ((expr) ? (void)0 : Assert::Fail(#expr, __FILE__, __LINE__, fmt __VA_OPT__(, ) __VA_ARGS__))
 
 /**
  * @def VERIFY_HR(hrExpr)

--- a/SparkEngine/Source/Utils/FileLogger.h
+++ b/SparkEngine/Source/Utils/FileLogger.h
@@ -419,14 +419,20 @@ namespace Spark
         if (Spark::FileLogger::GetInstance().IsInitialized())                                                          \
         {                                                                                                              \
             char _msg[1024];                                                                                           \
-            snprintf(_msg, sizeof(_msg), fmt, ##__VA_ARGS__);                                                          \
+            snprintf(_msg, sizeof(_msg), fmt __VA_OPT__(, ) __VA_ARGS__);                                              \
             Spark::FileLogger::GetInstance().Write(level, category, _msg, __FILE__, __LINE__, __FUNCTION__);           \
         }                                                                                                              \
     } while (0)
 
-#define SPARK_FILE_LOG_TRACE(cat, fmt, ...) SPARK_FILE_LOG(Spark::FileLogLevel::Trace, cat, fmt, ##__VA_ARGS__)
-#define SPARK_FILE_LOG_DEBUG(cat, fmt, ...) SPARK_FILE_LOG(Spark::FileLogLevel::Debug, cat, fmt, ##__VA_ARGS__)
-#define SPARK_FILE_LOG_INFO(cat, fmt, ...) SPARK_FILE_LOG(Spark::FileLogLevel::Info, cat, fmt, ##__VA_ARGS__)
-#define SPARK_FILE_LOG_WARN(cat, fmt, ...) SPARK_FILE_LOG(Spark::FileLogLevel::Warn, cat, fmt, ##__VA_ARGS__)
-#define SPARK_FILE_LOG_ERROR(cat, fmt, ...) SPARK_FILE_LOG(Spark::FileLogLevel::Error, cat, fmt, ##__VA_ARGS__)
-#define SPARK_FILE_LOG_FATAL(cat, fmt, ...) SPARK_FILE_LOG(Spark::FileLogLevel::Fatal, cat, fmt, ##__VA_ARGS__)
+#define SPARK_FILE_LOG_TRACE(cat, fmt, ...)                                                                            \
+    SPARK_FILE_LOG(Spark::FileLogLevel::Trace, cat, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define SPARK_FILE_LOG_DEBUG(cat, fmt, ...)                                                                            \
+    SPARK_FILE_LOG(Spark::FileLogLevel::Debug, cat, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define SPARK_FILE_LOG_INFO(cat, fmt, ...)                                                                             \
+    SPARK_FILE_LOG(Spark::FileLogLevel::Info, cat, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define SPARK_FILE_LOG_WARN(cat, fmt, ...)                                                                             \
+    SPARK_FILE_LOG(Spark::FileLogLevel::Warn, cat, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define SPARK_FILE_LOG_ERROR(cat, fmt, ...)                                                                            \
+    SPARK_FILE_LOG(Spark::FileLogLevel::Error, cat, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define SPARK_FILE_LOG_FATAL(cat, fmt, ...)                                                                            \
+    SPARK_FILE_LOG(Spark::FileLogLevel::Fatal, cat, fmt __VA_OPT__(, ) __VA_ARGS__)

--- a/SparkEngine/Source/Utils/LogMacros.h
+++ b/SparkEngine/Source/Utils/LogMacros.h
@@ -49,7 +49,7 @@
         if (_logger.ShouldLog(level, category))                                                                        \
         {                                                                                                              \
             char _sparkLogBuf[4096];                                                                                   \
-            snprintf(_sparkLogBuf, sizeof(_sparkLogBuf), fmt, ##__VA_ARGS__);                                          \
+            snprintf(_sparkLogBuf, sizeof(_sparkLogBuf), fmt __VA_OPT__(, ) __VA_ARGS__);                              \
             _logger.Log(level, category, __FILE__, __LINE__, __FUNCTION__, std::string(_sparkLogBuf));                 \
         }                                                                                                              \
     } while (0)
@@ -66,12 +66,12 @@
 #undef SPARK_LOG_ERROR
 #undef SPARK_LOG_FATAL
 
-#define SPARK_LOG_TRACE(cat, fmt, ...) SPARK_LOG(Spark::LogLevel::Trace, cat, fmt, ##__VA_ARGS__)
-#define SPARK_LOG_DEBUG(cat, fmt, ...) SPARK_LOG(Spark::LogLevel::Debug, cat, fmt, ##__VA_ARGS__)
-#define SPARK_LOG_INFO(cat, fmt, ...) SPARK_LOG(Spark::LogLevel::Info, cat, fmt, ##__VA_ARGS__)
-#define SPARK_LOG_WARN(cat, fmt, ...) SPARK_LOG(Spark::LogLevel::Warn, cat, fmt, ##__VA_ARGS__)
-#define SPARK_LOG_ERROR(cat, fmt, ...) SPARK_LOG(Spark::LogLevel::Error, cat, fmt, ##__VA_ARGS__)
-#define SPARK_LOG_FATAL(cat, fmt, ...) SPARK_LOG(Spark::LogLevel::Fatal, cat, fmt, ##__VA_ARGS__)
+#define SPARK_LOG_TRACE(cat, fmt, ...) SPARK_LOG(Spark::LogLevel::Trace, cat, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define SPARK_LOG_DEBUG(cat, fmt, ...) SPARK_LOG(Spark::LogLevel::Debug, cat, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define SPARK_LOG_INFO(cat, fmt, ...) SPARK_LOG(Spark::LogLevel::Info, cat, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define SPARK_LOG_WARN(cat, fmt, ...) SPARK_LOG(Spark::LogLevel::Warn, cat, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define SPARK_LOG_ERROR(cat, fmt, ...) SPARK_LOG(Spark::LogLevel::Error, cat, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define SPARK_LOG_FATAL(cat, fmt, ...) SPARK_LOG(Spark::LogLevel::Fatal, cat, fmt __VA_OPT__(, ) __VA_ARGS__)
 
 // ============================================================================
 // Compile-time stripping for Trace/Debug in Release builds
@@ -99,7 +99,7 @@
         if (!_sparkLogOnceFlag)                                                                                        \
         {                                                                                                              \
             _sparkLogOnceFlag = true;                                                                                  \
-            SPARK_LOG(level, cat, fmt, ##__VA_ARGS__);                                                                 \
+            SPARK_LOG(level, cat, fmt __VA_OPT__(, ) __VA_ARGS__);                                                     \
         }                                                                                                              \
     } while (0)
 
@@ -118,7 +118,7 @@
         if (++_sparkLogCounter >= (N))                                                                                 \
         {                                                                                                              \
             _sparkLogCounter = 0;                                                                                      \
-            SPARK_LOG(level, cat, fmt, ##__VA_ARGS__);                                                                 \
+            SPARK_LOG(level, cat, fmt __VA_OPT__(, ) __VA_ARGS__);                                                     \
         }                                                                                                              \
     } while (0)
 
@@ -135,7 +135,7 @@
     {                                                                                                                  \
         if (cond)                                                                                                      \
         {                                                                                                              \
-            SPARK_LOG(level, cat, fmt, ##__VA_ARGS__);                                                                 \
+            SPARK_LOG(level, cat, fmt __VA_OPT__(, ) __VA_ARGS__);                                                     \
         }                                                                                                              \
     } while (0)
 
@@ -156,7 +156,7 @@
         if (_sparkElapsed >= (_sparkInterval) || _sparkLastLogTime == std::chrono::steady_clock::time_point{})         \
         {                                                                                                              \
             _sparkLastLogTime = _sparkNow;                                                                             \
-            SPARK_LOG(level, cat, fmt, ##__VA_ARGS__);                                                                 \
+            SPARK_LOG(level, cat, fmt __VA_OPT__(, ) __VA_ARGS__);                                                     \
         }                                                                                                              \
     } while (0)
 

--- a/SparkEngine/Source/Utils/SparkError.h
+++ b/SparkEngine/Source/Utils/SparkError.h
@@ -287,8 +287,8 @@ namespace SparkError
         if (!(expr))                                                                                                   \
         {                                                                                                              \
             SparkError::LogMessage(SparkError::Severity::Fatal, "Verify", __FILE__, __LINE__, __FUNCTION__,            \
-                                   "VERIFY FAILED: %s -- " fmt, #expr, ##__VA_ARGS__);                                 \
-            Assert::Fail(#expr, __FILE__, __LINE__, fmt, ##__VA_ARGS__);                                               \
+                                   "VERIFY FAILED: %s -- " fmt, #expr __VA_OPT__(, ) __VA_ARGS__);                     \
+            Assert::Fail(#expr, __FILE__, __LINE__, fmt __VA_OPT__(, ) __VA_ARGS__);                                   \
         }                                                                                                              \
     } while (0)
 


### PR DESCRIPTION
Replace all uses of the GNU ##__VA_ARGS__ extension with the C++20 standard __VA_OPT__(,) __VA_ARGS__ pattern to eliminate -Wgnu-zero-variadic-macro-arguments warnings on Clang.

Affected files: LogMacros.h, FileLogger.h, Assert.h, SparkError.h, D3D12Device.cpp

https://claude.ai/code/session_01LscBGdoKXRra5rCpauoCF5