### PR TITLE
feat: add configurable logging levels via settings.ini

### DIFF
--- a/SparkEngine/Resources/Config/settings.ini
+++ b/SparkEngine/Resources/Config/settings.ini
@@ -232,3 +232,33 @@ GizmoScale = 1.0
 AutosaveEnabled = true
 AutosaveIntervalSeconds = 300.0
 UndoHistorySize = 100
+
+[Logging]
+# Global minimum log level: Trace, Debug, Info, Warn, Error, Fatal, Off
+GlobalLevel = Info
+# Minimum level at which stack traces are auto-captured (Off to disable)
+StackTraceLevel = Error
+# Category enable bitmask (hex). Each bit = one LogCategory.
+# Bit 0=Core, 1=Graphics, 2=Physics, 3=Audio, 4=AI, 5=Animation,
+# 6=ECS, 7=Network, 8=Input, 9=Scripting, 10=Scene, 11=Save,
+# 12=Cinematic, 13=Procedural, 14=Editor, 15=Game
+# 0xFFFFFFFF = all enabled
+CategoryMask = 0xFFFFFFFF
+# Per-category level overrides (leave empty to use GlobalLevel)
+# Valid values: Trace, Debug, Info, Warn, Error, Fatal, Off
+CoreLevel =
+GraphicsLevel =
+PhysicsLevel =
+AudioLevel =
+AILevel =
+AnimationLevel =
+ECSLevel =
+NetworkLevel =
+InputLevel =
+ScriptingLevel =
+SceneLevel =
+SaveLevel =
+CinematicLevel =
+ProceduralLevel =
+EditorLevel =
+GameLevel =

--- a/SparkEngine/Source/Core/EngineSettings.cpp
+++ b/SparkEngine/Source/Core/EngineSettings.cpp
@@ -352,6 +352,39 @@ void EngineSettings::ReadFromConfig()
     m_editor.autosaveEnabled = m_config.GetBool("Editor", "AutosaveEnabled", true);
     m_editor.autosaveIntervalSeconds = m_config.GetFloat("Editor", "AutosaveIntervalSeconds", 300.0f);
     m_editor.undoHistorySize = m_config.GetInt("Editor", "UndoHistorySize", 100);
+
+    // Logging
+    m_logging.globalLevel = m_config.GetString("Logging", "GlobalLevel", "Info");
+    m_logging.stackTraceLevel = m_config.GetString("Logging", "StackTraceLevel", "Error");
+
+    // CategoryMask: supports hex (0xFFFF) or decimal
+    std::string maskStr = m_config.GetString("Logging", "CategoryMask", "0xFFFFFFFF");
+    try
+    {
+        m_logging.categoryMask = static_cast<uint32_t>(std::stoul(maskStr, nullptr, 0));
+    }
+    catch (...)
+    {
+        m_logging.categoryMask = 0xFFFFFFFF;
+    }
+
+    // Per-category level overrides (empty = use global)
+    m_logging.coreLevel = m_config.GetString("Logging", "CoreLevel", "");
+    m_logging.graphicsLevel = m_config.GetString("Logging", "GraphicsLevel", "");
+    m_logging.physicsLevel = m_config.GetString("Logging", "PhysicsLevel", "");
+    m_logging.audioLevel = m_config.GetString("Logging", "AudioLevel", "");
+    m_logging.aiLevel = m_config.GetString("Logging", "AILevel", "");
+    m_logging.animationLevel = m_config.GetString("Logging", "AnimationLevel", "");
+    m_logging.ecsLevel = m_config.GetString("Logging", "ECSLevel", "");
+    m_logging.networkLevel = m_config.GetString("Logging", "NetworkLevel", "");
+    m_logging.inputLevel = m_config.GetString("Logging", "InputLevel", "");
+    m_logging.scriptingLevel = m_config.GetString("Logging", "ScriptingLevel", "");
+    m_logging.sceneLevel = m_config.GetString("Logging", "SceneLevel", "");
+    m_logging.saveLevel = m_config.GetString("Logging", "SaveLevel", "");
+    m_logging.cinematicLevel = m_config.GetString("Logging", "CinematicLevel", "");
+    m_logging.proceduralLevel = m_config.GetString("Logging", "ProceduralLevel", "");
+    m_logging.editorLevel = m_config.GetString("Logging", "EditorLevel", "");
+    m_logging.gameLevel = m_config.GetString("Logging", "GameLevel", "");
 }
 
 // =============================================================================
