### PR TITLE
feat: add defensive logging to 17 files across engine subsystems

### DIFF
--- a/SparkEditor/Source/MaterialEditor/MaterialEditor.cpp
+++ b/SparkEditor/Source/MaterialEditor/MaterialEditor.cpp
@@ -91,6 +91,8 @@ namespace SparkEditor
         std::ifstream file(filePath);
         if (!file.is_open())
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Graphics, "[MaterialEditor] Failed to open material file: %s",
+                           filePath.c_str());
             return false;
         }
 
@@ -98,6 +100,8 @@ namespace SparkEditor
         std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
         if (content.empty())
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Graphics, "[MaterialEditor] Material file is empty: %s",
+                           filePath.c_str());
             return false;
         }
 
@@ -117,6 +121,8 @@ namespace SparkEditor
         std::ofstream file(filePath);
         if (!file.is_open())
         {
+            SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "[MaterialEditor] Failed to save material to: %s",
+                            filePath.c_str());
             return false;
         }
 

--- a/SparkEngine/Source/Core/ModuleHotReload.cpp
+++ b/SparkEngine/Source/Core/ModuleHotReload.cpp
@@ -19,6 +19,11 @@ namespace Spark
 
     void ModuleHotReloadManager::Initialize(ModuleManager* moduleManager, IEngineContext* context)
     {
+        if (!moduleManager || !context)
+        {
+            SimpleConsole::GetInstance().LogWarning("ModuleHotReloadManager::Initialize called with null " +
+                                                    std::string(!moduleManager ? "moduleManager" : "context"));
+        }
         m_moduleManager = moduleManager;
         m_context = context;
 

--- a/SparkEngine/Source/Core/ResourceVersionTracker.cpp
+++ b/SparkEngine/Source/Core/ResourceVersionTracker.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "ResourceVersionTracker.h"
+#include "Utils/Validate.h"
 
 #include <format>
 
@@ -37,6 +38,7 @@ namespace Spark
         auto it = m_versions.find(path);
         if (it == m_versions.end())
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Core, "IncrementVersion: resource '%s' not registered", path.c_str());
             return 0;
         }
         return ++(it->second);

--- a/SparkEngine/Source/Engine/AI/NavMeshObstacles.cpp
+++ b/SparkEngine/Source/Engine/AI/NavMeshObstacles.cpp
@@ -55,6 +55,7 @@ namespace Spark::AI
         SPARK_TRACE_ENTER(Spark::LogCategory::AI);
         if (m_navMesh == nullptr)
         {
+            SPARK_LOG_WARN(Spark::LogCategory::AI, "AddObstacle called with no NavMesh set — obstacle not created");
             return InvalidObstacleHandle;
         }
 
@@ -119,6 +120,8 @@ namespace Spark::AI
     {
         if (m_navMesh == nullptr)
         {
+            SPARK_LOG_WARN(Spark::LogCategory::AI,
+                           "ApplyDirtyObstacles called with no NavMesh set — dirty obstacles not applied");
             return;
         }
 
@@ -241,6 +244,7 @@ namespace Spark::AI
     {
         if (m_navMesh == nullptr)
         {
+            SPARK_LOG_WARN(Spark::LogCategory::AI, "CarveObstacle called with no NavMesh set");
             return;
         }
 
@@ -263,6 +267,7 @@ namespace Spark::AI
     {
         if (m_navMesh == nullptr)
         {
+            SPARK_LOG_WARN(Spark::LogCategory::AI, "RestoreObstacle called with no NavMesh set");
             return;
         }
 

--- a/SparkEngine/Source/Engine/Dialogue/DynamicResponseSystem.cpp
+++ b/SparkEngine/Source/Engine/Dialogue/DynamicResponseSystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "DynamicResponseSystem.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <cmath>
@@ -55,6 +56,7 @@ namespace Spark::Dialogue
     {
         if (!m_initialized)
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Core, "DynamicResponseSystem::RegisterRule called before Initialize");
             return;
         }
         m_rules.push_back(rule);
@@ -68,6 +70,8 @@ namespace Spark::Dialogue
     {
         if (!m_initialized)
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Core, "DynamicResponseSystem::SendSignal('%s') called before Initialize",
+                           signalName.c_str());
             return;
         }
 

--- a/SparkEngine/Source/Engine/Modding/VirtualFileSystem.cpp
+++ b/SparkEngine/Source/Engine/Modding/VirtualFileSystem.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "VirtualFileSystem.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <filesystem>
@@ -45,6 +46,7 @@ namespace Spark
         std::ifstream file(fullPath, std::ios::binary | std::ios::ate);
         if (!file.is_open())
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Core, "VFS: Failed to open file '%s'", fullPath.c_str());
             return {};
         }
 
