### PR TITLE
fix: restore compiler warnings in physics code after Jolt suppression

### DIFF
--- a/SparkEditor/Source/Core/EditorIcons.h
+++ b/SparkEditor/Source/Core/EditorIcons.h
@@ -135,6 +135,8 @@
 // === Additional Icons ===
 #define ICON_FA_RUNNING "\xef\x9c\x8c"       // U+F70C (person-running)
 #define ICON_FA_CODE "\xef\x84\xa1"          // U+F121
+#define ICON_FA_CUBES "\xef\x86\xb3"         // U+F1B3
+#define ICON_FA_WIFI "\xef\x87\xab"          // U+F1EB
 #define ICON_FA_FONT "\xef\x80\xb1"          // U+F031
 #define ICON_FA_GRID "\xef\x80\x8a"          // U+F00A (alias for TH/grid)
 #define ICON_FA_HOME "\xef\x80\x95"          // U+F015

--- a/SparkEngine/Source/Core/EngineSettings.h
+++ b/SparkEngine/Source/Core/EngineSettings.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "Utils/ConfigParser.h"
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <functional>

--- a/SparkEngine/Source/Physics/CharacterController.cpp
+++ b/SparkEngine/Source/Physics/CharacterController.cpp
@@ -17,6 +17,7 @@
 #include <Jolt/Physics/PhysicsSystem.h>
 
 JPH_SUPPRESS_WARNINGS
+#include "JoltWarningRestore.h"
 
 using namespace DirectX;
 

--- a/SparkEngine/Source/Physics/JoltWarningRestore.h
+++ b/SparkEngine/Source/Physics/JoltWarningRestore.h
@@ -1,0 +1,39 @@
+/**
+ * @file JoltWarningRestore.h
+ * @brief Re-enables important compiler warnings after JPH_SUPPRESS_WARNINGS
+ *
+ * JPH_SUPPRESS_WARNINGS (from Jolt's Core.h) uses #pragma diagnostic ignored
+ * which applies from point of use to end of translation unit — suppressing
+ * warnings in our own code too. Include this header immediately after
+ * JPH_SUPPRESS_WARNINGS in each physics .cpp to restore key diagnostics.
+ */
+
+#pragma once
+
+// Re-enable warnings that matter for engine code correctness.
+// JPH_SUPPRESS_WARNINGS disables these globally; we restore them so our own
+// physics logic is still checked by the compiler.
+
+#if defined(__clang__)
+
+#pragma clang diagnostic warning "-Wsign-conversion"
+#pragma clang diagnostic warning "-Wuninitialized"
+#pragma clang diagnostic warning "-Wunused-parameter"
+#pragma clang diagnostic warning "-Wfloat-equal"
+#pragma clang diagnostic warning "-Wold-style-cast"
+#pragma clang diagnostic warning "-Wcast-align"
+
+#elif defined(__GNUC__)
+
+#pragma GCC diagnostic warning "-Wsign-conversion"
+#pragma GCC diagnostic warning "-Wuninitialized"
+#pragma GCC diagnostic warning "-Wmaybe-uninitialized"
+#pragma GCC diagnostic warning "-Wunused-parameter"
+
+#elif defined(_MSC_VER)
+
+#pragma warning(default : 4365) // signed/unsigned mismatch
+#pragma warning(default : 5219) // implicit conversion, possible loss of data
+#pragma warning(default : 4100) // unreferenced formal parameter
+
+#endif

--- a/SparkEngine/Source/Physics/PhysicsBodyImpl.cpp
+++ b/SparkEngine/Source/Physics/PhysicsBodyImpl.cpp
@@ -20,6 +20,7 @@
 #include <Jolt/Physics/Constraints/Constraint.h>
 
 JPH_SUPPRESS_WARNINGS
+#include "JoltWarningRestore.h"
 
 #include <sstream>
 

--- a/SparkEngine/Source/Physics/PhysicsShapeFactory.cpp
+++ b/SparkEngine/Source/Physics/PhysicsShapeFactory.cpp
@@ -34,6 +34,7 @@
 #include <Jolt/Physics/Collision/Shape/RotatedTranslatedShape.h>
 
 JPH_SUPPRESS_WARNINGS
+#include "JoltWarningRestore.h"
 
 using namespace DirectX;
 

--- a/SparkEngine/Source/Physics/PhysicsSystem.cpp
+++ b/SparkEngine/Source/Physics/PhysicsSystem.cpp
@@ -38,6 +38,7 @@
 #include <thread>
 
 JPH_SUPPRESS_WARNINGS
+#include "JoltWarningRestore.h"
 
 using namespace DirectX;
 
