### PR TITLE
Fix duplicate functions and consolidate startup paths

### DIFF
--- a/SparkEngine/Source/Core/SparkEngine.cpp
+++ b/SparkEngine/Source/Core/SparkEngine.cpp
@@ -170,6 +170,28 @@ std::unique_ptr<Spark::DialogueSystem> g_dialogueSystem;
 std::unique_ptr<Spark::ModSystem> g_modSystem;
 static Spark::DeltaSmoother g_deltaSmoother(10);
 
+// -----------------------------------------------------------------------------
+// Common initialization helpers (used by all startup paths)
+// -----------------------------------------------------------------------------
+
+static void InitPhysics()
+{
+#ifdef SPARK_BULLET_PHYSICS_AVAILABLE
+    g_physicsOwned = std::make_unique<PhysicsSystem>();
+    EngineContext::Get()->SetPhysics(g_physicsOwned.get());
+    if (g_graphics)
+        g_graphics->SetPhysicsSystem(g_physicsOwned.get());
+#endif
+}
+
+static void InitConsole()
+{
+    auto& console = Spark::SimpleConsole::GetInstance();
+    console.Initialize();
+    Spark::ConsoleProcessManager::GetInstance().Initialize();
+    InitDebugSystems();
+}
+
 #ifdef SPARK_HEADLESS_SUPPORT
 // g_headlessMode is defined in EngineContext.cpp (SparkEngineLib)
 static std::atomic<bool> g_shutdownRequested{false};
@@ -319,11 +341,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR 
         g_fileCache = std::make_unique<Spark::LocalFileCache>();
         EngineContext::Get()->RegisterSystem<Spark::LocalFileCache>(g_fileCache.get());
 
-        // Physics
-        {
-            g_physicsOwned = std::make_unique<PhysicsSystem>();
-            EngineContext::Get()->SetPhysics(g_physicsOwned.get());
-        }
+        InitPhysics();
 
         // Register core subsystems with dependency metadata
         Spark::EngineSetup::RegisterCoreSubsystems(*EngineContext::Get());
@@ -332,12 +350,8 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR 
         // Module loading
         g_moduleManager = std::make_unique<ModuleManager>();
 
+        InitConsole();
         auto& console = Spark::SimpleConsole::GetInstance();
-        if (console.Initialize())
-            console.LogSuccess("Headless server console initialized");
-
-        Spark::ConsoleProcessManager::GetInstance().Initialize();
-        InitDebugSystems();
 
         if (LoadGameModules(*g_moduleManager, lpCmdLine))
         {
@@ -441,12 +455,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR 
     EngineContext::Get()->RegisterSystem<Spark::LocalFileCache>(g_fileCache.get());
 
     // 5c. Create PhysicsSystem (owned here, not by GraphicsEngine)
-    {
-        g_physicsOwned = std::make_unique<PhysicsSystem>();
-        EngineContext::Get()->SetPhysics(g_physicsOwned.get());
-        if (g_graphics)
-            g_graphics->SetPhysicsSystem(g_physicsOwned.get());
-    }
+    InitPhysics();
 
     // 5d. Register core subsystems with dependency metadata (EngineSetup)
     Spark::EngineSetup::RegisterCoreSubsystems(*EngineContext::Get());
@@ -1439,6 +1448,28 @@ static void ShutdownDebugSystems()
     Spark::FileLogger::GetInstance().Shutdown();
 }
 
+// -----------------------------------------------------------------------------
+// Common initialization helpers (used by all Linux startup paths)
+// -----------------------------------------------------------------------------
+
+static void InitPhysics()
+{
+#ifdef SPARK_BULLET_PHYSICS_AVAILABLE
+    g_physicsOwned = std::make_unique<PhysicsSystem>();
+    EngineContext::Get()->SetPhysics(g_physicsOwned.get());
+    if (g_graphics)
+        g_graphics->SetPhysicsSystem(g_physicsOwned.get());
+#endif
+}
+
+static void InitConsole()
+{
+    auto& console = Spark::SimpleConsole::GetInstance();
+    console.Initialize();
+    Spark::ConsoleProcessManager::GetInstance().Initialize();
+    InitDebugSystems();
+}
+
 static std::atomic<bool> g_shutdownRequested{false};
 
 static void SignalHandler(int)