@@ -66,6 +68,7 @@ namespace Spark
         std::ifstream file(fullPath);
         if (!file.is_open())
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Core, "VFS: Failed to open text file '%s'", fullPath.c_str());
             return {};
         }
 

--- a/SparkEngine/Source/Engine/Networking/EntityReplicator.cpp
+++ b/SparkEngine/Source/Engine/Networking/EntityReplicator.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "EntityReplicator.h"
+#include "../../Utils/Validate.h"
 
 #include <cstring>
 
@@ -55,6 +56,8 @@ namespace Spark::Net
         auto it = m_entities.find(entityID);
         if (it == m_entities.end() || !it->second.serializer)
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "WriteCreatePacket: entity %u not found or has no serializer",
+                           entityID);
             return false;
         }
 
@@ -82,6 +85,8 @@ namespace Spark::Net
         auto it = m_entities.find(entityID);
         if (it == m_entities.end() || !it->second.serializer)
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "WriteUpdatePacket: entity %u not found or has no serializer",
+                           entityID);
             return false;
         }
 
@@ -141,6 +146,8 @@ namespace Spark::Net
         auto it = m_entities.find(entityID);
         if (it == m_entities.end() || !it->second.deserializer)
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "ProcessIncoming: entity %u not found or has no deserializer",
+                           entityID);
             return false;
         }
 
@@ -154,6 +161,9 @@ namespace Spark::Net
                 size_t bytesRead = entry.deserializer(i, buffer, offset);
                 if (bytesRead == 0)
                 {
+                    SPARK_LOG_ERROR(Spark::LogCategory::Network,
+                                    "ProcessIncoming: deserializer returned 0 bytes for entity %u field %u", entityID,
+                                    i);
                     return false;
                 }
                 offset += bytesRead;

--- a/SparkEngine/Source/Engine/Networking/NetworkManager.cpp
+++ b/SparkEngine/Source/Engine/Networking/NetworkManager.cpp
@@ -145,13 +145,17 @@ namespace Spark::Net
     {
         m_socket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
         if (m_socket == INVALID_SOCKET)
+        {
+            SPARK_LOG_ERROR(Spark::LogCategory::Network, "Failed to create UDP socket");
             return false;
+        }
 
-            // Set non-blocking mode
+        // Set non-blocking mode
 #ifdef SPARK_PLATFORM_WINDOWS
         u_long nonBlocking = 1;
         if (ioctlsocket(m_socket, FIONBIO, &nonBlocking) == SOCKET_ERROR)
         {
+            SPARK_LOG_ERROR(Spark::LogCategory::Network, "Failed to set socket to non-blocking mode");
             CloseSocket();
             return false;
         }
@@ -159,6 +163,7 @@ namespace Spark::Net
         int flags = fcntl(m_socket, F_GETFL, 0);
         if (flags == -1 || fcntl(m_socket, F_SETFL, flags | O_NONBLOCK) == -1)
         {
+            SPARK_LOG_ERROR(Spark::LogCategory::Network, "Failed to set socket to non-blocking mode");
             CloseSocket();
             return false;
         }
@@ -178,6 +183,7 @@ namespace Spark::Net
 
         if (::bind(m_socket, reinterpret_cast<const sockaddr*>(&localAddr), sizeof(localAddr)) == SOCKET_ERROR)
         {
+            SPARK_LOG_ERROR(Spark::LogCategory::Network, "Failed to bind socket to port %u", port);
             CloseSocket();
             return false;
         }
@@ -229,14 +235,20 @@ namespace Spark::Net
     {
         // Minimum header: magic(4) + type(2) + channel(1) + sender(4) + seq(4) + timestamp(4) + payloadLen(4) = 23
         if (length < 23)
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "Packet too small (%zu bytes, need 23 minimum)", length);
             return false;
+        }
 
         NetBuffer buf;
         buf.WriteBytes(data, length);
 
         uint32_t magic = buf.ReadUint32();
         if (magic != 0x5350524B)
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "Invalid packet magic 0x%08X (expected 0x5350524B)", magic);
             return false;
