### PR TITLE
Fix editor compilation errors in MaterialEditor and AIDebugPanel

### DIFF
--- a/SparkEditor/Source/MaterialEditor/MaterialEditor.cpp
+++ b/SparkEditor/Source/MaterialEditor/MaterialEditor.cpp
@@ -161,7 +161,7 @@ namespace SparkEditor
             Spark::Graphics::ShaderNode sn;
             sn.id = node->id;
             sn.type = static_cast<Spark::Graphics::ShaderNodeType>(static_cast<uint32_t>(node->type));
-            for (const auto& socket : node->inputs)
+            for (const auto& socket : node->inputSockets)
             {
                 Spark::Graphics::ShaderNodeInput si;
                 si.defaultValue[0] = socket.defaultValue.x;

--- a/SparkEditor/Source/Panels/AIDebugPanel.cpp
+++ b/SparkEditor/Source/Panels/AIDebugPanel.cpp
@@ -81,21 +81,21 @@ namespace SparkEditor
     // Agent List
     // =========================================================================
 
-    static const char* AgentStateToString(AIDebugPanel::AgentState state)
+    const char* AIDebugPanel::AgentStateToString(AgentState state)
     {
         switch (state)
         {
-        case AIDebugPanel::AgentState::Idle:
+        case AgentState::Idle:
             return "Idle";
-        case AIDebugPanel::AgentState::Patrolling:
+        case AgentState::Patrolling:
             return "Patrol";
-        case AIDebugPanel::AgentState::Alert:
+        case AgentState::Alert:
             return "Alert";
-        case AIDebugPanel::AgentState::Combat:
+        case AgentState::Combat:
             return "Combat";
-        case AIDebugPanel::AgentState::Fleeing:
+        case AgentState::Fleeing:
             return "Flee";
-        case AIDebugPanel::AgentState::Dead:
+        case AgentState::Dead:
             return "Dead";
         }
         return "Unknown";

--- a/SparkEditor/Source/Panels/AIDebugPanel.h
+++ b/SparkEditor/Source/Panels/AIDebugPanel.h
@@ -71,6 +71,9 @@ namespace SparkEditor
             std::string value;
         };
 
+        // Helpers
+        static const char* AgentStateToString(AgentState state);
+
         // UI rendering
         void RenderAgentList();
         void RenderBlackboardInspector();


### PR DESCRIPTION
- MaterialEditor.cpp: Use correct member name `inputSockets` instead of `inputs` on MaterialNode
- AIDebugPanel: Move AgentStateToString from free function to private static member to access private AgentState enum

https://claude.ai/code/session_01F216CFXH7Qpjp6DnRLbcTa