@@ -157,8 +158,8 @@ class SparkContactListener final : public JPH::ContactListener
     std::mutex m_contactMutex;
 
     JPH::ValidateResult OnContactValidate(const JPH::Body& inBody1, const JPH::Body& inBody2,
-                                          JPH::RVec3Arg inBaseOffset,
-                                          const JPH::CollideShapeResult& inCollisionResult) override
+                                          JPH::RVec3Arg /*inBaseOffset*/,
+                                          const JPH::CollideShapeResult& /*inCollisionResult*/) override
     {
         // Apply collision group/mask filtering from PhysicsBody wrappers
         if (m_physicsSystem)
@@ -271,12 +272,12 @@ class SparkContactListener final : public JPH::ContactListener
 class SparkBodyActivationListener final : public JPH::BodyActivationListener
 {
   public:
-    void OnBodyActivated(const JPH::BodyID& inBodyID, uint64_t inBodyUserData) override
+    void OnBodyActivated(const JPH::BodyID& /*inBodyID*/, uint64_t /*inBodyUserData*/) override
     {
         // Bodies waking up — can be used for LOD/optimization
     }
 
-    void OnBodyDeactivated(const JPH::BodyID& inBodyID, uint64_t inBodyUserData) override
+    void OnBodyDeactivated(const JPH::BodyID& /*inBodyID*/, uint64_t /*inBodyUserData*/) override
     {
         // Bodies going to sleep — can be used to stop updating transforms
     }

--- a/SparkEngine/Source/Physics/PhysicsSystemQueries.cpp
+++ b/SparkEngine/Source/Physics/PhysicsSystemQueries.cpp
@@ -53,6 +53,7 @@
 #include <Jolt/Physics/Collision/Shape/ScaledShape.h>
 
 JPH_SUPPRESS_WARNINGS
+#include "JoltWarningRestore.h"
 
 #include <algorithm>
 #include <mutex>
@@ -335,7 +336,8 @@ std::shared_ptr<PhysicsConstraint> PhysicsSystem::CreateSliderConstraint(std::sh
 
 std::shared_ptr<PhysicsConstraint> PhysicsSystem::CreateFixedConstraint(std::shared_ptr<PhysicsBody> bodyA,
                                                                         std::shared_ptr<PhysicsBody> bodyB,
-                                                                        const XMMATRIX& frameA, const XMMATRIX& frameB)
+                                                                        const XMMATRIX& frameA,
+                                                                        [[maybe_unused]] const XMMATRIX& frameB)
 {
     if (!m_joltSystem || !bodyA || !bodyB)
         return nullptr;

--- a/SparkEngine/Source/Physics/RagdollSystem.cpp
+++ b/SparkEngine/Source/Physics/RagdollSystem.cpp
@@ -14,6 +14,7 @@
 #include <Jolt/Jolt.h>
 
 JPH_SUPPRESS_WARNINGS
+#include "JoltWarningRestore.h"
 
 using namespace DirectX;
 
@@ -54,7 +55,7 @@ Ragdoll::Ragdoll(PhysicsSystem* physicsSystem, const RagdollDesc& desc) : m_phys
             continue;
 
         auto& child = m_parts[i];
-        auto& parent = m_parts[partDesc.parentIndex];
+        auto& parent = m_parts[static_cast<size_t>(partDesc.parentIndex)];
 
         if (!child.body || !parent.body)
         {

--- a/SparkEngine/Source/Physics/SoftBodyPhysics.cpp
+++ b/SparkEngine/Source/Physics/SoftBodyPhysics.cpp
@@ -20,6 +20,7 @@
 #include <Jolt/Physics/SoftBody/SoftBodyMotionProperties.h>
 
 JPH_SUPPRESS_WARNINGS
+#include "JoltWarningRestore.h"
 
 using namespace DirectX;
 

--- a/SparkEngine/Source/Physics/VehiclePhysics.cpp
+++ b/SparkEngine/Source/Physics/VehiclePhysics.cpp
@@ -22,6 +22,7 @@
 #include <Jolt/Physics/Vehicle/VehicleCollisionTester.h>
 
 JPH_SUPPRESS_WARNINGS
+#include "JoltWarningRestore.h"
 
 using namespace DirectX;
 


### PR DESCRIPTION
JPH_SUPPRESS_WARNINGS uses #pragma diagnostic ignored which applies to the entire translation unit, silently suppressing warnings in our own physics code (-Wsign-conversion, -Wmaybe-uninitialized, -Wunused-parameter, etc). Add JoltWarningRestore.h that re-enables key diagnostics after the Jolt macro, and fix the 5 previously-hidden warnings this surfaced.

https://claude.ai/code/session_01RJHXxWzpKFjKjUZYmfwcXb