### PR TITLE
feat: replace placeholder implementations with real functionality

### DIFF
--- a/SparkEditor/Source/Communication/EngineInterface.cpp
+++ b/SparkEditor/Source/Communication/EngineInterface.cpp
@@ -136,18 +136,99 @@ namespace SparkEditor
         SPARK_LOG_INFO(Spark::LogCategory::Editor, "EngineInterface connecting (timeout: %.1fs)", timeoutSeconds);
         std::cout << "Attempting to connect to engine (timeout: " << timeoutSeconds << "s)\n";
 
-        // For now, simulate a connection
-        // In a real implementation, this would attempt to connect to a named pipe
+        m_connectionStats.connectionAttempts++;
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(100)); // Simulate connection time
+        // Create the named pipe for engine communication
+        if (!CreateCommPipe())
+        {
+            std::cerr << "Connect failed: could not create named pipe '" << m_pipeName << "'\n";
+            SPARK_LOG_ERROR(Spark::LogCategory::Editor, "Failed to create named pipe: %s", m_pipeName.c_str());
+            return false;
+        }
+
+        // Wait for the engine process to connect to our pipe, with timeout
+        auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(static_cast<int64_t>(timeoutSeconds * 1000.0f));
+
+#ifdef _WIN32
+        // Use overlapped I/O for timeout support on Windows
+        HANDLE hPipe = static_cast<HANDLE>(m_pipeHandle);
+        OVERLAPPED overlapped = {};
+        overlapped.hEvent = ::CreateEventA(nullptr, TRUE, FALSE, nullptr);
+        if (!overlapped.hEvent)
+        {
+            std::cerr << "Connect failed: could not create event for overlapped I/O\n";
+            ::CloseHandle(hPipe);
+            m_pipeHandle = nullptr;
+            return false;
+        }
+
+        BOOL connected = ::ConnectNamedPipe(hPipe, &overlapped);
+        if (!connected)
+        {
+            DWORD err = ::GetLastError();
+            if (err == ERROR_PIPE_CONNECTED)
+            {
+                // Client connected between CreateNamedPipe and ConnectNamedPipe
+                std::cout << "Engine already connected to pipe\n";
+            }
+            else if (err == ERROR_IO_PENDING)
+            {
+                // Wait for connection with timeout
+                DWORD remainingMs = static_cast<DWORD>(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now())
+                        .count());
+                DWORD waitResult = ::WaitForSingleObject(overlapped.hEvent, remainingMs);
+                if (waitResult == WAIT_TIMEOUT)
+                {
+                    std::cerr << "Connect timed out after " << timeoutSeconds << "s\n";
+                    SPARK_LOG_WARNING(Spark::LogCategory::Editor, "Pipe connection timed out after %.1fs",
+                                      timeoutSeconds);
+                    ::CancelIo(hPipe);
+                    ::CloseHandle(overlapped.hEvent);
+                    ::CloseHandle(hPipe);
+                    m_pipeHandle = nullptr;
+                    return false;
+                }
+                else if (waitResult != WAIT_OBJECT_0)
+                {
+                    std::cerr << "Connect failed: WaitForSingleObject returned " << waitResult << "\n";
+                    ::CancelIo(hPipe);
+                    ::CloseHandle(overlapped.hEvent);
+                    ::CloseHandle(hPipe);
+                    m_pipeHandle = nullptr;
+                    return false;
+                }
+                // Connection succeeded via overlapped completion
+            }
+            else
+            {
+                std::cerr << "ConnectNamedPipe failed with error " << err << "\n";
+                SPARK_LOG_ERROR(Spark::LogCategory::Editor, "ConnectNamedPipe failed: %lu", err);
+                ::CloseHandle(overlapped.hEvent);
+                ::CloseHandle(hPipe);
+                m_pipeHandle = nullptr;
+                return false;
+            }
+        }
+
+        ::CloseHandle(overlapped.hEvent);
+#else
+        // On non-Windows platforms, ConnectToNamedPipe handles the blocking wait
+        if (!ConnectToNamedPipe())
+        {
+            std::cerr << "Connect failed: engine did not connect to pipe\n";
+            return false;
+        }
+#endif
 
         m_isConnected = true;
         m_connectionStartTime = std::chrono::steady_clock::now();