@@ -1744,25 +1775,15 @@ int main(int argc, char* argv[])
         g_timer = std::make_unique<Timer>();
         EngineContext::SetOwned(std::make_unique<EngineContext>(nullptr, nullptr, g_timer.get(), g_eventBus.get()));
 
-#ifdef SPARK_BULLET_PHYSICS_AVAILABLE
-        {
-            g_physicsOwned = std::make_unique<PhysicsSystem>();
-            EngineContext::Get()->SetPhysics(g_physicsOwned.get());
-        }
-#endif
+        InitPhysics();
 
         // Register core subsystems with dependency metadata
         Spark::EngineSetup::RegisterCoreSubsystems(*EngineContext::Get());
         Spark::EngineSetup::InitializeJobSystem();
 
         g_moduleManager = std::make_unique<ModuleManager>();
-
+        InitConsole();
         auto& console = Spark::SimpleConsole::GetInstance();
-        if (console.Initialize())
-            console.LogSuccess("Headless server console initialized");
-
-        Spark::ConsoleProcessManager::GetInstance().Initialize();
-        InitDebugSystems();
 
         if (LoadGameModulesLinux(*g_moduleManager, argc, argv))
         {
@@ -1885,14 +1906,7 @@ int main(int argc, char* argv[])
         std::make_unique<EngineContext>(g_graphics.get(), g_input.get(), g_timer.get(), g_eventBus.get()));
 
     // 5. Physics
-#ifdef SPARK_BULLET_PHYSICS_AVAILABLE
-    {
-        g_physicsOwned = std::make_unique<PhysicsSystem>();
-        EngineContext::Get()->SetPhysics(g_physicsOwned.get());
-        if (g_graphics)
-            g_graphics->SetPhysicsSystem(g_physicsOwned.get());
-    }
-#endif
+    InitPhysics();
 
     // 5b. Register core subsystems with dependency metadata (EngineSetup)
     Spark::EngineSetup::RegisterCoreSubsystems(*EngineContext::Get());
@@ -2154,12 +2168,7 @@ int main(int argc, char* argv[])
     EngineContext::SetOwned(
         std::make_unique<EngineContext>(g_graphics.get(), g_input.get(), g_timer.get(), g_eventBus.get()));
 
-#ifdef SPARK_BULLET_PHYSICS_AVAILABLE
-    {
-        g_physicsOwned = std::make_unique<PhysicsSystem>();
-        EngineContext::Get()->SetPhysics(g_physicsOwned.get());
-    }
-#endif
+    InitPhysics();
 
     // Register core subsystems with dependency metadata
     Spark::EngineSetup::RegisterCoreSubsystems(*EngineContext::Get());
@@ -2180,10 +2189,8 @@ int main(int argc, char* argv[])
 
     g_moduleManager = std::make_unique<ModuleManager>();
 
+    InitConsole();
     auto& console = Spark::SimpleConsole::GetInstance();
-    console.Initialize();
-    Spark::ConsoleProcessManager::GetInstance().Initialize();
-    InitDebugSystems();
     console.LogWarning("No SDL2 - engine will exit after initialization.");
     LogMissingModuleWarnings();
 

--- a/SparkEngine/Source/Graphics/MaterialSystem.cpp
+++ b/SparkEngine/Source/Graphics/MaterialSystem.cpp
@@ -1198,96 +1198,6 @@ HRESULT Material::CompileMaterial(ID3D11Device* device)
     return S_OK;
 }
 
