### PR TITLE
Fix coverage CI: prevent negative count errors in lcov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,7 +308,7 @@ jobs:
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
-            -DCMAKE_CXX_FLAGS="--coverage" -DCMAKE_C_FLAGS="--coverage" \
+            -DCMAKE_CXX_FLAGS="--coverage -fprofile-update=atomic" -DCMAKE_C_FLAGS="--coverage -fprofile-update=atomic" \
             -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
             -DBUILD_TESTS=ON
       - name: Build
@@ -317,9 +317,9 @@ jobs:
         run: cd build && ctest --output-on-failure
       - name: Generate coverage
         run: |
-          lcov --capture --directory build --output-file coverage.info --ignore-errors mismatch,mismatch,gcov --rc geninfo_unexecuted_blocks=1
-          lcov --remove coverage.info '/usr/*' '*/ThirdParty/*' '*/Tests/*' --output-file coverage.info --ignore-errors unused
-          lcov --list coverage.info --ignore-errors unused
+          lcov --capture --directory build --output-file coverage.info --ignore-errors mismatch,mismatch,gcov,negative --rc geninfo_unexecuted_blocks=1
+          lcov --remove coverage.info '/usr/*' '*/ThirdParty/*' '*/Tests/*' --output-file coverage.info --ignore-errors unused,negative
+          lcov --list coverage.info --ignore-errors unused,negative
       - name: Upload coverage
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary

- Add `-fprofile-update=atomic` to coverage build flags to prevent GCC from producing negative counts in `.gcda` files (root cause of `geninfo: ERROR: Unexpected negative count` on `char_traits.h`)
- Add `--ignore-errors negative` to all `lcov` commands as a safety net

## Test plan

- [ ] Verify the `coverage` CI job passes without negative count errors
- [ ] Confirm coverage report is still generated and uploaded correctly

https://claude.ai/code/session_012DQvZ1B9gAV5Psxvgaigry