### PR TITLE
Audit engine: add validation, error checks, and safety guards

### DIFF
--- a/GameModules/SparkGameMMO/Source/Inventory/MMOInventorySystem.cpp
+++ b/GameModules/SparkGameMMO/Source/Inventory/MMOInventorySystem.cpp
@@ -170,6 +170,8 @@ namespace MMO
         float addWeight = def->weight * count;
         if (currentWeight + addWeight > inv.maxWeight)
         {
+            if (def->weight <= 0.0f)
+                return 0; // Zero-weight items can't reduce over-weight
             int fittable = static_cast<int>((inv.maxWeight - currentWeight) / def->weight);
             if (fittable <= 0)
                 return 0;
@@ -265,6 +267,8 @@ namespace MMO
             return results;
 
         const auto& table = it->second;
+        if (table.totalWeight <= 0.0f)
+            return results;
         std::uniform_real_distribution<float> dist(0.0f, table.totalWeight);
 
         for (int r = 0; r < rolls; ++r)

--- a/SparkEditor/Source/SceneSystem/SceneSerializer.cpp
+++ b/SparkEditor/Source/SceneSystem/SceneSerializer.cpp
@@ -176,14 +176,16 @@ namespace SparkEditor
             return false;
 
         uint32_t magic = 0;
-        file.read(reinterpret_cast<char*>(&magic), sizeof(magic));
+        if (!file.read(reinterpret_cast<char*>(&magic), sizeof(magic)))
+            return false;
         if (magic == SCENE_FILE_MAGIC)
             return true;
 
         // Check for JSON format
         file.seekg(0);
         char firstChar = 0;
-        file.read(&firstChar, 1);
+        if (!file.read(&firstChar, 1))
+            return false;
         return firstChar == '{';
     }
 

--- a/SparkEngine/Source/Core/EngineContext.h
+++ b/SparkEngine/Source/Core/EngineContext.h
@@ -320,6 +320,29 @@ class EngineContext : public Spark::IEngineContext
         return nullptr;
     }
 
+    /**
+     * @brief Retrieve a subsystem with a logged warning if not registered
+     *
+     * Use this variant when the caller expects the subsystem to be present.
+     * Returns nullptr with a diagnostic log message if missing, making it
+     * easier to track down initialization-order bugs.
+     *
+     * @param callerName  Name of the calling function (for diagnostics)
+     * @return Pointer to the system, or nullptr if not registered (with warning logged)
+     */
+    template <typename T> T* GetSystemChecked(const char* callerName = nullptr) const
+    {
+        T* system = GetSystem<T>();
+        if (!system)
+        {
+            // Log through stderr since we can't depend on Logger being available
+            // (Logger itself might be the missing subsystem)
+            std::fprintf(stderr, "[EngineContext] WARNING: Subsystem not registered (requested by %s)\n",
+                         callerName ? callerName : "unknown");
+        }
+        return system;
+    }
+
     // =========================================================================
     // Dependency-aware subsystem registration and lifecycle (R1.2)
     // =========================================================================