-std::vector<std::string> Material::GetShaderPermutation() const
-{
-    std::vector<std::string> defines;
-
-    // Texture-based defines
-    if (HasTexture(MaterialTextureType::Albedo))
-        defines.push_back("HAS_ALBEDO_MAP");
-    if (HasTexture(MaterialTextureType::Normal))
-        defines.push_back("HAS_NORMAL_MAP");
-    if (HasTexture(MaterialTextureType::Metallic))
-        defines.push_back("HAS_METALLIC_MAP");
-    if (HasTexture(MaterialTextureType::Roughness))
-        defines.push_back("HAS_ROUGHNESS_MAP");
-    if (HasTexture(MaterialTextureType::Occlusion))
-        defines.push_back("HAS_OCCLUSION_MAP");
-    if (HasTexture(MaterialTextureType::Emissive))
-        defines.push_back("HAS_EMISSIVE_MAP");
-    if (HasTexture(MaterialTextureType::Height))
-        defines.push_back("HAS_HEIGHT_MAP");
-    if (HasTexture(MaterialTextureType::DetailAlbedo))
-        defines.push_back("HAS_DETAIL_ALBEDO_MAP");
-    if (HasTexture(MaterialTextureType::DetailNormal))
-        defines.push_back("HAS_DETAIL_NORMAL_MAP");
-    if (HasTexture(MaterialTextureType::Subsurface))
-        defines.push_back("HAS_SUBSURFACE_MAP");
-    if (HasTexture(MaterialTextureType::Transmission))
-        defines.push_back("HAS_TRANSMISSION_MAP");
-    if (HasTexture(MaterialTextureType::Clearcoat))
-        defines.push_back("HAS_CLEARCOAT_MAP");
-    if (HasTexture(MaterialTextureType::ClearcoatRoughness))
-        defines.push_back("HAS_CLEARCOAT_ROUGHNESS_MAP");
-    if (HasTexture(MaterialTextureType::Anisotropy))
-        defines.push_back("HAS_ANISOTROPY_MAP");
-
-    // Blend mode defines
-    switch (m_renderState.blendMode)
-    {
-    case BlendMode::AlphaTest:
-        defines.push_back("ALPHA_TEST");
-        break;
-    case BlendMode::Transparent:
-        defines.push_back("ALPHA_BLEND");
-        break;
-    case BlendMode::Additive:
-        defines.push_back("BLEND_ADDITIVE");
-        break;
-    case BlendMode::Multiply:
-        defines.push_back("BLEND_MULTIPLY");
-        break;
-    case BlendMode::Screen:
-        defines.push_back("BLEND_SCREEN");
-        break;
-    default:
-        break;
-    }
-
-    // Advanced feature defines
-    if (m_advancedProperties.subsurfaceEnabled)
-        defines.push_back("ENABLE_SUBSURFACE");
-    if (m_advancedProperties.clearcoatEnabled)
-        defines.push_back("ENABLE_CLEARCOAT");
-    if (m_advancedProperties.anisotropyEnabled)
-        defines.push_back("ENABLE_ANISOTROPY");
-    if (m_advancedProperties.transmissionEnabled)
-        defines.push_back("ENABLE_TRANSMISSION");
-    if (m_advancedProperties.sheenEnabled)
-        defines.push_back("ENABLE_SHEEN");
-    if (m_advancedProperties.iridescenceEnabled)
-        defines.push_back("ENABLE_IRIDESCENCE");
-
-    // Double-sided rendering
-    if (m_renderState.doubleSided)
-        defines.push_back("DOUBLE_SIDED");
-
-    // If active variant has additional defines, append them
-    if (!m_activeVariant.empty())
-    {
-        auto it = m_variants.find(m_activeVariant);
-        if (it != m_variants.end())
-        {
-            for (const auto& define : it->second)
-            {
-                defines.push_back(define);
-            }
-        }
-    }
-
-    return defines;
-}
-
 std::shared_ptr<Material> Material::CreateInstance(const std::string& instanceName) const
 {
     auto instance = std::make_shared<Material>(instanceName);
@@ -1736,16 +1646,6 @@ void MaterialSystem::BindMaterial(const std::shared_ptr<Material>& material)
         m_metrics.materialSwitches++;
         m_metrics.textureBinds += boundTextures;
     }
-}
-
-std::vector<std::string> MaterialSystem::GetShaderPermutation(const std::string& name) const
-{
-    auto material = GetMaterial(name);
-    if (material && material != m_defaultMaterial)
-    {
-        return material->GetShaderPermutation();
-    }
-    return {};
 }
 
 bool MaterialSystem::ReloadMaterial(const std::string& name)