@@ -587,6 +620,34 @@ void EngineSettings::WriteToConfig() const
     m_config.SetBool("Editor", "AutosaveEnabled", m_editor.autosaveEnabled);
     m_config.SetFloat("Editor", "AutosaveIntervalSeconds", m_editor.autosaveIntervalSeconds);
     m_config.SetInt("Editor", "UndoHistorySize", m_editor.undoHistorySize);
+
+    // Logging
+    m_config.SetString("Logging", "GlobalLevel", m_logging.globalLevel);
+    m_config.SetString("Logging", "StackTraceLevel", m_logging.stackTraceLevel);
+
+    // Write CategoryMask as hex for readability
+    {
+        char hexBuf[16];
+        snprintf(hexBuf, sizeof(hexBuf), "0x%08X", m_logging.categoryMask);
+        m_config.SetString("Logging", "CategoryMask", hexBuf);
+    }
+
+    m_config.SetString("Logging", "CoreLevel", m_logging.coreLevel);
+    m_config.SetString("Logging", "GraphicsLevel", m_logging.graphicsLevel);
+    m_config.SetString("Logging", "PhysicsLevel", m_logging.physicsLevel);
+    m_config.SetString("Logging", "AudioLevel", m_logging.audioLevel);
+    m_config.SetString("Logging", "AILevel", m_logging.aiLevel);
+    m_config.SetString("Logging", "AnimationLevel", m_logging.animationLevel);
+    m_config.SetString("Logging", "ECSLevel", m_logging.ecsLevel);
+    m_config.SetString("Logging", "NetworkLevel", m_logging.networkLevel);
+    m_config.SetString("Logging", "InputLevel", m_logging.inputLevel);
+    m_config.SetString("Logging", "ScriptingLevel", m_logging.scriptingLevel);
+    m_config.SetString("Logging", "SceneLevel", m_logging.sceneLevel);
+    m_config.SetString("Logging", "SaveLevel", m_logging.saveLevel);
+    m_config.SetString("Logging", "CinematicLevel", m_logging.cinematicLevel);
+    m_config.SetString("Logging", "ProceduralLevel", m_logging.proceduralLevel);
+    m_config.SetString("Logging", "EditorLevel", m_logging.editorLevel);
+    m_config.SetString("Logging", "GameLevel", m_logging.gameLevel);
 }
 
 // =============================================================================
@@ -638,7 +699,7 @@ std::vector<std::string> EngineSettings::GetSections() const
 {
     return {"Graphics", "Audio",      "Controls", "Game",       "Rendering",      "PostProcess",   "SSAO",
             "SSR",      "Volumetric", "TAA",      "MotionBlur", "DynamicQuality", "AudioExtended", "Physics",
-            "AI",       "Player",     "GameMode", "Camera",     "Editor"};
+            "AI",       "Player",     "GameMode", "Camera",     "Editor",         "Logging"};
 }
 
 std::vector<std::string> EngineSettings::GetKeys(const std::string& section) const

--- a/SparkEngine/Source/Core/EngineSettings.h
+++ b/SparkEngine/Source/Core/EngineSettings.h
@@ -332,6 +332,42 @@ class EngineSettings
         int undoHistorySize = 100;
     };
 
+    // ---- Logging ----
+
+    struct LoggingSettings
+    {
+        /// Global minimum log level: Trace, Debug, Info, Warn, Error, Fatal, Off
+        std::string globalLevel = "Info";
+
+        /// Minimum level at which stack traces are auto-captured (Off to disable)
+        std::string stackTraceLevel = "Error";
+
+        /// Category enable bitmask (hex or decimal). Each bit = one LogCategory.
+        /// 0xFFFF = all enabled, 0x0000 = all disabled.
+        /// Bit 0=Core, 1=Graphics, 2=Physics, 3=Audio, 4=AI, 5=Animation,
+        /// 6=ECS, 7=Network, 8=Input, 9=Scripting, 10=Scene, 11=Save,
+        /// 12=Cinematic, 13=Procedural, 14=Editor, 15=Game
+        uint32_t categoryMask = 0xFFFFFFFF;
+
+        /// Per-category level overrides (empty string = use global level)
+        std::string coreLevel;
+        std::string graphicsLevel;
+        std::string physicsLevel;
+        std::string audioLevel;
+        std::string aiLevel;
+        std::string animationLevel;
+        std::string ecsLevel;
+        std::string networkLevel;
+        std::string inputLevel;
+        std::string scriptingLevel;
+        std::string sceneLevel;
+        std::string saveLevel;
+        std::string cinematicLevel;
+        std::string proceduralLevel;
+        std::string editorLevel;
+        std::string gameLevel;
+    };
+
     // =========================================================================
     // Singleton access
     // =========================================================================