-        m_connectionStats.connectionAttempts++;
 
-        std::cout << "Successfully connected to engine\n";
+        std::cout << "Successfully connected to engine via named pipe '" << m_pipeName << "'\n";
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Connected to engine via pipe: %s", m_pipeName.c_str());
 
-        // Start communication thread
+        // Start communication thread for async command/event I/O
         if (!m_commThread)
         {
             m_commThread = std::make_unique<std::thread>(&EngineInterface::CommunicationThread, this);
@@ -167,11 +248,16 @@ namespace SparkEditor
 
         if (m_pipeHandle)
         {
-            // Close pipe handle (platform-specific cleanup would go here)
+#ifdef _WIN32
+            ::FlushFileBuffers(static_cast<HANDLE>(m_pipeHandle));
+            ::DisconnectNamedPipe(static_cast<HANDLE>(m_pipeHandle));
+            ::CloseHandle(static_cast<HANDLE>(m_pipeHandle));
+#endif
             m_pipeHandle = nullptr;
         }
 
         std::cout << "Disconnected from engine\n";
+        SPARK_LOG_INFO(Spark::LogCategory::Editor, "Disconnected from engine");
     }
 
     uint64_t EngineInterface::SendCommand(const EngineCommand& command)

--- a/SparkEditor/Source/Profiler/PerformanceProfiler.cpp
+++ b/SparkEditor/Source/Profiler/PerformanceProfiler.cpp
@@ -269,6 +269,12 @@ namespace SparkEditor
         }
     }
 
+    void PerformanceProfiler::SetDevice(ID3D11Device* device, ID3D11DeviceContext* context)
+    {
+        m_device = device;
+        m_context = context;
+    }
+
     void PerformanceProfiler::BeginGPUSample(const std::string& name, const std::string& shaderName)
     {
         if (!m_isProfiling)
@@ -278,12 +284,61 @@ namespace SparkEditor
         sample.name = name;
         sample.shaderName = shaderName;
         m_activeGPUSamples[name] = sample;
+
+        // Issue a D3D11 timestamp query if device is available
+        if (m_device && m_context)
+        {
+            // Start the per-frame disjoint query if not already active
+            if (!m_disjointActive)
+            {
+                D3D11_QUERY_DESC disjointDesc = {};
+                disjointDesc.Query = D3D11_QUERY_TIMESTAMP_DISJOINT;
+                HRESULT hr = m_device->CreateQuery(&disjointDesc, m_disjointQuery.ReleaseAndGetAddressOf());
+                if (SUCCEEDED(hr))
+                {
+                    m_context->Begin(m_disjointQuery.Get());
+                    m_disjointActive = true;
+                }
+            }
+
+            GPUQueryPair queryPair;
+            queryPair.name = name;
+            queryPair.shaderName = shaderName;
+
+            D3D11_QUERY_DESC tsDesc = {};
+            tsDesc.Query = D3D11_QUERY_TIMESTAMP;
+
+            HRESULT hr = m_device->CreateQuery(&tsDesc, queryPair.beginQuery.GetAddressOf());
+            if (SUCCEEDED(hr))
+            {
+                hr = m_device->CreateQuery(&tsDesc, queryPair.endQuery.GetAddressOf());
+            }
+
+            if (SUCCEEDED(hr))
+            {
+                m_context->End(queryPair.beginQuery.Get()); // Timestamp queries use End(), not Begin()
+                queryPair.begun = true;
+                m_pendingGPUQueries[name] = std::move(queryPair);
+            }
+        }
     }
 
     void PerformanceProfiler::EndGPUSample(const std::string& name)
     {
         if (!m_isProfiling)
             return;
+
+        // Issue the end timestamp query
+        if (m_context)
+        {
+            auto it = m_pendingGPUQueries.find(name);
+            if (it != m_pendingGPUQueries.end() && it->second.begun)
+            {
+                m_context->End(it->second.endQuery.Get());
+                it->second.ended = true;
+            }
+        }
+
         m_activeGPUSamples.erase(name);
     }
 