@@ -2993,6 +2893,7 @@ std::string MaterialSystem::Console_ListMaterialVariants(const std::string& mate
 #include <cmath>
 #include <cstring>
 #include <fstream>
+#include <iomanip>
 #include <filesystem>
 #include <sys/stat.h>
 
@@ -3100,80 +3001,119 @@ bool Material::SaveToFile(const std::string& filePath) const
         return false;
     }
 
+    if (m_name.empty())
+    {
+        return false;
+    }
+
+    // Use same INI format as Windows for cross-platform compatibility
     file << "# Spark Engine Material File\n";
-    file << "# Format version 1.0\n\n";
+    file << "# Version: 1.0\n\n";
 
-    file << "material \"" << m_name << "\"\n{\n";
+    file << "[Material]\n";
+    file << "Name=" << m_name << "\n";
+    file << "ActiveVariant=" << m_activeVariant << "\n\n";
 
-    // PBR properties
-    file << "  pbr\n  {\n";
-    file << "    albedo " << m_pbrProperties.albedoColor.x << " " << m_pbrProperties.albedoColor.y << " "
-         << m_pbrProperties.albedoColor.z << " " << m_pbrProperties.albedoColor.w << "\n";
-    file << "    metallic " << m_pbrProperties.metallicFactor << "\n";
-    file << "    roughness " << m_pbrProperties.roughnessFactor << "\n";
-    file << "    normalScale " << m_pbrProperties.normalScale << "\n";
-    file << "    occlusionStrength " << m_pbrProperties.occlusionStrength << "\n";
-    file << "    emissiveColor " << m_pbrProperties.emissiveColor.x << " " << m_pbrProperties.emissiveColor.y << " "
+    file << "[PBR]\n";
+    file << "AlbedoColor=" << m_pbrProperties.albedoColor.x << "," << m_pbrProperties.albedoColor.y << ","
+         << m_pbrProperties.albedoColor.z << "," << m_pbrProperties.albedoColor.w << "\n";
+    file << "MetallicFactor=" << std::fixed << std::setprecision(6) << m_pbrProperties.metallicFactor << "\n";
+    file << "RoughnessFactor=" << std::fixed << std::setprecision(6) << m_pbrProperties.roughnessFactor << "\n";
+    file << "NormalScale=" << std::fixed << std::setprecision(6) << m_pbrProperties.normalScale << "\n";
+    file << "OcclusionStrength=" << std::fixed << std::setprecision(6) << m_pbrProperties.occlusionStrength << "\n";
+    file << "EmissiveColor=" << m_pbrProperties.emissiveColor.x << "," << m_pbrProperties.emissiveColor.y << ","
          << m_pbrProperties.emissiveColor.z << "\n";
-    file << "    emissiveFactor " << m_pbrProperties.emissiveFactor << "\n";
-    file << "    alphaCutoff " << m_pbrProperties.alphaCutoff << "\n";
-    file << "    ior " << m_pbrProperties.indexOfRefraction << "\n";
-    file << "  }\n\n";
+    file << "EmissiveFactor=" << std::fixed << std::setprecision(6) << m_pbrProperties.emissiveFactor << "\n";
+    file << "AlphaCutoff=" << std::fixed << std::setprecision(6) << m_pbrProperties.alphaCutoff << "\n";
+    file << "IndexOfRefraction=" << std::fixed << std::setprecision(6) << m_pbrProperties.indexOfRefraction << "\n\n";
 