@@ -418,6 +454,9 @@ class EngineSettings
     EditorSettings& Editor() { return m_editor; }
     const EditorSettings& Editor() const { return m_editor; }
 
+    LoggingSettings& Logging() { return m_logging; }
+    const LoggingSettings& Logging() const { return m_logging; }
+
     // =========================================================================
     // Generic key access (for console commands)
     // =========================================================================
@@ -490,6 +529,7 @@ class EngineSettings
     GameModeSettings m_gameMode;
     CameraSettings m_camera;
     EditorSettings m_editor;
+    LoggingSettings m_logging;
 
     // Change listeners
     std::vector<SettingsChangedCallback> m_changeCallbacks;

--- a/SparkEngine/Source/Core/SparkEngine.cpp
+++ b/SparkEngine/Source/Core/SparkEngine.cpp
@@ -233,6 +233,49 @@ static void InitDebugSystems()
     logger.Initialize(/*enableAsync=*/false);
     logger.AddSink(std::make_unique<Spark::StderrSink>());
 
+    // Apply logging configuration from settings.ini [Logging] section
+    {
+        const auto& logCfg = EngineSettings::GetInstance().Logging();
+        Spark::Logger::Config cfg;
+        cfg.globalLevel = Spark::StringToLogLevel(logCfg.globalLevel, Spark::LogLevel::Info);
+        cfg.stackTraceLevel = Spark::StringToLogLevel(logCfg.stackTraceLevel, Spark::LogLevel::Error);
+        cfg.categoryMask = logCfg.categoryMask;
+
+        // Map per-category string overrides to LogLevel values
+        struct CatOverride
+        {
+            Spark::LogCategory cat;
+            const std::string& levelStr;
+        };
+        const CatOverride overrides[] = {
+            {Spark::LogCategory::Core, logCfg.coreLevel},
+            {Spark::LogCategory::Graphics, logCfg.graphicsLevel},
+            {Spark::LogCategory::Physics, logCfg.physicsLevel},
+            {Spark::LogCategory::Audio, logCfg.audioLevel},
+            {Spark::LogCategory::AI, logCfg.aiLevel},
+            {Spark::LogCategory::Animation, logCfg.animationLevel},
+            {Spark::LogCategory::ECS, logCfg.ecsLevel},
+            {Spark::LogCategory::Network, logCfg.networkLevel},
+            {Spark::LogCategory::Input, logCfg.inputLevel},
+            {Spark::LogCategory::Scripting, logCfg.scriptingLevel},
+            {Spark::LogCategory::Scene, logCfg.sceneLevel},
+            {Spark::LogCategory::Save, logCfg.saveLevel},
+            {Spark::LogCategory::Cinematic, logCfg.cinematicLevel},
+            {Spark::LogCategory::Procedural, logCfg.proceduralLevel},
+            {Spark::LogCategory::Editor, logCfg.editorLevel},
+            {Spark::LogCategory::Game, logCfg.gameLevel},
+        };
+        for (const auto& [cat, str] : overrides)
+        {
+            if (!str.empty())
+            {
+                auto idx = static_cast<size_t>(cat);
+                cfg.categoryLevels[idx] = Spark::StringToLogLevel(str, cfg.globalLevel);
+            }
+        }
+        logger.ApplyConfig(cfg);
+    }
+
     Spark::FileLogger::GetInstance().Initialize("Logs");
     Spark::ChromeTracing::GetInstance().Start();
 #ifndef NDEBUG

--- a/SparkEngine/Source/Utils/Logger.cpp
+++ b/SparkEngine/Source/Utils/Logger.cpp
@@ -201,9 +201,33 @@ namespace Spark
         return LogLevel::Trace;
     }
 
