### PR TITLE
fix: rename GetCurrentTime to avoid Windows API macro clash

### DIFF
--- a/.claude/index.md
+++ b/.claude/index.md
@@ -12,6 +12,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 | PCSX2 analysis (12 recommendations: save tags, null RHI, render ring, multi-ISA) | [knowledge/pcsx2-analysis.md](knowledge/pcsx2-analysis.md) | Decision | **Resolved** | 2026-03-20 |
 | 11-engine + 3-framework analysis (30 recommendations, ~20 engines total) | [knowledge/eleven-engine-analysis.md](knowledge/eleven-engine-analysis.md) | Decision | Active | 2026-03-20 |
 | 13 closed/proprietary engine analysis (15 recommendations, Blizzard/Havok/Frostbite/RAGE/id Tech/etc.) | [knowledge/closed-engines-analysis.md](knowledge/closed-engines-analysis.md) | Decision | Active | 2026-03-21 |
+| CI log access without gh CLI | [knowledge/ci-log-access.md](knowledge/ci-log-access.md) | Issue | **Resolved** | 2026-03-22 |
 | Effective dev workflows | [knowledge/workflow-patterns.md](knowledge/workflow-patterns.md) | Pattern | Active | 2026-03-14 |
 | SparkConsole refactor | [knowledge/sparkconsole-refactor-plan.md](knowledge/sparkconsole-refactor-plan.md) | Pattern | **Resolved** | 2026-03-17 |
 | Codebase non-obvious facts | [knowledge/codebase-observations.md](knowledge/codebase-observations.md) | Observation | Active | 2026-03-14 |
@@ -37,7 +38,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 
 ### Fixing problems (Issues)
 
-**Checking PR / CI status** → Use `gh run list` + `gh run view`, NOT `gh pr checks --watch`.
+**Checking PR / CI status** → Use `gh run list` + `gh run view`, NOT `gh pr checks --watch`. If `gh` unavailable, ask user for error text or reproduce locally with submodules. See [ci-log-access.md](knowledge/ci-log-access.md).
 
 **CI check failed** → Identify blocking vs. non-blocking jobs first. See CLAUDE.md CI jobs table.
 