-    // Advanced properties
-    file << "  advanced\n  {\n";
-    file << "    subsurface " << (m_advancedProperties.subsurfaceEnabled ? "true" : "false") << "\n";
-    file << "    clearcoat " << (m_advancedProperties.clearcoatEnabled ? "true" : "false") << "\n";
-    file << "    clearcoatFactor " << m_advancedProperties.clearcoatFactor << "\n";
-    file << "    clearcoatRoughness " << m_advancedProperties.clearcoatRoughness << "\n";
-    file << "    anisotropy " << (m_advancedProperties.anisotropyEnabled ? "true" : "false") << "\n";
-    file << "    anisotropyFactor " << m_advancedProperties.anisotropyFactor << "\n";
-    file << "    transmission " << (m_advancedProperties.transmissionEnabled ? "true" : "false") << "\n";
-    file << "    transmissionFactor " << m_advancedProperties.transmissionFactor << "\n";
-    file << "    sheen " << (m_advancedProperties.sheenEnabled ? "true" : "false") << "\n";
-    file << "    iridescence " << (m_advancedProperties.iridescenceEnabled ? "true" : "false") << "\n";
-    file << "  }\n\n";
+    file << "[Advanced]\n";
+    file << "SubsurfaceEnabled=" << (m_advancedProperties.subsurfaceEnabled ? "true" : "false") << "\n";
+    if (m_advancedProperties.subsurfaceEnabled)
+    {
+        file << "SubsurfaceColor=" << m_advancedProperties.subsurfaceColor.x << ","
+             << m_advancedProperties.subsurfaceColor.y << "," << m_advancedProperties.subsurfaceColor.z << "\n";
+        file << "SubsurfaceRadius=" << m_advancedProperties.subsurfaceRadius << "\n";
+    }
+    file << "ClearcoatEnabled=" << (m_advancedProperties.clearcoatEnabled ? "true" : "false") << "\n";
+    if (m_advancedProperties.clearcoatEnabled)
+    {
+        file << "ClearcoatFactor=" << m_advancedProperties.clearcoatFactor << "\n";
+        file << "ClearcoatRoughness=" << m_advancedProperties.clearcoatRoughness << "\n";
+    }
+    file << "AnisotropyEnabled=" << (m_advancedProperties.anisotropyEnabled ? "true" : "false") << "\n";
+    if (m_advancedProperties.anisotropyEnabled)
+    {
+        file << "AnisotropyFactor=" << m_advancedProperties.anisotropyFactor << "\n";
+        file << "AnisotropyDirection=" << m_advancedProperties.anisotropyDirection.x << ","
+             << m_advancedProperties.anisotropyDirection.y << "\n";
+    }
+    file << "TransmissionEnabled=" << (m_advancedProperties.transmissionEnabled ? "true" : "false") << "\n";
+    if (m_advancedProperties.transmissionEnabled)
+    {
+        file << "TransmissionFactor=" << m_advancedProperties.transmissionFactor << "\n";
+        file << "TransmissionColor=" << m_advancedProperties.transmissionColor.x << ","
+             << m_advancedProperties.transmissionColor.y << "," << m_advancedProperties.transmissionColor.z << "\n";
+    }
+    file << "SheenEnabled=" << (m_advancedProperties.sheenEnabled ? "true" : "false") << "\n";
+    if (m_advancedProperties.sheenEnabled)
+    {
+        file << "SheenColor=" << m_advancedProperties.sheenColor.x << "," << m_advancedProperties.sheenColor.y << ","
+             << m_advancedProperties.sheenColor.z << "\n";
+        file << "SheenRoughness=" << m_advancedProperties.sheenRoughness << "\n";
+    }
+    file << "IridescenceEnabled=" << (m_advancedProperties.iridescenceEnabled ? "true" : "false") << "\n";
+    if (m_advancedProperties.iridescenceEnabled)
+    {
+        file << "IridescenceFactor=" << m_advancedProperties.iridescenceFactor << "\n";
+        file << "IridescenceIOR=" << m_advancedProperties.iridescenceIOR << "\n";
+        file << "IridescenceThickness=" << m_advancedProperties.iridescenceThickness << "\n";
+    }
+    file << "\n";
 
-    // Render state
-    file << "  renderState\n  {\n";
-    file << "    blendMode " << static_cast<int>(m_renderState.blendMode) << "\n";
-    file << "    cullMode " << static_cast<int>(m_renderState.cullMode) << "\n";
-    file << "    depthTest " << (m_renderState.depthTest ? "true" : "false") << "\n";
-    file << "    depthWrite " << (m_renderState.depthWrite ? "true" : "false") << "\n";
-    file << "    castShadows " << (m_renderState.castShadows ? "true" : "false") << "\n";
-    file << "    receiveShadows " << (m_renderState.receiveShadows ? "true" : "false") << "\n";
-    file << "    renderQueue " << m_renderState.renderQueue << "\n";
-    file << "    doubleSided " << (m_renderState.doubleSided ? "true" : "false") << "\n";
-    file << "  }\n\n";
+    file << "[RenderState]\n";
+    file << "BlendMode=" << static_cast<int>(m_renderState.blendMode) << "\n";
+    file << "CullMode=" << static_cast<int>(m_renderState.cullMode) << "\n";
+    file << "DepthTest=" << (m_renderState.depthTest ? "true" : "false") << "\n";
+    file << "DepthWrite=" << (m_renderState.depthWrite ? "true" : "false") << "\n";
+    file << "CastShadows=" << (m_renderState.castShadows ? "true" : "false") << "\n";
+    file << "ReceiveShadows=" << (m_renderState.receiveShadows ? "true" : "false") << "\n";
+    file << "RenderQueue=" << m_renderState.renderQueue << "\n";
+    file << "DoubleSided=" << (m_renderState.doubleSided ? "true" : "false") << "\n\n";
 