+    void Logger::SetCategoryEnabled(LogCategory cat, bool enabled)
+    {
+        LogCategoryMask bit = LogCategoryBit(cat);
+        if (enabled)
+        {
+            m_categoryMask.fetch_or(bit, std::memory_order_relaxed);
+        }
+        else
+        {
+            m_categoryMask.fetch_and(~bit, std::memory_order_relaxed);
+        }
+    }
+
+    bool Logger::IsCategoryEnabled(LogCategory cat) const
+    {
+        return (m_categoryMask.load(std::memory_order_relaxed) & LogCategoryBit(cat)) != 0;
+    }
+
     bool Logger::ShouldLog(LogLevel level, LogCategory category) const
     {
-        // Check global level first (fast path)
+        // Check category bitmask first (fast path — entire category disabled)
+        if ((m_categoryMask.load(std::memory_order_relaxed) & LogCategoryBit(category)) == 0)
+        {
+            return false;
+        }
+
+        // Check global level
         if (level < m_globalLevel.load(std::memory_order_relaxed))
         {
             return false;
@@ -220,6 +244,28 @@ namespace Spark
         }
 
         return true;
+    }
+
+    // ============================================================================
+    // ApplyConfig — apply a logging configuration
+    // ============================================================================
+
+    void Logger::ApplyConfig(const Config& config)
+    {
+        SetGlobalLevel(config.globalLevel);
+        SetStackTraceLevel(config.stackTraceLevel);
+        SetCategoryMask(config.categoryMask);
+
+        for (size_t i = 0; i < static_cast<size_t>(LogCategory::Count); ++i)
+        {
+            LogLevel catLevel = config.categoryLevels[i];
+            // Trace means "no override — inherit global level"
+            if (catLevel == LogLevel::Trace && config.globalLevel != LogLevel::Trace)
+            {
+                catLevel = config.globalLevel;
+            }
+            SetCategoryLevel(static_cast<LogCategory>(i), catLevel);
+        }
     }
 
     // ============================================================================

--- a/SparkEngine/Source/Utils/Logger.h
+++ b/SparkEngine/Source/Utils/Logger.h
@@ -67,6 +67,39 @@ namespace Spark
     };
 
     /**
+     * @brief Convert a string to LogLevel enum (case-insensitive)
+     * @return The matching LogLevel, or defaultLevel if the string is unrecognized
+     */
+    inline LogLevel StringToLogLevel(std::string_view str, LogLevel defaultLevel = LogLevel::Info) noexcept
+    {
+        if (str.empty())
+            return defaultLevel;
+        // Case-insensitive first character check for fast matching
+        char c = str[0];
+        if (c >= 'a')
+            c -= 32; // toupper for ASCII lowercase
+        switch (c)
+        {
+        case 'T':
+            return LogLevel::Trace;
+        case 'D':
+            return LogLevel::Debug;
+        case 'I':
+            return LogLevel::Info;
+        case 'W':
+            return LogLevel::Warn;
+        case 'E':
+            return LogLevel::Error;
+        case 'F':
+            return LogLevel::Fatal;
+        case 'O':
+            return LogLevel::Off;
+        default:
+            return defaultLevel;
+        }
+    }
+
+    /**
      * @brief Convert LogLevel to string representation
      */
     inline std::string_view LogLevelToString(LogLevel level) noexcept
@@ -114,6 +147,22 @@ namespace Spark
         Game,
         Count
     };
