### PR TITLE
feat: expand engine settings with 3 new subsystems and 8 new editor tabs

### DIFF
--- a/SparkEditor/Source/Panels/ProjectSettingsPanel.cpp
+++ b/SparkEditor/Source/Panels/ProjectSettingsPanel.cpp
@@ -40,9 +40,24 @@ namespace SparkEditor
                     RenderGraphicsTab();
                     ImGui::EndTabItem();
                 }
+                if (ImGui::BeginTabItem(ICON_FA_CUBES " Rendering"))
+                {
+                    RenderRenderingTab();
+                    ImGui::EndTabItem();
+                }
+                if (ImGui::BeginTabItem(ICON_FA_MAGIC " Post-Process"))
+                {
+                    RenderPostProcessingTab();
+                    ImGui::EndTabItem();
+                }
                 if (ImGui::BeginTabItem(ICON_FA_VOLUME_UP " Audio"))
                 {
                     RenderAudioTab();
+                    ImGui::EndTabItem();
+                }
+                if (ImGui::BeginTabItem(ICON_FA_MOUSE_POINTER " Controls"))
+                {
+                    RenderControlsTab();
                     ImGui::EndTabItem();
                 }
                 if (ImGui::BeginTabItem(ICON_FA_ATOM " Physics"))
@@ -55,6 +70,11 @@ namespace SparkEditor
                     RenderAITab();
                     ImGui::EndTabItem();
                 }
+                if (ImGui::BeginTabItem(ICON_FA_USER " Player"))
+                {
+                    RenderPlayerTab();
+                    ImGui::EndTabItem();
+                }
                 if (ImGui::BeginTabItem(ICON_FA_GAMEPAD " Gameplay"))
                 {
                     RenderGameplayTab();
@@ -65,9 +85,29 @@ namespace SparkEditor
                     RenderCameraTab();
                     ImGui::EndTabItem();
                 }
+                if (ImGui::BeginTabItem(ICON_FA_WIFI " Network"))
+                {
+                    RenderNetworkTab();
+                    ImGui::EndTabItem();
+                }
+                if (ImGui::BeginTabItem(ICON_FA_CODE " Scripting"))
+                {
+                    RenderScriptingTab();
+                    ImGui::EndTabItem();
+                }
+                if (ImGui::BeginTabItem(ICON_FA_RUNNING " Animation"))
+                {
+                    RenderAnimationTab();
+                    ImGui::EndTabItem();
+                }
                 if (ImGui::BeginTabItem(ICON_FA_PENCIL_ALT " Editor"))
                 {
                     RenderEditorTab();
+                    ImGui::EndTabItem();
+                }
+                if (ImGui::BeginTabItem(ICON_FA_LIST " Logging"))
+                {
+                    RenderLoggingTab();
                     ImGui::EndTabItem();
                 }
                 if (ImGui::BeginTabItem(ICON_FA_INFO_CIRCLE " Project"))
@@ -157,23 +197,392 @@ namespace SparkEditor
     }
 
     // =========================================================================