+        }
 
         outMsg.type = static_cast<MessageType>(buf.ReadUint16());
         outMsg.channel = static_cast<ChannelType>(buf.ReadUint8());
@@ -246,12 +258,19 @@ namespace Spark::Net
         uint32_t payloadLen = buf.ReadUint32();
 
         if (buf.GetReadPosition() + payloadLen > length)
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "Payload length %u exceeds remaining packet data", payloadLen);
             return false;
+        }
 
         // Reject unreasonably large payloads to prevent memory exhaustion attacks
         constexpr uint32_t kMaxPayloadSize = 64 * 1024; // 64 KB
         if (payloadLen > kMaxPayloadSize)
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "Payload length %u exceeds max allowed (%u)", payloadLen,
+                           kMaxPayloadSize);
             return false;
+        }
 
         outMsg.payload.resize(payloadLen);
         if (payloadLen > 0)
@@ -265,7 +284,11 @@ namespace Spark::Net
     bool NetworkManager::SendRawTo(const std::vector<uint8_t>& data, const sockaddr_in& addr)
     {
         if (m_socket == INVALID_SOCKET || data.empty())
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "SendRawTo failed: %s",
+                           m_socket == INVALID_SOCKET ? "socket not open" : "empty data");
             return false;
+        }
 
         int sent = sendto(m_socket, reinterpret_cast<const char*>(data.data()), static_cast<int>(data.size()), 0,
                           reinterpret_cast<const sockaddr*>(&addr), sizeof(addr));
@@ -284,7 +307,10 @@ namespace Spark::Net
     int NetworkManager::ReceiveRaw(std::vector<uint8_t>& outData, sockaddr_in& outSender)
     {
         if (m_socket == INVALID_SOCKET)
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "ReceiveRaw called with invalid socket");
             return -1;
+        }
 
         static constexpr int MAX_PACKET_SIZE = 4096;
         outData.resize(MAX_PACKET_SIZE);

--- a/SparkEngine/Source/Engine/Streaming/SeamlessAreaManager.cpp
+++ b/SparkEngine/Source/Engine/Streaming/SeamlessAreaManager.cpp
@@ -9,6 +9,7 @@
 
 #include "SeamlessAreaManager.h"
 #include "../../Utils/SparkConsole.h"
+#include "../../Utils/Validate.h"
 
 #include <algorithm>
 #include <cmath>
@@ -113,6 +114,8 @@ namespace Spark::Streaming
         auto it = m_areas.find(areaId);
         if (it == m_areas.end())
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Scene, "[SeamlessAreaManager] UnregisterArea: area %u not found",
+                           areaId);
             return;
         }
 

--- a/SparkEngine/Source/Graphics/RHI/D3D11/D3D11Device.cpp
+++ b/SparkEngine/Source/Graphics/RHI/D3D11/D3D11Device.cpp
@@ -155,17 +155,29 @@ namespace Spark
                 ComPtr<IDXGIDevice> dxgiDevice;
                 HRESULT hr = device->QueryInterface(__uuidof(IDXGIDevice), &dxgiDevice);
                 if (FAILED(hr))
+                {
+                    SPARK_LOG_ERROR(Spark::LogCategory::Graphics,
+                                    "D3D11SwapChain: QueryInterface(IDXGIDevice) failed (HRESULT 0x%08lX)", hr);
                     return;
+                }
 
                 ComPtr<IDXGIAdapter> dxgiAdapter;
                 hr = dxgiDevice->GetAdapter(&dxgiAdapter);
                 if (FAILED(hr))
