### PR TITLE
fix: VulkanBuffer use-after-free, D3D11 WARP crash under Wine, add Wi…

### DIFF
--- a/SparkEngine/Source/Graphics/RHI/D3D11/D3D11Device.cpp
+++ b/SparkEngine/Source/Graphics/RHI/D3D11/D3D11Device.cpp
@@ -598,6 +598,26 @@ namespace Spark
                 SPARK_LOG_INFO(Spark::LogCategory::Graphics, "D3D11Device::Initialize starting");
                 m_debugEnabled = desc.enableDebugLayer;
 
+                // Detect Wine environment. Under Wine+DXVK, D3D11 is translated to
+                // Vulkan. WARP is unavailable and repeated D3D11 device creation can
+                // crash with Lavapipe (software Vulkan) due to DXVK state corruption.
+                static int s_wineDetected = -1;
+                static bool s_wineD3D11Failed = false;
+                if (s_wineDetected < 0)
+                {
+                    HMODULE ntdll = GetModuleHandleA("ntdll.dll");
+                    s_wineDetected = (ntdll && GetProcAddress(ntdll, "wine_get_version")) ? 1 : 0;
+                }
+
+                // If a previous D3D11 init already failed under Wine, don't retry —
+                // DXVK state may be corrupted and retrying can cause ACCESS_VIOLATION.
+                if (s_wineD3D11Failed)
+                {
+                    SPARK_LOG_WARN(Spark::LogCategory::Graphics,
+                                   "D3D11: Skipping init — previous attempt failed under Wine");
+                    return false;
+                }
+
                 UINT createFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
                 if (desc.enableDebugLayer)
                     createFlags |= D3D11_CREATE_DEVICE_DEBUG;