--- a/SparkEngine/Source/Engine/AI/BehaviorTreeNodes.h
+++ b/SparkEngine/Source/Engine/AI/BehaviorTreeNodes.h
@@ -208,6 +208,9 @@ namespace Spark::AI
 
         NodeStatus Tick(float deltaTime, Blackboard& blackboard) override
         {
+            if (!m_child)
+                return m_status = NodeStatus::Failure;
+
             NodeStatus status = m_child->Tick(deltaTime, blackboard);
             if (status == NodeStatus::Success)
                 return m_status = NodeStatus::Failure;
@@ -236,6 +239,9 @@ namespace Spark::AI
 
         NodeStatus Tick(float deltaTime, Blackboard& blackboard) override
         {
+            if (!m_child)
+                return m_status = NodeStatus::Failure;
+
             NodeStatus status = m_child->Tick(deltaTime, blackboard);
             if (status == NodeStatus::Running)
                 return m_status = NodeStatus::Running;
@@ -252,7 +258,8 @@ namespace Spark::AI
         {
             BTNode::Reset();
             m_currentCount = 0;
-            m_child->Reset();
+            if (m_child)
+                m_child->Reset();
         }
 
         const char* GetName() const override { return "Repeater"; }
@@ -280,6 +287,8 @@ namespace Spark::AI
 
         NodeStatus Tick(float deltaTime, Blackboard& blackboard) override
         {
+            if (!m_action)
+                return m_status = NodeStatus::Failure;
             return m_status = m_action(deltaTime, blackboard);
         }
 
@@ -306,6 +315,8 @@ namespace Spark::AI
 
         NodeStatus Tick(float deltaTime, Blackboard& blackboard) override
         {
+            if (!m_condition)
+                return m_status = NodeStatus::Failure;
             return m_status = m_condition(blackboard) ? NodeStatus::Success : NodeStatus::Failure;
         }
 

--- a/SparkEngine/Source/Engine/Animation/AnimationSystem.cpp
+++ b/SparkEngine/Source/Engine/Animation/AnimationSystem.cpp
@@ -419,6 +419,14 @@ namespace Spark::Animation
             // Read channels
             uint32_t channelCount = 0;
             file.read(reinterpret_cast<char*>(&channelCount), sizeof(channelCount));
+            // Sanity cap: prevent malformed files from causing huge allocations
+            constexpr uint32_t kMaxChannels = 10'000;
+            if (!file.good() || channelCount > kMaxChannels)
+            {
+                SPARK_LOG_WARN(LogCategory::Animation, "Invalid channel count %u in '%s'", channelCount,
+                               filepath.c_str());
+                break;
+            }
             clip->channels.reserve(channelCount);
 
             for (uint32_t ch = 0; ch < channelCount && file.good(); ++ch)
@@ -440,6 +448,9 @@ namespace Spark::Animation
                 // Read position keyframes
                 uint32_t posKeyCount = 0;
                 file.read(reinterpret_cast<char*>(&posKeyCount), sizeof(posKeyCount));
+                constexpr uint32_t kMaxKeyframes = 1'000'000;
+                if (posKeyCount > kMaxKeyframes)
+                    break;
                 boneAnim.positionKeys.resize(posKeyCount);
                 for (uint32_t k = 0; k < posKeyCount && file.good(); ++k)
                 {
@@ -450,6 +461,8 @@ namespace Spark::Animation
                 // Read rotation keyframes
                 uint32_t rotKeyCount = 0;
                 file.read(reinterpret_cast<char*>(&rotKeyCount), sizeof(rotKeyCount));
+                if (rotKeyCount > kMaxKeyframes)
+                    break;
                 boneAnim.rotationKeys.resize(rotKeyCount);
                 for (uint32_t k = 0; k < rotKeyCount && file.good(); ++k)
                 {
@@ -460,6 +473,8 @@ namespace Spark::Animation
                 // Read scale keyframes
                 uint32_t sclKeyCount = 0;
                 file.read(reinterpret_cast<char*>(&sclKeyCount), sizeof(sclKeyCount));
+                if (sclKeyCount > kMaxKeyframes)
+                    break;
                 boneAnim.scaleKeys.resize(sclKeyCount);
                 for (uint32_t k = 0; k < sclKeyCount && file.good(); ++k)
                 {

--- a/SparkEngine/Source/Engine/Gameplay/AbilitySystem.cpp
+++ b/SparkEngine/Source/Engine/Gameplay/AbilitySystem.cpp
@@ -228,6 +228,13 @@ namespace Spark::Gameplay
                 cast.phase = CastPhase::Failed;
             }
 
+            // Skip all phases that require a valid definition when def is null
+            if (!def && cast.phase != CastPhase::Completed && cast.phase != CastPhase::Failed &&
+                cast.phase != CastPhase::Interrupted)
+            {
+                cast.phase = CastPhase::Failed;
+            }
+
             switch (cast.phase)
             {
             case CastPhase::Casting:

--- a/SparkEngine/Source/Engine/Networking/EntityReplicator.cpp
+++ b/SparkEngine/Source/Engine/Networking/EntityReplicator.cpp
@@ -163,6 +163,13 @@ namespace Spark::Net
         {
             if ((dirtyMask >> i) & 1ULL)
             {
+                if (offset >= buffer.size())
+                {
+                    SPARK_LOG_WARN(Spark::LogCategory::Network,
+                                   "ProcessIncoming: buffer exhausted at field %u/%u for entity %u", i, fieldCount,
+                                   entityID);
+                    return true; // Partial update — not fatal
+                }
                 size_t bytesRead = entry.deserializer(i, buffer, offset);
                 if (bytesRead == 0)
                 {

--- a/SparkEngine/Source/Engine/Networking/NetworkReplication.cpp
+++ b/SparkEngine/Source/Engine/Networking/NetworkReplication.cpp
@@ -183,6 +183,11 @@ namespace Spark::Net
     void NetworkManager::DeserializeEntityState(NetBuffer& inBuffer)
     {
         uint32_t networkID = inBuffer.ReadUint32();
+        if (inBuffer.HasError())
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "DeserializeEntityState: malformed packet (no networkID)");
+            return;
+        }
 
         std::lock_guard<std::mutex> lock(m_replicationMutex);
         auto it = m_replicatedEntities.find(networkID);
@@ -197,7 +202,13 @@ namespace Spark::Net
             placeholder.velocity = inBuffer.ReadVector3();
             // Skip remaining property data
             uint16_t propCount = inBuffer.ReadUint16();
-            for (uint16_t i = 0; i < propCount; ++i)
+            if (inBuffer.HasError())
+            {
+                SPARK_LOG_WARN(Spark::LogCategory::Network,
+                               "DeserializeEntityState: truncated packet for placeholder netID=%u", networkID);
+                return;
+            }
+            for (uint16_t i = 0; i < propCount && !inBuffer.HasError(); ++i)
             {
                 inBuffer.ReadString(); // name
                 inBuffer.ReadUint8();  // type
@@ -215,11 +226,25 @@ namespace Spark::Net
         entity.lastUpdateTime = m_serverTime;
 
         uint16_t propCount = inBuffer.ReadUint16();
-        for (uint16_t i = 0; i < propCount; ++i)
+        if (inBuffer.HasError())
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "DeserializeEntityState: truncated packet for netID=%u",
+                           networkID);
+            return;
+        }
+        for (uint16_t i = 0; i < propCount && !inBuffer.HasError(); ++i)
         {
             std::string propName = inBuffer.ReadString();
             uint8_t propType = inBuffer.ReadUint8();
             (void)propType;
+
+            if (inBuffer.HasError())
+            {
+                SPARK_LOG_WARN(Spark::LogCategory::Network,
+                               "DeserializeEntityState: buffer error reading property %u/%u for netID=%u", i, propCount,
+                               networkID);
+                break;
+            }
 
             // Find matching property and deserialize
             for (auto& prop : entity.properties)

--- a/SparkEngine/Source/Engine/SaveSystem/SaveSystem.cpp
+++ b/SparkEngine/Source/Engine/SaveSystem/SaveSystem.cpp
@@ -1042,9 +1042,27 @@ namespace Spark
 
                 file.seekg(0, std::ios::end);
                 auto size = file.tellg();
+                if (size < 0)
+                    return false;
                 file.seekg(0, std::ios::beg);
+
+                // Sanity cap: reject unreasonably large save files (512 MB)
+                constexpr auto kMaxSaveFileSize = static_cast<std::streamoff>(512 * 1024 * 1024);
+                if (size > kMaxSaveFileSize)
+                {
+                    SPARK_LOG_WARN(Spark::LogCategory::Core, "Save file too large: %lld bytes",
+                                   static_cast<long long>(size));
+                    return false;
+                }
+
                 fileData.resize(static_cast<size_t>(size));
                 file.read(reinterpret_cast<char*>(fileData.data()), size);
+                if (!file)
+                {
+                    SPARK_LOG_WARN(Spark::LogCategory::Core, "Save file read incomplete: expected %lld bytes",
+                                   static_cast<long long>(size));
+                    return false;
+                }
             }
 
             if (fileData.size() < 8)
@@ -1101,12 +1119,25 @@ namespace Spark
             if (!readBytes(&entityCount, sizeof(entityCount)))
                 return false;
 
+            // Sanity cap: prevent malformed files from causing huge allocations
+            constexpr uint32_t kMaxEntities = 1'000'000;
+            if (entityCount > kMaxEntities)
+            {
+                SPARK_LOG_WARN(Spark::LogCategory::Core, "Save file entity count %u exceeds limit %u", entityCount,
+                               kMaxEntities);
+                return false;
+            }
+
             for (uint32_t i = 0; i < entityCount; ++i)
             {
                 SerializedEntity entity;
 
                 uint16_t nameLen;
                 if (!readBytes(&nameLen, sizeof(nameLen)))
+                    return false;
+                // Cap string lengths to prevent malformed data from causing huge allocations
+                constexpr uint16_t kMaxStringLen = 4096;
+                if (nameLen > kMaxStringLen)
                     return false;
                 entity.name.resize(nameLen);
                 if (!readBytes(entity.name.data(), nameLen))
@@ -1122,6 +1153,9 @@ namespace Spark
 
                     uint16_t typeLen;
                     if (!readBytes(&typeLen, sizeof(typeLen)))
+                        return false;
+                    constexpr uint16_t kMaxTypeLen = 4096;
+                    if (typeLen > kMaxTypeLen)
                         return false;
                     comp.typeName.resize(typeLen);
                     if (!readBytes(comp.typeName.data(), typeLen))
@@ -1160,6 +1194,9 @@ namespace Spark
             uint32_t customStateCount = 0;
             if (readBytes(&customStateCount, sizeof(customStateCount)))
             {
+                constexpr uint32_t kMaxCustomState = 100'000;
+                if (customStateCount > kMaxCustomState)
+                    return false;
                 for (uint32_t i = 0; i < customStateCount; ++i)
                 {
                     uint16_t keyLen;

--- a/SparkEngine/Source/Graphics/RHI/RHIAdapter.cpp
+++ b/SparkEngine/Source/Graphics/RHI/RHIAdapter.cpp
@@ -9,7 +9,6 @@
 #include "../../Utils/Validate.h"
 
 #include <algorithm>
-#include <cassert>
 
 namespace Spark::RHI
 {
@@ -75,6 +74,12 @@ namespace Spark::RHI
 
         m_device->BeginFrame();
         m_commandList = m_device->GetImmediateCommandList();
+        if (!m_commandList)
+        {
+            SPARK_LOG_ERROR(Spark::LogCategory::Graphics,
+                            "RHIAdapter::BeginFrame -- GetImmediateCommandList returned null");
+            return;
+        }
         m_commandList->Begin();
         m_frameActive = true;
     }
@@ -83,6 +88,12 @@ namespace Spark::RHI
     {
         SPARK_REQUIRE_MSG(Spark::LogCategory::Graphics, m_frameActive, "RHIAdapter::EndFrame -- no frame in progress");
 
+        if (!m_commandList)
+        {
+            SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "RHIAdapter::EndFrame -- command list is null");
+            m_frameActive = false;
+            return;
+        }
         m_commandList->End();
         m_device->EndFrame();
         m_frameActive = false;
@@ -94,13 +105,13 @@ namespace Spark::RHI
 
     void RHIAdapter::BeginPass(const char* name)
     {
-        assert(m_commandList && "RHIAdapter::BeginPass -- no active command list");
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->BeginEvent(name);
     }
 
     void RHIAdapter::EndPass()
     {
-        assert(m_commandList && "RHIAdapter::EndPass -- no active command list");
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->EndEvent();
     }
 
@@ -110,7 +121,7 @@ namespace Spark::RHI
 
     void RHIAdapter::SetRenderTargets(std::span<IRHITexture* const> renderTargets, IRHITexture* depthStencil)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
 
         auto count = static_cast<uint32_t>(renderTargets.size());
         m_commandList->SetRenderTargets(renderTargets.data(), count, depthStencil);
@@ -118,13 +129,13 @@ namespace Spark::RHI
 
     void RHIAdapter::ClearRenderTarget(IRHITexture* target, const float color[4])
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->ClearRenderTarget(target, color);
     }
 
     void RHIAdapter::ClearDepthStencil(IRHITexture* target, float depth, uint8_t stencil)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->ClearDepthStencil(target, depth, stencil);
     }
 
@@ -134,7 +145,7 @@ namespace Spark::RHI
 
     void RHIAdapter::SetViewport(float x, float y, float width, float height, float minDepth, float maxDepth)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
 
         RHIViewport vp{};
         vp.x = x;
@@ -153,7 +164,7 @@ namespace Spark::RHI
 
     void RHIAdapter::SetScissorRect(const AdapterScissorRect& rect)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
 
         RHIScissorRect sr{};
         sr.left = rect.left;
@@ -179,13 +190,13 @@ namespace Spark::RHI
 
     void RHIAdapter::SetPipelineState(IRHIPipelineState* pso)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->SetPipelineState(pso);
     }
 
     void RHIAdapter::SetPrimitiveTopology(RHIPrimitiveTopology topology)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->SetPrimitiveTopology(topology);
     }
 
@@ -195,31 +206,31 @@ namespace Spark::RHI
 
     void RHIAdapter::BindVertexBuffer(IRHIBuffer* buffer, uint32_t slot, uint32_t offset)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->SetVertexBuffer(buffer, slot, offset);
     }
 
     void RHIAdapter::BindIndexBuffer(IRHIBuffer* buffer, uint32_t offset)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->SetIndexBuffer(buffer, offset);
     }
 
     void RHIAdapter::BindConstantBuffer(RHIShaderStage stage, uint32_t slot, IRHIBuffer* buffer)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->SetConstantBuffer(stage, slot, buffer);
     }
 
     void RHIAdapter::BindTexture(RHIShaderStage stage, uint32_t slot, IRHITexture* texture)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->SetShaderResource(stage, slot, texture);
     }
 
     void RHIAdapter::BindSampler(RHIShaderStage stage, uint32_t slot, IRHISampler* sampler)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->SetSampler(stage, slot, sampler);
     }
 