-    // Texture slots
-    file << "  textures\n  {\n";
+    file << "[Textures]\n";
     for (const auto& pair : m_textures)
     {
-        if (pair.second.enabled && !pair.second.filePath.empty())
+        if (!pair.second.filePath.empty())
         {
-            file << "    slot " << static_cast<int>(pair.first) << " \"" << pair.second.filePath << "\"\n";
+            file << "Texture" << static_cast<int>(pair.first) << "=" << pair.second.filePath << "\n";
+            file << "Texture" << static_cast<int>(pair.first) << "_Enabled=" << (pair.second.enabled ? "true" : "false")
+                 << "\n";
+            file << "Texture" << static_cast<int>(pair.first) << "_Intensity=" << pair.second.intensity << "\n";
+            file << "Texture" << static_cast<int>(pair.first) << "_Tiling=" << pair.second.tiling.x << ","
+                 << pair.second.tiling.y << "\n";
+            file << "Texture" << static_cast<int>(pair.first) << "_Offset=" << pair.second.offset.x << ","
+                 << pair.second.offset.y << "\n";
         }
     }
-    file << "  }\n\n";
+    file << "\n";
 
-    // Variants
     if (!m_variants.empty())
     {
-        file << "  variants\n  {\n";
-        for (const auto& pair : m_variants)
+        file << "[Variants]\n";
+        for (const auto& variantPair : m_variants)
         {
-            file << "    variant \"" << pair.first << "\"";
-            for (const auto& define : pair.second)
+            file << "Variant_" << variantPair.first << "=";
+            for (size_t i = 0; i < variantPair.second.size(); ++i)
             {
-                file << " " << define;
+                if (i > 0)
+                    file << ",";
+                file << variantPair.second[i];
             }
             file << "\n";
         }
-        file << "  }\n";
     }
 
-    file << "}\n";
     file.close();
     return true;
 }
@@ -3347,91 +3287,6 @@ HRESULT Material::CompileMaterial(ID3D11Device* /*device*/)
     // No GPU pipeline state on Linux
     m_compiled = true;
     return S_OK;