@@ -617,6 +637,17 @@ namespace Spark
 
                 if (FAILED(hr))
                 {
+                    // Wine/DXVK does not support WARP (D3D_DRIVER_TYPE_WARP) and
+                    // will crash with ACCESS_VIOLATION instead of returning a clean
+                    // HRESULT failure. Skip WARP entirely when running under Wine.
+                    if (s_wineDetected)
+                    {
+                        SPARK_LOG_WARN(Spark::LogCategory::Graphics,
+                                       "D3D11: Running under Wine — WARP fallback unavailable");
+                        s_wineD3D11Failed = true;
+                        return false;
+                    }
+
                     SPARK_LOG_WARN(Spark::LogCategory::Graphics,
                                    "D3D11: Hardware device creation failed — falling back to WARP software rasterizer");
                     hr = D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_WARP, nullptr, createFlags, featureLevels,

--- a/SparkEngine/Source/Graphics/RHI/Vulkan/VulkanDevice.cpp
+++ b/SparkEngine/Source/Graphics/RHI/Vulkan/VulkanDevice.cpp
@@ -802,6 +802,9 @@ namespace Spark
 
             std::unique_ptr<IRHISwapChain> VulkanDevice::CreateSwapChain(const RHISwapChainDesc& desc)
             {
+                if (m_device == VK_NULL_HANDLE || m_instance == VK_NULL_HANDLE)
+                    return nullptr;
+
                 VkSurfaceKHR surface = VK_NULL_HANDLE;
 
 #ifdef _WIN32
@@ -819,6 +822,9 @@ namespace Spark
 
             std::unique_ptr<IRHIBuffer> VulkanDevice::CreateBuffer(const RHIBufferDesc& desc)
             {
+                if (m_device == VK_NULL_HANDLE)
+                    return nullptr;
+
                 VkBufferCreateInfo bufferInfo = {};
                 bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
                 bufferInfo.size = desc.size;
@@ -955,6 +961,9 @@ namespace Spark
 
             std::unique_ptr<IRHITexture> VulkanDevice::CreateTexture(const RHITextureDesc& desc)
             {
+                if (m_device == VK_NULL_HANDLE)
+                    return nullptr;
+
                 VkImageCreateInfo imageInfo = {};
                 imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
                 imageInfo.imageType = VK_IMAGE_TYPE_2D;

--- a/Tests/TestMain.cpp
+++ b/Tests/TestMain.cpp
@@ -29,7 +29,9 @@
 #include <random>
 #include <sstream>
 
-#ifndef _WIN32
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <csignal>
 #include <cstdio>
 #include <cstring>
@@ -55,10 +57,59 @@ struct TestResult
 };
 
 // ============================================================================
-// Signal handling — catch crashes so they don't silently kill the suite
+// Signal/exception handling — catch crashes so they don't silently kill the suite
 // ============================================================================
 
-#ifndef _WIN32
+#ifdef _WIN32
+static LONG WINAPI CrashExceptionFilter(EXCEPTION_POINTERS* exInfo)
+{
+    const char* excName = "UNKNOWN";
+    if (exInfo && exInfo->ExceptionRecord)
+    {
+        switch (exInfo->ExceptionRecord->ExceptionCode)
+        {
+        case EXCEPTION_ACCESS_VIOLATION:
+            excName = "ACCESS_VIOLATION";
+            break;
+        case EXCEPTION_STACK_OVERFLOW:
+            excName = "STACK_OVERFLOW";
+            break;
+        case EXCEPTION_INT_DIVIDE_BY_ZERO:
+            excName = "DIVIDE_BY_ZERO";
+            break;
+        case EXCEPTION_ILLEGAL_INSTRUCTION:
+            excName = "ILLEGAL_INSTRUCTION";
+            break;
+        default:
+            excName = "EXCEPTION";
+            break;
+        }
+    }
+
+    // Write crash info to stderr (OutputDebugString is not async-safe either)
+    HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
+    if (hErr != INVALID_HANDLE_VALUE)
+    {
+        DWORD written;
+        WriteFile(hErr, "\n[ CRASH  ] ", 12, &written, nullptr);
+        WriteFile(hErr, g_currentTest.c_str(), static_cast<DWORD>(g_currentTest.size()), &written, nullptr);
+        WriteFile(hErr, " (", 2, &written, nullptr);
+        WriteFile(hErr, excName, static_cast<DWORD>(strlen(excName)), &written, nullptr);
+        WriteFile(hErr, ")\n", 2, &written, nullptr);
+    }
+
+    // Print to stdout as well so test output captures it
+    std::cout << "\n[ CRASH  ] " << g_currentTest << " (" << excName << ")\n";
+    std::cout.flush();
+
+    ExitProcess(1);
+}
+
+static void InstallCrashHandlers()
+{
+    SetUnhandledExceptionFilter(CrashExceptionFilter);
+}
+#else
 static void CrashSignalHandler(int sig)
 {
     const char* sigName = "UNKNOWN";
@@ -251,9 +302,7 @@ static void PrintUsage(const char* argv0)
 
 int main(int argc, char** argv)
 {
-#ifndef _WIN32
     InstallCrashHandlers();
-#endif
 
     // Parse CLI arguments
     std::string outputFilePath;

--- a/Tests/TestVulkanLavapipe.cpp
+++ b/Tests/TestVulkanLavapipe.cpp
@@ -120,6 +120,10 @@ TEST(VulkanLavapipe_BufferCreation)
         EXPECT_TRUE(buffer->GetSize() == 1024);
     }
 
+    // Destroy buffer BEFORE shutting down the device — the buffer's destructor
+    // calls vkDestroyBuffer() which requires the VkDevice to still be alive.
+    buffer.reset();
+
     device.Shutdown();
 #endif
 }

--- a/Tests/TestWARPRendering.cpp
+++ b/Tests/TestWARPRendering.cpp
@@ -126,6 +126,10 @@ TEST(WARP_D3D11BufferCreation)
         EXPECT_TRUE(buffer->GetSize() == 1024);
     }
 
+    // Destroy buffer BEFORE shutting down the device — the buffer's destructor
+    // releases D3D11 resources that require the device to still be alive.
+    buffer.reset();
+
     device.Shutdown();
 #endif
 }


### PR DESCRIPTION
…ndows SEH crash handler

- Fix critical use-after-free in TestVulkanLavapipe: buffer destructor called vkDestroyBuffer on already-destroyed VkDevice. Explicitly reset buffer before device.Shutdown(). Same fix applied to TestWARPRendering.
- Add null device guards to Vulkan CreateSwapChain, CreateBuffer, and CreateTexture to prevent crashes when called after Shutdown().
- Detect Wine environment in D3D11Device::Initialize to skip WARP fallback (causes ACCESS_VIOLATION under Wine/DXVK) and cache failure to prevent repeated crash-prone D3D11 init attempts.
- Add Windows SEH crash handler (SetUnhandledExceptionFilter) to test runner so crashes under Wine are reported with test name instead of silently killing the process.

Results: 2509/2509 pass native Linux, 2502/2509 pass Wine+DXVK+Lavapipe
(7 expected failures: WARP unavailable, stack traces, timing).

https://claude.ai/code/session_01Rjmh8bayw5QU9aQaJdeMLC