@@ -229,27 +240,27 @@ namespace Spark::RHI
 
     void RHIAdapter::Draw(uint32_t vertexCount, uint32_t startVertex)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->Draw(vertexCount, startVertex);
     }
 
     void RHIAdapter::DrawIndexed(uint32_t indexCount, uint32_t startIndex, int32_t baseVertex)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->DrawIndexed(indexCount, startIndex, baseVertex);
     }
 
     void RHIAdapter::DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertex,
                                    uint32_t startInstance)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->DrawInstanced(vertexCount, instanceCount, startVertex, startInstance);
     }
 
     void RHIAdapter::DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount, uint32_t startIndex,
                                           int32_t baseVertex, uint32_t startInstance)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->DrawIndexedInstanced(indexCount, instanceCount, startIndex, baseVertex, startInstance);
     }
 
@@ -259,7 +270,7 @@ namespace Spark::RHI
 
     void RHIAdapter::Dispatch(uint32_t groupsX, uint32_t groupsY, uint32_t groupsZ)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->Dispatch(groupsX, groupsY, groupsZ);
     }
 
@@ -269,19 +280,19 @@ namespace Spark::RHI
 
     void RHIAdapter::DrawInstancedIndirect(IRHIBuffer* argsBuffer, uint32_t argsOffset)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->DrawInstancedIndirect(argsBuffer, argsOffset);
     }
 
     void RHIAdapter::DrawIndexedInstancedIndirect(IRHIBuffer* argsBuffer, uint32_t argsOffset)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->DrawIndexedInstancedIndirect(argsBuffer, argsOffset);
     }
 
     void RHIAdapter::DispatchIndirect(IRHIBuffer* argsBuffer, uint32_t argsOffset)
     {
-        assert(m_commandList);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_commandList);
         m_commandList->DispatchIndirect(argsBuffer, argsOffset);
     }
 