+    // Rendering Tab (Advanced)
+    // =========================================================================
+
+    void ProjectSettingsPanel::RenderRenderingTab()
+    {
+        auto& r = EngineSettings::GetInstance().Rendering();
+        auto& game = EngineSettings::GetInstance().Game();
+
+        if (ImGui::CollapsingHeader("Pipeline", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            const char* pathItems[] = {"Forward", "Deferred", "Forward+", "Clustered"};
+            if (ImGui::Combo("Render Path", &r.renderPath, pathItems, 4))
+                m_modified = true;
+
+            const char* presetItems[] = {"Low", "Medium", "High", "Ultra", "Custom"};
+            if (ImGui::Combo("Quality Preset", &r.qualityPreset, presetItems, 5))
+                m_modified = true;
+
+            if (ImGui::Checkbox("Show FPS", &game.showFPS))
+                m_modified = true;
+            if (ImGui::Checkbox("Show Debug Info", &game.showDebugInfo))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("Textures & Filtering"))
+        {
+            const char* texSizes[] = {"512", "1024", "2048", "4096", "8192"};
+            int texIdx = 2;
+            if (r.maxTextureSize <= 512)
+                texIdx = 0;
+            else if (r.maxTextureSize <= 1024)
+                texIdx = 1;
+            else if (r.maxTextureSize <= 2048)
+                texIdx = 2;
+            else if (r.maxTextureSize <= 4096)
+                texIdx = 3;
+            else
+                texIdx = 4;
+            if (ImGui::Combo("Max Texture Size", &texIdx, texSizes, 5))
+            {
+                const int sizes[] = {512, 1024, 2048, 4096, 8192};
+                r.maxTextureSize = sizes[texIdx];
+                m_modified = true;
+            }
+            if (ImGui::Checkbox("Anisotropic Filtering", &r.anisotropicFiltering))
+                m_modified = true;
+            if (r.anisotropicFiltering)
+            {
+                if (ImGui::SliderInt("Anisotropy Level", &r.anisotropyLevel, 1, 16))
+                    m_modified = true;
+            }
+        }
+
+        if (ImGui::CollapsingHeader("Shadows & Lighting"))
+        {
+            if (ImGui::Checkbox("Shadows", &r.shadows))
+                m_modified = true;
+            if (r.shadows)
+            {
+                const char* shadowSizes[] = {"512", "1024", "2048", "4096"};
+                int sIdx = 2;
+                if (r.shadowMapSize <= 512)
+                    sIdx = 0;
+                else if (r.shadowMapSize <= 1024)
+                    sIdx = 1;
+                else if (r.shadowMapSize <= 2048)
+                    sIdx = 2;
+                else
+                    sIdx = 3;
+                if (ImGui::Combo("Shadow Map Size", &sIdx, shadowSizes, 4))
+                {
+                    const int sizes[] = {512, 1024, 2048, 4096};
+                    r.shadowMapSize = sizes[sIdx];
+                    m_modified = true;
+                }
+                if (ImGui::SliderInt("Cascade Count", &r.cascadeCount, 1, 4))
+                    m_modified = true;
+            }
+        }
+
+        if (ImGui::CollapsingHeader("Effects Toggles"))
+        {
+            if (ImGui::Checkbox("Bloom", &r.bloom))
+                m_modified = true;
+            if (ImGui::Checkbox("SSAO", &r.ssao))
+                m_modified = true;
+            if (ImGui::Checkbox("TAA", &r.taa))
+                m_modified = true;
+            if (ImGui::Checkbox("Motion Blur", &r.motionBlur))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("Culling & LOD"))
+        {
+            if (ImGui::Checkbox("Frustum Culling", &r.frustumCulling))
+                m_modified = true;
+            if (ImGui::Checkbox("Occlusion Culling", &r.occlusionCulling))
+                m_modified = true;
+            if (ImGui::Checkbox("Level of Detail", &r.levelOfDetail))
+                m_modified = true;
+            if (ImGui::DragInt("Max Draw Calls", &r.maxDrawCalls, 10, 100, 100000))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("Dynamic Quality Scaler"))
+        {
+            auto& dq = EngineSettings::GetInstance().DynamicQuality();
+            if (ImGui::Checkbox("Dynamic Quality Enabled", &dq.enabled))
+                m_modified = true;
+            if (dq.enabled)
+            {
+                if (ImGui::DragFloat("Target Frame Time", &dq.targetFrameTimeMs, 0.5f, 4.0f, 66.0f, "%.1f ms"))
+                    m_modified = true;
+                ImGui::Text("Render Scale: %.2f - %.2f (step %.2f)", dq.minRenderScale, dq.maxRenderScale,
+                            dq.renderScaleStep);
+                if (ImGui::DragFloat("Min Render Scale", &dq.minRenderScale, 0.05f, 0.25f, dq.maxRenderScale))
+                    m_modified = true;
+                if (ImGui::DragFloat("Max Render Scale", &dq.maxRenderScale, 0.05f, dq.minRenderScale, 2.0f))
+                    m_modified = true;
+                if (ImGui::DragFloat("Shadow Scale Min", &dq.minShadowScale, 0.05f, 0.1f, dq.maxShadowScale))
+                    m_modified = true;
+                if (ImGui::DragFloat("Shadow Scale Max", &dq.maxShadowScale, 0.05f, dq.minShadowScale, 1.0f))
+                    m_modified = true;
+            }
+        }
+
+        if (ImGui::CollapsingHeader("Debug"))
+        {
+            if (ImGui::Checkbox("Wireframe Mode", &r.wireframeMode))
+                m_modified = true;
+            if (ImGui::Checkbox("Debug Mode", &r.debugMode))
+                m_modified = true;
+            if (ImGui::Checkbox("GPU Timing", &r.enableGPUTiming))
+                m_modified = true;
+        }
+    }
+
+    // =========================================================================
+    // Post-Processing Tab
+    // =========================================================================
+
+    void ProjectSettingsPanel::RenderPostProcessingTab()
+    {
+        auto& pp = EngineSettings::GetInstance().PostProcess();
+        auto& ssao = EngineSettings::GetInstance().SSAO();
+        auto& ssr = EngineSettings::GetInstance().SSR();
+        auto& vol = EngineSettings::GetInstance().Volumetric();
+        auto& taa = EngineSettings::GetInstance().TAA();
+        auto& mb = EngineSettings::GetInstance().MotionBlur();
+
+        if (ImGui::CollapsingHeader("Bloom", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            if (ImGui::Checkbox("Bloom Enabled", &pp.bloomEnabled))
+                m_modified = true;
+            if (pp.bloomEnabled)
+            {
+                if (ImGui::DragFloat("Threshold", &pp.bloomThreshold, 0.05f, 0.0f, 10.0f))
+                    m_modified = true;
+                if (ImGui::DragFloat("Intensity##Bloom", &pp.bloomIntensity, 0.05f, 0.0f, 10.0f))
+                    m_modified = true;
+                if (ImGui::DragFloat("Radius", &pp.bloomRadius, 0.1f, 0.0f, 10.0f))
+                    m_modified = true;
+                if (ImGui::SliderFloat("Soft Knee", &pp.bloomSoftKnee, 0.0f, 1.0f))
+                    m_modified = true;
+                if (ImGui::SliderInt("Iterations", &pp.bloomIterations, 1, 16))
+                    m_modified = true;
+            }
+        }
+
+        if (ImGui::CollapsingHeader("Tone Mapping"))
+        {
+            const char* tmItems[] = {"None", "Reinhard", "ReinhardJodie", "Uncharted2", "ACES", "AgX", "FilmicALU"};
+            if (ImGui::Combo("Operator", &pp.toneMappingOperator, tmItems, 7))
+                m_modified = true;
+            if (ImGui::DragFloat("Exposure", &pp.exposure, 0.05f, 0.01f, 20.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("Gamma", &pp.gamma, 0.05f, 0.5f, 5.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("White Point", &pp.whitePoint, 0.1f, 1.0f, 50.0f))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("Color Grading"))
+        {
+            if (ImGui::Checkbox("Color Grading Enabled", &pp.colorGradingEnabled))
+                m_modified = true;
+            if (pp.colorGradingEnabled)
+            {
+                if (ImGui::SliderFloat("Temperature", &pp.temperature, -1.0f, 1.0f))
+                    m_modified = true;
+                if (ImGui::SliderFloat("Tint", &pp.tint, -1.0f, 1.0f))
+                    m_modified = true;
+                if (ImGui::DragFloat("Contrast", &pp.contrast, 0.01f, 0.0f, 3.0f))
+                    m_modified = true;
+                if (ImGui::DragFloat("Brightness", &pp.brightness, 0.01f, -1.0f, 1.0f))
+                    m_modified = true;
+                if (ImGui::DragFloat("Saturation", &pp.saturation, 0.01f, 0.0f, 3.0f))
+                    m_modified = true;
+            }
+        }
+
+        if (ImGui::CollapsingHeader("SSAO"))
+        {
+            if (ImGui::Checkbox("SSAO Enabled", &ssao.enabled))
+                m_modified = true;
+            if (ssao.enabled)
+            {
+                if (ImGui::DragFloat("Radius##SSAO", &ssao.radius, 0.05f, 0.01f, 5.0f))
+                    m_modified = true;
+                if (ImGui::DragFloat("Intensity##SSAO", &ssao.intensity, 0.05f, 0.0f, 5.0f))
+                    m_modified = true;
+                if (ImGui::SliderInt("Sample Count##SSAO", &ssao.sampleCount, 4, 64))
+                    m_modified = true;
+                if (ImGui::DragFloat("Bias", &ssao.bias, 0.005f, 0.0f, 0.5f, "%.3f"))
+                    m_modified = true;
+                if (ImGui::Checkbox("Blur##SSAO", &ssao.blur))
+                    m_modified = true;
+            }
+        }
+
+        if (ImGui::CollapsingHeader("Screen-Space Reflections"))
+        {
+            if (ImGui::Checkbox("SSR Enabled", &ssr.enabled))
+                m_modified = true;
+            if (ssr.enabled)
+            {
+                if (ImGui::DragFloat("Max Distance##SSR", &ssr.maxDistance, 1.0f, 1.0f, 500.0f))
+                    m_modified = true;
+                if (ImGui::SliderInt("Max Steps##SSR", &ssr.maxSteps, 8, 256))
+                    m_modified = true;
+                if (ImGui::DragFloat("Thickness##SSR", &ssr.thickness, 0.05f, 0.01f, 5.0f))
+                    m_modified = true;
+                if (ImGui::DragFloat("Fade Start", &ssr.fadeStart, 1.0f, 0.0f, ssr.fadeEnd))
+                    m_modified = true;
+                if (ImGui::DragFloat("Fade End", &ssr.fadeEnd, 1.0f, ssr.fadeStart, 500.0f))
+                    m_modified = true;
+            }
+        }
+
+        if (ImGui::CollapsingHeader("Volumetric Lighting"))
+        {
+            if (ImGui::Checkbox("Volumetric Enabled", &vol.enabled))
+                m_modified = true;
+            if (vol.enabled)
+            {
+                if (ImGui::SliderInt("Sample Count##Vol", &vol.sampleCount, 8, 128))
+                    m_modified = true;
+                if (ImGui::DragFloat("Scattering", &vol.scattering, 0.01f, 0.0f, 1.0f))
+                    m_modified = true;
+                if (ImGui::DragFloat("Extinction", &vol.extinction, 0.001f, 0.0f, 0.1f, "%.4f"))
+                    m_modified = true;
+                if (ImGui::SliderFloat("Anisotropy##Vol", &vol.anisotropy, -1.0f, 1.0f))
+                    m_modified = true;
+            }
+        }
+
+        if (ImGui::CollapsingHeader("Temporal Anti-Aliasing"))
+        {
+            if (ImGui::Checkbox("TAA Enabled", &taa.enabled))
+                m_modified = true;
+            if (taa.enabled)
+            {
+                const char* qualItems[] = {"Low", "Medium", "High", "Ultra"};
+                if (ImGui::Combo("Quality##TAA", &taa.quality, qualItems, 4))
+                    m_modified = true;
+                const char* jitterItems[] = {"Halton 2,3", "Blue Noise", "Uniform 8x", "Interleaved Gradient"};
+                if (ImGui::Combo("Jitter Pattern", &taa.jitterPattern, jitterItems, 4))
+                    m_modified = true;
+                if (ImGui::SliderFloat("History Blend", &taa.historyBlendFactor, 0.0f, 1.0f))
+                    m_modified = true;
+                if (ImGui::SliderFloat("Sharpness##TAA", &taa.sharpness, 0.0f, 1.0f))
+                    m_modified = true;
+                if (ImGui::SliderFloat("Ghosting Rejection", &taa.ghostingRejectionStrength, 0.0f, 1.0f))
+                    m_modified = true;
+                if (ImGui::SliderFloat("Flicker Reduction", &taa.flickerReduction, 0.0f, 1.0f))
+                    m_modified = true;
+                if (ImGui::Checkbox("Use Motion Vectors", &taa.useMotionVectors))
+                    m_modified = true;
+                if (ImGui::Checkbox("Use YCoCg", &taa.useYCoCg))
+                    m_modified = true;
+            }
+        }
+
+        if (ImGui::CollapsingHeader("Motion Blur"))
+        {
+            if (ImGui::Checkbox("Motion Blur Enabled", &mb.enabled))
+                m_modified = true;
+            if (mb.enabled)
+            {
+                const char* mbTypes[] = {"Camera Only", "Per-Object", "Combined"};
+                if (ImGui::Combo("Type##MB", &mb.type, mbTypes, 3))
+                    m_modified = true;
+                if (ImGui::SliderFloat("Intensity##MB", &mb.intensity, 0.0f, 2.0f))
+                    m_modified = true;
+                if (ImGui::SliderInt("Sample Count##MB", &mb.sampleCount, 2, 32))
+                    m_modified = true;
+                if (ImGui::DragFloat("Max Blur Radius", &mb.maxBlurRadius, 1.0f, 1.0f, 128.0f))
+                    m_modified = true;
+                if (ImGui::DragFloat("Velocity Scale", &mb.velocityScale, 0.1f, 0.0f, 10.0f))
+                    m_modified = true;
+            }
+        }
+    }
+
+    // =========================================================================
     // Audio Tab
     // =========================================================================
 
     void ProjectSettingsPanel::RenderAudioTab()
     {
         auto& audio = EngineSettings::GetInstance().Audio();
+        auto& ext = EngineSettings::GetInstance().AudioExtended();
 
-        if (ImGui::SliderFloat("Master Volume", &audio.masterVolume, 0.0f, 1.0f))
-            m_modified = true;
-        if (ImGui::SliderFloat("SFX Volume", &audio.sfxVolume, 0.0f, 1.0f))
-            m_modified = true;
-        if (ImGui::SliderFloat("Music Volume", &audio.musicVolume, 0.0f, 1.0f))
-            m_modified = true;
-        if (ImGui::SliderFloat("Voice Volume", &audio.voiceVolume, 0.0f, 1.0f))
-            m_modified = true;
-        if (ImGui::Checkbox("Mute on Focus Loss", &audio.muteOnFocusLoss))
-            m_modified = true;
+        if (ImGui::CollapsingHeader("Volume", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            if (ImGui::SliderFloat("Master Volume", &audio.masterVolume, 0.0f, 1.0f))
+                m_modified = true;
+            if (ImGui::SliderFloat("SFX Volume", &audio.sfxVolume, 0.0f, 1.0f))
+                m_modified = true;
+            if (ImGui::SliderFloat("Music Volume", &audio.musicVolume, 0.0f, 1.0f))
+                m_modified = true;
+            if (ImGui::SliderFloat("Voice Volume", &audio.voiceVolume, 0.0f, 1.0f))
+                m_modified = true;
+            if (ImGui::Checkbox("Mute on Focus Loss", &audio.muteOnFocusLoss))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("3D Audio & Effects"))
+        {
+            if (ImGui::Checkbox("Enable 3D Audio", &ext.enable3D))
+                m_modified = true;
+            if (ImGui::Checkbox("Enable Reverb", &ext.enableReverb))
+                m_modified = true;
+            if (ImGui::Checkbox("Enable EAX", &ext.enableEAX))
+                m_modified = true;
+            if (ImGui::DragFloat("Doppler Scale", &ext.dopplerScale, 0.1f, 0.0f, 10.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("Distance Scale", &ext.distanceScale, 0.1f, 0.1f, 100.0f))
+                m_modified = true;
+            if (ImGui::DragInt("Max Sources", &ext.maxSources, 1, 8, 256))
+                m_modified = true;
+        }
+    }
+
+    // =========================================================================
+    // Controls Tab
+    // =========================================================================
+
+    void ProjectSettingsPanel::RenderControlsTab()
+    {
+        auto& ctrl = EngineSettings::GetInstance().Controls();
+        auto& game = EngineSettings::GetInstance().Game();
+
+        if (ImGui::CollapsingHeader("Mouse", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            if (ImGui::DragFloat("Sensitivity", &ctrl.mouseSensitivity, 0.05f, 0.05f, 10.0f))
+                m_modified = true;
+            if (ImGui::Checkbox("Invert Mouse Y", &ctrl.invertMouseY))
+                m_modified = true;
+            if (ImGui::DragFloat("Dead Zone", &ctrl.mouseDeadZone, 0.01f, 0.0f, 0.5f))
+                m_modified = true;
+            if (ImGui::Checkbox("Raw Mouse Input", &ctrl.rawMouseInput))
+                m_modified = true;
+            if (ImGui::Checkbox("Mouse Acceleration", &ctrl.mouseAcceleration))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("Game Display"))
+        {
+            const char* diffItems[] = {"Easy", "Normal", "Hard", "Nightmare"};
+            int diffIdx = 1;
+            if (game.difficulty == "Easy")
+                diffIdx = 0;
+            else if (game.difficulty == "Hard")
+                diffIdx = 2;
+            else if (game.difficulty == "Nightmare")
+                diffIdx = 3;
+            if (ImGui::Combo("Difficulty", &diffIdx, diffItems, 4))
+            {
+                const char* diffNames[] = {"Easy", "Normal", "Hard", "Nightmare"};
+                game.difficulty = diffNames[diffIdx];
+                m_modified = true;
+            }
+            if (ImGui::DragFloat("Field of View", &game.fieldOfView, 1.0f, 30.0f, 150.0f, "%.0f"))
+                m_modified = true;
+        }
     }
 
     // =========================================================================
@@ -235,6 +644,55 @@ namespace SparkEditor
             m_modified = true;
         if (ImGui::Checkbox("Can Use Cover", &ai.canUseCover))
             m_modified = true;
+    }
+
+    // =========================================================================
+    // Player Tab
+    // =========================================================================
+
+    void ProjectSettingsPanel::RenderPlayerTab()
+    {
+        auto& p = EngineSettings::GetInstance().Player();
+
+        if (ImGui::CollapsingHeader("Health & Defense", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            if (ImGui::DragFloat("Max Health", &p.maxHealth, 1.0f, 1.0f, 1000.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("Max Armor", &p.maxArmor, 1.0f, 0.0f, 1000.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("Max Shield", &p.maxShield, 1.0f, 0.0f, 500.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("Shield Recharge Rate", &p.shieldRechargeRate, 0.5f, 0.0f, 100.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("Shield Recharge Delay", &p.shieldRechargeDelay, 0.1f, 0.0f, 30.0f, "%.1f s"))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("Movement", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            if (ImGui::DragFloat("Move Speed##Player", &p.moveSpeed, 0.1f, 0.1f, 50.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("Jump Height", &p.jumpHeight, 0.1f, 0.0f, 20.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("Gravity Force", &p.gravityForce, 0.5f, 1.0f, 100.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("Friction##Player", &p.friction, 0.01f, 0.0f, 1.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("Sprint Multiplier", &p.sprintMultiplier, 0.1f, 1.0f, 5.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("Crouch Multiplier", &p.crouchMultiplier, 0.05f, 0.1f, 1.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("ADS Speed Multiplier", &p.adsSpeedMultiplier, 0.05f, 0.1f, 1.0f))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("Energy"))
+        {
+            if (ImGui::DragFloat("Max Energy", &p.maxEnergy, 1.0f, 0.0f, 500.0f))
+                m_modified = true;
+            if (ImGui::DragFloat("Energy Regen Rate", &p.energyRegenRate, 0.5f, 0.0f, 100.0f))
+                m_modified = true;
+        }
     }
 
     // =========================================================================
@@ -336,6 +794,221 @@ namespace SparkEditor
             m_modified = true;
         if (ImGui::DragInt("Undo History Size", &ed.undoHistorySize, 1, 10, 1000))
             m_modified = true;
+    }
+
+    // =========================================================================
+    // Network Tab
+    // =========================================================================
+
+    void ProjectSettingsPanel::RenderNetworkTab()
+    {
+        auto& net = EngineSettings::GetInstance().Network();
+
+        if (ImGui::CollapsingHeader("Server", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            if (ImGui::DragInt("Server Port", &net.serverPort, 1, 1024, 65535))
+                m_modified = true;
+            if (ImGui::DragInt("Max Clients", &net.maxClients, 1, 1, 128))
+                m_modified = true;
+            if (ImGui::DragFloat("Connection Timeout", &net.connectionTimeout, 0.5f, 1.0f, 60.0f, "%.1f s"))
+                m_modified = true;
+            if (ImGui::DragFloat("Heartbeat Interval", &net.heartbeatInterval, 0.1f, 0.1f, 10.0f, "%.1f s"))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("Replication"))
+        {
+            if (ImGui::DragFloat("Replication Rate", &net.replicationRate, 1.0f, 1.0f, 120.0f, "%.0f Hz"))
+                m_modified = true;
+            if (ImGui::DragFloat("Reliable Retransmit Base", &net.reliableRetransmitBase, 0.05f, 0.1f, 5.0f, "%.2f s"))
+                m_modified = true;
+            if (ImGui::DragInt("Max Reliable Retries", &net.maxReliableRetries, 1, 1, 20))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("Buffers & Features"))
+        {
+            if (ImGui::DragInt("Send Buffer Size", &net.sendBufferSize, 1024, 4096, 1048576))
+                m_modified = true;
+            if (ImGui::DragInt("Receive Buffer Size", &net.receiveBufferSize, 1024, 4096, 1048576))
+                m_modified = true;
+            if (ImGui::Checkbox("Enable Compression", &net.enableCompression))
+                m_modified = true;
+            if (ImGui::Checkbox("Enable Encryption", &net.enableEncryption))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("Lag Simulation (Dev Only)"))
+        {
+            ImGui::TextColored(ImVec4(1, 0.6f, 0, 1), "For development/testing only");
+            if (ImGui::DragFloat("Simulated Latency", &net.simulatedLatencyMs, 1.0f, 0.0f, 500.0f, "%.0f ms"))
+                m_modified = true;
+            if (ImGui::SliderFloat("Simulated Packet Loss", &net.simulatedPacketLoss, 0.0f, 1.0f, "%.2f"))
+                m_modified = true;
+            if (ImGui::DragFloat("Simulated Jitter", &net.simulatedJitterMs, 0.5f, 0.0f, 100.0f, "%.0f ms"))
+                m_modified = true;
+        }
+    }
+
+    // =========================================================================
+    // Scripting Tab
+    // =========================================================================
+
+    void ProjectSettingsPanel::RenderScriptingTab()
+    {
+        auto& s = EngineSettings::GetInstance().Scripting();
+
+        if (ImGui::CollapsingHeader("Hot Reload", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            if (ImGui::Checkbox("Hot Reload Enabled", &s.hotReloadEnabled))
+                m_modified = true;
+            if (s.hotReloadEnabled)
+            {
+                if (ImGui::DragFloat("Poll Interval", &s.hotReloadPollInterval, 0.1f, 0.1f, 10.0f, "%.1f s"))
+                    m_modified = true;
+            }
+        }
+
+        if (ImGui::CollapsingHeader("Execution", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            if (ImGui::DragInt("Context Pool Size", &s.contextPoolSize, 1, 1, 64))
+                m_modified = true;
+            if (ImGui::DragFloat("Execution Timeout", &s.executionTimeoutMs, 10.0f, 10.0f, 10000.0f, "%.0f ms"))
+                m_modified = true;
+            if (ImGui::DragInt("Max Call Stack Depth", &s.maxCallStackDepth, 1, 8, 256))
+                m_modified = true;
+            if (ImGui::DragInt("Max Script Memory", &s.maxScriptMemoryMB, 1, 8, 512, "%d MB"))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("Debug"))
+        {
+            if (ImGui::Checkbox("Generate Debug Info", &s.generateDebugInfo))
+                m_modified = true;
+            if (ImGui::Checkbox("Enable Profiler", &s.enableProfiler))
+                m_modified = true;
+        }
+    }
+
+    // =========================================================================
+    // Animation Tab
+    // =========================================================================
+
+    void ProjectSettingsPanel::RenderAnimationTab()
+    {
+        auto& a = EngineSettings::GetInstance().Animation();
+
+        if (ImGui::CollapsingHeader("Blending & Playback", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            if (ImGui::DragFloat("Default Blend Time", &a.defaultBlendTime, 0.01f, 0.0f, 2.0f, "%.2f s"))
+                m_modified = true;
+            if (ImGui::DragInt("Max Active Montages", &a.maxActiveMontages, 1, 1, 16))
+                m_modified = true;
+            if (ImGui::Checkbox("Enable Root Motion", &a.enableRootMotion))
+                m_modified = true;
+            if (ImGui::Checkbox("Enable Animation Events", &a.enableAnimationEvents))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("Inverse Kinematics"))
+        {
+            if (ImGui::DragInt("IK Solver Iterations", &a.ikSolverIterations, 1, 1, 50))
+                m_modified = true;
+            if (ImGui::DragFloat("IK Tolerance", &a.ikTolerance, 0.0001f, 0.0001f, 0.1f, "%.4f"))
+                m_modified = true;
+        }
+
+        if (ImGui::CollapsingHeader("Quality & LOD"))
+        {
+            const char* compItems[] = {"None", "Low", "Medium", "High"};
+            if (ImGui::Combo("Compression Quality", &a.compressionQuality, compItems, 4))
+                m_modified = true;
+            if (ImGui::DragFloat("LOD Distance Multiplier", &a.lodDistanceMultiplier, 0.1f, 0.1f, 5.0f))
+                m_modified = true;
+        }
+    }
+
+    // =========================================================================
+    // Logging Tab
+    // =========================================================================
+
+    void ProjectSettingsPanel::RenderLoggingTab()
+    {
+        auto& log = EngineSettings::GetInstance().Logging();
+
+        const char* levelItems[] = {"Trace", "Debug", "Info", "Warn", "Error", "Fatal", "Off"};
+        auto levelCombo = [&](const char* label, std::string& level, bool allowEmpty = false)
+        {
+            int idx = 2; // Info default
+            if (level == "Trace")
+                idx = 0;
+            else if (level == "Debug")
+                idx = 1;
+            else if (level == "Info")
+                idx = 2;
+            else if (level == "Warn")
+                idx = 3;
+            else if (level == "Error")
+                idx = 4;
+            else if (level == "Fatal")
+                idx = 5;
+            else if (level == "Off")
+                idx = 6;
+            else if (allowEmpty && level.empty())
+                idx = -1;
+
+            if (allowEmpty)
+            {
+                const char* extItems[] = {"(Use Global)", "Trace", "Debug", "Info", "Warn", "Error", "Fatal", "Off"};
+                int extIdx = idx + 1;
+                if (idx == -1)
+                    extIdx = 0;
+                if (ImGui::Combo(label, &extIdx, extItems, 8))
+                {
+                    if (extIdx == 0)
+                        level = "";
+                    else
+                        level = extItems[extIdx];
+                    m_modified = true;
+                }
+            }
+            else
+            {
+                if (ImGui::Combo(label, &idx, levelItems, 7))
+                {
+                    level = levelItems[idx];
+                    m_modified = true;
+                }
+            }
+        };
+
+        if (ImGui::CollapsingHeader("Global", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            levelCombo("Global Level", log.globalLevel);
+            levelCombo("Stack Trace Level", log.stackTraceLevel);
+        }
+
+        if (ImGui::CollapsingHeader("Per-Category Overrides"))
+        {
+            ImGui::TextWrapped("Set per-category levels, or leave as '(Use Global)' to inherit.");
+            ImGui::Separator();
+            levelCombo("Core", log.coreLevel, true);
+            levelCombo("Graphics##Log", log.graphicsLevel, true);
+            levelCombo("Physics##Log", log.physicsLevel, true);
+            levelCombo("Audio##Log", log.audioLevel, true);
+            levelCombo("AI##Log", log.aiLevel, true);
+            levelCombo("Animation##Log", log.animationLevel, true);
+            levelCombo("ECS", log.ecsLevel, true);
+            levelCombo("Network##Log", log.networkLevel, true);
+            levelCombo("Input", log.inputLevel, true);
+            levelCombo("Scripting##Log", log.scriptingLevel, true);
+            levelCombo("Scene", log.sceneLevel, true);
+            levelCombo("Save", log.saveLevel, true);
+            levelCombo("Cinematic", log.cinematicLevel, true);
+            levelCombo("Procedural", log.proceduralLevel, true);
+            levelCombo("Editor##Log", log.editorLevel, true);
+            levelCombo("Game##Log", log.gameLevel, true);
+        }
     }
 
     // =========================================================================

--- a/SparkEditor/Source/Panels/ProjectSettingsPanel.h
+++ b/SparkEditor/Source/Panels/ProjectSettingsPanel.h
@@ -32,12 +32,20 @@ namespace SparkEditor
       private:
         void RenderToolbar();
         void RenderGraphicsTab();
+        void RenderRenderingTab();
+        void RenderPostProcessingTab();
         void RenderAudioTab();
+        void RenderControlsTab();
         void RenderPhysicsTab();
         void RenderAITab();
+        void RenderPlayerTab();
         void RenderGameplayTab();
         void RenderCameraTab();
+        void RenderNetworkTab();
+        void RenderScriptingTab();
+        void RenderAnimationTab();
         void RenderEditorTab();
+        void RenderLoggingTab();
         void RenderProjectInfoTab();
 
         int m_activeTab = 0;

--- a/SparkEngine/Source/Core/EngineSettings.cpp
+++ b/SparkEngine/Source/Core/EngineSettings.cpp
@@ -116,6 +116,10 @@ void EngineSettings::ResetToDefaults()
     m_gameMode = GameModeSettings{};
     m_camera = CameraSettings{};
     m_editor = EditorSettings{};
+    m_network = NetworkSettings{};
+    m_scripting = ScriptingSettings{};
+    m_animation = AnimationSettings{};
+    m_logging = LoggingSettings{};
     PopulateDefaults();
 }
 
@@ -352,6 +356,42 @@ void EngineSettings::ReadFromConfig()
     m_editor.autosaveEnabled = m_config.GetBool("Editor", "AutosaveEnabled", true);
     m_editor.autosaveIntervalSeconds = m_config.GetFloat("Editor", "AutosaveIntervalSeconds", 300.0f);
     m_editor.undoHistorySize = m_config.GetInt("Editor", "UndoHistorySize", 100);
+
+    // Network
+    m_network.serverPort = m_config.GetInt("Network", "ServerPort", 27015);
+    m_network.maxClients = m_config.GetInt("Network", "MaxClients", 32);
+    m_network.connectionTimeout = m_config.GetFloat("Network", "ConnectionTimeout", 10.0f);
+    m_network.heartbeatInterval = m_config.GetFloat("Network", "HeartbeatInterval", 1.0f);
+    m_network.replicationRate = m_config.GetFloat("Network", "ReplicationRate", 20.0f);
+    m_network.reliableRetransmitBase = m_config.GetFloat("Network", "ReliableRetransmitBase", 0.5f);
+    m_network.maxReliableRetries = m_config.GetInt("Network", "MaxReliableRetries", 5);
+    m_network.sendBufferSize = m_config.GetInt("Network", "SendBufferSize", 65536);
+    m_network.receiveBufferSize = m_config.GetInt("Network", "ReceiveBufferSize", 65536);
+    m_network.enableCompression = m_config.GetBool("Network", "EnableCompression", false);
+    m_network.enableEncryption = m_config.GetBool("Network", "EnableEncryption", false);
+    m_network.simulatedLatencyMs = m_config.GetFloat("Network", "SimulatedLatencyMs", 0.0f);
+    m_network.simulatedPacketLoss = m_config.GetFloat("Network", "SimulatedPacketLoss", 0.0f);
+    m_network.simulatedJitterMs = m_config.GetFloat("Network", "SimulatedJitterMs", 0.0f);
+
+    // Scripting
+    m_scripting.hotReloadEnabled = m_config.GetBool("Scripting", "HotReloadEnabled", true);
+    m_scripting.hotReloadPollInterval = m_config.GetFloat("Scripting", "HotReloadPollInterval", 1.0f);
+    m_scripting.contextPoolSize = m_config.GetInt("Scripting", "ContextPoolSize", 8);
+    m_scripting.executionTimeoutMs = m_config.GetFloat("Scripting", "ExecutionTimeoutMs", 100.0f);
+    m_scripting.generateDebugInfo = m_config.GetBool("Scripting", "GenerateDebugInfo", true);
+    m_scripting.maxCallStackDepth = m_config.GetInt("Scripting", "MaxCallStackDepth", 64);
+    m_scripting.maxScriptMemoryMB = m_config.GetInt("Scripting", "MaxScriptMemoryMB", 64);
+    m_scripting.enableProfiler = m_config.GetBool("Scripting", "EnableProfiler", false);
+
+    // Animation
+    m_animation.defaultBlendTime = m_config.GetFloat("Animation", "DefaultBlendTime", 0.2f);
+    m_animation.ikSolverIterations = m_config.GetInt("Animation", "IKSolverIterations", 10);
+    m_animation.ikTolerance = m_config.GetFloat("Animation", "IKTolerance", 0.001f);
+    m_animation.maxActiveMontages = m_config.GetInt("Animation", "MaxActiveMontages", 4);
+    m_animation.enableRootMotion = m_config.GetBool("Animation", "EnableRootMotion", true);
+    m_animation.lodDistanceMultiplier = m_config.GetFloat("Animation", "LODDistanceMultiplier", 1.0f);
+    m_animation.compressionQuality = m_config.GetInt("Animation", "CompressionQuality", 2);
+    m_animation.enableAnimationEvents = m_config.GetBool("Animation", "EnableAnimationEvents", true);
 
     // Logging
     m_logging.globalLevel = m_config.GetString("Logging", "GlobalLevel", "Info");
@@ -621,6 +661,42 @@ void EngineSettings::WriteToConfig() const
     m_config.SetFloat("Editor", "AutosaveIntervalSeconds", m_editor.autosaveIntervalSeconds);
     m_config.SetInt("Editor", "UndoHistorySize", m_editor.undoHistorySize);
 
+    // Network
+    m_config.SetInt("Network", "ServerPort", m_network.serverPort);
+    m_config.SetInt("Network", "MaxClients", m_network.maxClients);
+    m_config.SetFloat("Network", "ConnectionTimeout", m_network.connectionTimeout);
+    m_config.SetFloat("Network", "HeartbeatInterval", m_network.heartbeatInterval);
+    m_config.SetFloat("Network", "ReplicationRate", m_network.replicationRate);
+    m_config.SetFloat("Network", "ReliableRetransmitBase", m_network.reliableRetransmitBase);
+    m_config.SetInt("Network", "MaxReliableRetries", m_network.maxReliableRetries);
+    m_config.SetInt("Network", "SendBufferSize", m_network.sendBufferSize);
+    m_config.SetInt("Network", "ReceiveBufferSize", m_network.receiveBufferSize);
+    m_config.SetBool("Network", "EnableCompression", m_network.enableCompression);
+    m_config.SetBool("Network", "EnableEncryption", m_network.enableEncryption);
+    m_config.SetFloat("Network", "SimulatedLatencyMs", m_network.simulatedLatencyMs);
+    m_config.SetFloat("Network", "SimulatedPacketLoss", m_network.simulatedPacketLoss);
+    m_config.SetFloat("Network", "SimulatedJitterMs", m_network.simulatedJitterMs);
+
+    // Scripting
+    m_config.SetBool("Scripting", "HotReloadEnabled", m_scripting.hotReloadEnabled);
+    m_config.SetFloat("Scripting", "HotReloadPollInterval", m_scripting.hotReloadPollInterval);
+    m_config.SetInt("Scripting", "ContextPoolSize", m_scripting.contextPoolSize);
+    m_config.SetFloat("Scripting", "ExecutionTimeoutMs", m_scripting.executionTimeoutMs);
+    m_config.SetBool("Scripting", "GenerateDebugInfo", m_scripting.generateDebugInfo);
+    m_config.SetInt("Scripting", "MaxCallStackDepth", m_scripting.maxCallStackDepth);
+    m_config.SetInt("Scripting", "MaxScriptMemoryMB", m_scripting.maxScriptMemoryMB);
+    m_config.SetBool("Scripting", "EnableProfiler", m_scripting.enableProfiler);
+
+    // Animation
+    m_config.SetFloat("Animation", "DefaultBlendTime", m_animation.defaultBlendTime);
+    m_config.SetInt("Animation", "IKSolverIterations", m_animation.ikSolverIterations);
+    m_config.SetFloat("Animation", "IKTolerance", m_animation.ikTolerance);
+    m_config.SetInt("Animation", "MaxActiveMontages", m_animation.maxActiveMontages);
+    m_config.SetBool("Animation", "EnableRootMotion", m_animation.enableRootMotion);
+    m_config.SetFloat("Animation", "LODDistanceMultiplier", m_animation.lodDistanceMultiplier);
+    m_config.SetInt("Animation", "CompressionQuality", m_animation.compressionQuality);
+    m_config.SetBool("Animation", "EnableAnimationEvents", m_animation.enableAnimationEvents);
+
     // Logging
     m_config.SetString("Logging", "GlobalLevel", m_logging.globalLevel);
     m_config.SetString("Logging", "StackTraceLevel", m_logging.stackTraceLevel);
@@ -697,9 +773,9 @@ bool EngineSettings::SetValue(const std::string& section, const std::string& key
 
 std::vector<std::string> EngineSettings::GetSections() const
 {
-    return {"Graphics", "Audio",      "Controls", "Game",       "Rendering",      "PostProcess",   "SSAO",
-            "SSR",      "Volumetric", "TAA",      "MotionBlur", "DynamicQuality", "AudioExtended", "Physics",
-            "AI",       "Player",     "GameMode", "Camera",     "Editor",         "Logging"};
+    return {"Graphics",   "Audio",  "Controls",   "Game",           "Rendering",     "PostProcess", "SSAO",   "SSR",
+            "Volumetric", "TAA",    "MotionBlur", "DynamicQuality", "AudioExtended", "Physics",     "AI",     "Player",
+            "GameMode",   "Camera", "Editor",     "Network",        "Scripting",     "Animation",   "Logging"};
 }
 
 std::vector<std::string> EngineSettings::GetKeys(const std::string& section) const

--- a/SparkEngine/Source/Core/EngineSettings.h
+++ b/SparkEngine/Source/Core/EngineSettings.h
@@ -332,6 +332,55 @@ class EngineSettings
         int undoHistorySize = 100;
     };
 
+    // ---- Network ----
+
+    struct NetworkSettings
+    {
+        int serverPort = 27015;
+        int maxClients = 32;
+        float connectionTimeout = 10.0f;
+        float heartbeatInterval = 1.0f;
+        float replicationRate = 20.0f; // Updates per second
+        float reliableRetransmitBase = 0.5f;
+        int maxReliableRetries = 5;
+        int sendBufferSize = 65536;
+        int receiveBufferSize = 65536;
+        bool enableCompression = false;
+        bool enableEncryption = false;
+        // Lag simulation (development only)
+        float simulatedLatencyMs = 0.0f;
+        float simulatedPacketLoss = 0.0f;
+        float simulatedJitterMs = 0.0f;
+    };
+
+    // ---- Scripting ----
+
+    struct ScriptingSettings
+    {
+        bool hotReloadEnabled = true;
+        float hotReloadPollInterval = 1.0f; // Seconds between file change checks
+        int contextPoolSize = 8;
+        float executionTimeoutMs = 100.0f;
+        bool generateDebugInfo = true;
+        int maxCallStackDepth = 64;
+        int maxScriptMemoryMB = 64;
+        bool enableProfiler = false;
+    };
+
+    // ---- Animation ----
+
+    struct AnimationSettings
+    {
+        float defaultBlendTime = 0.2f;
+        int ikSolverIterations = 10;
+        float ikTolerance = 0.001f;
+        int maxActiveMontages = 4;
+        bool enableRootMotion = true;
+        float lodDistanceMultiplier = 1.0f; // Skeleton LOD distance scale
+        int compressionQuality = 2;         // 0=None, 1=Low, 2=Medium, 3=High
+        bool enableAnimationEvents = true;
+    };
+
     // ---- Logging ----
 
     struct LoggingSettings
@@ -454,6 +503,15 @@ class EngineSettings
     EditorSettings& Editor() { return m_editor; }
     const EditorSettings& Editor() const { return m_editor; }
 
+    NetworkSettings& Network() { return m_network; }
+    const NetworkSettings& Network() const { return m_network; }
+
+    ScriptingSettings& Scripting() { return m_scripting; }
+    const ScriptingSettings& Scripting() const { return m_scripting; }
+
+    AnimationSettings& Animation() { return m_animation; }
+    const AnimationSettings& Animation() const { return m_animation; }
+
     LoggingSettings& Logging() { return m_logging; }
     const LoggingSettings& Logging() const { return m_logging; }
 
@@ -529,6 +587,9 @@ class EngineSettings
     GameModeSettings m_gameMode;
     CameraSettings m_camera;
     EditorSettings m_editor;
+    NetworkSettings m_network;
+    ScriptingSettings m_scripting;
+    AnimationSettings m_animation;
     LoggingSettings m_logging;
 
     // Change listeners

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -130,5 +130,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 209 |
 | Test cases | 2508+ |
 | Wiki pages | 65 |
-| *Last synced* | *2026-03-28 19:15* |
+| *Last synced* | *2026-03-28 21:01* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
Add NetworkSettings (port, clients, timeouts, replication, lag sim), ScriptingSettings (hot reload, context pool, execution limits), and AnimationSettings (blend times, IK params, compression, root motion) to EngineSettings with full INI serialization.

Expand ProjectSettingsPanel from 8 to 16 tabs: add Rendering (advanced pipeline, textures, shadows, culling, LOD, dynamic quality scaler), Post-Processing (bloom, tone mapping, color grading, SSAO, SSR, volumetric, TAA, motion blur), Controls (mouse, difficulty, FOV), Player (health, movement, shield, energy), Network, Scripting, Animation, and Logging (global + per-category level overrides). Expand Audio tab with 3D audio/reverb/EAX/doppler settings.

Total configurable settings: ~200 across 23 INI sections.

https://claude.ai/code/session_01BTEJyvTvi6J94UpaoZrzG2