### PR TITLE
fix: resolve build errors in Debug builds, OpenGL backend, and Vulkan…

### DIFF
--- a/SparkEditor/Source/AssetPipeline/AdvancedAssetPipelineUI.cpp
+++ b/SparkEditor/Source/AssetPipeline/AdvancedAssetPipelineUI.cpp
@@ -9,6 +9,7 @@
 #include <imgui.h>
 #include <algorithm>
 #include <filesystem>
+#include <fstream>
 #include <sstream>
 
 namespace fs = std::filesystem;

--- a/SparkEngine/Source/Core/SparkEngine.cpp
+++ b/SparkEngine/Source/Core/SparkEngine.cpp
@@ -310,9 +310,7 @@ static void InitGameplaySystems()
     Spark::Graphics::TransientResourcePool::GetInstance().Initialize();
     Spark::Graphics::ClipmapTerrain::GetInstance().Initialize();
     Spark::Graphics::VirtualTextureManager::GetInstance().Initialize();
-#ifndef NDEBUG
-    Spark::ProfileProperties::GetInstance().Initialize();
-#endif
+    // ProfileProperties is ready after GetInstance() — no Initialize() needed
     Spark::PluginRegistry::InitializeAll();
 
     // AngelScript scripting engine

--- a/SparkEngine/Source/Graphics/RHI/OpenGL/OpenGLDevice.cpp
+++ b/SparkEngine/Source/Graphics/RHI/OpenGL/OpenGLDevice.cpp
@@ -372,7 +372,10 @@ namespace Spark
             // GL COMMAND LIST
             // ============================================================================
 
-            GLCommandList::GLCommandList(bool isImmediate) : m_isImmediate(isImmediate) {}
+            GLCommandList::GLCommandList(bool isImmediate, RHIStatistics* statistics)
+                : m_isImmediate(isImmediate), m_statistics(statistics)
+            {
+            }
 
             void GLCommandList::Begin() {}
             void GLCommandList::End()
@@ -1277,7 +1280,7 @@ namespace Spark
 
             IRHICommandList* GLDevice::CreateDeferredCommandList()
             {
-                return new GLCommandList(false);
+                return new GLCommandList(false, &m_statistics);
             }
 
             void GLDevice::ExecuteCommandList(IRHICommandList*) {}

--- a/SparkEngine/Source/Graphics/RHI/Vulkan/VulkanFormatHelpers.cpp
+++ b/SparkEngine/Source/Graphics/RHI/Vulkan/VulkanFormatHelpers.cpp
@@ -300,9 +300,6 @@ namespace Spark
 
         } // namespace Vulkan
     } // namespace RHI
-
-} // namespace Vulkan
-} // namespace RHI
 } // namespace Spark
 
 #endif // SPARK_VULKAN_SUPPORT

--- a/SparkEngine/Source/Graphics/RenderGraph.h
+++ b/SparkEngine/Source/Graphics/RenderGraph.h
@@ -916,7 +916,7 @@ namespace Spark::Graphics
                     continue;
                 }
 
-                RenderTargetDesc rtDesc;
+                ::RenderTargetDesc rtDesc;
                 rtDesc.name = res.name;
                 rtDesc.width = res.textureDesc.width;
                 rtDesc.height = res.textureDesc.height;
@@ -928,7 +928,7 @@ namespace Spark::Graphics
                 rtDesc.clearDepth = res.textureDesc.clearDepth;
                 rtDesc.clearStencil = res.textureDesc.clearStencil;
 
-                auto rt = std::make_shared<RenderTarget>(rtDesc);
+                auto rt = std::make_shared<::RenderTarget>(rtDesc);
                 if (SUCCEEDED(rt->Create(m_device)))
                 {
                     res.physicalTexture = std::move(rt);


### PR DESCRIPTION
… format helpers

- Remove invalid ProfileProperties::Initialize() call (class has no such method; singleton is ready after construction). This caused Debug build failures on all platforms since the call was guarded by #ifndef NDEBUG.
- Fix GLCommandList constructor signature mismatch: implementation now matches the header declaration (bool, RHIStatistics*) and passes statistics to deferred lists.
- Remove duplicate namespace closing braces in VulkanFormatHelpers.cpp that caused compilation errors when Vulkan SDK is available.

https://claude.ai/code/session_01NvX5PB4c3TieGXhAnzPzzB