### PR TITLE
Fix Windows build error and suppress Bullet3 third-party warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,12 +501,21 @@ if(BULLET_FOUND)
             BulletDynamics BulletCollision LinearMath
             BulletSoftBody BulletInverseDynamics
             Bullet3Common Bullet3Collision Bullet3Dynamics Bullet3Geometry
+            Bullet3OpenCL_clew Bullet2FileLoader
         )
             if(TARGET ${_bullet_target})
                 target_compile_options(${_bullet_target} PRIVATE
                     -Wno-deprecated-copy
                     -Wno-implicit-fallthrough
+                    -Wno-unused-but-set-variable
+                    -Wno-deprecated-volatile
                 )
+                if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|IntelLLVM")
+                    target_compile_options(${_bullet_target} PRIVATE
+                        -Wno-single-bit-bitfield-constant-conversion
+                        -Wno-null-pointer-subtraction
+                    )
+                endif()
             endif()
         endforeach()
     endif()

--- a/SparkEngine/Source/Graphics/GraphicsEngine.cpp
+++ b/SparkEngine/Source/Graphics/GraphicsEngine.cpp
@@ -1328,45 +1328,6 @@ void GraphicsEngine::RenderPostProcessing()
         m_postProcessing->Render();
     }
 
-    // Also dispatch through RHI path for cross-platform passes
-    auto& rhi = GetRHI();
-    if (rhi.initialized)
-    {
-        Spark::RHI::IRHICommandList* cmd = rhi.bridge.GetCommandList();
-        if (cmd)
-        {
-            uint32_t passCount = 0;
-            cmd->BeginEvent("PostProcessing_RHI");
-
-            if (m_settings.bloom)
-            {
-                cmd->BeginEvent("Bloom");
-                cmd->Draw(3, 0);
-                passCount++;
-                cmd->EndEvent();
-            }
-
-            if (m_settings.ssao)
-            {
-                cmd->BeginEvent("SSAO");
-                cmd->Draw(3, 0);
-                passCount++;
-                cmd->EndEvent();
-            }
-
-            if (m_hdrEnabled)
-            {
-                cmd->BeginEvent("ToneMapping");
-                cmd->Draw(3, 0);
-                passCount++;
-                cmd->EndEvent();
-            }
-
-            m_statistics.postProcessPasses = passCount + m_postProcessing->GetActivePassCount();
-            cmd->EndEvent();
-        }
-    }
-
     auto endTime = std::chrono::high_resolution_clock::now();
     m_statistics.postProcessTime = std::chrono::duration<float, std::milli>(endTime - m_postProcessStartTime).count();
 }
@@ -1385,30 +1346,6 @@ void GraphicsEngine::RenderTemporalEffects()
             m_statistics.postProcessPasses++;
         if (m_settings.motionBlur)
             m_statistics.postProcessPasses++;
-    }
-
-    // Also dispatch through RHI path for cross-platform tracking
-    auto& rhi = GetRHI();
-    if (rhi.initialized)
-    {
-        Spark::RHI::IRHICommandList* cmd = rhi.bridge.GetCommandList();
-        if (cmd)
-        {
-            cmd->BeginEvent("TemporalEffects_RHI");
-            if (m_settings.taa)
-            {
-                cmd->BeginEvent("TAA");
-                cmd->Draw(3, 0);
-                cmd->EndEvent();
-            }
-            if (m_settings.motionBlur)
-            {
-                cmd->BeginEvent("MotionBlur");
-                cmd->Draw(3, 0);
-                cmd->EndEvent();
-            }
-            cmd->EndEvent();
-        }
     }
 }
 


### PR DESCRIPTION
Remove GetRHI() calls from Windows RenderPostProcessing/RenderTemporalEffects (GetRHI is a Linux-only static function). Suppress unused-but-set-variable, deprecated-volatile, and Clang-specific warnings for all Bullet3 targets.

https://claude.ai/code/session_01Fxd5Tzy1k7VFyAPK9VCc9H