+
+    /// Bitmask type for enabling/disabling entire log categories.
+    /// Each bit corresponds to a LogCategory (bit 0 = Core, bit 1 = Graphics, etc.)
+    using LogCategoryMask = uint32_t;
+
+    /// All categories enabled (default)
+    inline constexpr LogCategoryMask kLogCategoryAll = 0xFFFFFFFF;
+
+    /// No categories enabled
+    inline constexpr LogCategoryMask kLogCategoryNone = 0;
+
+    /// Get the bitmask bit for a single category
+    inline constexpr LogCategoryMask LogCategoryBit(LogCategory cat) noexcept
+    {
+        return static_cast<LogCategoryMask>(1u) << static_cast<uint8_t>(cat);
+    }
 
     /**
      * @brief Convert LogCategory to string representation
@@ -402,6 +451,29 @@ namespace Spark
         LogLevel GetStackTraceLevel() const { return m_stackTraceLevel.load(std::memory_order_relaxed); }
 
         /**
+         * @brief Set the category enable bitmask
+         *
+         * Each bit corresponds to a LogCategory. Only categories with their bit
+         * set will produce output. Default is kLogCategoryAll (all enabled).
+         */
+        void SetCategoryMask(LogCategoryMask mask) { m_categoryMask.store(mask, std::memory_order_relaxed); }
+
+        /**
+         * @brief Get the current category enable bitmask
+         */
+        LogCategoryMask GetCategoryMask() const { return m_categoryMask.load(std::memory_order_relaxed); }
+
+        /**
+         * @brief Enable or disable a single category in the bitmask
+         */
+        void SetCategoryEnabled(LogCategory cat, bool enabled);
+
+        /**
+         * @brief Check if a category is enabled in the bitmask
+         */
+        bool IsCategoryEnabled(LogCategory cat) const;
+
+        /**
          * @brief Check if a message at the given level and category would be logged
          */
         bool ShouldLog(LogLevel level, LogCategory category) const;
@@ -434,6 +506,29 @@ namespace Spark
 
         bool IsInitialized() const { return m_initialized.load(std::memory_order_acquire); }
 
+        /**
+         * @brief Configuration struct for loading logging settings from config files
+         */
+        struct Config
+        {
+            LogLevel globalLevel = LogLevel::Info;
+            LogLevel stackTraceLevel = LogLevel::Error;
+            LogCategoryMask categoryMask = kLogCategoryAll;
+            /// Per-category level overrides. LogLevel::Trace means "use global level".
+            std::array<LogLevel, static_cast<size_t>(LogCategory::Count)> categoryLevels{};
+
+            Config() { categoryLevels.fill(LogLevel::Trace); }
+        };
+
+        /**
+         * @brief Apply a logging configuration
+         *
+         * Sets global level, per-category levels, category bitmask, and
+         * stack trace threshold from the given Config struct. Categories whose
+         * level is set to Trace in the Config inherit the global level.
+         */
+        void ApplyConfig(const Config& config);
+
       private:
         Logger() = default;
         ~Logger() { Shutdown(); }
@@ -459,7 +554,8 @@ namespace Spark
         std::atomic<bool> m_initialized{false};
         std::atomic<bool> m_asyncEnabled{false};
         std::atomic<LogLevel> m_globalLevel{LogLevel::Trace};
-        std::atomic<LogLevel> m_stackTraceLevel{LogLevel::Error}; ///< Auto-capture threshold
+        std::atomic<LogLevel> m_stackTraceLevel{LogLevel::Error};     ///< Auto-capture threshold
+        std::atomic<LogCategoryMask> m_categoryMask{kLogCategoryAll}; ///< Category enable bitmask
 
         // Per-category filtering
         std::array<std::atomic<LogLevel>, static_cast<size_t>(LogCategory::Count)> m_categoryLevels;

--- a/Tests/TestLogger.cpp
+++ b/Tests/TestLogger.cpp
@@ -327,3 +327,134 @@ TEST(Logger_IsInitialized)
     logger.Shutdown();
     EXPECT_FALSE(logger.IsInitialized());
 }
