### PR TITLE
Fix Windows MSVC and Linux Clang build errors

### DIFF
--- a/SparkEditor/Source/LevelStreaming/LevelStreamingSystem.cpp
+++ b/SparkEditor/Source/LevelStreaming/LevelStreamingSystem.cpp
@@ -140,7 +140,7 @@ namespace SparkEditor
 
     void LevelStreamingSystem::Render()
     {
-        if (!ImGui::Begin(GetName().c_str(), &m_visible))
+        if (!ImGui::Begin(GetName().c_str(), &m_isVisible))
         {
             ImGui::End();
             return;
@@ -360,7 +360,7 @@ namespace SparkEditor
         return file.good();
     }
 
-    bool LevelStreamingSystem::AddTile(const WorldTile& tile)
+    bool LevelStreamingSystem::AddTile(WorldTile tile)
     {
         // Check for duplicate name
         for (const auto& t : m_tiles)
@@ -368,7 +368,7 @@ namespace SparkEditor
             if (t.name == tile.name)
                 return false;
         }
-        m_tiles.push_back(tile);
+        m_tiles.push_back(std::move(tile));
         m_tiles.back().state = StreamingState::UNLOADED;
         SetModified(true);
         return true;
@@ -551,7 +551,7 @@ namespace SparkEditor
                 tile.streamingDistance = m_worldSettings.defaultStreamingDistance;
                 tile.unloadingDistance = m_worldSettings.defaultUnloadingDistance;
                 tile.streamingMethod = m_worldSettings.defaultStreamingMethod;
-                if (AddTile(tile))
+                if (AddTile(std::move(tile)))
                     ++count;
             }
         }
@@ -744,7 +744,7 @@ namespace SparkEditor
             newTile.name = "Tile_" + std::to_string(m_tiles.size());
             newTile.streamingDistance = m_worldSettings.defaultStreamingDistance;
             newTile.unloadingDistance = m_worldSettings.defaultUnloadingDistance;
-            AddTile(newTile);
+            AddTile(std::move(newTile));
         }
 
         ImGui::Separator();

--- a/SparkEditor/Source/LevelStreaming/LevelStreamingSystem.h
+++ b/SparkEditor/Source/LevelStreaming/LevelStreamingSystem.h
@@ -329,7 +329,7 @@ namespace SparkEditor
      * @param tile Tile to add
      * @return true if tile was added successfully
      */
-        bool AddTile(const WorldTile& tile);
+        bool AddTile(WorldTile tile);
 
         /**
      * @brief Remove tile from world

--- a/SparkEngine/Source/Core/SparkEngine.cpp
+++ b/SparkEngine/Source/Core/SparkEngine.cpp
@@ -13,6 +13,12 @@
 
 #include "Platform.h"
 
+// On Windows, framework.h must come before any header that uses Win32 types
+// (HINSTANCE, HMODULE, HWND, etc.) because it pulls in <windows.h>.
+#ifdef SPARK_PLATFORM_WINDOWS
+#include "framework.h"
+#endif
+
 // ============================================================================
 // Common includes (shared between all platforms)
 // ============================================================================
@@ -65,7 +71,6 @@
 
 // Platform-specific includes
 #ifdef SPARK_PLATFORM_WINDOWS
-#include "framework.h"
 #include "Utils/Assert.h"
 #include "Utils/SparkError.h"
 #include "Utils/Validate.h"
@@ -73,8 +78,6 @@
 #include "Utils/CrashHandler.h"
 #include "Utils/D3DUtils.h"
 #include "Utils/LocalFileCache.h"
-#include <Windows.h>
-#include <DirectXMath.h>
 #else
 #include <csignal>
 #include <cstring>


### PR DESCRIPTION
Windows: Move framework.h include before SparkEngine.h to ensure Win32 types (HINSTANCE, HMODULE, HWND) are defined before use. Remove redundant <Windows.h> and <DirectXMath.h> includes.

Linux: Fix LevelStreamingSystem compilation errors:
- m_visible -> m_isVisible (correct member name from EditorPanel)
- AddTile takes WorldTile by value + std::move at call sites (WorldTile contains std::future which is non-copyable)

https://claude.ai/code/session_01RNrGx56uxYFZSHPpggMG4U