@@ -1059,31 +1114,79 @@ namespace SparkEditor
 
     void PerformanceProfiler::ProcessGPUQueries()
     {
-        // Process pending GPU timestamp queries and compute durations
         if (!m_currentFrame)
             return;
 
+        // Collect results from D3D11 timestamp queries
+        if (m_context && m_disjointActive && m_disjointQuery)
+        {
+            // End the disjoint query for this frame
+            m_context->End(m_disjointQuery.Get());
+            m_disjointActive = false;
+
+            // Retrieve the disjoint query data (contains GPU frequency)
+            D3D11_QUERY_DATA_TIMESTAMP_DISJOINT disjointData = {};
+            HRESULT hr = m_context->GetData(m_disjointQuery.Get(), &disjointData, sizeof(disjointData), 0);
+
+            if (SUCCEEDED(hr) && !disjointData.Disjoint && disjointData.Frequency > 0)
+            {
+                // Collect timestamp results for all completed query pairs
+                for (auto it = m_pendingGPUQueries.begin(); it != m_pendingGPUQueries.end();)
+                {
+                    auto& [name, queryPair] = *it;
+                    if (!queryPair.begun || !queryPair.ended)
+                    {
+                        ++it;
+                        continue;
+                    }
+
+                    UINT64 beginTimestamp = 0;
+                    UINT64 endTimestamp = 0;
+
+                    HRESULT hrBegin =
+                        m_context->GetData(queryPair.beginQuery.Get(), &beginTimestamp, sizeof(UINT64), 0);
+                    HRESULT hrEnd = m_context->GetData(queryPair.endQuery.Get(), &endTimestamp, sizeof(UINT64), 0);
+
+                    if (SUCCEEDED(hrBegin) && SUCCEEDED(hrEnd) && endTimestamp > beginTimestamp)
+                    {
+                        float durationMs = static_cast<float>(endTimestamp - beginTimestamp) /
+                                           static_cast<float>(disjointData.Frequency) * 1000.0f;
+
+                        GPUProfileSample sample;
+                        sample.name = queryPair.name;
+                        sample.shaderName = queryPair.shaderName;
+                        sample.startTimestamp = beginTimestamp;
+                        sample.endTimestamp = endTimestamp;
+                        sample.duration = durationMs;
+
+                        m_currentFrame->gpuSamples.push_back(sample);
+                    }
+
+                    it = m_pendingGPUQueries.erase(it);
+                }
+            }
+            else
+            {
+                // Disjoint or failed — discard all pending queries
+                m_pendingGPUQueries.clear();
+            }
+        }
+
+        // Fallback: process any samples with manually-set timestamps (non-D3D11 path)
         for (auto& [name, sample] : m_activeGPUSamples)
         {
-            // In a real implementation, we'd query D3D11 timestamp queries here
-            // For now, add the sample data to the current frame
             if (sample.endTimestamp > sample.startTimestamp)
             {
                 sample.duration =
                     static_cast<float>(sample.endTimestamp - sample.startTimestamp) / 1000000.0f; // ns to ms
+                if (sample.duration > 0.0f)
+                {
+                    m_currentFrame->gpuSamples.push_back(sample);
+                }
             }
         }
 
-        // Move completed GPU samples to current frame
-        for (const auto& [name, sample] : m_activeGPUSamples)
-        {
-            if (sample.duration > 0.0f)
-            {
-                m_currentFrame->gpuSamples.push_back(sample);
-            }
-        }
-
-        // Calculate total GPU time
+        // Calculate total GPU time from all collected samples
         float totalGpuTime = 0.0f;
         for (const auto& sample : m_currentFrame->gpuSamples)
         {

--- a/SparkEditor/Source/Profiler/PerformanceProfiler.h
+++ b/SparkEditor/Source/Profiler/PerformanceProfiler.h
@@ -140,6 +140,13 @@ namespace SparkEditor
         void EndGPUSample(const std::string& name);
 
         /**
+     * @brief Set the D3D11 device and context for GPU timestamp queries
+     * @param device D3D11 device for creating query objects
+     * @param context D3D11 device context for issuing and collecting queries
+     */
+        void SetDevice(ID3D11Device* device, ID3D11DeviceContext* context);
+
+        /**
      * @brief Record memory allocation
      * @param category Memory category
      * @param bytes Number of bytes allocated
@@ -375,6 +382,21 @@ namespace SparkEditor
         Microsoft::WRL::ComPtr<ID3D11Device> m_device;                        ///< DirectX device
         Microsoft::WRL::ComPtr<ID3D11DeviceContext> m_context;                ///< DirectX context
         std::vector<Microsoft::WRL::ComPtr<ID3D11Query>> m_gpuQueries;        ///< GPU timing queries
+
+        /// @brief Tracks a pair of D3D11 timestamp queries for a named GPU sample
+        struct GPUQueryPair
+        {
+            Microsoft::WRL::ComPtr<ID3D11Query> beginQuery; ///< Timestamp at sample start
+            Microsoft::WRL::ComPtr<ID3D11Query> endQuery;   ///< Timestamp at sample end
+            std::string name;                               ///< Sample name
+            std::string shaderName;                         ///< Associated shader
+            bool begun = false;                             ///< Whether begin was issued
+            bool ended = false;                             ///< Whether end was issued
+        };
+
+        std::unordered_map<std::string, GPUQueryPair> m_pendingGPUQueries; ///< In-flight GPU queries
+        Microsoft::WRL::ComPtr<ID3D11Query> m_disjointQuery;               ///< Per-frame disjoint query
+        bool m_disjointActive = false;                                     ///< Whether disjoint query is active
 
         // Memory profiling
         std::unordered_map<void*, std::pair<std::string, size_t>> m_memoryAllocations; ///< Active allocations

--- a/SparkEngine/Source/Graphics/RHI/OpenGL/OpenGLDevice.cpp
+++ b/SparkEngine/Source/Graphics/RHI/OpenGL/OpenGLDevice.cpp
@@ -695,10 +695,69 @@ namespace Spark
                 SPARK_LOG_INFO(Spark::LogCategory::Graphics, "GLDevice::Initialize starting");
                 m_debugEnabled = desc.enableDebugLayer;
 
-                // GLAD must be loaded before any GL calls
-                // In a real implementation, context creation happens first
+                // OpenGL requires a current context before any GL calls (including GLAD loading).
+                // Create a temporary hidden window and context to bootstrap GLAD, then tear it down.
+                // The real context is created later by GLSwapChain with the application window.
+#ifdef _WIN32
+                WNDCLASSA wc = {};
+                wc.lpfnWndProc = DefWindowProcA;
+                wc.hInstance = GetModuleHandleA(nullptr);
+                wc.lpszClassName = "SparkGLBootstrap";
+                RegisterClassA(&wc);
+
+                HWND bootstrapWindow = CreateWindowExA(0, wc.lpszClassName, "SparkGLBootstrap", 0, 0, 0, 1, 1, nullptr,
+                                                       nullptr, wc.hInstance, nullptr);
+                if (!bootstrapWindow)
+                {
+                    SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "Failed to create bootstrap window");
+                    return false;
+                }
+
+                HDC bootstrapDC = GetDC(bootstrapWindow);
+
+                PIXELFORMATDESCRIPTOR pfd = {};
+                pfd.nSize = sizeof(pfd);
+                pfd.nVersion = 1;
+                pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+                pfd.iPixelType = PFD_TYPE_RGBA;
+                pfd.cColorBits = 32;
+                pfd.cDepthBits = 24;
+                pfd.cStencilBits = 8;
+
+                int pixelFormat = ChoosePixelFormat(bootstrapDC, &pfd);
+                if (!pixelFormat || !SetPixelFormat(bootstrapDC, pixelFormat, &pfd))
+                {
+                    SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "Failed to set pixel format on bootstrap context");
+                    ReleaseDC(bootstrapWindow, bootstrapDC);
+                    DestroyWindow(bootstrapWindow);
+                    UnregisterClassA(wc.lpszClassName, wc.hInstance);
+                    return false;
+                }
+
+                HGLRC bootstrapContext = wglCreateContext(bootstrapDC);
+                if (!bootstrapContext)
+                {
+                    SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "Failed to create bootstrap GL context");
+                    ReleaseDC(bootstrapWindow, bootstrapDC);
+                    DestroyWindow(bootstrapWindow);
+                    UnregisterClassA(wc.lpszClassName, wc.hInstance);
+                    return false;
+                }
+
+                wglMakeCurrent(bootstrapDC, bootstrapContext);
+#endif
+
+                // GLAD can now load OpenGL function pointers from the current context
                 if (!gladLoadGL())
                 {
+                    SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "gladLoadGL failed — no valid GL context");
+#ifdef _WIN32
+                    wglMakeCurrent(nullptr, nullptr);
+                    wglDeleteContext(bootstrapContext);
+                    ReleaseDC(bootstrapWindow, bootstrapDC);
+                    DestroyWindow(bootstrapWindow);
+                    UnregisterClassA(wc.lpszClassName, wc.hInstance);
+#endif
                     return false;
                 }
 
@@ -706,11 +765,52 @@ namespace Spark
                 {
                     glEnable(GL_DEBUG_OUTPUT);
                     glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+
+                    // Register debug message callback for driver error/warning reporting
+                    glDebugMessageCallback(
+                        [](GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei /*length*/,
+                           const GLchar* message, const void* /*userParam*/)
+                        {
+                            // Skip verbose notifications to avoid log spam
+                            if (severity == GL_DEBUG_SEVERITY_NOTIFICATION)
+                                return;
+
+                            const char* severityStr = "INFO";
+                            if (severity == GL_DEBUG_SEVERITY_HIGH)
+                                severityStr = "HIGH";
+                            else if (severity == GL_DEBUG_SEVERITY_MEDIUM)
+                                severityStr = "MEDIUM";
+                            else if (severity == GL_DEBUG_SEVERITY_LOW)
+                                severityStr = "LOW";
+
+                            SPARK_LOG_WARNING(Spark::LogCategory::Graphics, "GL Debug [%s] src=%u type=%u id=%u: %s",
+                                              severityStr, source, type, id, message);
+                        },
+                        nullptr);
+
+                    // Enable all debug messages except notifications
+                    glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DEBUG_SEVERITY_NOTIFICATION, 0, nullptr,
+                                          GL_FALSE);
+                    glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DEBUG_SEVERITY_LOW, 0, nullptr, GL_TRUE);
+                    glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DEBUG_SEVERITY_MEDIUM, 0, nullptr, GL_TRUE);
+                    glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DEBUG_SEVERITY_HIGH, 0, nullptr, GL_TRUE);
                 }
 
                 QueryCapabilities();
 