--- a/.claude/knowledge/ci-log-access.md
+++ b/.claude/knowledge/ci-log-access.md
@@ -1,0 +1,59 @@
+# Accessing CI Build Logs Without gh CLI
+
+**Last updated:** 2026-03-22
+**Type:** Issue
+**Status:** Resolved
+
+## Description
+
+When `gh` CLI is not installed (common in sandboxed/container environments), accessing GitHub Actions build logs requires workarounds. The standard `gh run view --log-failed` approach fails entirely.
+
+## Context
+
+The Claude Code web environment does not have `gh` CLI installed. `pip install gh` installs a wrong Python package (not GitHub CLI). `apt-get install` may be blocked by lock files or missing repos. GitHub Actions log URLs are JavaScript-rendered and not accessible via simple HTTP fetch.
+
+## Methods Tried
+
+1. **`gh run view <RUN_ID> --log-failed`** → FAILED — `gh` not installed, cannot be installed via pip.
+2. **`pip install gh`** → FAILED — installs wrong package (Python gitpython wrapper, not GitHub CLI).
+3. **`WebFetch` on GitHub Actions job page** → FAILED — logs are lazy-loaded via JavaScript; HTML contains only job metadata, not actual compiler output.
+4. **GitHub REST API via curl (`/repos/.../actions/jobs/.../logs`)** → FAILED — requires admin rights / authentication token.
+5. **Local proxy API** → FAILED — proxy only supports git operations, not GitHub API endpoints.
+6. **WebFetch on commit checks page** → FAILED — same JS rendering issue.
+7. **WebFetch on raw/download log URLs** → FAILED — 404, requires auth.
+8. **Ask user to paste errors from CI** → WORKED — user provided the actual MSVC error messages directly.
+
+## Solution
+
+When `gh` CLI is unavailable and GitHub Actions logs cannot be fetched programmatically:
+
+### Primary workaround: Ask the user
+The most reliable approach is to ask the user to copy-paste the error messages from the GitHub Actions UI. This is fast and accurate.
+
+### Secondary workaround: Reproduce locally
+Match the CI build environment as closely as possible:
+1. Initialize git submodules: `git submodule update --init --recursive`
+2. Install CI dependencies: `libgl-dev libvulkan-dev libsdl2-dev`
+3. Build with same flags as CI (see `.github/workflows/build.yml`)
+
+**Key difference between local and CI**: CI uses `submodules: recursive` and installs `libsdl2-dev`, enabling code paths that are disabled locally (SDL2 windowing, editor on Linux, etc.). Always init submodules before attempting local reproduction.
+
+### Tertiary workaround: Check commit/PR page metadata
+`WebFetch` on the main run page can sometimes show:
+- Which jobs failed and their exit codes
+- Annotation counts
+- Triggering commit SHA and branch
+- PR number
+
+This narrows the search space even without full logs.
+
+### Common CI-only errors that don't reproduce locally
+- **Windows API macro clashes**: `GetCurrentTime`, `CreateWindow`, `GetObject`, `SendMessage`, `GetMessage`, `LoadImage`, `DrawText` etc. are macros in `<windows.h>`. Methods with these names compile fine on Linux but fail on MSVC.
+- **Missing includes**: Headers implicitly included on one platform but not another (e.g., `<cstring>` for `memcpy` on Clang).
+- **SDL2-gated code paths**: Code inside `#ifdef SPARK_SDL2_AVAILABLE` only compiles when SDL2 is found by CMake.
+
+## Notes
+
+- Always check `Assert.h` for existing `#undef` workarounds before adding new ones.
+- The `.github/workflows/build.yml` file documents the exact CI build configurations — mirror them locally.
+- When encountering Windows macro clashes, rename the method rather than adding `#undef` — it's a more robust fix.

--- a/SparkEditor/Source/Communication/EngineInterface.cpp
+++ b/SparkEditor/Source/Communication/EngineInterface.cpp
@@ -147,10 +147,9 @@ namespace SparkEditor
         }
 
         // Wait for the engine process to connect to our pipe, with timeout
+#ifdef _WIN32
         auto deadline = std::chrono::steady_clock::now() +
                         std::chrono::milliseconds(static_cast<int64_t>(timeoutSeconds * 1000.0f));
-
-#ifdef _WIN32
         // Use overlapped I/O for timeout support on Windows
         HANDLE hPipe = static_cast<HANDLE>(m_pipeHandle);
         OVERLAPPED overlapped = {};

--- a/SparkEditor/Source/Core/EditorMenuBar.cpp
+++ b/SparkEditor/Source/Core/EditorMenuBar.cpp
@@ -7,6 +7,8 @@
  */
 #include "EditorUI.h"
 #include "EditorIcons.h"
+#include "EditorTheme.h"
+#include "../Panels/HierarchyPanel.h"
 #include "../Utils/SparkConsole.h"
 #include "EditorApplication.h"
 #include <imgui.h>