+
+// =============================================================================
+// StringToLogLevel
+// =============================================================================
+
+TEST(Logger_StringToLogLevel)
+{
+    EXPECT_TRUE(Spark::StringToLogLevel("Trace") == Spark::LogLevel::Trace);
+    EXPECT_TRUE(Spark::StringToLogLevel("Debug") == Spark::LogLevel::Debug);
+    EXPECT_TRUE(Spark::StringToLogLevel("Info") == Spark::LogLevel::Info);
+    EXPECT_TRUE(Spark::StringToLogLevel("Warn") == Spark::LogLevel::Warn);
+    EXPECT_TRUE(Spark::StringToLogLevel("Error") == Spark::LogLevel::Error);
+    EXPECT_TRUE(Spark::StringToLogLevel("Fatal") == Spark::LogLevel::Fatal);
+    EXPECT_TRUE(Spark::StringToLogLevel("Off") == Spark::LogLevel::Off);
+
+    // Case-insensitive (first char)
+    EXPECT_TRUE(Spark::StringToLogLevel("trace") == Spark::LogLevel::Trace);
+    EXPECT_TRUE(Spark::StringToLogLevel("debug") == Spark::LogLevel::Debug);
+    EXPECT_TRUE(Spark::StringToLogLevel("info") == Spark::LogLevel::Info);
+    EXPECT_TRUE(Spark::StringToLogLevel("warn") == Spark::LogLevel::Warn);
+    EXPECT_TRUE(Spark::StringToLogLevel("error") == Spark::LogLevel::Error);
+    EXPECT_TRUE(Spark::StringToLogLevel("fatal") == Spark::LogLevel::Fatal);
+    EXPECT_TRUE(Spark::StringToLogLevel("off") == Spark::LogLevel::Off);
+
+    // Unknown string returns default
+    EXPECT_TRUE(Spark::StringToLogLevel("") == Spark::LogLevel::Info);
+    EXPECT_TRUE(Spark::StringToLogLevel("unknown") == Spark::LogLevel::Info);
+    EXPECT_TRUE(Spark::StringToLogLevel("", Spark::LogLevel::Warn) == Spark::LogLevel::Warn);
+}
+
+// =============================================================================
+// Category Bitmask
+// =============================================================================
+
+TEST(Logger_CategoryBitmask)
+{
+    auto& logger = Spark::Logger::Get();
+    logger.Initialize(false);
+    logger.SetGlobalLevel(Spark::LogLevel::Trace);
+
+    // All categories enabled by default
+    EXPECT_EQ(logger.GetCategoryMask(), Spark::kLogCategoryAll);
+    EXPECT_TRUE(logger.IsCategoryEnabled(Spark::LogCategory::Core));
+    EXPECT_TRUE(logger.IsCategoryEnabled(Spark::LogCategory::Graphics));
+
+    // Disable Graphics via bitmask
+    logger.SetCategoryEnabled(Spark::LogCategory::Graphics, false);
+    EXPECT_FALSE(logger.IsCategoryEnabled(Spark::LogCategory::Graphics));
+    EXPECT_TRUE(logger.IsCategoryEnabled(Spark::LogCategory::Core));
+
+    // Messages to disabled category should be filtered
+    EXPECT_FALSE(logger.ShouldLog(Spark::LogLevel::Error, Spark::LogCategory::Graphics));
+    EXPECT_TRUE(logger.ShouldLog(Spark::LogLevel::Error, Spark::LogCategory::Core));
+
+    // Re-enable
+    logger.SetCategoryEnabled(Spark::LogCategory::Graphics, true);
+    EXPECT_TRUE(logger.IsCategoryEnabled(Spark::LogCategory::Graphics));
+    EXPECT_TRUE(logger.ShouldLog(Spark::LogLevel::Error, Spark::LogCategory::Graphics));
+
+    // Set entire mask
+    logger.SetCategoryMask(Spark::kLogCategoryNone);
+    EXPECT_FALSE(logger.ShouldLog(Spark::LogLevel::Fatal, Spark::LogCategory::Core));
+    EXPECT_FALSE(logger.ShouldLog(Spark::LogLevel::Fatal, Spark::LogCategory::Graphics));
+
+    // Restore
+    logger.SetCategoryMask(Spark::kLogCategoryAll);
+    logger.Shutdown();
+}
+
+TEST(Logger_CategoryBitHelper)
+{
+    // Verify each category maps to the correct bit position
+    EXPECT_EQ(Spark::LogCategoryBit(Spark::LogCategory::Core), 1u << 0);
+    EXPECT_EQ(Spark::LogCategoryBit(Spark::LogCategory::Graphics), 1u << 1);
+    EXPECT_EQ(Spark::LogCategoryBit(Spark::LogCategory::Physics), 1u << 2);
+    EXPECT_EQ(Spark::LogCategoryBit(Spark::LogCategory::Audio), 1u << 3);
+    EXPECT_EQ(Spark::LogCategoryBit(Spark::LogCategory::Editor), 1u << 14);
+    EXPECT_EQ(Spark::LogCategoryBit(Spark::LogCategory::Game), 1u << 15);
+}
+
+// =============================================================================
+// LoadFromConfig
+// =============================================================================
+
+TEST(Logger_ApplyConfig)
+{
+    auto& logger = Spark::Logger::Get();
+    logger.Initialize(false);
+
+    Spark::Logger::Config cfg;
+    cfg.globalLevel = Spark::LogLevel::Warn;
+    cfg.stackTraceLevel = Spark::LogLevel::Fatal;
+    cfg.categoryMask =
+        Spark::LogCategoryBit(Spark::LogCategory::Core) | Spark::LogCategoryBit(Spark::LogCategory::Graphics);
+
+    // Graphics overridden to Error, Core left at Trace (inherits global Warn)
+    cfg.categoryLevels[static_cast<size_t>(Spark::LogCategory::Graphics)] = Spark::LogLevel::Error;
+
+    logger.ApplyConfig(cfg);
+
+    // Verify global level
+    EXPECT_TRUE(logger.GetGlobalLevel() == Spark::LogLevel::Warn);
+
+    // Verify stack trace level
+    EXPECT_TRUE(logger.GetStackTraceLevel() == Spark::LogLevel::Fatal);
+
+    // Verify category mask — only Core and Graphics enabled
+    EXPECT_TRUE(logger.IsCategoryEnabled(Spark::LogCategory::Core));
+    EXPECT_TRUE(logger.IsCategoryEnabled(Spark::LogCategory::Graphics));
+    EXPECT_FALSE(logger.IsCategoryEnabled(Spark::LogCategory::Physics));
+
+    // Verify per-category levels
+    EXPECT_TRUE(logger.GetCategoryLevel(Spark::LogCategory::Graphics) == Spark::LogLevel::Error);
+    EXPECT_TRUE(logger.GetCategoryLevel(Spark::LogCategory::Core) == Spark::LogLevel::Warn);
+
+    // Physics is masked off — ShouldLog returns false regardless of level
+    EXPECT_FALSE(logger.ShouldLog(Spark::LogLevel::Fatal, Spark::LogCategory::Physics));
+
+    // Core logs Warn and above
+    EXPECT_FALSE(logger.ShouldLog(Spark::LogLevel::Info, Spark::LogCategory::Core));
+    EXPECT_TRUE(logger.ShouldLog(Spark::LogLevel::Warn, Spark::LogCategory::Core));
+
+    // Graphics logs Error and above
+    EXPECT_FALSE(logger.ShouldLog(Spark::LogLevel::Warn, Spark::LogCategory::Graphics));
+    EXPECT_TRUE(logger.ShouldLog(Spark::LogLevel::Error, Spark::LogCategory::Graphics));
+
+    // Restore defaults
+    Spark::Logger::Config defaults;
+    logger.ApplyConfig(defaults);
+    logger.Shutdown();
+}

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -128,7 +128,7 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | ECS Systems | 64 |
 | Editor Panels | 51 |
 | Test files | 209 |