@@ -291,7 +302,7 @@ namespace Spark::RHI
 
     IRHIBuffer* RHIAdapter::CreateVertexBuffer(const void* data, uint64_t size, uint32_t stride)
     {
-        assert(m_device);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, m_device, nullptr);
 
         RHIBufferDesc desc{};
         desc.size = size;
@@ -310,7 +321,7 @@ namespace Spark::RHI
 
     IRHIBuffer* RHIAdapter::CreateIndexBuffer(const void* data, uint64_t size, uint32_t stride)
     {
-        assert(m_device);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, m_device, nullptr);
 
         RHIBufferDesc desc{};
         desc.size = size;
@@ -329,7 +340,7 @@ namespace Spark::RHI
 
     IRHIBuffer* RHIAdapter::CreateConstantBuffer(uint64_t size)
     {
-        assert(m_device);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, m_device, nullptr);
 
         RHIBufferDesc desc{};
         desc.size = size;
@@ -348,7 +359,7 @@ namespace Spark::RHI
 
     IRHIBuffer* RHIAdapter::CreateStructuredBuffer(const void* data, uint64_t size, uint32_t stride)
     {
-        assert(m_device);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, m_device, nullptr);
 
         RHIBufferDesc desc{};
         desc.size = size;
@@ -372,7 +383,7 @@ namespace Spark::RHI
     IRHITexture* RHIAdapter::CreateTexture2D(uint32_t width, uint32_t height, PixelFormat format, RHITextureUsage usage,
                                              const void* initialData)
     {
-        assert(m_device);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, m_device, nullptr);
 
         RHITextureDesc desc{};
         desc.width = width;
