### PR TITLE
Add setup script and knowledge base for MinGW+Wine cross-compilation

### DIFF
--- a/.claude/index.md
+++ b/.claude/index.md
@@ -27,6 +27,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 | ThirdParty dependencies | [knowledge/thirdparty-dependencies-audit.md](knowledge/thirdparty-dependencies-audit.md) | Observation | Active | 2026-03-17 |
 | Load test baseline (frame/CPU/memory benchmarks) | [knowledge/load-test-baseline.md](knowledge/load-test-baseline.md) | Observation | Active | 2026-03-26 |
 | Live editor testing (Xvfb + Mesa llvmpipe) | [knowledge/live-editor-testing.md](knowledge/live-editor-testing.md) | Pattern | Active | 2026-03-28 |
+| MinGW + Wine cross-compilation (D3D11/D3D12 on Linux) | [knowledge/mingw-wine-cross-compilation.md](knowledge/mingw-wine-cross-compilation.md) | Pattern | Active | 2026-03-28 |
 ## Quick Reference
 
 ### Current Engine State (2026-03-22)

--- a/.claude/knowledge/mingw-wine-cross-compilation.md
+++ b/.claude/knowledge/mingw-wine-cross-compilation.md
@@ -1,0 +1,94 @@
+# MinGW + Wine Cross-Compilation (D3D11/D3D12 on Linux)
+
+**Last updated:** 2026-03-28
+**Type:** Pattern
+**Status:** Active
+
+## Description
+
+SparkEngine can cross-compile its Windows D3D11/D3D12 code paths on Linux using MinGW-w64, then run the resulting `.exe` under Wine. Combined with DXVK (D3D11→Vulkan), VKD3D-Proton (D3D12→Vulkan), and Mesa Lavapipe (software Vulkan), this exercises the exact same `_WIN32` code that MSVC compiles — without Windows or a GPU.
+
+## Approach
+
+### The Stack
+
+```
+D3D11/D3D12 C++ (same #ifdef _WIN32 paths as MSVC)
+  → MinGW-w64 (x86_64-w64-mingw32-g++) → .exe
+  → Wine (translates Windows API calls)
+  → DXVK (translates D3D11 → Vulkan)
+  → VKD3D-Proton (translates D3D12 → Vulkan)
+  → Lavapipe (software Vulkan on CPU)
+```
+
+### Prerequisites
+
+```bash
+sudo tools/setup-mingw-wine.sh          # Install everything
+tools/setup-mingw-wine.sh --check       # Verify installation
+```
+
+Or manually:
+```bash
+sudo apt-get install mingw-w64 wine64 mesa-vulkan-drivers
+# Optional: sudo apt-get install dxvk
+```
+
+### Build and Run
+
+```bash
+cmake --preset linux-mingw-release
+cmake --build build/linux-mingw-release
+tools/wine-run.sh build/linux-mingw-release/bin/SparkTests.exe
+```
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `cmake/toolchains/mingw-w64-x86_64.cmake` | CMake toolchain (sets cross-compiler, sysroot, static linking) |
+| `tools/wine-run.sh` | Wine runner (auto-detects DXVK, VKD3D-Proton, Lavapipe) |
+| `tools/setup-mingw-wine.sh` | Install + verify all prerequisites |
+| `CMakePresets.json` | `linux-mingw-release` / `linux-mingw-debug` presets |
+
+### CMake Changes for MinGW
+
+1. `SPARK_PLATFORM_WINDOWS` is now defined for `MINGW` (was MSVC-only) — needed for D3D11 includes
+2. `d3d12` added to Windows link libraries (was missing)
+3. MinGW detected as GCC, so GCC flags apply (not `/W3` etc.)
+4. Toolchain sets `-static-libgcc -static-libstdc++` so .exe doesn't need MinGW DLLs
+
+### Software Rendering Fallback (All Backends)
+
+| Backend | Windows Software | Linux Software |
+|---------|-----------------|----------------|
+| D3D11 | WARP (`D3D_DRIVER_TYPE_WARP`) | Wine + DXVK + Lavapipe |
+| D3D12 | WARP (`EnumWarpAdapter()`) | Wine + VKD3D-Proton + Lavapipe |
+| Vulkan | — | Lavapipe (`VK_PHYSICAL_DEVICE_TYPE_CPU`) |
+| OpenGL | — | llvmpipe (EGL headless or GLX+Xvfb) |
+| None | NullRHIDevice | NullRHIDevice |
+
+All backends track `isSoftwareDevice` in `RHIDeviceCapabilities`.
+
+### CI Job
+
+`build-linux-mingw-wine` in `.github/workflows/build.yml`:
+- `continue-on-error: true` (non-blocking)
+- Installs MinGW, Wine, Mesa Lavapipe
+- Cross-compiles with MinGW toolchain
+- Runs tests under Wine
+
+### Troubleshooting
+
+- **MinGW `d3d11.h` not found**: Ensure `mingw-w64` package is installed (includes DirectX headers)
+- **Wine crashes**: Check `WINEDEBUG=warn+all` for details. `wineboot --init` resets the prefix.
+- **Lavapipe not detected**: Set `VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json`
+- **DXVK not available**: Wine's built-in WineD3D translates D3D→OpenGL (slower but works)
+- **`apt-get` timeouts**: Use `--fix-broken` and retry. Sandbox environments may block package downloads.
+
+## Notes
+
+- MinGW defines `_WIN32` automatically — D3D12 code compiles without changes
+- D3D11 code needs `SPARK_PLATFORM_WINDOWS` (now set for MinGW in CMakeLists.txt)
+- MSVC-specific features (`__declspec`, `#pragma comment(lib)`) are handled by MinGW compatibility
+- The `#pragma comment(lib, ...)` in D3D11Device.cpp is MSVC-only; MinGW uses CMake's `target_link_libraries`

