### PR TITLE
feat: add macOS compatibility infrastructure (CMake presets, CI, POSI…

### DIFF
--- a/.claude/index.md
+++ b/.claude/index.md
@@ -30,6 +30,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 | MinGW + Wine cross-compilation (D3D11/D3D12 on Linux) | [knowledge/mingw-wine-cross-compilation.md](knowledge/mingw-wine-cross-compilation.md) | Pattern | Active | 2026-03-28 |
 | Hardware acceleration (8 GPU systems, 72 tests) | [knowledge/hardware-acceleration-systems.md](knowledge/hardware-acceleration-systems.md) | Decision | Active | 2026-03-28 |
 | RAII deep analysis (all subsystems, all items resolved) | [knowledge/raii-codebase-analysis.md](knowledge/raii-codebase-analysis.md) | Observation | **Resolved** | 2026-03-28 |
+| Mac compatibility analysis (gaps, roadmap, changes) | [knowledge/mac-compatibility-analysis.md](knowledge/mac-compatibility-analysis.md) | Observation | Active | 2026-03-28 |
 ## Quick Reference
 
 ### Current Engine State (2026-03-22)

--- a/.claude/knowledge/mac-compatibility-analysis.md
+++ b/.claude/knowledge/mac-compatibility-analysis.md
@@ -1,0 +1,51 @@
+# Mac Compatibility Analysis
+
+**Last updated:** 2026-03-28
+**Type:** Observation
+**Status:** Active
+
+## Description
+
+Deep analysis of macOS compatibility for SparkEngine, covering all subsystems from graphics to audio to build infrastructure.
+
+## Details
+
+### Ready (no work needed)
+- **Platform abstraction**: `Platform.h` detects `__APPLE__`, defines `SPARK_PLATFORM_MACOS`, Apple Clang detected
+- **Audio**: `OpenALAudioEngine.h` compiles for macOS (guard: `!SPARK_PLATFORM_WINDOWS`)
+- **Networking**: POSIX sockets with `fcntl()` fallback in `UDPTransport.h`
+- **Physics**: Jolt Physics is cross-platform; Metal compute optional via `xcrun`
+- **Module loading**: `dlopen`/`dlsym` fallback in `ModuleManager.cpp` for `.dylib`
+- **Crash handling**: POSIX signals + `backtrace()` (now includes macOS guards)
+- **Console process manager**: POSIX `fork`/`exec` (now includes macOS guards)
+- **Third-party deps**: All support macOS (Jolt, EnTT, ImGui, AngelScript, SDL2, GLAD, OpenAL, Recast)
+
+### Critical gaps
+1. **Metal backend**: Header-only (`MetalDevice.h`, 542 lines). No `.mm` implementation exists. ~2,500 lines needed.
+2. **Input system**: `InputManager.cpp` is Win32-only. Needs SDL2 variant for macOS.
+3. **OpenGL on Mac**: macOS caps at GL 4.1; engine uses GL 4.6. Not viable long-term.
+
+### Fastest path to Mac graphics
+Vulkan via **MoltenVK** — `VulkanDevice.h` already defines `VK_USE_PLATFORM_METAL_EXT`. Existing SPIR-V pipeline works unchanged.
+
+### Changes made in this session
+- Added macOS CMake presets (`macos-debug`, `macos-release`, `macos-metal`) to `CMakePresets.json`
+- Expanded `SPARK_PLATFORM_LINUX` guards to `SPARK_PLATFORM_LINUX || SPARK_PLATFORM_MACOS` in:
+  - `CrashHandler.cpp` (includes, signal handler, system info with macOS `sysctl`/`mach` APIs)
+  - `ConsoleProcessManagerLinux.cpp`, `ConsoleProcessManager.cpp`, `ConsoleProcessManager.h`
+  - `ConsoleProcessManagerStub.cpp` (excluded macOS from stub)
+- Added macOS framework linking in `CMakeLists.txt` (Cocoa, IOKit, CoreVideo + rpath)
+- Added `build-macos` CI job (continue-on-error, Apple Clang, SDL2+OpenGL)
+
+### Key files
+- `SparkEngine/Source/Graphics/RHI/Metal/MetalDevice.h` — Metal interface (header only)
+- `SparkEngine/Source/Graphics/RHI/RHIFactory.cpp` — Backend selection (Metal on `__APPLE__`)
+- `SparkEngine/Source/Core/Platform.h` — Platform/compiler detection
+- `SparkEngine/Source/Audio/OpenALAudioEngine.h` — Cross-platform audio
+- `SparkEngine/Source/Input/InputManager.cpp` — Win32-only (needs SDL2 variant)
+
+## Notes
+
+- Metal files are excluded from clang-format CI checks (`-not -path '*/Metal/*'`)
+- macOS CI job uses `continue-on-error: true` until support stabilizes
+- MoltenVK path avoids ~2,500 lines of Objective-C++ Metal implementation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -766,6 +766,87 @@ jobs:
         retention-days: 14
 
   # ===========================================================================
+  # macOS Build — Apple Clang (experimental)
+  # Validates cross-platform compatibility on macOS with SDL2 + OpenGL.
+  # Marked continue-on-error until macOS support is fully stabilized.
+  # ===========================================================================
+  build-macos:
+    runs-on: macos-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        config: [Debug, Release]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+
+    - name: Install dependencies
+      run: brew install cmake sdl2
+
+    - name: Configure CMake
+      run: |
+        cmake -B build \
+          -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
+          -DBUILD_TESTS=ON \
+          -DENABLE_VULKAN=OFF \
+          -DENABLE_OPENGL=ON \
+          -DENABLE_METAL=OFF 2>&1 | tee cmake-configure.log
+
+    - name: Build
+      run: cmake --build build --parallel $(sysctl -n hw.logicalcpu) 2>&1 | tee cmake-build.log
+
+    - name: Run Tests
+      if: matrix.config == 'Release'
+      run: cd build && ./bin/SparkTests 2>&1 | tee ../test-results.log
+
+    - name: Report errors to PR
+      if: failure() && github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          let body = `## :warning: build-macos (${{ matrix.config }}) failed\n\n`;
+          body += `> This is a **non-blocking** job. macOS support is experimental.\n\n`;
+
+          for (const [label, file] of [
+            ['CMake Configure', 'cmake-configure.log'],
+            ['Build Output', 'cmake-build.log'],
+            ['Test Results', 'test-results.log']
+          ]) {
+            try {
+              const log = fs.readFileSync(file, 'utf8');
+              const lines = log.split('\n');
+              const issues = lines.filter(l =>
+                /error[:\s]|warning[:\s]|FAILED|FAIL:|fatal error/i.test(l)
+              );
+              if (issues.length > 0) {
+                const snippet = issues.slice(-80).join('\n');
+                body += `### ${label}\n\`\`\`\n${snippet.slice(-30000)}\n\`\`\`\n\n`;
+              }
+            } catch (e) { /* file doesn't exist */ }
+          }
+
+          if (body.includes('```')) {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body.slice(0, 65000)
+            });
+          }
+
+    - name: Upload Build Artifacts
+      if: matrix.config == 'Release'
+      uses: actions/upload-artifact@v7
+      with:
+        name: SparkEngine-macOS-${{ matrix.config }}
+        path: build/bin/
+        retention-days: 14
+
+  # ===========================================================================
   # Code Coverage — GCC with lcov
   # ===========================================================================
   coverage:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ SparkEngine is a C++23 open-source 3D game engine (with C++26 forward-compatibil
 - **Networking**: UDP client/server, AreaServer/WorldServer architecture (HeroEngine-inspired)
 - **Large worlds**: Floating-point origin rebasing, seamless area streaming
 - **Headless/Software rendering**: NullRHIDevice fallback (no GPU) or full CPU rendering via OpenGL + Mesa llvmpipe
-- **Primary platform**: Windows 10+ (MSVC); Linux/macOS are experimental
+- **Primary platform**: Windows 10+ (MSVC); Linux/macOS are experimental (macOS has CI job + CMake presets)
 
 ## Build
 
@@ -20,6 +20,7 @@ SparkEngine is a C++23 open-source 3D game engine (with C++26 forward-compatibil
 # Generate (pick one)
 cmake --preset windows-release       # Windows MSVC
 cmake --preset linux-gcc-release     # Linux GCC
+cmake --preset macos-release         # macOS Apple Clang (experimental)
 
 # Build
 cmake --build build --config Release
@@ -523,6 +524,7 @@ ctest --test-dir build -C Release --output-on-failure
 | `build-windows-vs2022` | windows-latest | MSVC v143 | Debug, Release | `-DBUILD_TESTS=ON` |
 | `build-windows-vs2026` | windows-latest | MSVC v144 | Debug, Release | `continue-on-error` |
 | `build-linux-mingw-wine` | ubuntu-24.04 | MinGW-w64 + Wine | Release | `continue-on-error`, D3D11/D3D12 on Linux |
+| `build-macos` | macos-latest | Apple Clang | Debug, Release | `continue-on-error`, SDL2 + OpenGL |
 | `coverage` | ubuntu-24.04 | GCC | Debug | `--coverage` + lcov |
 | `clang-tidy` | ubuntu-24.04 | Clang | Debug | `continue-on-error` |
 | `todo-count` | ubuntu-24.04 | — | — | threshold: 20 |
@@ -532,7 +534,7 @@ ctest --test-dir build -C Release --output-on-failure
 - **Never** consider a PR done until `gh pr checks` shows all required checks passing.
 - If a check fails, download the failed run logs with `gh run view <ID> --log-failed`, diagnose, fix locally, push, and re-poll.
 - For Windows-only failures that cannot be reproduced on Linux, inspect the CI logs carefully and fix based on MSVC-specific diagnostics (e.g., `/W4` warnings, MSVC type conversion rules, Windows SDK headers).
-- The `build-windows-vs2026`, `build-linux-mingw-wine`, and `clang-tidy` jobs use `continue-on-error` — failures there are warnings, not blockers.
+- The `build-windows-vs2026`, `build-linux-mingw-wine`, `build-macos`, and `clang-tidy` jobs use `continue-on-error` — failures there are warnings, not blockers.
 
 ## Documentation generation
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1000,6 +1000,17 @@ if(SPARK_METAL_AVAILABLE)
     message(STATUS "SparkEngine: Metal backend ENABLED")
 endif()
 
+# --- macOS platform frameworks and rpath ---
+if(APPLE)
+    # Cocoa is needed for windowing when SDL2 is not available
+    target_link_libraries(SparkEngineLib PUBLIC "-framework Cocoa" "-framework IOKit" "-framework CoreVideo")
+    # Set rpath for .dylib game modules and shared libraries
+    set(CMAKE_MACOSX_RPATH ON)
+    set(CMAKE_INSTALL_RPATH "@executable_path;@executable_path/../lib")
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+    message(STATUS "SparkEngine: macOS frameworks linked (Cocoa, IOKit, CoreVideo)")
+endif()
+
 # --- Hybrid Ray Tracing ---
 if(ENABLE_HYBRID_RT)
     target_compile_definitions(SparkEngineLib PUBLIC SPARK_HYBRID_RT=1)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -215,6 +215,51 @@
             }
         },
         {
+            "name": "macos-debug",
+            "displayName": "macOS Debug (Apple Clang)",
+            "inherits": "default",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "ENABLE_VULKAN": "ON",
+                "ENABLE_OPENGL": "ON"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            }
+        },
+        {
+            "name": "macos-release",
+            "displayName": "macOS Release (Apple Clang)",
+            "inherits": "default",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "ENABLE_VULKAN": "ON",
+                "ENABLE_OPENGL": "ON"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            }
+        },
+        {
+            "name": "macos-metal",
+            "displayName": "macOS Release with Metal (Apple Clang)",
+            "inherits": "default",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "ENABLE_METAL": "ON",
+                "ENABLE_VULKAN": "OFF"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            }
+        },
+        {
             "name": "minimal",
             "displayName": "Minimal Build (core only)",
             "inherits": "default",
@@ -272,6 +317,18 @@
         {
             "name": "linux-shipping",
             "configurePreset": "linux-shipping"
+        },
+        {
+            "name": "macos-debug",
+            "configurePreset": "macos-debug"
+        },
+        {
+            "name": "macos-release",
+            "configurePreset": "macos-release"
+        },
+        {
+            "name": "macos-metal",
+            "configurePreset": "macos-metal"
         },
         {
             "name": "linux-mingw-release",

--- a/SparkEngine/Source/Utils/ConsoleProcessManager.cpp
+++ b/SparkEngine/Source/Utils/ConsoleProcessManager.cpp
@@ -22,7 +22,7 @@
 #include <algorithm>
 #include <cstring>
 
-#ifdef SPARK_PLATFORM_LINUX
+#if defined(SPARK_PLATFORM_LINUX) || defined(SPARK_PLATFORM_MACOS)
 #include <signal.h>
 #include <unistd.h>
 #endif

--- a/SparkEngine/Source/Utils/ConsoleProcessManager.h
+++ b/SparkEngine/Source/Utils/ConsoleProcessManager.h
@@ -131,8 +131,8 @@ namespace Spark
         WinHandle m_stdInWrite;    ///< Write end — engine writes log messages here.
         WinHandle m_stdOutRead;    ///< Read end — engine reads commands from child's stdout.
         WinHandle m_stdOutWrite;   ///< Write end of the pipe connected to child's stdout.
-#elif defined(SPARK_PLATFORM_LINUX)
-        // Linux process/pipe file descriptors for SparkConsole subprocess
+#elif defined(SPARK_PLATFORM_LINUX) || defined(SPARK_PLATFORM_MACOS)
+        // POSIX process/pipe file descriptors for SparkConsole subprocess
         pid_t m_childPid = -1;             ///< PID of the child console process (-1 = not launched).
         int m_pipeToChild[2] = {-1, -1};   ///< [0]=read, [1]=write — engine writes to child stdin.
         int m_pipeFromChild[2] = {-1, -1}; ///< [0]=read, [1]=write — engine reads from child stdout.

--- a/SparkEngine/Source/Utils/ConsoleProcessManagerLinux.cpp
+++ b/SparkEngine/Source/Utils/ConsoleProcessManagerLinux.cpp
@@ -1,14 +1,14 @@
 /**
  * @file ConsoleProcessManagerLinux.cpp
- * @brief Linux implementation of ConsoleProcessManager
+ * @brief Linux/macOS implementation of ConsoleProcessManager
  *
  * Uses fork/exec, POSIX pipes, and poll() for communication with
- * the SparkConsole subprocess.
+ * the SparkConsole subprocess. macOS shares the same POSIX APIs.
  */
 
 #include "Core/Platform.h"
 
-#ifdef SPARK_PLATFORM_LINUX
+#if defined(SPARK_PLATFORM_LINUX) || defined(SPARK_PLATFORM_MACOS)
 
 #include "ConsoleProcessManager.h"
 #include "Utils/Assert.h"
@@ -328,4 +328,4 @@ namespace Spark
 
 } // namespace Spark
 
-#endif // SPARK_PLATFORM_LINUX
+#endif // SPARK_PLATFORM_LINUX || SPARK_PLATFORM_MACOS

--- a/SparkEngine/Source/Utils/ConsoleProcessManagerStub.cpp
+++ b/SparkEngine/Source/Utils/ConsoleProcessManagerStub.cpp
@@ -8,7 +8,7 @@
 
 #include "Core/Platform.h"
 
-#if !defined(SPARK_PLATFORM_WINDOWS) && !defined(SPARK_PLATFORM_LINUX)
+#if !defined(SPARK_PLATFORM_WINDOWS) && !defined(SPARK_PLATFORM_LINUX) && !defined(SPARK_PLATFORM_MACOS)
 
 #include "ConsoleProcessManager.h"
 #include <iostream>

--- a/SparkEngine/Source/Utils/CrashHandler.cpp
+++ b/SparkEngine/Source/Utils/CrashHandler.cpp
@@ -35,26 +35,33 @@
 #pragma comment(lib, "dbghelp.lib")
 #pragma comment(lib, "windowscodecs.lib")
 #pragma comment(lib, "dxgi.lib")
-#elif defined(SPARK_PLATFORM_LINUX)
+#elif defined(SPARK_PLATFORM_LINUX) || defined(SPARK_PLATFORM_MACOS)
 #include <signal.h>
 #include <unistd.h>
-#include <sys/syscall.h>
 #include <execinfo.h>
 #include <cxxabi.h>
 #include <sys/utsname.h>
-#include <sys/sysinfo.h>
 #include <sys/resource.h>
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <fstream>
 #include <climits>
 #include <cstdlib>
+#ifdef SPARK_PLATFORM_LINUX
+#include <sys/syscall.h>
+#include <sys/sysinfo.h>
+#endif
+#ifdef SPARK_PLATFORM_MACOS
+#include <sys/sysctl.h>
+#include <mach/mach.h>
+#include <pthread.h>
+#endif
 #endif
 
 static CrashConfig g_cfg;
 static std::mutex g_lock;
 static bool g_triggerCrashOnAssert = false;
-#ifdef SPARK_PLATFORM_LINUX
+#if defined(SPARK_PLATFORM_LINUX) || defined(SPARK_PLATFORM_MACOS)
 static volatile sig_atomic_t g_inSignalHandler = 0;
 #endif
 
@@ -952,10 +959,10 @@ static bool Upload(const std::string& url, const std::wstring& file, const std::
 #endif
 
 // ============================================================================
-// LINUX IMPLEMENTATION
+// LINUX / MACOS IMPLEMENTATION (POSIX)
 // ============================================================================
 
-#elif defined(SPARK_PLATFORM_LINUX)
+#elif defined(SPARK_PLATFORM_LINUX) || defined(SPARK_PLATFORM_MACOS)
 
 static std::string CaptureStackTraceString()
 {
@@ -1011,6 +1018,7 @@ static std::string LinuxSystemInfo()
         s << "OS: " << un.sysname << " " << un.release << " " << un.machine << "\n";
     }
 
+#ifdef SPARK_PLATFORM_LINUX
     struct sysinfo si;
     if (sysinfo(&si) == 0)
     {
@@ -1020,8 +1028,27 @@ static std::string LinuxSystemInfo()
         s << "RAM Avail : " << (si.freeram * si.mem_unit >> 20) << " MiB\n";
         s << "Uptime    : " << si.uptime << " seconds\n";
     }
+#elif defined(SPARK_PLATFORM_MACOS)
+    {
+        long nprocs = sysconf(_SC_NPROCESSORS_ONLN);
+        s << "CPU Cores : " << nprocs << "\n";
+        int64_t memSize = 0;
+        size_t len = sizeof(memSize);
+        if (sysctlbyname("hw.memsize", &memSize, &len, nullptr, 0) == 0)
+            s << "RAM Total : " << (memSize >> 20) << " MiB\n";
+        mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+        vm_statistics64_data_t vmstat;
+        if (host_statistics64(mach_host_self(), HOST_VM_INFO64, reinterpret_cast<host_info64_t>(&vmstat), &count) ==
+            KERN_SUCCESS)
+        {
+            int64_t pageSize = sysconf(_SC_PAGESIZE);
+            int64_t freePages = vmstat.free_count + vmstat.inactive_count;
+            s << "RAM Avail : " << (freePages * pageSize >> 20) << " MiB\n";
+        }
+    }
+#endif
 
-    // Try to read GPU info from /proc/driver/nvidia or lspci
+    // Try to read GPU info from /proc/driver/nvidia or lspci (Linux only)
     std::ifstream gpuFile("/proc/driver/nvidia/gpus/0/information");
     if (gpuFile.is_open())
     {
@@ -1158,11 +1185,15 @@ static void HandleLinuxCrash(int sig, siginfo_t* info, void* context)
 
         std::ostringstream log;
         log << "================================================================\n";
-        log << "           SPARK ENGINE CRASH REPORT (Linux)\n";
+        log << "           SPARK ENGINE CRASH REPORT (POSIX)\n";
         log << "================================================================\n\n";
         log << "Timestamp  : " << stamp << "\n";
         log << "Process ID : " << getpid() << "\n";
+#ifdef SPARK_PLATFORM_LINUX
         log << "Thread ID  : " << static_cast<unsigned long>(syscall(SYS_gettid)) << "\n\n";
+#else
+        log << "Thread ID  : " << pthread_mach_thread_np(pthread_self()) << "\n\n";
+#endif
 
         log << "*** CRASH DETECTED ***\n";
         log << "Signal     : " << sig << " - " << sigName << "\n";

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -130,5 +130,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 208 |
 | Test cases | 2477+ |
 | Wiki pages | 65 |
-| *Last synced* | *2026-03-28 11:28* |
+| *Last synced* | *2026-03-28 13:41* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
…X guards)

- Add macOS CMake presets (macos-debug, macos-release, macos-metal)
- Add build-macos CI job (Apple Clang, SDL2+OpenGL, continue-on-error)
- Expand SPARK_PLATFORM_LINUX guards to include SPARK_PLATFORM_MACOS in CrashHandler, ConsoleProcessManager (POSIX fork/exec/pipes shared)
- Add macOS-specific system info (sysctl, mach APIs) in crash handler
- Add macOS framework linking (Cocoa, IOKit, CoreVideo) and rpath config
- Update CLAUDE.md with macOS preset and CI documentation
- Add .claude/knowledge entry for Mac compatibility analysis

https://claude.ai/code/session_01VewudHP3wEMGJQDUsXraqc