@@ -399,7 +410,7 @@ namespace Spark::RHI
 
     IRHITexture* RHIAdapter::CreateDepthStencil(uint32_t width, uint32_t height, PixelFormat format)
     {
-        assert(m_device);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, m_device, nullptr);
 
         RHITextureDesc desc{};
         desc.width = width;
@@ -424,7 +435,7 @@ namespace Spark::RHI
 
     IRHITexture* RHIAdapter::CreateRenderTarget(uint32_t width, uint32_t height, PixelFormat format)
     {
-        assert(m_device);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, m_device, nullptr);
 
         RHITextureDesc desc{};
         desc.width = width;
@@ -451,7 +462,7 @@ namespace Spark::RHI
 
     IRHISampler* RHIAdapter::CreateSampler(const RHISamplerDesc& desc)
     {
-        assert(m_device);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, m_device, nullptr);
 
         auto sampler = m_device->CreateSampler(desc);
         IRHISampler* raw = sampler.get();
@@ -467,7 +478,7 @@ namespace Spark::RHI
     IRHIPipelineState* RHIAdapter::CreateGraphicsPipeline(const RHIPipelineStateDesc& desc, IRHIShader* vertexShader,
                                                           IRHIShader* pixelShader)
     {
-        assert(m_device);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, m_device, nullptr);
 
         auto pso = m_device->CreatePipelineState(desc, vertexShader, pixelShader);
         IRHIPipelineState* raw = pso.get();