+                // Tear down the bootstrap context — the real context will be created by GLSwapChain
+#ifdef _WIN32
+                wglMakeCurrent(nullptr, nullptr);
+                wglDeleteContext(bootstrapContext);
+                ReleaseDC(bootstrapWindow, bootstrapDC);
+                DestroyWindow(bootstrapWindow);
+                UnregisterClassA(wc.lpszClassName, wc.hInstance);
+#endif
+
                 m_immediateCommandList = std::make_unique<GLCommandList>(true, &m_statistics);
+
+                SPARK_LOG_INFO(Spark::LogCategory::Graphics, "GLDevice initialized: %s (%s)",
+                               m_capabilities.deviceName.c_str(), m_capabilities.apiVersion.c_str());
 
                 return true;
             }

--- a/SparkGame/Source/Game/Game.cpp
+++ b/SparkGame/Source/Game/Game.cpp
@@ -115,6 +115,9 @@ HRESULT Game::Initialize(GraphicsEngine* graphics, InputManager* input)
         return hr;
     }
 
+    // Set graphics engine for weapon rendering shader setup
+    m_player->SetGraphicsEngine(m_graphics);
+
     // Set default class (Scout)
     m_player->SetClass(PlayerClass::SCOUT, m_classSystem.get());
     LOG_TO_CONSOLE_IMMEDIATE(L"Player class set to Scout (default)", L"SUCCESS");

