### PR TITLE
Fix PipelineStateCache class redefinition and MSVC 'far' keyword conf…

### DIFF
--- a/SparkEngine/Source/Graphics/GraphicsEngine.h
+++ b/SparkEngine/Source/Graphics/GraphicsEngine.h
@@ -247,8 +247,8 @@ class GraphicsEngine
 
 #ifdef SPARK_PLATFORM_WINDOWS
     /** @brief Get the pipeline state cache for hash-based D3D11 state deduplication. */
-    Spark::Graphics::PipelineStateCache* GetPipelineStateCache() { return &m_pipelineStateCache; }
-    const Spark::Graphics::PipelineStateCache* GetPipelineStateCache() const { return &m_pipelineStateCache; }
+    Spark::Graphics::D3D11PipelineStateCache* GetPipelineStateCache() { return &m_pipelineStateCache; }
+    const Spark::Graphics::D3D11PipelineStateCache* GetPipelineStateCache() const { return &m_pipelineStateCache; }
 
     /** @brief Get the render target pool for transient RT recycling. */
     Spark::Graphics::RenderTargetPool* GetRenderTargetPool() { return &m_renderTargetPool; }
@@ -601,15 +601,15 @@ class GraphicsEngine
     // ========================================================================
 
 #ifdef SPARK_PLATFORM_WINDOWS
-    Spark::Graphics::PipelineStateCache m_pipelineStateCache;     ///< Hash-based D3D11 state caching
-    Spark::Graphics::RenderTargetPool m_renderTargetPool;         ///< Pooled transient render targets
-    Spark::Graphics::GPUSceneBuffer m_gpuSceneBuffer;             ///< Persistent GPU instance buffer
-    Spark::Graphics::BVHAccelerator m_bvhAccelerator;             ///< SAH-based BVH for culling
-    Spark::Graphics::ConstantBufferRing m_constantBufferRing;     ///< Ring-buffer CB sub-allocation
-    Spark::Graphics::GPUDebugMarkers m_gpuDebugMarkers;           ///< PIX/RenderDoc GPU annotations
-    Spark::Graphics::GPUTimestampQuery m_gpuTimestampQuery;       ///< Per-pass GPU timing queries
-#endif                                                            // SPARK_PLATFORM_WINDOWS
-    std::vector<Spark::Graphics::DrawSortEntry> m_sortedDrawList; ///< Sorted draw list per frame
+    Spark::Graphics::D3D11PipelineStateCache m_pipelineStateCache; ///< Hash-based D3D11 state caching
+    Spark::Graphics::RenderTargetPool m_renderTargetPool;          ///< Pooled transient render targets
+    Spark::Graphics::GPUSceneBuffer m_gpuSceneBuffer;              ///< Persistent GPU instance buffer
+    Spark::Graphics::BVHAccelerator m_bvhAccelerator;              ///< SAH-based BVH for culling
+    Spark::Graphics::ConstantBufferRing m_constantBufferRing;      ///< Ring-buffer CB sub-allocation
+    Spark::Graphics::GPUDebugMarkers m_gpuDebugMarkers;            ///< PIX/RenderDoc GPU annotations
+    Spark::Graphics::GPUTimestampQuery m_gpuTimestampQuery;        ///< Per-pass GPU timing queries
+#endif                                                             // SPARK_PLATFORM_WINDOWS
+    std::vector<Spark::Graphics::DrawSortEntry> m_sortedDrawList;  ///< Sorted draw list per frame
 
     // Basic shader system resources (fallback rendering pipeline)
     ComPtr<ID3D11VertexShader> m_basicVertexShader;

--- a/SparkEngine/Source/Graphics/PipelineStateCache.h
+++ b/SparkEngine/Source/Graphics/PipelineStateCache.h
@@ -111,11 +111,11 @@ namespace Spark::Graphics
     /**
      * @brief Caches D3D11 pipeline state objects and tracks dirty state to minimize API calls.
      */
-    class PipelineStateCache
+    class D3D11PipelineStateCache
     {
       public:
-        PipelineStateCache() = default;
-        ~PipelineStateCache() = default;
+        D3D11PipelineStateCache() = default;
+        ~D3D11PipelineStateCache() = default;
 
         /**
          * @brief Initialize the cache with a D3D11 device.

--- a/Tests/TestEnvironmentQuery.cpp
+++ b/Tests/TestEnvironmentQuery.cpp
@@ -109,9 +109,9 @@ TEST(EQS_DistanceScorer)
     close.position = {2.0f, 0.0f, 0.0f};
     float closeScore = scorer.Score(close);
 
-    EQSItem far;
-    far.position = {15.0f, 0.0f, 0.0f};
-    float farScore = scorer.Score(far);
+    EQSItem farItem;
+    farItem.position = {15.0f, 0.0f, 0.0f};
+    float farScore = scorer.Score(farItem);
 
     EXPECT_GT(closeScore, farScore);
     EXPECT_GE(closeScore, 0.0f);

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -130,5 +130,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 143 |
 | Test cases | 1589+ |
 | Wiki pages | 63 |
-| *Last synced* | *2026-03-22 03:29* |
+| *Last synced* | *2026-03-22 05:51* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
…lict

Two classes named PipelineStateCache existed in Spark::Graphics — the D3D11-specific cache (Graphics/PipelineStateCache.h) and the RHI flyweight cache (Graphics/RHI/ PipelineStateCache.h). When both headers were included via SparkEngine.cpp, MSVC reported C2011 redefinition errors. Renamed the D3D11 version to D3D11PipelineStateCache.

Also renamed variable 'far' to 'farItem' in TestEnvironmentQuery.cpp — 'far' is a legacy Windows macro that expands to nothing, causing syntax errors on MSVC.

https://claude.ai/code/session_011fyEPKuk2bkx3yRvsrmo6d