### PR TITLE
Update repo docs with accurate metrics and build options

### DIFF
--- a/.claude/index.md
+++ b/.claude/index.md
@@ -31,8 +31,8 @@ _Read this at every session start (after git sync). Each row links to a detailed
 
 - **Physics**: Jolt Physics (migrated from Bullet3). Use `EngineContext::Get()->GetPhysics()`
 - **Networking**: Enabled by default (`ENABLE_NETWORKING=ON`), UDP sockets, no external deps
-- **Tests**: 160 test files, 1808 tests passing
-- **Editor**: 51 panels, all wired including GizmoSystem, CollaborativeEditSession, CinematicSequencer, TimeOfDay, AbilityEditor, TriggerEditor, ConditionEditor, DecalEditor
+- **Tests**: 170 test files, 1,989 tests passing
+- **Editor**: 52 panels, all wired including GizmoSystem, CollaborativeEditSession, CinematicSequencer, TimeOfDay, AbilityEditor, TriggerEditor, ConditionEditor, DecalEditor
 - **Rendering**: All 12 former stubs now have .cpp implementations (ShadowAtlas, ScreenSpaceEffects, GPUOcclusionCulling, FroxelVolumetricFog, DynamicQualityScaler, DDGIProbeSystem, AdaptiveProbeVolumes, LightProbeSystem, SkyAtmosphere, WaterRenderer, ClusteredLightCulling, DynamicQualityTypes)
 - **Post-processing**: Bloom, auto-exposure, tonemapping (ACES/Filmic/Neutral/Reinhard), color grading (LGG)
 - **Infrastructure**: JobSystem wired, DeferredDeletionQueue in RHI, collision layer filtering, EntityEventBus cleanup, archetype spawn overrides

--- a/.claude/knowledge/documentation-coverage-audit.md
+++ b/.claude/knowledge/documentation-coverage-audit.md
@@ -17,7 +17,7 @@
 - **Total pages**: 64 (excluding _Sidebar.md)
 - **Key new pages**: Codebase-Statistics.md, Codebase-Health.md
 - All 25+ engine subsystems have wiki pages
-- Test counts updated to 1,808 cases across 160 files
+- Test counts updated to 1,989 cases across 170 files
 
 ### Consolidated Analysis Data (2026-03-24)
 

--- a/.claude/knowledge/eleven-engine-analysis.md
+++ b/.claude/knowledge/eleven-engine-analysis.md
@@ -11,7 +11,7 @@ Comprehensive cross-engine analysis of 11 engines and 3 rendering frameworks, id
 
 ## Context
 