--- a/SparkGame/Source/Game/Player.cpp
+++ b/SparkGame/Source/Game/Player.cpp
@@ -12,7 +12,8 @@
 #include "Utils/MathUtils.h"
 #include "Game/Console.h"
 #include "Utils/ConsoleProcessManager.h"
-#include "Game/Model.h" // Add Model class for weapon rendering
+#include "Game/Model.h"
+#include "Graphics/GraphicsEngine.h"
 #include <algorithm>
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
@@ -221,14 +222,10 @@ void Player::RenderWeapon(const XMMATRIX& view, const XMMATRIX& proj)
         XMMATRIX cameraRotation = XMMatrixInverse(nullptr, view);
         weaponWorld = weaponWorld * cameraRotation;
 
-        // Set up constant buffer for weapon rendering (simplified)
-        // In a real implementation, you'd set shader constants here
-        // For now, we'll just assume the shaders are already bound
-
-        // Render the weapon model
+        // Set up shaders and constant buffers, then render the weapon model
         try
         {
-            currentWeaponModel->Render(m_context);
+            currentWeaponModel->Render(m_context, m_graphics, &weaponWorld, &view, &proj);
         }
         catch (...)
         {

--- a/SparkGame/Source/Game/Player.h
+++ b/SparkGame/Source/Game/Player.h
@@ -35,6 +35,7 @@
 using SparkEditor::WeaponType;
 
 // Forward declarations
+class GraphicsEngine;
 namespace Spark
 {
     class SimpleConsole;
@@ -474,6 +475,12 @@ class SPARK_GAME_API Player : public GameObject
      */
     void SetInteractionSystem(Spark::InteractionSystem* interactSystem) { m_interactionSystem = interactSystem; }
 
+    /**
+     * @brief Set the graphics engine for weapon rendering shader setup
+     * @param graphics Graphics engine pointer (not owned)
+     */
+    void SetGraphicsEngine(GraphicsEngine* graphics) { m_graphics = graphics; }
+
     // ============================================================================
     // CONSOLE INTEGRATION METHODS - Full Cross-Code Hooking
     // ============================================================================
@@ -655,6 +662,7 @@ class SPARK_GAME_API Player : public GameObject
     // External references (not owned)
     SparkEngineCamera* m_camera{nullptr};                  ///< Reference to camera system
     InputManager* m_input{nullptr};                        ///< Reference to input manager
+    GraphicsEngine* m_graphics{nullptr};                   ///< Reference to graphics engine
     ProjectilePool* m_projectilePool{nullptr};             ///< Reference to projectile pool
     std::unique_ptr<ProjectilePool> m_ownedProjectilePool; ///< Owned pool if created by Player
 


### PR DESCRIPTION
- EngineInterface::Connect: real named pipe creation with overlapped I/O timeout support, proper cleanup on disconnect (FlushFileBuffers, DisconnectNamedPipe, CloseHandle)
- PerformanceProfiler::ProcessGPUQueries: D3D11 timestamp queries with disjoint query for GPU frequency, per-sample begin/end query pairs, SetDevice() method for device injection
- Player::RenderWeapon: pass GraphicsEngine to Model::Render for proper shader binding and constant buffer setup (world/view/proj matrices)
- GLDevice::Initialize: bootstrap hidden window + GL context for GLAD loading, debug message callback with severity filtering, proper teardown before real context creation by GLSwapChain

https://claude.ai/code/session_01GxZTb53dT1EdqbkL8Wqx5v