--- a/SparkEngine/Source/Engine/Animation/AnimationSystem.cpp
+++ b/SparkEngine/Source/Engine/Animation/AnimationSystem.cpp
@@ -1225,7 +1225,7 @@ namespace Spark::Animation
         auto currentClip = mgr.GetClip(currentClipName);
         if (currentClip)
         {
-            AnimationEvaluator::SampleClip(*currentClip, *skeleton, stateMachine.GetCurrentTime(),
+            AnimationEvaluator::SampleClip(*currentClip, *skeleton, stateMachine.GetCurrentPlaybackTime(),
                                            blendResult.localTransforms);
         }
 

--- a/SparkEngine/Source/Engine/Animation/AnimationSystem.h
+++ b/SparkEngine/Source/Engine/Animation/AnimationSystem.h
@@ -143,7 +143,7 @@ namespace Spark::Animation
      * @brief Get the current playback time within the active clip (seconds).
      * @return  Elapsed time within the current clip.
      */
-        float GetCurrentTime() const { return m_currentTime; }
+        float GetCurrentPlaybackTime() const { return m_currentTime; }
 
         /**
      * @brief Get the crossfade blend factor in [0, 1] during a transition.

--- a/SparkEngine/Source/Engine/Cinematic/Sequencer.cpp
+++ b/SparkEngine/Source/Engine/Cinematic/Sequencer.cpp
@@ -751,7 +751,7 @@ namespace Spark::Cinematic
         std::ostringstream ss;
         ss << "=== Sequence: " << name << " ===\n";
         ss << "Duration: " << seq->GetDuration() << "s\n";
-        ss << "Current Time: " << seq->GetCurrentTime() << "s\n";
+        ss << "Current Time: " << seq->GetCurrentPlaybackTime() << "s\n";
         ss << "Speed: " << seq->GetPlaybackSpeed() << "x\n";
         ss << "Looping: " << (seq->IsLooping() ? "Yes" : "No") << "\n";
         ss << "Tracks: " << seq->GetTracks().size() << "\n";

--- a/SparkEngine/Source/Engine/Cinematic/Sequencer.h
+++ b/SparkEngine/Source/Engine/Cinematic/Sequencer.h
@@ -278,7 +278,7 @@ namespace Spark::Cinematic
 
         // State queries
         const std::string& GetName() const { return m_name; }
-        float GetCurrentTime() const { return m_currentTime; }
+        float GetCurrentPlaybackTime() const { return m_currentTime; }
         float GetDuration() const;
         SequencePlayState GetPlayState() const { return m_playState; }
         float GetPlaybackSpeed() const { return m_playbackSpeed; }

--- a/SparkGameMMO/Source/Chat/MMOChatSystem.cpp
+++ b/SparkGameMMO/Source/Chat/MMOChatSystem.cpp
@@ -14,6 +14,11 @@
 #include <imgui.h>
 #endif
 
+// Windows.h defines SendMessage as SendMessageA/SendMessageW — undo that
+#ifdef SendMessage
+#undef SendMessage
+#endif
+
 namespace MMO
 {
 

--- a/SparkGameMMO/Source/Chat/MMOChatSystem.h
+++ b/SparkGameMMO/Source/Chat/MMOChatSystem.h
@@ -22,6 +22,11 @@
 #include <string>
 #include <vector>
 
+// Windows.h defines SendMessage as SendMessageA/SendMessageW — undo that
+#ifdef SendMessage
+#undef SendMessage
+#endif
+
 namespace MMO
 {
 

--- a/Tests/TestAnimationSystem.cpp
+++ b/Tests/TestAnimationSystem.cpp
@@ -350,7 +350,7 @@ namespace TestAnim
         }
 
         const std::string& GetCurrentStateName() const { return m_currentState; }
-        float GetCurrentTime() const { return m_currentTime; }
+        float GetCurrentPlaybackTime() const { return m_currentTime; }
         float GetBlendFactor() const { return m_blendFactor; }
         bool IsTransitioning() const { return m_isTransitioning; }
         const std::string& GetTargetStateName() const { return m_targetState; }

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -130,5 +130,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 143 |
 | Test cases | 1589+ |
 | Wiki pages | 63 |
-| *Last synced* | *2026-03-21 14:41* |
+| *Last synced* | *2026-03-22 03:29* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
GetCurrentTime is #define'd as GetTickCount() in <windows.h>, causing MSVC C2039 errors in AnimationStateMachine and Sequencer. Renamed to GetCurrentPlaybackTime in all affected locations.

https://claude.ai/code/session_01TJvcFGy69cZzriEK8VLJzf