-}
-
-std::vector<std::string> Material::GetShaderPermutation() const
-{
-    std::vector<std::string> defines;
-
-    if (HasTexture(MaterialTextureType::Albedo))
-        defines.push_back("HAS_ALBEDO_MAP");
-    if (HasTexture(MaterialTextureType::Normal))
-        defines.push_back("HAS_NORMAL_MAP");
-    if (HasTexture(MaterialTextureType::Metallic))
-        defines.push_back("HAS_METALLIC_MAP");
-    if (HasTexture(MaterialTextureType::Roughness))
-        defines.push_back("HAS_ROUGHNESS_MAP");
-    if (HasTexture(MaterialTextureType::Occlusion))
-        defines.push_back("HAS_OCCLUSION_MAP");
-    if (HasTexture(MaterialTextureType::Emissive))
-        defines.push_back("HAS_EMISSIVE_MAP");
-    if (HasTexture(MaterialTextureType::Height))
-        defines.push_back("HAS_HEIGHT_MAP");
-    if (HasTexture(MaterialTextureType::DetailAlbedo))
-        defines.push_back("HAS_DETAIL_ALBEDO_MAP");
-    if (HasTexture(MaterialTextureType::DetailNormal))
-        defines.push_back("HAS_DETAIL_NORMAL_MAP");
-    if (HasTexture(MaterialTextureType::Subsurface))
-        defines.push_back("HAS_SUBSURFACE_MAP");
-    if (HasTexture(MaterialTextureType::Transmission))
-        defines.push_back("HAS_TRANSMISSION_MAP");
-    if (HasTexture(MaterialTextureType::Clearcoat))
-        defines.push_back("HAS_CLEARCOAT_MAP");
-    if (HasTexture(MaterialTextureType::ClearcoatRoughness))
-        defines.push_back("HAS_CLEARCOAT_ROUGHNESS_MAP");
-    if (HasTexture(MaterialTextureType::Anisotropy))
-        defines.push_back("HAS_ANISOTROPY_MAP");
-
-    switch (m_renderState.blendMode)
-    {
-    case BlendMode::AlphaTest:
-        defines.push_back("ALPHA_TEST");
-        break;
-    case BlendMode::Transparent:
-        defines.push_back("ALPHA_BLEND");
-        break;
-    case BlendMode::Additive:
-        defines.push_back("BLEND_ADDITIVE");
-        break;
-    case BlendMode::Multiply:
-        defines.push_back("BLEND_MULTIPLY");
-        break;
-    case BlendMode::Screen:
-        defines.push_back("BLEND_SCREEN");
-        break;
-    default:
-        break;
-    }
-
-    if (m_advancedProperties.subsurfaceEnabled)
-        defines.push_back("ENABLE_SUBSURFACE");
-    if (m_advancedProperties.clearcoatEnabled)
-        defines.push_back("ENABLE_CLEARCOAT");
-    if (m_advancedProperties.anisotropyEnabled)
-        defines.push_back("ENABLE_ANISOTROPY");
-    if (m_advancedProperties.transmissionEnabled)
-        defines.push_back("ENABLE_TRANSMISSION");
-    if (m_advancedProperties.sheenEnabled)
-        defines.push_back("ENABLE_SHEEN");
-    if (m_advancedProperties.iridescenceEnabled)
-        defines.push_back("ENABLE_IRIDESCENCE");
-
-    if (m_renderState.doubleSided)
-        defines.push_back("DOUBLE_SIDED");
-
-    if (!m_activeVariant.empty())
-    {
-        auto it = m_variants.find(m_activeVariant);
-        if (it != m_variants.end())
-        {
-            for (const auto& define : it->second)
-            {
-                defines.push_back(define);
-            }
-        }
-    }
-
-    return defines;
 }
 
 std::shared_ptr<Material> Material::CreateInstance(const std::string& instanceName) const
@@ -3699,16 +3554,6 @@ void MaterialSystem::BindMaterial(const std::shared_ptr<Material>& material)
         std::lock_guard<std::mutex> lock(m_metricsMutex);
         m_metrics.materialSwitches++;
     }
-}
-
-std::vector<std::string> MaterialSystem::GetShaderPermutation(const std::string& name) const
-{
-    auto material = GetMaterial(name);
-    if (material)
-    {
-        return material->GetShaderPermutation();
-    }
-    return {};
 }
 
 bool MaterialSystem::ReloadMaterial(const std::string& name)
@@ -4324,3 +4169,102 @@ MaterialTextureType MaterialSystem::StringToTextureType(const std::string& str) 
 }
 
 #endif // SPARK_PLATFORM_WINDOWS