@@ -482,7 +493,7 @@ namespace Spark::RHI
 
     IRHIShader* RHIAdapter::CreateShader(const RHIShaderDesc& desc)
     {
-        assert(m_device);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, m_device, nullptr);
 
         auto shader = m_device->CreateShader(desc);
         IRHIShader* raw = shader.get();
@@ -497,19 +508,22 @@ namespace Spark::RHI
 
     void RHIAdapter::UpdateBuffer(IRHIBuffer* buffer, const void* data, size_t size, size_t offset)
     {
-        assert(m_device && buffer);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_device);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, buffer);
         m_device->UpdateBuffer(buffer, data, size, offset);
     }
 
     void* RHIAdapter::MapBuffer(IRHIBuffer* buffer)
     {
-        assert(m_device && buffer);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, m_device, nullptr);
+        SPARK_VALIDATE_NOT_NULL_RET(Spark::LogCategory::Graphics, buffer, nullptr);
         return m_device->MapBuffer(buffer);
     }
 
     void RHIAdapter::UnmapBuffer(IRHIBuffer* buffer)
     {
-        assert(m_device && buffer);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, m_device);
+        SPARK_VALIDATE_NOT_NULL(Spark::LogCategory::Graphics, buffer);
         m_device->UnmapBuffer(buffer);
     }
 
