### PR TITLE
Fix Split("", ',') crash causing CI test failures

### DIFF
--- a/SparkEngine/Source/Utils/StringUtils.h
+++ b/SparkEngine/Source/Utils/StringUtils.h
@@ -105,12 +105,15 @@ namespace Spark
         inline std::vector<std::string> Split(const std::string& str, char delimiter)
         {
             std::vector<std::string> tokens;
-            std::string token;
-            std::istringstream stream(str);
-            while (std::getline(stream, token, delimiter))
+            size_t start = 0;
+            size_t end = str.find(delimiter);
+            while (end != std::string::npos)
             {
-                tokens.push_back(token);
+                tokens.push_back(str.substr(start, end - start));
+                start = end + 1;
+                end = str.find(delimiter, start);
             }
+            tokens.push_back(str.substr(start));
             return tokens;
         }
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -130,5 +130,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 211 |
 | Test cases | 2666+ |
 | Wiki pages | 66 |
-| *Last synced* | *2026-03-31 01:41* |
+| *Last synced* | *2026-03-31 05:16* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
The char-delimiter Split() used std::getline with std::istringstream, which returns zero tokens for empty strings on GCC. Tests then accessed parts[0] on an empty vector, causing a segfault that killed the test runner. This crashed both build-windows-vs2022 (Release) and Code Coverage (GCC) CI jobs.

Replace with a find-based implementation that correctly handles empty strings, trailing delimiters, and matches the string-delimiter overload.

https://claude.ai/code/session_018XfnqPeeTKyieDKGzqSESU