-| Test cases | 2504+ |
+| Test cases | 2508+ |
 | Wiki pages | 65 |
-| *Last synced* | *2026-03-28 18:00* |
+| *Last synced* | *2026-03-28 19:15* |
 <!-- /AUTO:stats -->

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -481,7 +481,7 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 ## Test File Inventory
 
 <!-- AUTO:test_inventory -->
-*209 test files, 2504+ test cases*
+*209 test files, 2508+ test cases*
 
 | Test File | Test Cases |
 |-----------|------------|
@@ -592,7 +592,7 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 | `TestLocalFileCache` | 15 |
 | `TestLocalizationSystem` | 6 |
 | `TestLockFreeRingAllocator` | 3 |
-| `TestLogger` | 14 |
+| `TestLogger` | 18 |
 | `TestMaterialDefinition` | 10 |
 | `TestMaterialEffects` | 5 |
 | `TestMathUtils` | 11 |


### PR DESCRIPTION
Add a [Logging] section to settings.ini that controls global log level, per-category level overrides, a category bitmask for enabling/disabling entire subsystems, and the stack trace auto-capture threshold. This replaces hardcoded log levels with user-configurable settings that are loaded at engine startup alongside other EngineSettings.

Key additions:
- LoggingSettings struct in EngineSettings with all 16 category overrides
- LogCategoryMask bitmask type with per-bit category enable/disable
- StringToLogLevel parser for config file string values
- Logger::ApplyConfig() to apply a complete logging configuration
- 4 new unit tests (StringToLogLevel, CategoryBitmask, CategoryBitHelper, ApplyConfig)

https://claude.ai/code/session_01CC64x2P2E5cgruqwwK3DvA