-SparkEngine already has: EnTT ECS, D3D11 primary RHI with D3D12/Vulkan/Metal/OpenGL experimental, Bullet Physics, AngelScript scripting, ImGui editor (32 panels), UDP networking with AreaServer/WorldServer, EntityReplicator with dirty tracking, RenderGraph, PipelineStateCache, TransientResourcePool, JobSystem, SaveSystem, and 45+ working systems from prior analyses.
+SparkEngine already has: EnTT ECS, D3D11 primary RHI with D3D12/Vulkan/Metal/OpenGL experimental, Jolt Physics, AngelScript scripting, ImGui editor (52 panels), UDP networking with AreaServer/WorldServer, EntityReplicator with dirty tracking, RenderGraph, PipelineStateCache, TransientResourcePool, JobSystem, SaveSystem, and 45+ working systems from prior analyses.
 
 ## Engine-by-Engine Key Findings
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@ SparkEngine/         ← Executable host (like Unreal's runtime)
       Cinematic/     ← Sequencer system
     Utils/           ← SparkConsole.h, Logger, Profiler, CrashHandler, Assert.h
 
-SparkEditor/         ← ImGui-based editor (32 panels)
+SparkEditor/         ← ImGui-based editor (52 panels)
   Source/            ← Animation, AssetBrowser, BuildSystem, Gizmos, LevelStreaming,
                        MaterialEditor, Profiler, VersionControl, etc.
 
@@ -40,7 +40,7 @@ SparkConsole/        ← External debug console app (named pipe communication)
 
 Shaders/HLSL/        ← DirectX shaders (PBR, post-processing, compute)
 Shaders/GLSL/        ← OpenGL shaders (experimental)
-Tests/               ← 145 unit tests, CTest integration
+Tests/               ← 1,989 unit tests across 170 files, CTest integration
 Templates/           ← Game module templates
 Assets/              ← Demo scenes, models, scripts
 ```

--- a/.github/prompts/build-test.prompt.md
+++ b/.github/prompts/build-test.prompt.md
@@ -65,7 +65,7 @@ Builds on every push/PR: Windows MSVC + Linux GCC + Linux Clang (Debug + Release
 
 ## Testing
 
-145 unit tests in `Tests/` with internal framework + CTest.
+1,989 unit tests across 170 files in `Tests/` with internal framework + CTest.
 
 ```bash
 cd build && ctest --output-on-failure          # all tests

--- a/.github/prompts/copilot-instructions.md
+++ b/.github/prompts/copilot-instructions.md
@@ -28,7 +28,7 @@ SparkEngine/         ← Executable host (like Unreal's runtime)
       Cinematic/     ← Sequencer system
     Utils/           ← SparkConsole.h, Logger, Profiler, CrashHandler, Assert.h
 
-SparkEditor/         ← ImGui-based editor (32 panels)
+SparkEditor/         ← ImGui-based editor (52 panels)
   Source/            ← Animation, AssetBrowser, BuildSystem, Gizmos, LevelStreaming,
                        MaterialEditor, Profiler, VersionControl, etc.
 
@@ -40,7 +40,7 @@ SparkConsole/        ← External debug console app (named pipe communication)
 
 Shaders/HLSL/        ← DirectX shaders (PBR, post-processing, compute)
 Shaders/GLSL/        ← OpenGL shaders (experimental)
-Tests/               ← 145 unit tests, CTest integration
+Tests/               ← 1,989 unit tests across 170 files, CTest integration
 Templates/           ← Game module templates
 Assets/              ← Demo scenes, models, scripts
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ cmake --build build --config Release
 cd build && ctest --output-on-failure
 ```
 
-CMake 3.25+, C++23 required. GCC 13+, Clang 17+, or MSVC 19.36+ (VS 2022 17.6+). Key toggles: `ENABLE_EDITOR`, `ENABLE_GRAPHICS`, `ENABLE_PHYSX`, `ENABLE_AI`, `ENABLE_ANIMATION`, `ENABLE_NETWORKING` (ON by default), `ENABLE_VULKAN`, `ENABLE_OPENGL`, `ENABLE_SAVE_SYSTEM`, `ENABLE_PROCEDURAL`, `ENABLE_CINEMATIC`, `ENABLE_EVENT_SYSTEM`, `ENABLE_DECALS`, `ENABLE_MESH_LOD`, `ENABLE_DXR` (OFF by default), `BUILD_TESTS`, `BUILD_GAME_MODULES` (ON by default — set OFF for engine-only builds).
+CMake 3.25+, C++23 required. GCC 13+, Clang 17+, or MSVC 19.36+ (VS 2022 17.6+). Key toggles: `ENABLE_EDITOR`, `ENABLE_GRAPHICS`, `ENABLE_NETWORKING` (ON by default), `ENABLE_VULKAN`, `ENABLE_OPENGL`, `ENABLE_METAL` (OFF), `ENABLE_DXR` (OFF), `ENABLE_HYBRID_RT`, `ENABLE_RECAST`, `ENABLE_SDL2` (auto-ON on Linux), `SPARK_HEADLESS_SUPPORT`, `SPARK_DOUBLE_PRECISION_PHYSICS` (OFF), `BUILD_TESTS`, `BUILD_GAME_MODULES` (ON by default — set OFF for engine-only builds).
 
 ## Anti-Bloat Guidelines
 
@@ -151,14 +151,14 @@ SparkEngine/Source/Engine/UI/            — UI system
 SparkEngine/Source/Engine/VR/            — VR headset/controller/tracking
 SparkEngine/Source/Utils/                — Console, Logger, Profiler, Assert
 SparkEditor/Source/Communication/        — CollaborativeEditSession (multi-user editing)
-SparkEditor/Source/                      — ImGui editor (22 subsystems, 32 specialized panels)
+SparkEditor/Source/                      — ImGui editor (22 subsystems, 52 specialized panels)
 GameModules/                             — Game module directory (auto-discovered by CMake)
 GameModules/SparkGame/Source/            — Example FPS game module (DLL)
 GameModules/SparkGameMMO/Source/         — Example MMO game module (DLL)
 SparkConsole/src/                        — Standalone console application
 SparkShaderCompiler/src/                 — Shader compilation tool
 SparkSDK/                                — Public SDK/interface headers
-Tests/                                   — 145 unit tests, CTest
+Tests/                                   — 1,989 unit tests across 170 files, CTest
 ```
 
 ## ECS execution order
@@ -552,6 +552,6 @@ These are confirmed bloat problems discovered during audit. They must be fixed b
 - `.clang-format` enforces Microsoft-based style (Allman braces, 120-col, 4-space indent)
 - `.clang-tidy` checks for bugprone, modernize, performance, and readability issues
 - Doxygen config lives in `docs/Doxyfile.txt`; wiki pages in `wiki/`
-- 82+ unit tests in `Tests/`; always run `ctest` after changes
+- 1,989 unit tests across 170 files in `Tests/`; always run `ctest` after changes
 - **SparkConsole communicates with the engine via stdin/stdout pipes.** ConsoleProcessManager launches the subprocess and owns the pipe. SimpleConsole is the engine-side log sink only — it is not an IPC layer.
 - **ConsoleProcessManager must be initialized at engine startup** and `ProcessCommands()` must be called each frame. Without this, SparkConsole.exe never launches and commands are never executed.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 **Quality & Testing:**
 
-[![Tests](https://img.shields.io/badge/tests-1%2C808_cases-brightgreen)](https://github.com/Krilliac/SparkEngine/tree/master/Tests)
+[![Tests](https://img.shields.io/badge/tests-1%2C989_cases-brightgreen)](https://github.com/Krilliac/SparkEngine/tree/master/Tests)
 [![ASan](https://img.shields.io/badge/sanitizers-ASan_%2B_UBSan-green)](https://github.com/Krilliac/SparkEngine/actions/workflows/build.yml)
 [![clang--format](https://img.shields.io/badge/style-clang--format-blue)](https://github.com/Krilliac/SparkEngine/blob/master/.clang-format)
 [![clang--tidy](https://img.shields.io/badge/analysis-clang--tidy-blue)](https://github.com/Krilliac/SparkEngine/blob/master/.clang-tidy)
@@ -102,7 +102,7 @@ AngelScript with Unity-style hot-reload (file watcher with debouncing and state 
 
 ### Editor
 
-ImGui-powered visual editor with 32 specialized panels: scene hierarchy, inspector, asset browser, game viewport, gizmos (ImGuizmo), node graphs (imnodes), animation timeline, material editor, terrain editing, weapon editor, profiler, AI editor, physics debug, 2D editors, FPS tools, version control integration, build/deployment system, level streaming, search, prefab system, project management, scene statistics, collaborative multi-user editing (HeroEngine-inspired node locking, edit broadcasting, peer presence awareness), docking, and theming. Full undo/redo support and play-mode editing.
+ImGui-powered visual editor with 52 specialized panels: scene hierarchy, inspector, asset browser, game viewport, gizmos (ImGuizmo), node graphs (imnodes), animation timeline, material editor, terrain editing, weapon editor, profiler, AI editor, physics debug, 2D editors, FPS tools, version control integration, build/deployment system, level streaming, search, prefab system, project management, scene statistics, collaborative multi-user editing (HeroEngine-inspired node locking, edit broadcasting, peer presence awareness), docking, and theming. Full undo/redo support and play-mode editing.
 
 ### Procedural Generation
 
@@ -279,11 +279,21 @@ SparkEngine/
 |       |-- SceneManager/    # Scene and level management
 |       |-- Utils/           # Logging, profiler, crash handler, console, debug tools
 |-- SparkEditor/
-|   |-- Source/              # ImGui editor (32 panels)
+|   |-- Source/              # ImGui editor (52 panels)
 |-- SparkConsole/
 |   |-- src/                 # Standalone debug console application
 |-- SparkShaderCompiler/
 |   |-- src/                 # Offline shader compilation tool
+|-- SparkSDK/                # Public SDK/interface headers
+|-- GameModules/             # Game module shared libraries (8 modules)
+|   |-- SparkGame/           # Base game module
+|   |-- SparkGameFPS/        # FPS game module
+|   |-- SparkGameMMO/        # MMO game module
+|   |-- SparkGameRPG/        # RPG game module
+|   |-- SparkGameARPG/       # Action RPG game module
+|   |-- SparkGameRTS/        # RTS game module
+|   |-- SparkGameRacing/     # Racing game module
+|   |-- SparkGamePlatformer/ # Platformer game module
 |-- ThirdParty/              # Git submodules (see Dependencies)
 |-- Shaders/
 |   |-- HLSL/               # DirectX shaders
@@ -293,11 +303,14 @@ SparkEngine/
 |   |-- Models/             # 3D model files (.obj)
 |   |-- Scenes/             # Level/scene JSON files
 |   |-- Scripts/            # AngelScript game scripts
-|-- Tests/                   # 1,808 unit tests across 160 files (CTest)
+|-- Templates/               # Game module project templates
+|-- Tests/                   # 1,989 unit tests across 170 files (CTest)
 |-- tools/
 |   |-- SparkBuild.exe       # Pre-built SparkBuild binary
 |   |-- update-sparkbuild.*  # Manual update scripts (ps1/sh)
-|-- docs/                    # Doxygen docs, roadmap, status reports
+|-- docs/                    # Doxygen docs, wiki, API reference
+|-- wiki/                    # 64 wiki pages covering all subsystems
+|-- cmake/                   # CMake utility modules
 |-- .github/
 |   |-- workflows/          # CI/CD (build + release)
 |   |-- prompts/            # AI assistant prompt library
@@ -336,7 +349,7 @@ The following libraries are included directly in the source tree:
 
 ## Tests
 
-1,808 unit tests across 160 test files covering all major engine systems, built with a lightweight internal test framework (no external test dependencies). Integrated with CMake's CTest.
+1,989 unit tests across 170 test files covering all major engine systems, built with a lightweight internal test framework (no external test dependencies). Integrated with CMake's CTest.
 
 ```bash
 # Build and run tests
@@ -353,37 +366,26 @@ All options are passed to CMake via `-D<OPTION>=ON/OFF`.
 
 | Option | Default | Description |
 |---|:---:|---|
-| `BUILD_TESTS` | OFF | Unit tests (CTest) |
-| `ENABLE_EDITOR` | ON | ImGui visual editor |
 | `ENABLE_GRAPHICS` | ON | Graphics rendering system |
-| `ENABLE_PHYSX` | ON | Physics engine (Jolt Physics) |
-| `ENABLE_PROFILING` | ON | Performance profiling |
+| `ENABLE_EDITOR` | ON | ImGui visual editor |
+| `ENABLE_PROFILING` | ON | Performance profiling tools |
+| `ENABLE_NETWORKING` | ON | UDP networking (client/server, area servers, replication) |
 | `ENABLE_VULKAN` | ON | Vulkan graphics backend (experimental) |
 | `ENABLE_OPENGL` | ON | OpenGL graphics backend (experimental) |
-| `ENABLE_AI` | ON | AI and navigation systems |
-| `ENABLE_ANIMATION` | ON | Skeletal animation |
-| `ENABLE_SAVE_SYSTEM` | ON | Save/load system |
-| `ENABLE_TERRAIN_SYSTEM` | ON | Heightmap terrain |
-| `ENABLE_POST_PROCESSING` | ON | Bloom, tone mapping, FXAA |
-| `ENABLE_LIGHTING_SYSTEM` | ON | Advanced lighting / IBL |
-| `ENABLE_ADVANCED_INPUT` | ON | Extended input features |
-| `ENABLE_ASSET_STREAMING` | ON | Runtime asset streaming |
-| `ENABLE_HOT_RELOAD` | ON | Script hot-reload |
-| `ENABLE_COLLABORATIVE` | ON | Collaborative features |
-| `ENABLE_PROCEDURAL` | ON | Procedural generation |
-| `ENABLE_CINEMATIC` | ON | Cinematic sequencer |
-| `ENABLE_DECALS` | ON | Decal system |
-| `ENABLE_MESH_LOD` | ON | Mesh level-of-detail |
-| `ENABLE_WEATHER` | ON | Dynamic weather system |
-| `ENABLE_INVENTORY` | ON | Inventory system |
-| `ENABLE_QUEST_SYSTEM` | ON | Quest tracking |
-| `ENABLE_EVENT_SYSTEM` | ON | Event system |
-| `ENABLE_DAY_NIGHT` | ON | Day/night cycle |
-| `ENABLE_SCREEN_SPACE` | ON | Screen-space effects |
-| `ENABLE_FOG_SYSTEM` | ON | Volumetric fog |
-| `ENABLE_NETWORKING` | ON | UDP networking (client/server, area servers, replication) |
+| `ENABLE_METAL` | OFF | Metal graphics backend (macOS, experimental) |
 | `ENABLE_DXR` | OFF | DirectX Raytracing (experimental, needs D3D12) |
-| `ENABLE_SDL2` | OFF | SDL2 cross-platform input |
+| `ENABLE_HYBRID_RT` | ON | Hybrid ray tracing (SDFGI software + optional hardware DXR/Vulkan RT) |
+| `ENABLE_RECAST` | ON | Recast/Detour navmesh generation |
+| `ENABLE_SDL2` | OFF | SDL2 cross-platform input (auto-enabled on Linux) |
+| `SPARK_HEADLESS_SUPPORT` | ON | Headless/dedicated server mode support |
+| `BUILD_TESTS` | ON | Build test suite (CTest) |
+| `BUILD_GAME_MODULES` | ON | Build in-tree game modules (SparkGameFPS, SparkGameMMO, etc.) |
+| `SPARK_STRICT_DEPS` | OFF | FATAL_ERROR on missing critical dependencies (Jolt, ImGui, EnTT) |
+| `SPARK_SUPPRESS_THIRDPARTY_WARNINGS` | ON | Suppress compiler warnings from third-party libraries |
+| `SPARK_DOUBLE_PRECISION_PHYSICS` | OFF | Double precision physics (JPH_DOUBLE_PRECISION) for large worlds |
+| `ENABLE_CONSOLE_IN_SHIPPING` | OFF | Include SparkConsole in Shipping builds |
+| `ENABLE_DEVCOMMANDS_IN_SHIPPING` | OFF | Include developer commands in Shipping builds |
+| `STRIP_DEBUG_SYMBOLS` | OFF | Strip debug symbols from the final binary |
 
 ```bash
 # Example: minimal build without editor

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ The Doxygen configuration indexes the following:
 | Directory | Description |
 |-----------|-------------|
 | `SparkEngine/Source/` | Core engine library (all subsystems) |
-| `SparkEditor/Source/` | ImGui visual editor (32 panels) |
+| `SparkEditor/Source/` | ImGui visual editor (52 panels) |
 | `SparkConsole/src/` | Standalone debug console application |
 | `SparkShaderCompiler/src/` | Offline shader compilation tool |
 | `GameModules/SparkGame/Source/` | Example FPS game module |

--- a/wiki/Architecture-Overview.md
+++ b/wiki/Architecture-Overview.md
@@ -351,7 +351,7 @@ SparkEngine/
 ├── ThirdParty/               # Git submodules (15 libraries)
 ├── Assets/                   # Models, Scenes, Scripts
 ├── Shaders/                  # HLSL, GLSL, Compiled bytecode
-├── Tests/                    # 160 test files, 1,800+ test cases
+├── Tests/                    # 170 test files, 1,989 test cases
 ├── Tools/                    # CLI tools (spark-cli, SparkBuild)
 ├── docs/                     # API docs, gap analysis, roadmap
 ├── wiki/                     # Wiki documentation pages

--- a/wiki/Codebase-Health.md
+++ b/wiki/Codebase-Health.md
@@ -2,7 +2,7 @@
 
 System maturity status, known gaps, and improvement priorities across the SparkEngine codebase. This page consolidates findings from comprehensive gap analyses and code quality audits.
 
-Last updated: 2026-03-24
+Last updated: 2026-03-26
 
 ## System Maturity Overview
 
@@ -116,7 +116,7 @@ Status legend: **DONE** = fully implemented and wired in | **PARTIAL** = core wo
 
 | System | Status | Notes |
 |--------|:------:|-------|
-| ImGui editor core | **DONE** | 51 panel classes, docking, theming |
+| ImGui editor core | **DONE** | 52 panel classes, docking, theming |
 | Scene hierarchy | **DONE** | Tree view with drag-drop |
 | Inspector | **DONE** | Component renderers |
 | Material editor | **DONE** | PBR material editing |
@@ -158,7 +158,7 @@ Status legend: **DONE** = fully implemented and wired in | **PARTIAL** = core wo
 
 - **Modular service locator** — EngineContext provides clean subsystem access with dependency-aware initialization
 - **Comprehensive ECS** — 80+ component types with well-ordered system execution
-- **Strong test coverage** — 1,808 test cases across 160 files covering all major subsystems
+- **Strong test coverage** — 1,989 test cases across 170 files covering all major subsystems
 - **Consistent code style** — clang-format enforced in CI, Allman braces, 120-col limit
 - **RHI abstraction** — Clean backend selection via factory pattern
 

--- a/wiki/Codebase-Statistics.md
+++ b/wiki/Codebase-Statistics.md
@@ -1,6 +1,6 @@
 # Codebase Statistics
 
-Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-03-24.
+Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-03-26.
 
 ## Code Volume
 
@@ -8,13 +8,13 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-03-
 
 | Section | Lines |
 |---------|------:|
-| **SparkEngine/Source** | 203,317 |
+| **SparkEngine/Source** | 203,969 |
 | **SparkEditor/Source** | 72,945 |
-| **GameModules** | 50,630 |
-| **Tests** | 41,279 |
+| **GameModules** | 50,807 |
+| **Tests** | 48,990 |
 | **SparkConsole/src** | 1,793 |
 | **SparkShaderCompiler/src** | 533 |
-| **Total C++ (excl. ThirdParty)** | **~371,500** |
+| **Total C++ (excl. ThirdParty)** | **~379,000** |
 
 ### File Counts
 
@@ -25,7 +25,7 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-03-
 | HLSL shader files | 70 |
 | GLSL shader files | 14 |
 | AngelScript files (.as) | 1 |
-| Test files (.h + .cpp) | 160 |
+| Test files (.h + .cpp) | 172 |
 | Wiki pages (.md) | 64 |
 
 ### Code Density
@@ -97,7 +97,7 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-03-
 | Metric | Count |
 |--------|------:|
 | Editor panel header files | 52 |
-| Editor panel classes | 51 |
+| Editor panel classes | 52 |
 | Total editor lines | 72,945 |
 | Console command registrations | 101 |
 
@@ -105,8 +105,8 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-03-
 
 | Metric | Count |
 |--------|------:|
-| Test files | 160 |
-| TEST() definitions | 1,808 |
+| Test files | 170 |
+| TEST() definitions | 1,989 |
 | Subsystems covered | All major |
 | CI configurations | 10 jobs |
 | Sanitizer coverage | ASan + UBSan |
@@ -116,7 +116,7 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-03-
 | Metric | Count |
 |--------|------:|
 | CMake option() declarations | 21 |
-| ENABLE_* feature toggles | 14 |
+| ENABLE_* feature toggles | 13 |
 | CI jobs | 10 |
 | Supported compilers | MSVC v143/v144, GCC 13+, Clang 17+ |
 | Platforms | Windows, Linux, macOS (experimental) |

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -130,5 +130,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 169 |
 | Test cases | 1988+ |
 | Wiki pages | 65 |
-| *Last synced* | *2026-03-26 05:57* |
+| *Last synced* | *2026-03-26 06:29* |
 <!-- /AUTO:stats -->

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -58,6 +58,7 @@
 - [RHI Abstraction Layer](RHI-Abstraction-Layer)
 - [D3D12 Backend](D3D12-Backend)
 - [DXR Raytracing](DXR-Raytracing)
+- [Hybrid Ray Tracing](Hybrid-Ray-Tracing)
 - [Upscaling (DLSS/FSR)](Upscaling-System)
 
 ### Advanced


### PR DESCRIPTION
- Test counts: 1,808 → 1,989 across 160 → 170 files
- Editor panels: 32 → 52 across all documentation
- Build options table: replaced 31 phantom CMake options with the 20 actual options from CMakeLists.txt (removed ENABLE_PHYSX, ENABLE_AI, etc. that never existed; added ENABLE_HYBRID_RT, ENABLE_RECAST, BUILD_GAME_MODULES, SPARK_HEADLESS_SUPPORT, SPARK_DOUBLE_PRECISION_PHYSICS, etc.)
- Project structure: added SparkSDK/, GameModules/ (8 modules), Templates/, wiki/, cmake/ directories
- LOC: updated SparkEngine/Source 203,317 → 203,969, GameModules 50,630 → 50,807, Tests 41,279 → 48,990, total ~371,500 → ~379,000
- Wiki sidebar: added Hybrid Ray Tracing page link
- Updated across 14 files: README.md, CLAUDE.md, docs/README.md, 4 wiki pages, 3 GitHub prompt/instruction files, 3 .claude knowledge files

https://claude.ai/code/session_01AJ47YRAGV5AjhvJKrsXgRy