### PR TITLE
Add Doxygen documentation to Graphics .cpp files

### DIFF
--- a/SparkEngine/Source/Graphics/GraphicsEngine.cpp
+++ b/SparkEngine/Source/Graphics/GraphicsEngine.cpp
@@ -1,6 +1,16 @@
 #include "../Core/Platform.h"
 #ifdef SPARK_PLATFORM_WINDOWS
-// GraphicsEngine.cpp - COMPLETE IMPLEMENTATION WITH ALL 600+ LINES RESTORED
+/**
+ * @file GraphicsEngine.cpp
+ * @brief Central rendering orchestrator for SparkEngine (D3D11)
+ *
+ * Manages the full rendering lifecycle: D3D11 device/swap chain initialization,
+ * shader compilation, render target management, lighting, shadow mapping,
+ * post-processing (HDR, bloom, SSAO, TAA, SSR, volumetrics), and frame
+ * presentation. Integrates with MaterialSystem, TextureSystem, LightingSystem,
+ * AssetPipeline, and PostProcessingPipeline. Supports forward and deferred
+ * rendering pipelines, configurable MSAA, and real-time settings adjustment.
+ */
 #include "GraphicsEngine.h"
 #include "../Utils/Assert.h"
 #include "../Utils/SparkError.h"

--- a/SparkEngine/Source/Graphics/Mesh.cpp
+++ b/SparkEngine/Source/Graphics/Mesh.cpp
@@ -1,5 +1,14 @@
 #include "../Core/Platform.h"
-// Mesh.cpp
+/**
+ * @file Mesh.cpp
+ * @brief CPU-side mesh geometry and D3D11 GPU buffer management
+ *
+ * Supports loading OBJ files via tinyobjloader, procedural primitive generation
+ * (cube, sphere, plane, triangle, pyramid), automatic normal calculation via
+ * cross-product accumulation, and D3D11 vertex/index buffer creation.
+ * Dual implementation: Windows uses DirectXMath + D3D11; Linux stores CPU-side
+ * data for the RHI abstraction layer.
+ */
 #include "Mesh.h"
 #include "Utils/Assert.h"
 #include "../Utils/Validate.h"
@@ -59,6 +68,9 @@ void Mesh::Shutdown()
     std::wcout << L"[INFO] Mesh shutdown complete." << std::endl;
 }
 
+/// Loads an OBJ mesh from disk using tinyobjloader. Converts wide path to UTF-8,
+/// extracts positions/normals/UVs per-index (expanding shared vertices), recalculates
+/// normals if any are zero, then uploads to GPU via CreateBuffers().
 bool Mesh::LoadFromFile(const std::wstring& path)
 {
     SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
@@ -449,9 +461,10 @@ HRESULT Mesh::CreatePyramid(float size, float height)
     return CreateFromVertices(vertices, indices);
 }
 
+/// Computes per-face normals via cross product and assigns to all three triangle vertices.
+/// Note: this produces flat shading; smooth normals would require accumulation + normalization.
 void Mesh::CalculateNormals()
 {
-    // **FIXED: Removed excessive logging**
     ASSERT(!m_vertices.empty() && !m_indices.empty());
 
     for (size_t i = 0; i + 2 < m_indices.size(); i += 3)
@@ -478,9 +491,10 @@ void Mesh::CalculateNormals()
     }
 }
 
+/// Creates D3D11 vertex and index buffers from CPU-side data. Releases any
+/// previously allocated buffers first to prevent COM object leaks.
 HRESULT Mesh::CreateBuffers()
 {
-    // **FIXED: Removed excessive logging**
     ASSERT(m_device);
     ASSERT(!m_vertices.empty() && !m_indices.empty());
 
@@ -532,6 +546,8 @@ HRESULT Mesh::CreateBuffers()
     return S_OK;
 }
 
