### PR TITLE
Add missing SparkConsole.h include to Graphics source files

### DIFF
--- a/SparkEngine/Source/Graphics/GraphicsConsoleOps.cpp
+++ b/SparkEngine/Source/Graphics/GraphicsConsoleOps.cpp
@@ -14,6 +14,7 @@
 #include "LightingSystem.h"
 #include "AssetPipeline.h"
 #include "../Utils/LogMacros.h"
+#include "../Utils/SparkConsole.h"
 
 #include <Windows.h>
 #include <d3d11_1.h>

--- a/SparkEngine/Source/Graphics/GraphicsDeviceResources.cpp
+++ b/SparkEngine/Source/Graphics/GraphicsDeviceResources.cpp
@@ -14,6 +14,7 @@
 #include "LightingSystem.h"
 #include "MaterialSystem.h"
 #include "../Utils/LogMacros.h"
+#include "../Utils/SparkConsole.h"
 
 #include <Windows.h>
 #include <d3d11_1.h>

--- a/SparkEngine/Source/Graphics/GraphicsRenderPipelines.cpp
+++ b/SparkEngine/Source/Graphics/GraphicsRenderPipelines.cpp
@@ -15,6 +15,7 @@
 #include "TemporalEffects.h"
 #include "../Game/GameObject.h"
 #include "../Utils/LogMacros.h"
+#include "../Utils/SparkConsole.h"
 #ifdef SPARK_HYBRID_RT
 #include "HybridRT/HybridRTManager.h"
 #ifdef SPARK_HARDWARE_RT

--- a/SparkEngine/Source/Graphics/GraphicsStateAndSettings.cpp
+++ b/SparkEngine/Source/Graphics/GraphicsStateAndSettings.cpp
@@ -17,6 +17,7 @@
 #include "TemporalEffects.h"
 #include "ScreenSpaceEffects.h"
 #include "../Utils/LogMacros.h"
+#include "../Utils/SparkConsole.h"
 
 #include <Windows.h>
 #include <d3d11_1.h>


### PR DESCRIPTION
GraphicsConsoleOps.cpp, GraphicsRenderPipelines.cpp, GraphicsStateAndSettings.cpp, and GraphicsDeviceResources.cpp all use the LOG_TO_CONSOLE_IMMEDIATE macro (which expands to Spark::SimpleConsole::GetInstance()) but only included LogMacros.h without the SparkConsole.h header that defines the SimpleConsole class. This caused C3861/C3083 errors on MSVC.

https://claude.ai/code/session_0155FkfMwWaVhBGZgjQp2mw8