--- a/tools/setup-mingw-wine.sh
+++ b/tools/setup-mingw-wine.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# setup-mingw-wine.sh — Install all prerequisites for cross-compiling
+# SparkEngine's Windows D3D11/D3D12 backends on Linux and running under Wine.
+#
+# Usage:
+#   sudo tools/setup-mingw-wine.sh
+#   tools/setup-mingw-wine.sh --check    # Verify installation without installing
+#
+# After installation, build and run:
+#   cmake --preset linux-mingw-release
+#   cmake --build build/linux-mingw-release
+#   tools/wine-run.sh build/linux-mingw-release/bin/SparkTests.exe
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+ok()   { echo -e "${GREEN}[OK]${NC}    $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC}  $1"; }
+fail() { echo -e "${RED}[MISS]${NC}  $1"; }
+
+# ============================================================================
+# Check mode — verify what's installed without changing anything
+# ============================================================================
+
+check_installation() {
+    echo "=== SparkEngine MinGW + Wine Cross-Compilation Check ==="
+    echo ""
+    local all_ok=true
+
+    # MinGW
+    if command -v x86_64-w64-mingw32-g++ &>/dev/null; then
+        ok "MinGW-w64 g++: $(x86_64-w64-mingw32-g++ --version | head -1)"
+    else
+        fail "MinGW-w64 g++ not found"
+        all_ok=false
+    fi
+
+    if command -v x86_64-w64-mingw32-gcc &>/dev/null; then
+        ok "MinGW-w64 gcc: $(x86_64-w64-mingw32-gcc --version | head -1)"
+    else
+        fail "MinGW-w64 gcc not found"
+        all_ok=false
+    fi
+
+    # Check for D3D headers in MinGW sysroot
+    if [ -f /usr/x86_64-w64-mingw32/include/d3d11.h ]; then
+        ok "D3D11 headers present (d3d11.h)"
+    else
+        fail "D3D11 headers missing"
+        all_ok=false
+    fi
+
+    if [ -f /usr/x86_64-w64-mingw32/include/d3d12.h ]; then
+        ok "D3D12 headers present (d3d12.h)"
+    else
+        fail "D3D12 headers missing"
+        all_ok=false
+    fi
+
+    # Wine
+    if command -v wine64 &>/dev/null; then
+        ok "Wine: $(wine64 --version 2>/dev/null || echo 'version unknown')"
+    else
+        fail "Wine not found"
+        all_ok=false
+    fi
+
+    if command -v wineboot &>/dev/null; then
+        ok "wineboot available"
+    else
+        fail "wineboot not found"
+        all_ok=false
+    fi
+
+    # Mesa Lavapipe (software Vulkan)
+    local lavapipe_found=false
+    for icd in \
+        /usr/share/vulkan/icd.d/lvp_icd.x86_64.json \
+        /usr/share/vulkan/icd.d/lvp_icd.json; do
+        if [ -f "$icd" ]; then
+            ok "Lavapipe ICD: $icd"
+            lavapipe_found=true
+            break
+        fi
+    done
+    if [ "$lavapipe_found" = false ]; then
+        fail "Lavapipe (mesa-vulkan-drivers) not found"
+        all_ok=false
+    fi
+
+    # DXVK (optional — D3D11->Vulkan translation)
+    local dxvk_found=false
+    for path in /usr/share/dxvk/x64 /usr/lib/dxvk /opt/dxvk/x64; do
+        if [ -f "$path/d3d11.dll" ]; then
+            ok "DXVK: $path"
+            dxvk_found=true
+            break
+        fi
+    done
+    if [ "$dxvk_found" = false ]; then
+        warn "DXVK not found (optional — Wine's built-in WineD3D will be used for D3D11)"
+    fi
+
+    # VKD3D-Proton (optional — D3D12->Vulkan translation)
+    local vkd3d_found=false
+    for path in /usr/share/vkd3d-proton/x64 /usr/lib/vkd3d-proton /opt/vkd3d-proton/x64; do
+        if [ -f "$path/d3d12.dll" ]; then
+            ok "VKD3D-Proton: $path"
+            vkd3d_found=true
+            break
+        fi
+    done
+    if [ "$vkd3d_found" = false ]; then
+        warn "VKD3D-Proton not found (optional — D3D12 codepaths won't be exercised at runtime)"
+    fi
+
+    # CMake
+    if command -v cmake &>/dev/null; then
+        ok "CMake: $(cmake --version | head -1)"
+    else
+        fail "CMake not found"
+        all_ok=false
+    fi
+
+    echo ""
+    if [ "$all_ok" = true ]; then
+        echo -e "${GREEN}All required tools are installed. Ready to cross-compile.${NC}"
+        echo ""
+        echo "Build:  cmake --preset linux-mingw-release && cmake --build build/linux-mingw-release"
+        echo "Run:    tools/wine-run.sh build/linux-mingw-release/bin/SparkTests.exe"
+        return 0
+    else
+        echo -e "${RED}Some required tools are missing. Run: sudo tools/setup-mingw-wine.sh${NC}"
+        return 1
+    fi
+}
+
+if [ "${1:-}" = "--check" ]; then
+    check_installation
+    exit $?
+fi
+
+# ============================================================================
+# Install mode — must run as root
+# ============================================================================
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Run with sudo: sudo $0"
+    exit 1
+fi
+
+echo "=== Installing MinGW + Wine Cross-Compilation Prerequisites ==="
+echo ""
+
+# Step 1: Update package lists
+echo ">>> Updating package lists..."
+apt-get update -qq
+
+# Step 2: Install MinGW-w64 cross-compiler
+echo ">>> Installing MinGW-w64 (cross-compiler for Windows targets)..."
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    mingw-w64 \
+    cmake \
+    ccache
+
+# Step 3: Install Wine (for running .exe files)
+echo ">>> Installing Wine..."
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    wine64
+
+# Step 4: Install Mesa Lavapipe (software Vulkan for GPU-less environments)
+echo ">>> Installing Mesa Lavapipe (software Vulkan)..."
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    mesa-vulkan-drivers
+
+# Step 5: Install DXVK (optional — D3D11->Vulkan translation)
+echo ">>> Installing DXVK (D3D11->Vulkan, optional)..."
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    dxvk 2>/dev/null || echo "  DXVK package not available — Wine's built-in WineD3D will be used"
+
+echo ""
+echo "=== Installation Complete ==="
+echo ""
+
+# Run verification
+check_installation

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -130,5 +130,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 180 |
 | Test cases | 2172+ |
 | Wiki pages | 65 |
-| *Last synced* | *2026-03-28 06:12* |
+| *Last synced* | *2026-03-28 08:19* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
New files:
- tools/setup-mingw-wine.sh: install + verify all prerequisites (MinGW, Wine, Mesa Lavapipe, DXVK). Supports --check mode.
- .claude/knowledge/mingw-wine-cross-compilation.md: complete reference for the cross-compilation stack, troubleshooting, and CI integration.

https://claude.ai/code/session_01Auy51Pq8mmdKcTDQ3LtTSf