+
+// ============================================================================
+// PLATFORM-INDEPENDENT IMPLEMENTATIONS
+// ============================================================================
+
+std::vector<std::string> Material::GetShaderPermutation() const
+{
+    std::vector<std::string> defines;
+
+    if (HasTexture(MaterialTextureType::Albedo))
+        defines.push_back("HAS_ALBEDO_MAP");
+    if (HasTexture(MaterialTextureType::Normal))
+        defines.push_back("HAS_NORMAL_MAP");
+    if (HasTexture(MaterialTextureType::Metallic))
+        defines.push_back("HAS_METALLIC_MAP");
+    if (HasTexture(MaterialTextureType::Roughness))
+        defines.push_back("HAS_ROUGHNESS_MAP");
+    if (HasTexture(MaterialTextureType::Occlusion))
+        defines.push_back("HAS_OCCLUSION_MAP");
+    if (HasTexture(MaterialTextureType::Emissive))
+        defines.push_back("HAS_EMISSIVE_MAP");
+    if (HasTexture(MaterialTextureType::Height))
+        defines.push_back("HAS_HEIGHT_MAP");
+    if (HasTexture(MaterialTextureType::DetailAlbedo))
+        defines.push_back("HAS_DETAIL_ALBEDO_MAP");
+    if (HasTexture(MaterialTextureType::DetailNormal))
+        defines.push_back("HAS_DETAIL_NORMAL_MAP");
+    if (HasTexture(MaterialTextureType::Subsurface))
+        defines.push_back("HAS_SUBSURFACE_MAP");
+    if (HasTexture(MaterialTextureType::Transmission))
+        defines.push_back("HAS_TRANSMISSION_MAP");
+    if (HasTexture(MaterialTextureType::Clearcoat))
+        defines.push_back("HAS_CLEARCOAT_MAP");
+    if (HasTexture(MaterialTextureType::ClearcoatRoughness))
+        defines.push_back("HAS_CLEARCOAT_ROUGHNESS_MAP");
+    if (HasTexture(MaterialTextureType::Anisotropy))
+        defines.push_back("HAS_ANISOTROPY_MAP");
+
+    switch (m_renderState.blendMode)
+    {
+    case BlendMode::AlphaTest:
+        defines.push_back("ALPHA_TEST");
+        break;
+    case BlendMode::Transparent:
+        defines.push_back("ALPHA_BLEND");
+        break;
+    case BlendMode::Additive:
+        defines.push_back("BLEND_ADDITIVE");
+        break;
+    case BlendMode::Multiply:
+        defines.push_back("BLEND_MULTIPLY");
+        break;
+    case BlendMode::Screen:
+        defines.push_back("BLEND_SCREEN");
+        break;
+    default:
+        break;
+    }
+
+    if (m_advancedProperties.subsurfaceEnabled)
+        defines.push_back("ENABLE_SUBSURFACE");
+    if (m_advancedProperties.clearcoatEnabled)
+        defines.push_back("ENABLE_CLEARCOAT");
+    if (m_advancedProperties.anisotropyEnabled)
+        defines.push_back("ENABLE_ANISOTROPY");
+    if (m_advancedProperties.transmissionEnabled)
+        defines.push_back("ENABLE_TRANSMISSION");
+    if (m_advancedProperties.sheenEnabled)
+        defines.push_back("ENABLE_SHEEN");
+    if (m_advancedProperties.iridescenceEnabled)
+        defines.push_back("ENABLE_IRIDESCENCE");
+
+    if (m_renderState.doubleSided)
+        defines.push_back("DOUBLE_SIDED");
+
+    if (!m_activeVariant.empty())
+    {
+        auto it = m_variants.find(m_activeVariant);
+        if (it != m_variants.end())
+        {
+            for (const auto& define : it->second)
+            {
+                defines.push_back(define);
+            }
+        }
+    }
+
+    return defines;
+}
+
+std::vector<std::string> MaterialSystem::GetShaderPermutation(const std::string& name) const
+{
+    auto material = GetMaterial(name);
+    if (material && material != m_defaultMaterial)
+    {
+        return material->GetShaderPermutation();
+    }
+    return {};
+}


### PR DESCRIPTION
MaterialSystem.cpp:
- Extract Material::GetShaderPermutation() from Windows/Linux #ifdef sections into a single shared implementation (was duplicated verbatim)
- Extract MaterialSystem::GetShaderPermutation() wrapper into shared section, fixing Linux version which was missing the m_defaultMaterial check present in Windows
- Align Linux Material::SaveToFile() to use same INI format as Windows (was using incompatible DSL format, making material files non-portable)

SparkEngine.cpp:
- Add InitPhysics() helper to replace 5 duplicate PhysicsSystem creation blocks across Windows/Linux startup paths
- Add InitConsole() helper to replace 3 duplicate console+debug init blocks (headless Windows, headless Linux, fallback Linux)
- Net reduction: 49 lines removed

https://claude.ai/code/session_012FLCYc4eLyyRnHt62ZuM3s