+                {
+                    SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "D3D11SwapChain: GetAdapter failed (HRESULT 0x%08lX)",
+                                    hr);
                     return;
+                }
 
                 ComPtr<IDXGIFactory2> dxgiFactory;
                 hr = dxgiAdapter->GetParent(__uuidof(IDXGIFactory2), &dxgiFactory);
                 if (FAILED(hr))
+                {
+                    SPARK_LOG_ERROR(Spark::LogCategory::Graphics,
+                                    "D3D11SwapChain: GetParent(IDXGIFactory2) failed (HRESULT 0x%08lX)", hr);
                     return;
+                }
 
                 DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
                 swapChainDesc.Width = desc.width;
@@ -180,7 +192,11 @@ namespace Spark
                 HWND hwnd = static_cast<HWND>(desc.windowHandle);
                 hr = dxgiFactory->CreateSwapChainForHwnd(device, hwnd, &swapChainDesc, nullptr, nullptr, &m_swapChain);
                 if (FAILED(hr))
+                {
+                    SPARK_LOG_ERROR(Spark::LogCategory::Graphics,
+                                    "D3D11SwapChain: CreateSwapChainForHwnd failed (HRESULT 0x%08lX)", hr);
                     return;
+                }
 
                 CreateBackBufferViews();
             }

--- a/SparkEngine/Source/Graphics/RHI/D3D12/D3D12Device.cpp
+++ b/SparkEngine/Source/Graphics/RHI/D3D12/D3D12Device.cpp
@@ -338,15 +338,24 @@ namespace Spark
                 queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
                 queueDesc.Priority = D3D12_COMMAND_QUEUE_PRIORITY_NORMAL;
                 if (FAILED(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_directQueue))))
+                {
+                    SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "D3D12: Failed to create direct command queue");
                     return false;
+                }
 
                 queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
                 if (FAILED(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_copyQueue))))
+                {
+                    SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "D3D12: Failed to create copy command queue");
                     return false;
+                }
 
                 queueDesc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
                 if (FAILED(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&m_computeQueue))))
+                {
+                    SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "D3D12: Failed to create compute command queue");
                     return false;
+                }
 
                 return true;
             }