+/// Binds vertex/index buffers to the input assembler and issues an indexed draw call.
+/// Uses triangle list topology with 32-bit indices.
 void Mesh::Render(ID3D11DeviceContext* ctx)
 {
     SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, ctx && m_vb && m_ib && m_indexCount > 0,
@@ -542,7 +558,6 @@ void Mesh::Render(ID3D11DeviceContext* ctx)
     ctx->IASetIndexBuffer(m_ib, DXGI_FORMAT_R32_UINT, 0);
     ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
-    // **ENSURE PROPER RENDERING STATE**
     ctx->DrawIndexed(m_indexCount, 0, 0);
 
     // **ONLY log rendering statistics occasionally for debugging**
@@ -557,7 +572,7 @@ void Mesh::Render(ID3D11DeviceContext* ctx)
 #else // !SPARK_PLATFORM_WINDOWS
 
 // ============================================================================
-// Linux implementation using RHI abstraction
+// Linux implementation — stores CPU-side geometry; GPU upload deferred to RHI
 // ============================================================================
 #include "Mesh.h"
 #include "../Utils/Validate.h"
@@ -862,7 +877,8 @@ bool Mesh::LoadFromFile(const std::wstring& path)
     m_vertices.clear();
     m_indices.clear();
 
-    // Use a map to deduplicate vertices
+    // Deduplicate vertices using a hash combining vertex/normal/texcoord indices.
+    // This reduces vertex count for shared geometry (e.g., smooth-shaded faces).
     std::unordered_map<size_t, unsigned int> uniqueVertices;
 
     for (const auto& shape : shapes)

--- a/SparkEngine/Source/Graphics/ParticleSystem.cpp
+++ b/SparkEngine/Source/Graphics/ParticleSystem.cpp
@@ -1,6 +1,14 @@
 #include "Core/Platform.h"
 #ifdef SPARK_PLATFORM_WINDOWS
-// ParticleSystem.cpp
+/**
+ * @file ParticleSystem.cpp
+ * @brief GPU-accelerated particle emitter and system manager
+ *
+ * Implements billboard particle emission with configurable rate, burst, duration,
+ * and looping. Particles are updated CPU-side (velocity, gravity, lifetime, color
+ * interpolation, size scaling) then uploaded to a dynamic vertex buffer for
+ * rendering. Thread-local RNG ensures safe parallel emission.
+ */
 #include "ParticleSystem.h"
 #include "Utils/Assert.h"
 #include "../Utils/Validate.h"
@@ -12,15 +20,18 @@
 #ifdef SPARK_PLATFORM_WINDOWS
 
 using namespace DirectX;
-// Thread-local random engine for particle randomization
+/// Thread-local Mersenne Twister RNG seeded from hardware entropy.
+/// Thread-local avoids contention when multiple emitters update in parallel.
 static thread_local std::mt19937 s_rng(std::random_device{}());
 
+/// Returns a uniformly distributed float in [lo, hi].
 static float RandomFloat(float lo, float hi)
 {
     std::uniform_real_distribution<float> dist(lo, hi);
     return dist(s_rng);
 }
 
+/// Returns a uniformly distributed float in [0, 1].
 static float RandomFloat01()
 {
     return RandomFloat(0.0f, 1.0f);
@@ -58,6 +69,9 @@ HRESULT ParticleEmitter::Initialize(ID3D11Device* device)
     return device->CreateBuffer(&bd, nullptr, m_vertexBuffer.GetAddressOf());
 }
 
+/// Per-frame emitter update: manages lifetime, emission accumulation, burst timing,
+/// and per-particle physics (velocity, gravity, color/size interpolation, death).
+/// Uses a fractional accumulator for emission rate so sub-frame emission is smooth.
 void ParticleEmitter::Update(float deltaTime)
 {
     if (!m_playing)
@@ -65,13 +79,13 @@ void ParticleEmitter::Update(float deltaTime)
 
     m_elapsedTime += deltaTime;
 
-    // Check duration (non-looping emitters)
+    // Non-looping emitters stop after their duration expires
     if (!m_desc.loop && m_desc.duration > 0.0f && m_elapsedTime >= m_desc.duration)
     {
         m_playing = false;
     }
 
-    // Emit new particles based on rate
+    // Accumulate fractional particles from emission rate; spawn one per whole unit
     if (m_playing)
     {
         m_emissionAccumulator += m_desc.emissionRate * deltaTime;
@@ -81,7 +95,7 @@ void ParticleEmitter::Update(float deltaTime)
             m_emissionAccumulator -= 1.0f;
         }
 
-        // Handle burst emission
+        // Periodic burst: spawn burstCount particles at fixed intervals
         if (m_desc.burstInterval > 0.0f)
         {
             m_burstTimer += deltaTime;

--- a/SparkEngine/Source/Graphics/RenderDevice.cpp
+++ b/SparkEngine/Source/Graphics/RenderDevice.cpp
@@ -1,5 +1,14 @@
 #include "../Core/Platform.h"
 #ifdef SPARK_PLATFORM_WINDOWS
+/**
+ * @file RenderDevice.cpp
+ * @brief Core GPU device and swap chain management for Direct3D 11
+ *
+ * Owns the D3D11 device, immediate context, swap chain, and back buffer views.
+ * Handles device creation with feature-level negotiation (11.0/11.1), DXGI
+ * swap chain setup via FLIP_DISCARD, and viewport/render-target binding.
+ * Resize support tears down old views and recreates them without device loss.
+ */
 
 #include "RenderDevice.h"
 #include "RHI/RHIFactory.h"
@@ -15,6 +24,8 @@ namespace Spark::Graphics
         Shutdown();
     }
 
+    /// Initializes the D3D11 device, swap chain, back buffer RTV, and depth-stencil view.
+    /// Auto backend defaults to D3D11 on Windows. Returns false on any creation failure.
     bool RenderDevice::Initialize(Spark::NativeWindowHandle hwnd, uint32_t width, uint32_t height, bool fullscreen,
                                   RHI::GraphicsBackend backend)
     {
@@ -58,6 +69,7 @@ namespace Spark::Graphics
         return true;
     }
 
+    /// Releases all D3D11 resources in reverse creation order: views, swap chain, context, device.
     void RenderDevice::Shutdown()
     {
         SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
@@ -73,6 +85,8 @@ namespace Spark::Graphics
         m_rhiDevice.reset();
     }
 
+    /// Handles window resize: releases old views, unbinds render targets,
+    /// resizes the swap chain buffers, then recreates back buffer and depth-stencil views.
     bool RenderDevice::Resize(uint32_t width, uint32_t height)
     {
         if (width == 0 || height == 0)
@@ -108,6 +122,7 @@ namespace Spark::Graphics
         return true;
     }
 
+    /// Presents the back buffer. syncInterval=1 enables VSync, 0 presents immediately.
     void RenderDevice::Present(bool vsync)
     {
 #ifdef SPARK_PLATFORM_WINDOWS
@@ -119,9 +134,13 @@ namespace Spark::Graphics
 #endif
     }
 
+    /// Creates the D3D11 device (hardware driver, feature level 11.0+), immediate context,
+    /// and DXGI swap chain. Uses FLIP_DISCARD with double-buffering and R8G8B8A8_UNORM format.
+    /// Queries VRAM from the adapter descriptor for telemetry.
     bool RenderDevice::CreateDevice(Spark::NativeWindowHandle hwnd, uint32_t width, uint32_t height, bool fullscreen)
     {
 #ifdef SPARK_PLATFORM_WINDOWS
+        // Configure swap chain: double-buffered FLIP_DISCARD for low-latency presentation
         DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
         swapChainDesc.Width = width;
         swapChainDesc.Height = height;
@@ -187,6 +206,8 @@ namespace Spark::Graphics
         return true;
     }
 
+    /// Creates the back buffer RTV, depth-stencil texture (D24_UNORM_S8_UINT),
+    /// depth-stencil view, viewport, and binds them as the active render targets.
     bool RenderDevice::CreateBackBufferViews()
     {
 #ifdef SPARK_PLATFORM_WINDOWS

--- a/SparkEngine/Source/Graphics/RenderPipeline.cpp
+++ b/SparkEngine/Source/Graphics/RenderPipeline.cpp
@@ -1,5 +1,14 @@
 #include "../Core/Platform.h"
 #ifdef SPARK_PLATFORM_WINDOWS
+/**
+ * @file RenderPipeline.cpp
+ * @brief Render graph-based pipeline that manages ordered render passes
+ *
+ * Orchestrates the frame rendering pipeline through registered passes sorted
+ * by phase (Shadow -> Geometry -> Lighting -> Transparent -> PostProcess -> UI -> Debug).
+ * Each pass contributes to a RenderGraph that is compiled (topological sort,
+ * dead-pass elimination, resource aliasing) and executed each frame.
+ */
 
 #include "RenderPipeline.h"
 #include "../Utils/Validate.h"
@@ -8,6 +17,7 @@
 namespace Spark::Graphics
 {
 
+    /// Creates the render graph and registers default passes matching the GraphicsEngine pipeline.
     bool RenderPipeline::Initialize(RenderDevice* device)
     {
         SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
@@ -29,6 +39,8 @@ namespace Spark::Graphics
         m_device = nullptr;
     }
 
+    /// Executes a single frame: re-sorts passes if dirty, builds the render graph
+    /// from enabled passes, compiles it (dependency sort + dead-pass culling), then executes.
     void RenderPipeline::ExecuteFrame(const DirectX::XMMATRIX& viewMatrix, const DirectX::XMMATRIX& projMatrix,
                                       const DirectX::XMFLOAT3& cameraPos)
     {
@@ -62,6 +74,8 @@ namespace Spark::Graphics
         m_renderGraph->Execute();
     }
 
+    /// Registers a named render pass at a given phase. Replaces any existing pass with the same name.
+    /// Marks the pass list dirty so it will be re-sorted before the next frame execution.
     void RenderPipeline::RegisterPass(const std::string& name, PassPhase phase, PassSetupFn setupFn)
     {
         SPARK_VALIDATE_NOT_EMPTY(Spark::LogCategory::Graphics, name);
@@ -124,10 +138,11 @@ namespace Spark::Graphics
         return result;
     }
 
+    /// Registers placeholder passes for the standard rendering pipeline stages.
+    /// These no-op passes define the phase ordering and will be replaced with real
+    /// implementations as the RHI migration progresses.
     void RenderPipeline::BuildDefaultPasses()
     {
-        // Register default passes matching the existing GraphicsEngine pipeline.
-        // Each pass is a no-op setup that will be filled in as the RHI migration progresses.
 
         RegisterPass("ShadowPass", PassPhase::Shadow,
                      [](RenderGraph& graph)
@@ -190,6 +205,7 @@ namespace Spark::Graphics
                      });
     }
 
+    /// Stable-sorts passes by phase enum value, preserving registration order within the same phase.
     void RenderPipeline::SortPasses()
     {
         std::stable_sort(m_passes.begin(), m_passes.end(), [](const RegisteredPass& a, const RegisteredPass& b)

--- a/SparkEngine/Source/Graphics/SceneRenderer.cpp
+++ b/SparkEngine/Source/Graphics/SceneRenderer.cpp
@@ -1,5 +1,14 @@
 #include "../Core/Platform.h"
 #ifdef SPARK_PLATFORM_WINDOWS
+/**
+ * @file SceneRenderer.cpp
+ * @brief High-level scene rendering: draw command submission, frustum culling, and sorting
+ *
+ * Collects draw commands each frame via Submit(), then CullAndSort() performs
+ * clip-space frustum culling with a conservative margin and sorts visible
+ * commands by material (batching) then by distance (front-to-back for opaque).
+ * Uses a per-frame linear allocator to minimize allocation overhead.
+ */
 
 #include "SceneRenderer.h"
 #include "../Utils/Validate.h"
@@ -10,6 +19,7 @@ namespace Spark::Graphics
 
     const std::string SceneRenderer::s_emptyString;
 
+    /// Pre-allocates draw command storage up to the specified maximum.
     bool SceneRenderer::Initialize(uint32_t maxDrawCommands)
     {
         SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
@@ -32,6 +42,7 @@ namespace Spark::Graphics
         m_pathLookup.clear();
     }
 
+    /// Clears all draw commands and resets the per-frame linear allocator for the new frame.
     void SceneRenderer::BeginFrame()
     {
         m_drawCommands.clear();
@@ -64,6 +75,11 @@ namespace Spark::Graphics
         Submit(meshHandle, materialHandle, worldMatrix, castShadows);
     }
 
+    /// Frustum-culls draw commands and sorts survivors for efficient rendering.
+    /// Culling transforms each object's world position to clip space and tests against
+    /// NDC bounds with a kMargin=2.0 expansion to account for object bounding radius.
+    /// Survivors are sorted by material sortKey (minimizes state changes) then by
+    /// squared distance to camera (front-to-back reduces overdraw for opaque geometry).
     void SceneRenderer::CullAndSort(const DirectX::XMMATRIX& viewMatrix, const DirectX::XMMATRIX& projMatrix,
                                     const DirectX::XMFLOAT3& cameraPos)
     {

--- a/SparkEngine/Source/Graphics/Shader.cpp
+++ b/SparkEngine/Source/Graphics/Shader.cpp
@@ -1,6 +1,15 @@
 #include "../Core/Platform.h"
 #ifdef SPARK_PLATFORM_WINDOWS
-// Shader.cpp - Enhanced shader system implementation with AAA features (C++14 compatible)
+/**
+ * @file Shader.cpp
+ * @brief D3D11 shader compilation, variant management, and hot-reload system
+ *
+ * Compiles HLSL vertex/pixel/geometry/compute shaders via D3DCompile, manages
+ * shader variants (permutations with different #defines), supports runtime
+ * hot-reload by monitoring file timestamps, and caches compiled bytecode via
+ * LocalFileCache for faster subsequent loads. Input layout creation is automatic
+ * based on shader reflection.
+ */
 #include "Shader.h"
 #include "Utils/Assert.h"
 #include "../Utils/Validate.h"


### PR DESCRIPTION
Add @file/@brief headers and inline documentation comments to 7 core
Graphics source files: GraphicsEngine, Mesh, ParticleSystem, RenderDevice,
RenderPipeline, SceneRenderer, and Shader. Documents key functions with
/// comments explaining algorithms (frustum culling, particle emission,
buffer management) and replaces generic comments with precise descriptions.

https://claude.ai/code/session_01WzzUt6qyTrYN9QdjJSpprD