@@ -575,7 +589,7 @@ namespace Spark::RHI
 
     const RHIDeviceCapabilities& RHIAdapter::GetCapabilities() const
     {
-        assert(m_device);
+        SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, m_device);
         return m_device->GetCapabilities();
     }
 
@@ -590,7 +604,7 @@ namespace Spark::RHI
 
     const RHIStatistics& RHIAdapter::GetStatistics() const
     {
-        assert(m_device);
+        SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Graphics, m_device);
         return m_device->GetStatistics();
     }
 

--- a/SparkEngine/Source/Graphics/TextureSystem.cpp
+++ b/SparkEngine/Source/Graphics/TextureSystem.cpp
@@ -77,6 +77,15 @@ HRESULT Texture::CreateFromFile(const std::string& filePath, ID3D11Device* devic
     if (FAILED(hr))
         return hr;
 
+    // Validate dimensions before allocation to prevent integer overflow
+    if (width == 0 || height == 0)
+        return E_INVALIDARG;
+
+    // Check for multiplication overflow: width * 4 * height
+    constexpr UINT kMaxTextureBytes = 256u * 1024u * 1024u; // 256 MB sanity limit
+    if (width > kMaxTextureBytes / 4 || (width * 4) > kMaxTextureBytes / height)
+        return E_OUTOFMEMORY;
+
     // Read pixel data
     UINT stride = width * 4;
     UINT bufferSize = stride * height;
@@ -99,7 +108,10 @@ HRESULT Texture::CreateFromFile(const std::string& filePath, ID3D11Device* devic
 
 HRESULT Texture::CreateFromData(const void* data, size_t dataSize, ID3D11Device* device)
 {
-    if (!device || !data)
+    if (!device || !data || dataSize == 0)
+        return E_INVALIDARG;
+
+    if (m_desc.width == 0 || m_desc.height == 0)
         return E_INVALIDARG;
 
     D3D11_TEXTURE2D_DESC texDesc = {};


### PR DESCRIPTION
Fix critical null dereference in AbilitySystem::UpdateCasts when def is null but cast phase is not terminal. Add integer overflow protection to TextureSystem for width*height calculations. Cap deserialization sizes in SaveSystem and AnimationSystem to prevent malformed files from causing unbounded allocations. Add buffer error checking to NetworkReplication deserialization and EntityReplicator offset validation. Replace debug-only assert() calls in RHIAdapter with SPARK_VALIDATE macros that work in Release builds. Add null child/callback guards to BehaviorTree decorator and leaf nodes. Add file-read result validation to SceneSerializer and SaveSystem. Guard against division-by-zero in MMO inventory weight and loot table rolls. Add GetSystemChecked<T>() to EngineContext for diagnostic-logged subsystem lookups.

https://claude.ai/code/session_016wjqeUyxrCrmMwZ44hVXWF