--- a/SparkEngine/Source/Graphics/RHI/OpenGL/OpenGLDevice.cpp
+++ b/SparkEngine/Source/Graphics/RHI/OpenGL/OpenGLDevice.cpp
@@ -437,7 +437,11 @@ namespace Spark
             void GLCommandList::SetPipelineState(IRHIPipelineState* pipelineState)
             {
                 if (!pipelineState)
+                {
+                    SPARK_LOG_WARN(Spark::LogCategory::Graphics,
+                                   "GL: SetPipelineState called with null pipeline state");
                     return;
+                }
                 auto* glPSO = static_cast<GLPipelineState*>(pipelineState);
 
                 m_currentProgram = glPSO->GetGLProgram();
@@ -484,7 +488,10 @@ namespace Spark
             void GLCommandList::SetVertexBuffer(IRHIBuffer* buffer, uint32_t, uint32_t)
             {
                 if (!buffer)
+                {
+                    SPARK_LOG_WARN(Spark::LogCategory::Graphics, "GL: SetVertexBuffer called with null buffer");
                     return;
+                }
                 auto* glBuf = static_cast<GLBuffer*>(buffer);
                 glBindBuffer(GL_ARRAY_BUFFER, glBuf->GetGLBuffer());
             }
@@ -492,7 +499,10 @@ namespace Spark
             void GLCommandList::SetIndexBuffer(IRHIBuffer* buffer, uint32_t)
             {
                 if (!buffer)
+                {
+                    SPARK_LOG_WARN(Spark::LogCategory::Graphics, "GL: SetIndexBuffer called with null buffer");
                     return;
+                }
                 auto* glBuf = static_cast<GLBuffer*>(buffer);
                 m_boundIndexBuffer = glBuf->GetGLBuffer();
                 m_indexStride = glBuf->GetStride();
@@ -502,7 +512,11 @@ namespace Spark
             void GLCommandList::SetConstantBuffer(RHIShaderStage, uint32_t slot, IRHIBuffer* buffer)
             {
                 if (!buffer)
+                {
+                    SPARK_LOG_WARN(Spark::LogCategory::Graphics,
+                                   "GL: SetConstantBuffer called with null buffer (slot %u)", slot);
                     return;
+                }
                 auto* glBuf = static_cast<GLBuffer*>(buffer);
                 glBindBufferBase(GL_UNIFORM_BUFFER, slot, glBuf->GetGLBuffer());
                 if (m_statistics)
@@ -620,7 +634,11 @@ namespace Spark
             void GLCommandList::DrawInstancedIndirect(IRHIBuffer* argsBuffer, uint32_t argsOffset)
             {
                 if (!argsBuffer)
+                {
+                    SPARK_LOG_WARN(Spark::LogCategory::Graphics,
+                                   "GL: DrawInstancedIndirect called with null args buffer");
                     return;
+                }
                 auto* glBuf = static_cast<GLBuffer*>(argsBuffer);
                 glBindBuffer(GL_DRAW_INDIRECT_BUFFER, glBuf->GetGLBuffer());
                 glDrawArraysIndirect(m_currentTopology,
@@ -632,7 +650,11 @@ namespace Spark
             void GLCommandList::DrawIndexedInstancedIndirect(IRHIBuffer* argsBuffer, uint32_t argsOffset)
             {
                 if (!argsBuffer)
+                {
+                    SPARK_LOG_WARN(Spark::LogCategory::Graphics,
+                                   "GL: DrawIndexedInstancedIndirect called with null args buffer");
                     return;
+                }
                 auto* glBuf = static_cast<GLBuffer*>(argsBuffer);
                 glBindBuffer(GL_DRAW_INDIRECT_BUFFER, glBuf->GetGLBuffer());
                 glDrawElementsIndirect(m_currentTopology, GL_UNSIGNED_INT,
@@ -644,7 +666,10 @@ namespace Spark
             void GLCommandList::DispatchIndirect(IRHIBuffer* argsBuffer, uint32_t argsOffset)
             {
                 if (!argsBuffer)
+                {
+                    SPARK_LOG_WARN(Spark::LogCategory::Graphics, "GL: DispatchIndirect called with null args buffer");
                     return;
+                }
                 auto* glBuf = static_cast<GLBuffer*>(argsBuffer);
                 glBindBuffer(GL_DISPATCH_INDIRECT_BUFFER, glBuf->GetGLBuffer());
                 glDispatchComputeIndirect(static_cast<GLintptr>(argsOffset));
@@ -656,7 +681,11 @@ namespace Spark
             void GLCommandList::CopyTexture(IRHITexture* dst, IRHITexture* src)
             {
                 if (!dst || !src)
+                {
+                    SPARK_LOG_WARN(Spark::LogCategory::Graphics, "GL: CopyTexture called with null %s",
+                                   !dst ? "destination" : "source");
                     return;
+                }
                 auto* glDst = static_cast<GLTexture*>(dst);
                 auto* glSrc = static_cast<GLTexture*>(src);
                 glCopyImageSubData(glSrc->GetGLTexture(), GL_TEXTURE_2D, 0, 0, 0, 0, glDst->GetGLTexture(),

--- a/SparkEngine/Source/Physics/CharacterController.cpp
+++ b/SparkEngine/Source/Physics/CharacterController.cpp
@@ -8,6 +8,7 @@
 
 #include "CharacterController.h"
 #include "PhysicsSystem.h"
+#include "../Utils/Validate.h"
 
 #include <Jolt/Jolt.h>
 #include <Jolt/Physics/Character/CharacterVirtual.h>
@@ -27,7 +28,11 @@ CharacterController::CharacterController(PhysicsSystem* physicsSystem, const Cha
     : m_physicsSystem(physicsSystem), m_desc(desc)
 {
     if (!physicsSystem || !physicsSystem->GetJoltSystem())
+    {
+        SPARK_LOG_ERROR(Spark::LogCategory::Physics, "CharacterController: null %s — character will not be created",
+                        !physicsSystem ? "PhysicsSystem" : "JoltSystem");
         return;
+    }
 
     auto* joltSystem = physicsSystem->GetJoltSystem();
 
@@ -72,7 +77,11 @@ CharacterController::~CharacterController()
 void CharacterController::Update(float deltaTime, const XMFLOAT3& gravity)
 {
     if (!m_joltCharacter || !m_physicsSystem || !m_physicsSystem->GetJoltSystem())
+    {
+        SPARK_LOG_WARN(Spark::LogCategory::Physics, "CharacterController::Update skipped — null %s",
+                       !m_joltCharacter ? "JoltCharacter" : (!m_physicsSystem ? "PhysicsSystem" : "JoltSystem"));
         return;
+    }
 
     auto* character = m_joltCharacter;
     auto* joltSystem = m_physicsSystem->GetJoltSystem();

--- a/SparkEngine/Source/Physics/PhysicsShapeFactory.cpp
+++ b/SparkEngine/Source/Physics/PhysicsShapeFactory.cpp
@@ -12,6 +12,7 @@
 
 #include "PhysicsSystem.h"
 #include "../Utils/Hash.h"
+#include "../Utils/Validate.h"
 
 #include <Jolt/Jolt.h>
 #include <Jolt/Physics/Collision/Shape/BoxShape.h>
@@ -76,6 +77,8 @@ void* PhysicsSystem::CreateCollisionShape(const CollisionShapeDesc& desc)
     {
         if (desc.heightfieldData.empty() || desc.heightfieldSamples == 0)
         {
+            SPARK_LOG_WARN(Spark::LogCategory::Physics,
+                           "Heightfield shape requested with empty data or zero samples — falling back to box");
             shape = CreateBoxShape(desc.dimensions);
         }
         else
@@ -87,9 +90,14 @@ void* PhysicsSystem::CreateCollisionShape(const CollisionShapeDesc& desc)
                                                      desc.heightfieldSamples);
             auto result = hfSettings.Create();
             if (!result.HasError())
+            {
                 shape = new JPH::ShapeRefC(result.Get());
+            }
             else
+            {
+                SPARK_LOG_WARN(Spark::LogCategory::Physics, "Heightfield shape creation failed — falling back to box");
                 shape = CreateBoxShape(desc.dimensions);
+            }
         }
         break;
     }
@@ -181,6 +189,8 @@ void* PhysicsSystem::CreateCollisionShape(const CollisionShapeDesc& desc)
     case CollisionShapeType::MutableCompound:
     case CollisionShapeType::Compound:
     default:
+        SPARK_LOG_WARN(Spark::LogCategory::Physics, "Unknown or unhandled shape type %d — falling back to box",
+                       static_cast<int>(desc.type));
         shape = CreateBoxShape(desc.dimensions);
         break;
     }

--- a/SparkEngine/Source/Utils/ConsoleProcessManager.cpp
+++ b/SparkEngine/Source/Utils/ConsoleProcessManager.cpp
@@ -196,6 +196,11 @@ namespace Spark
         {
             m_commandRegistry->RegisterCommand(name, handler, description, usage);
         }
+        else
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Core, "RegisterCommand('%s') dropped — command registry not initialized",
+                           name.c_str());
+        }
     }
 
     // ============================================================================

--- a/SparkEngine/Source/Utils/ConsoleProcessManagerWin32.cpp
+++ b/SparkEngine/Source/Utils/ConsoleProcessManagerWin32.cpp
@@ -182,9 +182,13 @@ namespace Spark
         HANDLE hChildStdOutRead, hChildStdOutWrite;
 
         if (!CreatePipe(&hChildStdInRead, &hChildStdInWrite, &sa, 0))
+        {
+            SPARK_LOG_ERROR(Spark::LogCategory::Core, "CreatePipe failed for stdin (error %lu)", GetLastError());
             return false;
+        }
         if (!CreatePipe(&hChildStdOutRead, &hChildStdOutWrite, &sa, 0))
         {
+            SPARK_LOG_ERROR(Spark::LogCategory::Core, "CreatePipe failed for stdout (error %lu)", GetLastError());
             CloseHandle(hChildStdInRead);
             CloseHandle(hChildStdInWrite);
             return false;
@@ -207,6 +211,8 @@ namespace Spark
 
         if (!success)
         {
+            SPARK_LOG_ERROR(Spark::LogCategory::Core, "CreateProcessW failed for SparkConsole (error %lu)",
+                            GetLastError());
             CloseHandle(hChildStdInRead);
             CloseHandle(hChildStdInWrite);
             CloseHandle(hChildStdOutRead);
@@ -234,6 +240,8 @@ namespace Spark
         DWORD bytesAvailable = 0;
         if (!PeekNamedPipe(m_stdOutRead, NULL, 0, NULL, &bytesAvailable, NULL))
         {
+            SPARK_LOG_ERROR(Spark::LogCategory::Core, "PeekNamedPipe failed (error %lu) — marking console as stopped",
+                            GetLastError());
             m_consoleRunning = false;
             return false;
         }
@@ -245,6 +253,7 @@ namespace Spark
         DWORD bytesToRead = std::min(bytesAvailable, static_cast<DWORD>(sizeof(buffer) - 1));
         if (!ReadFile(m_stdOutRead, buffer, bytesToRead, &bytesRead, NULL))
         {
+            SPARK_LOG_ERROR(Spark::LogCategory::Core, "ReadFile failed on console pipe (error %lu)", GetLastError());
             m_consoleRunning = false;
             return false;
         }
@@ -272,7 +281,11 @@ namespace Spark
 
         int utf8Size = WideCharToMultiByte(CP_UTF8, 0, message.c_str(), -1, NULL, 0, NULL, NULL);
         if (utf8Size <= 0)
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Core, "WideCharToMultiByte failed for console message (error %lu)",
+                           GetLastError());
             return false;
+        }
 
         std::string utf8Message(utf8Size, '\0');
         WideCharToMultiByte(CP_UTF8, 0, message.c_str(), -1, &utf8Message[0], utf8Size, NULL, NULL);

--- a/SparkEngine/Source/Utils/Logger.cpp
+++ b/SparkEngine/Source/Utils/Logger.cpp
@@ -380,9 +380,10 @@ namespace Spark
         {
             std::filesystem::create_directories(m_config.directory);
         }
-        catch (const std::filesystem::filesystem_error&)
+        catch (const std::filesystem::filesystem_error& e)
         {
-            // Best effort
+            fprintf(stderr, "[FileSink] Failed to create log directory '%s': %s\n", m_config.directory.c_str(),
+                    e.what());
         }
 
         // Generate timestamped filename


### PR DESCRIPTION
Deep scan identified ~90 silent error paths across the codebase. Added SPARK_LOG_ERROR/WARN logging to the highest-impact silent failures:

HIGH severity (was masking serious bugs):
- ConsoleProcessManagerWin32: Win32 API failures (CreatePipe, CreateProcess, ReadFile, PeekNamedPipe, WideCharToMultiByte)
- NetworkManager: socket creation, bind, non-blocking mode, packet validation (magic, size, payload overflow)
- NavMeshObstacles: all null-navmesh checks in Add/Apply/Carve/Restore
- CharacterController: null PhysicsSystem/JoltSystem in constructor and Update
- D3D11SwapChain: 4 HRESULT failures in constructor (QueryInterface, GetAdapter, GetParent, CreateSwapChain)
- D3D12Device: 3 command queue creation failures
- OpenGL: 8 null-pointer checks in GLCommandList (SetPipelineState, buffers, indirect draws, CopyTexture)
- EntityReplicator: missing entity/serializer/deserializer, zero-byte deserialization
- PhysicsShapeFactory: silent shape fallbacks now logged (heightfield, compound, default)

MEDIUM severity (useful for debugging):
- ResourceVersionTracker: IncrementVersion on unregistered resource
- VirtualFileSystem: file open failures
- ConsoleProcessManager: null command registry
- DynamicResponseSystem: calls before Initialize
- SeamlessAreaManager: UnregisterArea for unknown area
- ModuleHotReload: null parameter validation
- MaterialEditor: Load/Save file failures
- Logger/FileSink: filesystem error in directory creation

All 17 files pass clang-format, build (GCC Release), and 100% tests.

https://claude.ai/code/session_013hssZfdFBNa4KNG4gxsZTz