### PR TITLE
fix: wire unified Logger with StderrSink so SPARK_LOG_* output is vis…

### DIFF
--- a/SparkEngine/Source/Core/SparkEngine.cpp
+++ b/SparkEngine/Source/Core/SparkEngine.cpp
@@ -53,6 +53,7 @@
 #include "Utils/DebugDraw.h"
 #include "Utils/DebugOverlay.h"
 #include "Utils/FileLogger.h"
+#include "Utils/Logger.h"
 #include "Utils/JobSystem.h"
 #include "Graphics/DecalSystem.h"
 #include "Graphics/MeshLOD.h"
@@ -221,6 +222,11 @@ static void LogMissingModuleWarnings()
 
 static void InitDebugSystems()
 {
+    // Initialize the unified Logger with a stderr sink so SPARK_LOG_* output is visible
+    auto& logger = Spark::Logger::Get();
+    logger.Initialize(/*enableAsync=*/false);
+    logger.AddSink(std::make_unique<Spark::StderrSink>());
+
     Spark::FileLogger::GetInstance().Initialize("Logs");
     Spark::ChromeTracing::GetInstance().Start();
 #ifndef NDEBUG


### PR DESCRIPTION
…ible

The unified Logger (used by SPARK_LOG_* macros including MemoryMonitor) had no sinks and was never initialized, so all log output was silently discarded. Add Logger::Initialize() and a StderrSink in InitDebugSystems() so memory monitor status, anomalies, and all other SPARK_LOG_* messages appear on stderr.

https://claude.ai/code/session_01AjxtiXyFzTe9hMwz1gzaA7