### PR TITLE
Optimization pass: reduce code duplication and split oversized functi…

### DIFF
--- a/.claude/knowledge/code-quality-violations.md
+++ b/.claude/knowledge/code-quality-violations.md
@@ -11,6 +11,8 @@ Comprehensive audit of CLAUDE.md hard limit violations beyond file/class size: o
 
 **Progress (2026-03-31):** Down from 66 oversized functions to 9 remaining (86% reduction). RegisterDefaultCommands split into 3 focused functions. InspectorComponentRenderers.cpp split into 4 domain-specific files. MaterialSystem "duplicates" confirmed as wrapper+impl (not true duplicates). Remaining oversized functions are mostly clear linear code (data-driven arena creation, UI callbacks) that would lose readability if split further.
 
+**Progress (2026-03-31, optimization pass):** SaveSystem::RegisterBuiltins() (425 lines) split into 3 domain functions. SaveSystem::SerializeWorld() (124 lines) refactored with TrySerialize<T> template. ConsoleApp Run/ReadEngineInput/ReadUserInput split into focused helpers. SparkEngine RunHeadlessWindows trimmed.
+
 ---
 
 ## 1. Functions Over 50 Lines (66 Violations)

--- a/.claude/knowledge/codebase-bloat-audit-2026-03-15.md
+++ b/.claude/knowledge/codebase-bloat-audit-2026-03-15.md
@@ -16,6 +16,15 @@ Comprehensive audit combining prior findings (March 14) with new deep analysis. 
 
 **Progress (2026-03-31):** InspectorComponentRenderers.cpp (1,887 lines) split into 4 domain-specific files (~470 lines each): Core3D, 2D, Gameplay, Reflected. ConsoleApp::RegisterDefaultCommands (321 lines) split into 3 focused functions: RegisterCoreCommands, RegisterDiagnosticCommands, RegisterAliasCommands. Oversized function count reduced from 66 to 9 (86% reduction). CLAUDE.md phantom system references (Procedural, Stats) removed.
 
+**Progress (2026-03-31, optimization pass):** ~1100 lines net reduction across 5 files:
+- InputManager.cpp: Windows/Linux code consolidated — shared key mapping, query methods, console integration defined once (1338→840, -37%)
+- UpscalingSystem.cpp: 640 lines of inline HLSL shaders extracted to UpscalingShaders.h (1335→652, -51%)
+- SaveSystem.cpp: RegisterBuiltins() split into 3 domain functions; SerializeWorld() refactored with TrySerialize<T> template (1350→1274)
+- ConsoleApp.cpp: Run/ReadEngineInput/ReadUserInput split into focused helpers
+- SparkEngine.cpp: RunHeadlessWindows refactored to reuse existing helpers
+- AudioMixer ODR issue confirmed FALSE — MusicManager.h defines AudioBusMixer, not AudioMixer
+- MaterialSystem duplicates confirmed RESOLVED in prior sessions
+
 ---
 
 ## 1. Oversized Files (Hard Limit Violations)

--- a/SparkConsole/src/ConsoleApp.cpp
+++ b/SparkConsole/src/ConsoleApp.cpp
@@ -86,7 +86,7 @@ ConsoleApp::~ConsoleApp()
     }
 }
 
-void ConsoleApp::Run()
+void ConsoleApp::PrintBanner()
 {
 #ifdef SPARK_PLATFORM_WINDOWS
     [[maybe_unused]] int rc_ = system("cls");
@@ -99,7 +99,10 @@ void ConsoleApp::Run()
     std::wcout << L"========================================" << std::endl;
     std::wcout << std::endl;
     PrintLog(L"Console application started. Type 'help' for commands or 'exit' to quit.");
+}
 
+bool ConsoleApp::DetectPipeMode()
+{
 #ifdef SPARK_PLATFORM_WINDOWS
     HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
     DWORD fileType = GetFileType(hStdin);
@@ -116,140 +119,97 @@ void ConsoleApp::Run()
         PrintLog(L"Running in standalone mode. Engine commands will not be available.");
         PrintLog(L"Waiting for SparkEngine to connect... (or type commands to use standalone)");
     }
+    return pipeMode;
+}
 
-    std::string input;
-    int noInputCounter = 0;
+void ConsoleApp::PollPipeModeInput(std::string& input, int& noInputCounter, bool& pipeMode,
+                                   std::atomic<bool>& keyboardThreadRunning)
+{
+#ifdef SPARK_PLATFORM_WINDOWS
+    HANDLE hConsoleOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    CONSOLE_SCREEN_BUFFER_INFO csbi;
+    GetConsoleScreenBufferInfo(hConsoleOut, &csbi);
 
-    // In pipe mode, start a separate thread for keyboard input
-    std::thread keyboardThread;
-    std::atomic<bool> keyboardThreadRunning{false};
+    SetConsoleTextAttribute(hConsoleOut, FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+    WriteConsoleW(hConsoleOut, L"> ", 2, NULL, NULL);
+    SetConsoleTextAttribute(hConsoleOut, FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
+#else
+    std::cout << ANSI_GREEN_BOLD << "> " << ANSI_RESET << std::flush;
+#endif
 
-    if (pipeMode)
-    {
-        keyboardThreadRunning = true;
-        keyboardThread = std::thread(
-            [&]()
-            {
-                while (keyboardThreadRunning && m_running)
-                {
-#ifdef SPARK_PLATFORM_WINDOWS
-                    if (_kbhit())
-                    {
-                        char ch = _getch();
-#else
-                    if (LinuxKbhit())
-                    {
-                        char ch = LinuxGetch();
-#endif
-                        if (ch == '\r' || ch == '\n')
-                        {
-                            if (!input.empty())
-                            {
-                                AddToHistory(input);
-                                if (input == "exit" || input == "quit")
-                                {
-                                    PrintLog(L"Console shutting down...");
-                                    m_running = false;
-                                    keyboardThreadRunning = false;
-                                    break;
-                                }
-                                // Send command to engine via stdout
-                                std::cout << input << std::endl;
-                                std::cout.flush();
-                                input.clear();
-                            }
-#ifdef SPARK_PLATFORM_WINDOWS
-                            HANDLE hConsoleOut = GetStdHandle(STD_OUTPUT_HANDLE);
-                            WriteConsoleW(hConsoleOut, L"\n", 1, NULL, NULL);
-#else
-                            std::cout << std::endl;
-#endif
-                        }
-                        else if (ch == '\b' || ch == 127) // 127 = DEL on Linux
-                        {
-                            if (!input.empty())
-                            {
-                                input.pop_back();
-#ifdef SPARK_PLATFORM_WINDOWS
-                                HANDLE hConsoleOut = GetStdHandle(STD_OUTPUT_HANDLE);
-                                WriteConsoleW(hConsoleOut, L"\b \b", 3, NULL, NULL);
-#else
-                                std::cout << "\b \b" << std::flush;
-#endif
-                            }
-                        }
-                        else if (ch >= 32 && ch <= 126)
-                        {
-                            input += ch;
-#ifdef SPARK_PLATFORM_WINDOWS
-                            HANDLE hConsoleOut = GetStdHandle(STD_OUTPUT_HANDLE);
-                            wchar_t wch = static_cast<wchar_t>(ch);
-                            WriteConsoleW(hConsoleOut, &wch, 1, NULL, NULL);
-#else
-                            std::cout << ch << std::flush;
-#endif
-                        }
-                    }
-                    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-                }
-            });
-    }
+    // Just sleep and let the keyboard thread and ReadEngineInput thread do their work
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    while (m_running)
-    {
-        // In pipe mode, display prompt and let keyboard thread handle input
-        if (pipeMode)
+    noInputCounter++;
+    if (noInputCounter > 100)
+    { // Check connection every 10 seconds
+#ifdef SPARK_PLATFORM_WINDOWS
+        HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
+        DWORD newFileType = GetFileType(hStdin);
+        if (newFileType != FILE_TYPE_PIPE)
         {
-#ifdef SPARK_PLATFORM_WINDOWS
-            HANDLE hConsoleOut = GetStdHandle(STD_OUTPUT_HANDLE);
-            CONSOLE_SCREEN_BUFFER_INFO csbi;
-            GetConsoleScreenBufferInfo(hConsoleOut, &csbi);
-
-            SetConsoleTextAttribute(hConsoleOut, FOREGROUND_GREEN | FOREGROUND_INTENSITY);
-            WriteConsoleW(hConsoleOut, L"> ", 2, NULL, NULL);
-            SetConsoleTextAttribute(hConsoleOut, FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
-#else
-            std::cout << ANSI_GREEN_BOLD << "> " << ANSI_RESET << std::flush;
-#endif
-
-            // Just sleep and let the keyboard thread and ReadEngineInput thread do their work
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-            noInputCounter++;
-            if (noInputCounter > 100)
-            { // Check connection every 10 seconds
-#ifdef SPARK_PLATFORM_WINDOWS
-                DWORD newFileType = GetFileType(hStdin);
-                if (newFileType != FILE_TYPE_PIPE)
-                {
-                    PrintLog(L"Engine connection lost. Switching to standalone mode.");
-                    pipeMode = false;
-                    keyboardThreadRunning = false;
-                }
-#endif
-                noInputCounter = 0;
-            }
+            PrintLog(L"Engine connection lost. Switching to standalone mode.");
+            pipeMode = false;
+            keyboardThreadRunning = false;
         }
-        else
-        {
-            // Standalone mode - use standard input handling
-#ifdef SPARK_PLATFORM_WINDOWS
-            SetConsoleColor(FOREGROUND_GREEN | FOREGROUND_INTENSITY);
-#else
-            std::cout << ANSI_GREEN_BOLD;
 #endif
-            std::cout << "> ";
-#ifdef SPARK_PLATFORM_WINDOWS
-            SetConsoleColor(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
-#else
-            std::cout << ANSI_RESET;
-#endif
-            std::cout.flush();
+        noInputCounter = 0;
+    }
+}
 
-            if (std::getline(std::cin, input))
+void ConsoleApp::PollStandaloneInput(std::string& input)
+{
+#ifdef SPARK_PLATFORM_WINDOWS
+    SetConsoleColor(FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+#else
+    std::cout << ANSI_GREEN_BOLD;
+#endif
+    std::cout << "> ";
+#ifdef SPARK_PLATFORM_WINDOWS
+    SetConsoleColor(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
+#else
+    std::cout << ANSI_RESET;
+#endif
+    std::cout.flush();
+
+    if (std::getline(std::cin, input))
+    {
+        input.erase(0, input.find_first_not_of(" \t"));
+        input.erase(input.find_last_not_of(" \t") + 1);
+        if (!input.empty())
+        {
+            AddToHistory(input);
+            if (input == "exit" || input == "quit")
             {
-                input.erase(0, input.find_first_not_of(" \t"));
-                input.erase(input.find_last_not_of(" \t") + 1);
+                PrintLog(L"Console shutting down...");
+                m_running = false;
+                return;
+            }
+            ExecuteCommand(input);
+        }
+    }
+    else
+    {
+        PrintLog(L"Input stream closed. Exiting...");
+        m_running = false;
+    }
+}
+
+void ConsoleApp::PipeKeyboardThreadFunc(std::string& input, std::atomic<bool>& keyboardThreadRunning)
+{
+    while (keyboardThreadRunning && m_running)
+    {
+#ifdef SPARK_PLATFORM_WINDOWS
+        if (_kbhit())
+        {
+            char ch = _getch();
+#else
+        if (LinuxKbhit())
+        {
+            char ch = LinuxGetch();
+#endif
+            if (ch == '\r' || ch == '\n')
+            {
                 if (!input.empty())
                 {
                     AddToHistory(input);
@@ -257,17 +217,60 @@ void ConsoleApp::Run()
                     {
                         PrintLog(L"Console shutting down...");
                         m_running = false;
+                        keyboardThreadRunning = false;
                         break;
                     }
-                    ExecuteCommand(input);
+                    std::cout << input << std::endl;
+                    std::cout.flush();
+                    input.clear();
                 }
+#ifdef SPARK_PLATFORM_WINDOWS
+                HANDLE hConsoleOut = GetStdHandle(STD_OUTPUT_HANDLE);
+                WriteConsoleW(hConsoleOut, L"\n", 1, NULL, NULL);
+#else
+                std::cout << std::endl;
+#endif
             }
-            else
+            else if (ch == '\b' || ch == 127)
             {
-                PrintLog(L"Input stream closed. Exiting...");
-                m_running = false;
-                break;
+                HandleBackspaceKey(input);
             }
+            else if (ch >= 32 && ch <= 126)
+            {
+                HandlePrintableChar(input, ch);
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+}
+
+void ConsoleApp::Run()
+{
+    PrintBanner();
+    bool pipeMode = DetectPipeMode();
+
+    std::string input;
+    int noInputCounter = 0;
+
+    std::thread keyboardThread;
+    std::atomic<bool> keyboardThreadRunning{false};
+
+    if (pipeMode)
+    {
+        keyboardThreadRunning = true;
+        keyboardThread =
+            std::thread(&ConsoleApp::PipeKeyboardThreadFunc, this, std::ref(input), std::ref(keyboardThreadRunning));
+    }
+
+    while (m_running)
+    {
+        if (pipeMode)
+        {
+            PollPipeModeInput(input, noInputCounter, pipeMode, keyboardThreadRunning);
+        }
+        else
+        {
+            PollStandaloneInput(input);
         }
     }
 
@@ -275,31 +278,112 @@ void ConsoleApp::Run()
     if (keyboardThreadRunning)
     {
         keyboardThreadRunning = false;
-        if (keyboardThread.joinable())
-        {
-            keyboardThread.join();
-        }
+    }
+    if (keyboardThread.joinable())
+    {
+        keyboardThread.join();
     }
 
     PrintLog(L"Console application terminated.");
 }
 
-void ConsoleApp::ReadEngineInput()
+void ConsoleApp::ProcessPipeMessages(const std::string& message)
 {
-    // This method reads messages from the engine via stdin (which is redirected from engine's pipe)
-    std::string line;
+    std::istringstream iss(message);
+    std::string pipeLine;
+    while (std::getline(iss, pipeLine))
+    {
+        if (pipeLine.empty())
+        {
+            continue;
+        }
+
+        // Remove carriage return if present
+        if (pipeLine.back() == '\r')
+        {
+            pipeLine.pop_back();
+        }
+        if (pipeLine.empty())
+        {
+            continue;
+        }
 
 #ifdef SPARK_PLATFORM_WINDOWS
+        OutputDebugStringA(("ReadEngineInput: Processing line: " + pipeLine + "\n").c_str());
+#endif
+
+        std::wstring wMessage(pipeLine.begin(), pipeLine.end());
+        PrintEngineLog(wMessage);
+
+        m_messageBuffer.push_back(wMessage);
+        if (m_messageBuffer.size() > MAX_BUFFER_SIZE)
+        {
+            m_messageBuffer.pop_front();
+        }
+    }
+}
+
+#ifdef SPARK_PLATFORM_WINDOWS
+bool ConsoleApp::PollWindowsPipeData(HANDLE hStdin)
+{
     char buffer[1024];
     DWORD bytesRead = 0;
+    DWORD bytesAvailable = 0;
+    BOOL pipeResult = PeekNamedPipe(hStdin, NULL, 0, NULL, &bytesAvailable, NULL);
+
+    if (!pipeResult)
+    {
+        DWORD error = GetLastError();
+        if (error == ERROR_BROKEN_PIPE || error == ERROR_INVALID_HANDLE)
+        {
+            PrintLog(L"Engine pipe connection lost.");
+            OutputDebugStringA("ReadEngineInput: Pipe connection lost\n");
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        return true;
+    }
+
+    if (bytesAvailable > 0)
+    {
+        OutputDebugStringA(("ReadEngineInput: " + std::to_string(bytesAvailable) + " bytes available\n").c_str());
+
+        DWORD bytesToRead = std::min(bytesAvailable, static_cast<DWORD>(sizeof(buffer) - 1));
+        if (ReadFile(hStdin, buffer, bytesToRead, &bytesRead, NULL))
+        {
+            if (bytesRead > 0)
+            {
+                buffer[bytesRead] = '\0';
+                std::string message(buffer);
+
+                std::string debugMsg = "ReadEngineInput: Received data: " + message.substr(0, 100) + "\n";
+                OutputDebugStringA(debugMsg.c_str());
+
+                ProcessPipeMessages(message);
+            }
+        }
+        else
+        {
+            DWORD error = GetLastError();
+            OutputDebugStringA(("ReadEngineInput: ReadFile failed with error " + std::to_string(error) + "\n").c_str());
+            if (error == ERROR_BROKEN_PIPE)
+            {
+                PrintLog(L"Engine connection lost.");
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+void ConsoleApp::ReadEngineInputWindows()
+{
     HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
 
     OutputDebugStringA("ReadEngineInput: Starting engine input reader thread\n");
 
-    // Check if stdin is redirected (connected to a pipe)
     DWORD fileType = GetFileType(hStdin);
-
-    // Try to detect if we're connected to a pipe by testing for pipe-specific operations
     DWORD bytesAvailable = 0;
     BOOL isPipeConnected = PeekNamedPipe(hStdin, NULL, 0, NULL, &bytesAvailable, NULL);
 
@@ -312,97 +396,24 @@ void ConsoleApp::ReadEngineInput()
     {
         PrintLog(L"No pipe connection detected. Running in standalone mode.");
         OutputDebugStringA("ReadEngineInput: No pipe connection detected\n");
-        return; // Exit thread if no pipe connection
+        return;
     }
 
     while (m_running)
     {
-        // Check if data is available
-        DWORD bytesAvailable2 = 0;
-        BOOL pipeResult = PeekNamedPipe(hStdin, NULL, 0, NULL, &bytesAvailable2, NULL);
-
-        if (!pipeResult)
+        if (!PollWindowsPipeData(hStdin))
         {
-            DWORD error = GetLastError();
-            if (error == ERROR_BROKEN_PIPE || error == ERROR_INVALID_HANDLE)
-            {
-                PrintLog(L"Engine pipe connection lost.");
-                OutputDebugStringA("ReadEngineInput: Pipe connection lost\n");
-                break;
-            }
-            // For other errors, continue trying
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            continue;
+            break;
         }
-
-        if (bytesAvailable2 > 0)
-        {
-            OutputDebugStringA(("ReadEngineInput: " + std::to_string(bytesAvailable2) + " bytes available\n").c_str());
-
-            // Read available data
-            DWORD bytesToRead = std::min(bytesAvailable2, static_cast<DWORD>(sizeof(buffer) - 1));
-            if (ReadFile(hStdin, buffer, bytesToRead, &bytesRead, NULL))
-            {
-                if (bytesRead > 0)
-                {
-                    buffer[bytesRead] = '\0';
-                    std::string message(buffer);
-
-                    std::string debugMsg = "ReadEngineInput: Received data: " + message.substr(0, 100) + "\n";
-                    OutputDebugStringA(debugMsg.c_str());
-
-                    // Process each line in the message
-                    std::istringstream iss(message);
-                    std::string pipeLine;
-                    while (std::getline(iss, pipeLine))
-                    {
-                        if (!pipeLine.empty())
-                        {
-                            // Remove carriage return if present
-                            if (!pipeLine.empty() && pipeLine.back() == '\r')
-                            {
-                                pipeLine.pop_back();
-                            }
-
-                            if (!pipeLine.empty())
-                            {
-                                OutputDebugStringA(("ReadEngineInput: Processing line: " + pipeLine + "\n").c_str());
-
-                                // Convert to wide string and display
-                                std::wstring wMessage(pipeLine.begin(), pipeLine.end());
-                                PrintEngineLog(wMessage);
-
-                                // Add to message buffer
-                                m_messageBuffer.push_back(wMessage);
-                                if (m_messageBuffer.size() > MAX_BUFFER_SIZE)
-                                {
-                                    m_messageBuffer.pop_front();
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            else
-            {
-                DWORD error = GetLastError();
-                OutputDebugStringA(
-                    ("ReadEngineInput: ReadFile failed with error " + std::to_string(error) + "\n").c_str());
-                if (error == ERROR_BROKEN_PIPE)
-                {
-                    PrintLog(L"Engine connection lost.");
-                    break;
-                }
-            }
-        }
-
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
 
     OutputDebugStringA("ReadEngineInput: Engine input reader thread terminated\n");
     PrintLog(L"Engine input reader thread terminated.");
-
-#else  // Linux/macOS
+}
+#else
+void ConsoleApp::ReadEngineInputPosix()
+{
     if (!LinuxIsStdinPipe())
     {
         PrintLog(L"No pipe connection detected. Running in standalone mode.");
@@ -429,35 +440,10 @@ void ConsoleApp::ReadEngineInput()
             if (bytesRead > 0)
             {
                 buffer[bytesRead] = '\0';
-                std::string message(buffer);
-
-                std::istringstream iss(message);
-                std::string pipeLine;
-                while (std::getline(iss, pipeLine))
-                {
-                    if (!pipeLine.empty())
-                    {
-                        if (!pipeLine.empty() && pipeLine.back() == '\r')
-                        {
-                            pipeLine.pop_back();
-                        }
-                        if (!pipeLine.empty())
-                        {
-                            std::wstring wMessage(pipeLine.begin(), pipeLine.end());
-                            PrintEngineLog(wMessage);
-
-                            m_messageBuffer.push_back(wMessage);
-                            if (m_messageBuffer.size() > MAX_BUFFER_SIZE)
-                            {
-                                m_messageBuffer.pop_front();
-                            }
-                        }
-                    }
-                }
+                ProcessPipeMessages(std::string(buffer));
             }
             else if (bytesRead == 0)
             {
-                // EOF - pipe closed
                 PrintLog(L"Engine pipe connection closed.");
                 break;
             }
@@ -470,12 +456,129 @@ void ConsoleApp::ReadEngineInput()
     }
 
     PrintLog(L"Engine input reader thread terminated.");
+}
 #endif // SPARK_PLATFORM_WINDOWS
+
+void ConsoleApp::ReadEngineInput()
+{
+#ifdef SPARK_PLATFORM_WINDOWS
+    ReadEngineInputWindows();
+#else
+    ReadEngineInputPosix();
+#endif
+}
+
+void ConsoleApp::HandleArrowKey(std::string& input, char scanCode)
+{
+    switch (scanCode)
+    {
+    case 72:
+    { // Up arrow - previous command
+        std::string prev = GetPreviousCommand();
+        if (!prev.empty())
+        {
+            ClearInputLine();
+            input = prev;
+            UpdateInputLine(input);
+        }
+        break;
+    }
+    case 80:
+    { // Down arrow - next command
+        ClearInputLine();
+        std::string next = GetNextCommand();
+        input = next;
+        UpdateInputLine(input);
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+#ifndef SPARK_PLATFORM_WINDOWS
+void ConsoleApp::HandleLinuxEscapeSequence(std::string& input)
+{
+    if (LinuxKbhit())
+    {
+        char seq = LinuxGetch();
+        if (seq == '[' && LinuxKbhit())
+        {
+            char arrow = LinuxGetch();
+            if (arrow == 'A')
+            { // Up arrow
+                std::string prev = GetPreviousCommand();
+                if (!prev.empty())
+                {
+                    ClearInputLine();
+                    input = prev;
+                    UpdateInputLine(input);
+                }
+            }
+            else if (arrow == 'B')
+            { // Down arrow
+                ClearInputLine();
+                std::string next = GetNextCommand();
+                input = next;
+                UpdateInputLine(input);
+            }
+        }
+    }
+    else
+    {
+        // Standalone Escape - clear line
+        ClearInputLine();
+        input.clear();
+    }
+}
+#endif
+
+void ConsoleApp::HandleEnterKey(std::string& input)
+{
+#ifdef SPARK_PLATFORM_WINDOWS
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    WriteConsoleW(hOut, L"\n", 1, NULL, NULL);
+#else
+    std::cout << std::endl;
+#endif
+
+    if (!input.empty())
+    {
+        AddToHistory(input);
+        std::string resolved = ResolveAlias(input);
+        ExecuteCommand(resolved);
+        input.clear();
+    }
+}
+
+void ConsoleApp::HandleBackspaceKey(std::string& input)
+{
+    if (!input.empty())
+    {
+        input.pop_back();
+#ifdef SPARK_PLATFORM_WINDOWS
+        HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+        WriteConsoleW(hOut, L"\b \b", 3, NULL, NULL);
+#else
+        std::cout << "\b \b" << std::flush;
+#endif
+    }
+}
+
+void ConsoleApp::HandlePrintableChar(std::string& input, char ch)
+{
+    input += ch;
+#ifdef SPARK_PLATFORM_WINDOWS
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    wchar_t wch = static_cast<wchar_t>(ch);
+    WriteConsoleW(hOut, &wch, 1, NULL, NULL);
+#else
+    std::cout << ch << std::flush;
+#endif
 }
 
 void ConsoleApp::ReadUserInput()
 {
-    // Advanced input handling with history navigation and tab completion
     std::string input;
 
     while (m_running)
@@ -498,67 +601,13 @@ void ConsoleApp::ReadUserInput()
 #else
                 char scanCode = LinuxGetch();
 #endif
-                switch (scanCode)
-                {
-                case 72:
-                { // Up arrow - previous command
-                    std::string prev = GetPreviousCommand();
-                    if (!prev.empty())
-                    {
-                        ClearInputLine();
-                        input = prev;
-                        UpdateInputLine(input);
-                    }
-                    break;
-                }
-                case 80:
-                { // Down arrow - next command
-                    ClearInputLine();
-                    std::string next = GetNextCommand();
-                    input = next;
-                    UpdateInputLine(input);
-                    break;
-                }
-                default:
-                    break;
-                }
+                HandleArrowKey(input, scanCode);
                 continue;
             }
 #ifndef SPARK_PLATFORM_WINDOWS
-            // Linux escape sequences (e.g. arrow keys: ESC [ A/B/C/D)
             if (ch == 27)
             {
-                if (LinuxKbhit())
-                {
-                    char seq = LinuxGetch();
-                    if (seq == '[' && LinuxKbhit())
-                    {
-                        char arrow = LinuxGetch();
-                        if (arrow == 'A')
-                        { // Up arrow
-                            std::string prev = GetPreviousCommand();
-                            if (!prev.empty())
-                            {
-                                ClearInputLine();
-                                input = prev;
-                                UpdateInputLine(input);
-                            }
-                        }
-                        else if (arrow == 'B')
-                        { // Down arrow
-                            ClearInputLine();
-                            std::string next = GetNextCommand();
-                            input = next;
-                            UpdateInputLine(input);
-                        }
-                    }
-                }
-                else
-                {
-                    // Standalone Escape - clear line
-                    ClearInputLine();
-                    input.clear();
-                }
+                HandleLinuxEscapeSequence(input);
                 continue;
             }
 #endif
@@ -572,33 +621,11 @@ void ConsoleApp::ReadUserInput()
 
             if (ch == '\r' || ch == '\n')
             {
-#ifdef SPARK_PLATFORM_WINDOWS
-                HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-                WriteConsoleW(hOut, L"\n", 1, NULL, NULL);
-#else
-                std::cout << std::endl;
-#endif
-
-                if (!input.empty())
-                {
-                    AddToHistory(input);
-                    std::string resolved = ResolveAlias(input);
-                    ExecuteCommand(resolved);
-                    input.clear();
-                }
+                HandleEnterKey(input);
             }
-            else if (ch == '\b' || ch == 127) // 127 = DEL on Linux
+            else if (ch == '\b' || ch == 127)
             {
-                if (!input.empty())
-                {
-                    input.pop_back();
-#ifdef SPARK_PLATFORM_WINDOWS
-                    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-                    WriteConsoleW(hOut, L"\b \b", 3, NULL, NULL);
-#else
-                    std::cout << "\b \b" << std::flush;
-#endif
-                }
+                HandleBackspaceKey(input);
             }
             else if (ch == '\t')
             {
@@ -611,14 +638,7 @@ void ConsoleApp::ReadUserInput()
             }
             else if (ch >= 32 && ch <= 126)
             {
-                input += ch;
-#ifdef SPARK_PLATFORM_WINDOWS
-                HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-                wchar_t wch = static_cast<wchar_t>(ch);
-                WriteConsoleW(hOut, &wch, 1, NULL, NULL);
-#else
-                std::cout << ch << std::flush;
-#endif
+                HandlePrintableChar(input, ch);
             }
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -666,56 +686,38 @@ std::vector<std::string> ConsoleApp::GetCompletions(const std::string& prefix)
     return completions;
 }
 
-void ConsoleApp::HandleTabCompletion(std::string& input)
+void ConsoleApp::DisplayCompletionCandidates()
 {
-    if (input.empty())
-        return;
-
-    if (m_tabIndex == -1)
-    {
-        m_tabPrefix = input;
-        m_tabCompletions = GetCompletions(m_tabPrefix);
-        if (m_tabCompletions.empty())
-            return;
-        m_tabIndex = 0;
-    }
-    else
-    {
-        m_tabIndex = (m_tabIndex + 1) % static_cast<int>(m_tabCompletions.size());
-    }
-
-    // Show all completions on first tab when multiple matches
-    if (m_tabCompletions.size() > 1 && m_tabIndex == 0)
-    {
 #ifdef SPARK_PLATFORM_WINDOWS
-        HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-        WriteConsoleW(hOut, L"\n", 1, NULL, NULL);
-        SetConsoleColor(FOREGROUND_BLUE | FOREGROUND_GREEN);
-        for (const auto& comp : m_tabCompletions)
-        {
-            std::wstring wcomp(comp.begin(), comp.end());
-            wcomp += L"  ";
-            WriteConsoleW(hOut, wcomp.c_str(), static_cast<DWORD>(wcomp.length()), NULL, NULL);
-        }
-        WriteConsoleW(hOut, L"\n", 1, NULL, NULL);
-        SetConsoleColor(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
-
-        // Re-display prompt
-        SetConsoleColor(FOREGROUND_GREEN | FOREGROUND_INTENSITY);
-        WriteConsoleW(hOut, L"> ", 2, NULL, NULL);
-        SetConsoleColor(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
-#else
-        std::cout << "\n" << ANSI_CYAN;
-        for (const auto& comp : m_tabCompletions)
-        {
-            std::cout << comp << "  ";
-        }
-        std::cout << ANSI_RESET << "\n";
-        std::cout << ANSI_GREEN_BOLD << "> " << ANSI_RESET;
-#endif
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    WriteConsoleW(hOut, L"\n", 1, NULL, NULL);
+    SetConsoleColor(FOREGROUND_BLUE | FOREGROUND_GREEN);
+    for (const auto& comp : m_tabCompletions)
+    {
+        std::wstring wcomp(comp.begin(), comp.end());
+        wcomp += L"  ";
+        WriteConsoleW(hOut, wcomp.c_str(), static_cast<DWORD>(wcomp.length()), NULL, NULL);
     }
+    WriteConsoleW(hOut, L"\n", 1, NULL, NULL);
+    SetConsoleColor(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
 
-    // Replace input with completion
+    // Re-display prompt
+    SetConsoleColor(FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+    WriteConsoleW(hOut, L"> ", 2, NULL, NULL);
+    SetConsoleColor(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
+#else
+    std::cout << "\n" << ANSI_CYAN;
+    for (const auto& comp : m_tabCompletions)
+    {
+        std::cout << comp << "  ";
+    }
+    std::cout << ANSI_RESET << "\n";
+    std::cout << ANSI_GREEN_BOLD << "> " << ANSI_RESET;
+#endif
+}
+
+void ConsoleApp::ReplaceInputWithCompletion(std::string& input)
+{
 #ifdef SPARK_PLATFORM_WINDOWS
     HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
     for (size_t i = 0; i < input.size(); ++i)
@@ -734,6 +736,32 @@ void ConsoleApp::HandleTabCompletion(std::string& input)
     input = m_tabCompletions[m_tabIndex];
     std::cout << input << std::flush;
 #endif
+}
+
+void ConsoleApp::HandleTabCompletion(std::string& input)
+{
+    if (input.empty())
+        return;
+
+    if (m_tabIndex == -1)
+    {
+        m_tabPrefix = input;
+        m_tabCompletions = GetCompletions(m_tabPrefix);
+        if (m_tabCompletions.empty())
+            return;
+        m_tabIndex = 0;
+    }
+    else
+    {
+        m_tabIndex = (m_tabIndex + 1) % static_cast<int>(m_tabCompletions.size());
+    }
+
+    if (m_tabCompletions.size() > 1 && m_tabIndex == 0)
+    {
+        DisplayCompletionCandidates();
+    }
+
+    ReplaceInputWithCompletion(input);
 }
 
 std::string ConsoleApp::ResolveAlias(const std::string& input)
@@ -791,6 +819,29 @@ void ConsoleApp::PrintLog(const std::wstring& msg)
     }
 }
 
+void ConsoleApp::PrintDuplicateSkipNotice(int skippedCount)
+{
+    auto currentTime = std::chrono::system_clock::now();
+    auto time_t = std::chrono::system_clock::to_time_t(currentTime);
+#ifdef SPARK_PLATFORM_WINDOWS
+    HANDLE hConsoleOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    SetConsoleTextAttribute(hConsoleOut, FOREGROUND_RED | FOREGROUND_GREEN);
+
+    std::wstringstream skipMsg;
+    skipMsg << L"[" << std::put_time(std::localtime(&time_t), L"%H:%M:%S") << L"] ENGINE: (Skipped " << skippedCount
+            << L" duplicate messages)\n";
+
+    std::wstring skipStr = skipMsg.str();
+    DWORD written;
+    WriteConsoleW(hConsoleOut, skipStr.c_str(), static_cast<DWORD>(skipStr.length()), &written, NULL);
+#else
+    std::stringstream skipMsg;
+    skipMsg << "[" << std::put_time(std::localtime(&time_t), "%H:%M:%S") << "] ENGINE: (Skipped " << skippedCount
+            << " duplicate messages)";
+    std::cout << ANSI_YELLOW << skipMsg.str() << ANSI_RESET << std::endl;
+#endif
+}
+
 void ConsoleApp::PrintEngineLog(const std::wstring& msg)
 {
     std::lock_guard<std::mutex> lock(m_outputMutex);
@@ -803,38 +854,19 @@ void ConsoleApp::PrintEngineLog(const std::wstring& msg)
     auto now = std::chrono::steady_clock::now();
     auto timeDiff = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastLogTime).count();
 
-    // If same message within 200ms, count as duplicate
     if (msg == lastMessage && timeDiff < 200)
     {
         duplicateCount++;
         if (duplicateCount > 3)
         {
-            return; // Skip excessive duplicate messages
+            return;
         }
     }
     else
     {
         if (duplicateCount > 3)
         {
-            auto currentTime = std::chrono::system_clock::now();
-            auto time_t = std::chrono::system_clock::to_time_t(currentTime);
-#ifdef SPARK_PLATFORM_WINDOWS
-            HANDLE hConsoleOut = GetStdHandle(STD_OUTPUT_HANDLE);
-            SetConsoleTextAttribute(hConsoleOut, FOREGROUND_RED | FOREGROUND_GREEN);
-
-            std::wstringstream skipMsg;
-            skipMsg << L"[" << std::put_time(std::localtime(&time_t), L"%H:%M:%S") << L"] ENGINE: (Skipped "
-                    << duplicateCount - 3 << L" duplicate messages)\n";
-
-            std::wstring skipStr = skipMsg.str();
-            DWORD written;
-            WriteConsoleW(hConsoleOut, skipStr.c_str(), static_cast<DWORD>(skipStr.length()), &written, NULL);
-#else
-            std::stringstream skipMsg;
-            skipMsg << "[" << std::put_time(std::localtime(&time_t), "%H:%M:%S") << "] ENGINE: (Skipped "
-                    << duplicateCount - 3 << " duplicate messages)";
-            std::cout << ANSI_YELLOW << skipMsg.str() << ANSI_RESET << std::endl;
-#endif
+            PrintDuplicateSkipNotice(duplicateCount - 3);
         }
         duplicateCount = 0;
         lastMessage = msg;

--- a/SparkConsole/src/ConsoleApp.h
+++ b/SparkConsole/src/ConsoleApp.h
@@ -49,10 +49,38 @@ class ConsoleApp
     void ReadEngineInput(); ///< Background thread: reads log messages from engine pipe.
     void ReadUserInput();   ///< Main thread: reads keyboard input and dispatches commands.
 
+    // --- Run() helpers ---
+    void PrintBanner();    ///< Clear screen and print the startup banner.
+    bool DetectPipeMode(); ///< Detect if stdin is a pipe; print connection status. Returns true if pipe mode.
+    void PipeKeyboardThreadFunc(std::string& input,
+                                std::atomic<bool>& keyboardThreadRunning); ///< Keyboard input loop for pipe mode.
+    void PollPipeModeInput(std::string& input, int& noInputCounter, bool& pipeMode,
+                           std::atomic<bool>& keyboardThreadRunning); ///< One iteration of pipe-mode input polling.
+    void PollStandaloneInput(std::string& input); ///< One iteration of standalone-mode input polling.
+
+    // --- ReadEngineInput() helpers ---
+    void ProcessPipeMessages(const std::string& message); ///< Parse newline-delimited pipe data into log lines.
+#ifdef SPARK_PLATFORM_WINDOWS
+    bool PollWindowsPipeData(HANDLE hStdin); ///< Read one batch from pipe; returns false if pipe lost.
+    void ReadEngineInputWindows();           ///< Windows pipe reading loop.
+#else
+    void ReadEngineInputPosix(); ///< POSIX (Linux/macOS) pipe reading loop.
+#endif
+
+    // --- ReadUserInput() helpers ---
+    void HandleArrowKey(std::string& input, char scanCode); ///< Process up/down arrow for history navigation.
+#ifndef SPARK_PLATFORM_WINDOWS
+    void HandleLinuxEscapeSequence(std::string& input); ///< Process Linux ESC-[ arrow sequences.
+#endif
+    void HandleEnterKey(std::string& input);               ///< Process Enter keypress (submit command).
+    void HandleBackspaceKey(std::string& input);           ///< Process Backspace/DEL keypress.
+    void HandlePrintableChar(std::string& input, char ch); ///< Process a printable character keypress.
+
     // --- Display ---
-    void PrintLog(const std::wstring& msg);       ///< Print a raw log line to the console.
-    void PrintEngineLog(const std::wstring& msg); ///< Print an engine log line with severity coloring.
-    void PrintResult(const std::string& result);  ///< Print a command result string.
+    void PrintLog(const std::wstring& msg);          ///< Print a raw log line to the console.
+    void PrintEngineLog(const std::wstring& msg);    ///< Print an engine log line with severity coloring.
+    void PrintDuplicateSkipNotice(int skippedCount); ///< Print a notice about skipped duplicate engine messages.
+    void PrintResult(const std::string& result);     ///< Print a command result string.
 #ifdef SPARK_PLATFORM_WINDOWS
     void SetConsoleColor(WORD color); ///< Set Win32 console text color attribute.
 #else
@@ -79,6 +107,8 @@ class ConsoleApp
     // --- Tab completion ---
     std::vector<std::string> GetCompletions(const std::string& prefix); ///< Find commands matching a prefix.
     void HandleTabCompletion(std::string& input);                       ///< Cycle through completions on Tab press.
+    void DisplayCompletionCandidates();                  ///< Print all tab-completion candidates to console.
+    void ReplaceInputWithCompletion(std::string& input); ///< Replace current input text with selected completion.
 
     // --- Alias system ---
     std::string ResolveAlias(const std::string& input); ///< Expand aliases before command dispatch.

--- a/SparkEngine/Source/Core/SparkEngine.cpp
+++ b/SparkEngine/Source/Core/SparkEngine.cpp
@@ -418,27 +418,28 @@ static void SetupCrashHandler()
 }
 
 #ifdef SPARK_HEADLESS_SUPPORT
+
 /**
- * @brief Run the engine in headless/dedicated server mode (Windows).
- *
- * Allocates a console, initializes server-only subsystems, runs a fixed 60 Hz
- * tick loop, and shuts down cleanly on Ctrl+C.
+ * @brief Attach a Win32 console for headless stdout/stderr/stdin.
  */
-static int RunHeadlessWindows(LPWSTR lpCmdLine)
+static void AllocHeadlessConsole()
 {
-    // Allocate a console for stdout/stderr output
     AllocConsole();
     FILE* fp = nullptr;
     freopen_s(&fp, "CONOUT$", "w", stdout);
     freopen_s(&fp, "CONOUT$", "w", stderr);
     freopen_s(&fp, "CONIN$", "r", stdin);
-
-    // Install Ctrl+C handler for graceful shutdown
     SetConsoleCtrlHandler(HeadlessCtrlHandler, TRUE);
+}
 
-    Spark::SimpleConsole::GetInstance().LogInfo("=== Spark Engine (Headless/Dedicated Server) ===");
-
-    // Initialize only the subsystems needed for headless operation
+/**
+ * @brief Initialize headless engine context (no graphics, no input).
+ *
+ * Reuses the same pattern as InitEngineContext() but passes nullptr for
+ * graphics and input — headless mode has no GPU or window.
+ */
+static bool InitHeadlessEngineContext()
+{
     g_timer = std::make_unique<Timer>();
     g_eventBus = std::make_unique<Spark::EventBus>();
     EngineContext::SetOwned(std::make_unique<EngineContext>(nullptr, nullptr, g_timer.get(), g_eventBus.get()));
@@ -447,28 +448,34 @@ static int RunHeadlessWindows(LPWSTR lpCmdLine)
     if (!ctx)
     {
         SPARK_LOG_ERROR(Spark::LogCategory::Core, "EngineContext is null after SetOwned — headless init aborted");
-        return 1;
+        return false;
     }
 
-    // File cache
     g_fileCache = std::make_unique<Spark::LocalFileCache>();
     ctx->SetFileCache(g_fileCache.get());
 
     InitPhysics();
 
-    // Register core subsystems with dependency metadata
     Spark::EngineSetup::RegisterCoreSubsystems(*ctx);
     Spark::EngineSetup::InitializeJobSystem();
 
-    // Module loading
-    g_moduleManager = std::make_unique<ModuleManager>();
+    ctx->SetSaveSystem(&Spark::SaveSystem::GetInstance());
+    ctx->SetCoroutineScheduler(&Spark::CoroutineScheduler::GetInstance());
 
-    InitConsole();
+    return true;
+}
+
+/**
+ * @brief Load modules and register console commands for headless mode.
+ */
+static void LoadHeadlessModules(LPWSTR lpCmdLine)
+{
+    g_moduleManager = std::make_unique<ModuleManager>();
     auto& console = Spark::SimpleConsole::GetInstance();
 
     if (LoadGameModules(*g_moduleManager, lpCmdLine))
     {
-        g_moduleManager->InitializeAll(ctx);
+        g_moduleManager->InitializeAll(EngineContext::Get());
         console.LogSuccess("Loaded " + std::to_string(g_moduleManager->GetModuleCount()) + " module(s)");
     }
     else
@@ -476,31 +483,39 @@ static int RunHeadlessWindows(LPWSTR lpCmdLine)
         console.LogWarning("No game modules found. Running engine-only headless mode.");
     }
 
-    // Module hot-reload watcher
     g_moduleHotReload = std::make_unique<Spark::ModuleHotReloadManager>();
-    g_moduleHotReload->Initialize(g_moduleManager.get(), ctx);
+    g_moduleHotReload->Initialize(g_moduleManager.get(), EngineContext::Get());
     g_moduleHotReload->WatchAllLoadedModules();
     g_moduleHotReload->Start();
 
-    // SaveSystem
-    if (!Spark::SaveSystem::GetInstance().Initialize("Saves"))
-    {
-        Spark::SimpleConsole::GetInstance().LogWarning("SaveSystem initialization failed — save/load unavailable");
-    }
-    ctx->SetSaveSystem(&Spark::SaveSystem::GetInstance());
-    console.LogInfo("SaveSystem initialized");
-
-    // CoroutineScheduler
-    ctx->SetCoroutineScheduler(&Spark::CoroutineScheduler::GetInstance());
-
-    // Register console commands
-    if (g_graphics)
-        Spark::Graphics::RegisterGraphicsConsoleCommands(*g_graphics);
     Spark::RegisterEngineConsoleCommands(g_moduleManager.get(), g_audioEngine.get(), g_moduleHotReload.get());
     Spark::SubsystemFaultIsolator::GetInstance().RegisterConsoleCommands();
+}
+
+/**
+ * @brief Run the engine in headless/dedicated server mode (Windows).
+ *
+ * Allocates a console, initializes server-only subsystems, runs a fixed 60 Hz
+ * tick loop, and shuts down cleanly on Ctrl+C.
+ */
+static int RunHeadlessWindows(LPWSTR lpCmdLine)
+{
+    AllocHeadlessConsole();
+    Spark::SimpleConsole::GetInstance().LogInfo("=== Spark Engine (Headless/Dedicated Server) ===");
+
+    if (!InitHeadlessEngineContext())
+        return 1;
+
+    if (!Spark::SaveSystem::GetInstance().Initialize("Saves"))
+        Spark::SimpleConsole::GetInstance().LogWarning("SaveSystem initialization failed — save/load unavailable");
+    Spark::SimpleConsole::GetInstance().LogInfo("SaveSystem initialized");
+
+    InitConsole();
+    LoadHeadlessModules(lpCmdLine);
 
     // Fixed 60 Hz server loop
     constexpr auto TICK_INTERVAL = std::chrono::microseconds(16667);
+    auto& console = Spark::SimpleConsole::GetInstance();
     console.LogInfo("Starting headless server loop (60 Hz)...");
     console.LogInfo("Press Ctrl+C or type 'quit' to stop.");
 

--- a/SparkEngine/Source/Engine/SaveSystem/SaveSystem.cpp
+++ b/SparkEngine/Source/Engine/SaveSystem/SaveSystem.cpp
@@ -144,10 +144,13 @@ namespace Spark
         return it->second;
     }
 
-    void ComponentSerializerRegistry::RegisterBuiltins()
+    // ============================================================================
+    // Domain-specific serializer registration (called from RegisterBuiltins)
+    // ============================================================================
+
+    static void RegisterCoreSerializers(ComponentSerializerRegistry& reg)
     {
-        // Transform
-        Register(
+        reg.Register(
             "Transform",
             [](const void* comp) -> SerializedComponent
             {
@@ -174,8 +177,7 @@ namespace Spark
                 t.scale = {SafeGetFloat(p, "sx", 1), SafeGetFloat(p, "sy", 1), SafeGetFloat(p, "sz", 1)};
             });
 
-        // MeshRenderer
-        Register(
+        reg.Register(
             "MeshRenderer",
             [](const void* comp) -> SerializedComponent
             {
@@ -200,84 +202,7 @@ namespace Spark
                 m.visible = SafeGetString(p, "visible") != "0";
             });
 
-        // HealthComponent
-        Register(
-            "HealthComponent",
-            [](const void* comp) -> SerializedComponent
-            {
-                const auto* h = static_cast<const HealthComponent*>(comp);
-                SerializedComponent sc;
-                sc.typeName = "HealthComponent";
-                sc.properties["health"] = std::to_string(h->health);
-                sc.properties["maxHealth"] = std::to_string(h->maxHealth);
-                sc.properties["isDead"] = h->isDead ? "1" : "0";
-                return sc;
-            },
-            [](World& world, EntityID entity, const SerializedComponent& data)
-            {
-                auto& h = world.AddComponent<HealthComponent>(entity);
-                auto& p = data.properties;
-                h.health = SafeGetFloat(p, "health", 100.0f);
-                h.maxHealth = SafeGetFloat(p, "maxHealth", 100.0f);
-                h.isDead = SafeGetString(p, "isDead") == "1";
-            });
-
-        // LightComponent
-        Register(
-            "LightComponent",
-            [](const void* comp) -> SerializedComponent
-            {
-                const auto* l = static_cast<const LightComponent*>(comp);
-                SerializedComponent sc;
-                sc.typeName = "LightComponent";
-                sc.properties["type"] = std::to_string(static_cast<int>(l->type));
-                sc.properties["cr"] = std::to_string(l->color.x);
-                sc.properties["cg"] = std::to_string(l->color.y);
-                sc.properties["cb"] = std::to_string(l->color.z);
-                sc.properties["intensity"] = std::to_string(l->intensity);
-                sc.properties["range"] = std::to_string(l->range);
-                sc.properties["castShadows"] = l->castShadows ? "1" : "0";
-                return sc;
-            },
-            [](World& world, EntityID entity, const SerializedComponent& data)
-            {
-                auto& l = world.AddComponent<LightComponent>(entity);
-                auto& p = data.properties;
-                l.type = static_cast<LightComponent::Type>(static_cast<int>(SafeGetFloat(p, "type", 1)));
-                l.color = {SafeGetFloat(p, "cr", 1), SafeGetFloat(p, "cg", 1), SafeGetFloat(p, "cb", 1)};
-                l.intensity = SafeGetFloat(p, "intensity", 1.0f);
-                l.range = SafeGetFloat(p, "range", 10.0f);
-                l.castShadows = SafeGetString(p, "castShadows") == "1";
-            });
-
-        // AudioSourceComponent
-        Register(
-            "AudioSourceComponent",
-            [](const void* comp) -> SerializedComponent
-            {
-                const auto* a = static_cast<const AudioSourceComponent*>(comp);
-                SerializedComponent sc;
-                sc.typeName = "AudioSourceComponent";
-                sc.properties["soundName"] = a->soundName;
-                sc.properties["volume"] = std::to_string(a->volume);
-                sc.properties["is3D"] = a->is3D ? "1" : "0";
-                sc.properties["loop"] = a->loop ? "1" : "0";
-                sc.properties["playOnAwake"] = a->playOnAwake ? "1" : "0";
-                return sc;
-            },
-            [](World& world, EntityID entity, const SerializedComponent& data)
-            {
-                auto& a = world.AddComponent<AudioSourceComponent>(entity);
-                auto& p = data.properties;
-                a.soundName = SafeGetString(p, "soundName");
-                a.volume = SafeGetFloat(p, "volume", 1.0f);
-                a.is3D = SafeGetString(p, "is3D") != "0";
-                a.loop = SafeGetString(p, "loop") == "1";
-                a.playOnAwake = SafeGetString(p, "playOnAwake") == "1";
-            });
-
-        // Camera
-        Register(
+        reg.Register(
             "Camera",
             [](const void* comp) -> SerializedComponent
             {
@@ -300,8 +225,7 @@ namespace Spark
                 c.isMainCamera = SafeGetString(p, "isMainCamera") == "1";
             });
 
-        // Script
-        Register(
+        reg.Register(
             "Script",
             [](const void* comp) -> SerializedComponent
             {
@@ -326,201 +250,13 @@ namespace Spark
                 s.started = SafeGetString(p, "started") == "1";
             });
 
-        // RigidBodyComponent
-        Register(
-            "RigidBodyComponent",
-            [](const void* comp) -> SerializedComponent
-            {
-                const auto* rb = static_cast<const RigidBodyComponent*>(comp);
-                SerializedComponent sc;
-                sc.typeName = "RigidBodyComponent";
-                sc.properties["type"] = std::to_string(static_cast<int>(rb->type));
-                sc.properties["mass"] = std::to_string(rb->mass);
-                sc.properties["friction"] = std::to_string(rb->friction);
-                sc.properties["restitution"] = std::to_string(rb->restitution);
-                sc.properties["linearDamping"] = std::to_string(rb->linearDamping);
-                sc.properties["angularDamping"] = std::to_string(rb->angularDamping);
-                sc.properties["isTrigger"] = rb->isTrigger ? "1" : "0";
-                sc.properties["lvx"] = std::to_string(rb->linearVelocity.x);
-                sc.properties["lvy"] = std::to_string(rb->linearVelocity.y);
-                sc.properties["lvz"] = std::to_string(rb->linearVelocity.z);
-                sc.properties["avx"] = std::to_string(rb->angularVelocity.x);
-                sc.properties["avy"] = std::to_string(rb->angularVelocity.y);
-                sc.properties["avz"] = std::to_string(rb->angularVelocity.z);
-                // physicsBodyHandle is runtime-only, skip
-                return sc;
-            },
-            [](World& world, EntityID entity, const SerializedComponent& data)
-            {
-                auto& rb = world.AddComponent<RigidBodyComponent>(entity);
-                auto& p = data.properties;
-                rb.type = static_cast<RigidBodyComponent::Type>(static_cast<int>(SafeGetFloat(p, "type", 2)));
-                rb.mass = SafeGetFloat(p, "mass", 1.0f);
-                rb.friction = SafeGetFloat(p, "friction", 0.5f);
-                rb.restitution = SafeGetFloat(p, "restitution", 0.1f);
-                rb.linearDamping = SafeGetFloat(p, "linearDamping", 0.1f);
-                rb.angularDamping = SafeGetFloat(p, "angularDamping", 0.1f);
-                rb.isTrigger = SafeGetString(p, "isTrigger") == "1";
-                rb.linearVelocity = {SafeGetFloat(p, "lvx", 0), SafeGetFloat(p, "lvy", 0), SafeGetFloat(p, "lvz", 0)};
-                rb.angularVelocity = {SafeGetFloat(p, "avx", 0), SafeGetFloat(p, "avy", 0), SafeGetFloat(p, "avz", 0)};
-                rb.physicsBodyHandle = nullptr;
-            });
-
-        // ColliderComponent
-        Register(
-            "ColliderComponent",
-            [](const void* comp) -> SerializedComponent
-            {
-                const auto* col = static_cast<const ColliderComponent*>(comp);
-                SerializedComponent sc;
-                sc.typeName = "ColliderComponent";
-                sc.properties["shape"] = std::to_string(static_cast<int>(col->shape));
-                sc.properties["hex"] = std::to_string(col->halfExtents.x);
-                sc.properties["hey"] = std::to_string(col->halfExtents.y);
-                sc.properties["hez"] = std::to_string(col->halfExtents.z);
-                sc.properties["radius"] = std::to_string(col->radius);
-                sc.properties["height"] = std::to_string(col->height);
-                sc.properties["ox"] = std::to_string(col->offset.x);
-                sc.properties["oy"] = std::to_string(col->offset.y);
-                sc.properties["oz"] = std::to_string(col->offset.z);
-                return sc;
-            },
-            [](World& world, EntityID entity, const SerializedComponent& data)
-            {
-                auto& col = world.AddComponent<ColliderComponent>(entity);
-                auto& p = data.properties;
-                col.shape = static_cast<ColliderComponent::Shape>(static_cast<int>(SafeGetFloat(p, "shape", 0)));
-                col.halfExtents = {SafeGetFloat(p, "hex", 0.5f), SafeGetFloat(p, "hey", 0.5f),
-                                   SafeGetFloat(p, "hez", 0.5f)};
-                col.radius = SafeGetFloat(p, "radius", 0.5f);
-                col.height = SafeGetFloat(p, "height", 1.0f);
-                col.offset = {SafeGetFloat(p, "ox", 0), SafeGetFloat(p, "oy", 0), SafeGetFloat(p, "oz", 0)};
-            });
-
-        // ParticleEmitterComponent
-        Register(
-            "ParticleEmitterComponent",
-            [](const void* comp) -> SerializedComponent
-            {
-                const auto* pe = static_cast<const ParticleEmitterComponent*>(comp);
-                SerializedComponent sc;
-                sc.typeName = "ParticleEmitterComponent";
-                sc.properties["effectName"] = pe->effectName;
-                sc.properties["autoPlay"] = pe->autoPlay ? "1" : "0";
-                sc.properties["isPlaying"] = pe->isPlaying ? "1" : "0";
-                sc.properties["emissionRate"] = std::to_string(pe->emissionRate);
-                sc.properties["lifetime"] = std::to_string(pe->lifetime);
-                sc.properties["scr"] = std::to_string(pe->startColor.x);
-                sc.properties["scg"] = std::to_string(pe->startColor.y);
-                sc.properties["scb"] = std::to_string(pe->startColor.z);
-                sc.properties["sca"] = std::to_string(pe->startColor.w);
-                sc.properties["startSize"] = std::to_string(pe->startSize);
-                sc.properties["startSpeed"] = std::to_string(pe->startSpeed);
-                // emitterHandle is runtime-only, skip
-                return sc;
-            },
-            [](World& world, EntityID entity, const SerializedComponent& data)
-            {
-                auto& pe = world.AddComponent<ParticleEmitterComponent>(entity);
-                auto& p = data.properties;
-                pe.effectName = SafeGetString(p, "effectName");
-                pe.autoPlay = SafeGetString(p, "autoPlay") != "0";
-                pe.isPlaying = SafeGetString(p, "isPlaying") == "1";
-                pe.emissionRate = SafeGetFloat(p, "emissionRate", 10.0f);
-                pe.lifetime = SafeGetFloat(p, "lifetime", 1.0f);
-                pe.startColor = {SafeGetFloat(p, "scr", 1), SafeGetFloat(p, "scg", 1), SafeGetFloat(p, "scb", 1),
-                                 SafeGetFloat(p, "sca", 1)};
-                pe.startSize = SafeGetFloat(p, "startSize", 0.1f);
-                pe.startSpeed = SafeGetFloat(p, "startSpeed", 1.0f);
-                pe.emitterHandle = nullptr;
-            });
-
-        // AnimationController
-        Register(
-            "AnimationController",
-            [](const void* comp) -> SerializedComponent
-            {
-                const auto* ac = static_cast<const AnimationController*>(comp);
-                SerializedComponent sc;
-                sc.typeName = "AnimationController";
-                sc.properties["currentAnimation"] = ac->currentAnimation;
-                sc.properties["defaultAnimation"] = ac->defaultAnimation;
-                sc.properties["playbackSpeed"] = std::to_string(ac->playbackSpeed);
-                sc.properties["currentTime"] = std::to_string(ac->currentTime);
-                sc.properties["playing"] = ac->playing ? "1" : "0";
-                sc.properties["loop"] = ac->loop ? "1" : "0";
-                // Serialize availableAnimations as comma-separated string
-                std::string animList;
-                for (size_t i = 0; i < ac->availableAnimations.size(); ++i)
-                {
-                    if (i > 0)
-                        animList += ",";
-                    animList += ac->availableAnimations[i];
-                }
-                sc.properties["availableAnimations"] = animList;
-                // animInstanceHandle is runtime-only, skip
-                return sc;
-            },
-            [](World& world, EntityID entity, const SerializedComponent& data)
-            {
-                auto& ac = world.AddComponent<AnimationController>(entity);
-                auto& p = data.properties;
-                ac.currentAnimation = SafeGetString(p, "currentAnimation");
-                ac.defaultAnimation = SafeGetString(p, "defaultAnimation");
-                ac.playbackSpeed = SafeGetFloat(p, "playbackSpeed", 1.0f);
-                ac.currentTime = SafeGetFloat(p, "currentTime", 0.0f);
-                ac.playing = SafeGetString(p, "playing") != "0";
-                ac.loop = SafeGetString(p, "loop") != "0";
-                // Deserialize availableAnimations from comma-separated string
-                std::string animList = SafeGetString(p, "availableAnimations");
-                if (!animList.empty())
-                {
-                    std::istringstream iss(animList);
-                    std::string anim;
-                    while (std::getline(iss, anim, ','))
-                    {
-                        if (!anim.empty())
-                            ac.availableAnimations.push_back(anim);
-                    }
-                }
-                ac.animInstanceHandle = nullptr;
-            });
-
-        // NetworkIdentity
-        Register(
-            "NetworkIdentity",
-            [](const void* comp) -> SerializedComponent
-            {
-                const auto* ni = static_cast<const NetworkIdentity*>(comp);
-                SerializedComponent sc;
-                sc.typeName = "NetworkIdentity";
-                sc.properties["networkID"] = std::to_string(ni->networkID);
-                sc.properties["ownerClientID"] = std::to_string(ni->ownerClientID);
-                sc.properties["isLocalAuthority"] = ni->isLocalAuthority ? "1" : "0";
-                sc.properties["replicateTransform"] = ni->replicateTransform ? "1" : "0";
-                sc.properties["replicateHealth"] = ni->replicateHealth ? "1" : "0";
-                return sc;
-            },
-            [](World& world, EntityID entity, const SerializedComponent& data)
-            {
-                auto& ni = world.AddComponent<NetworkIdentity>(entity);
-                auto& p = data.properties;
-                ni.networkID = SafeGetUint32(p, "networkID", 0);
-                ni.ownerClientID = SafeGetUint32(p, "ownerClientID", 0);
-                ni.isLocalAuthority = SafeGetString(p, "isLocalAuthority") == "1";
-                ni.replicateTransform = SafeGetString(p, "replicateTransform") != "0";
-                ni.replicateHealth = SafeGetString(p, "replicateHealth") != "0";
-            });
-
-        // TagComponent
-        Register(
+        reg.Register(
             "TagComponent",
             [](const void* comp) -> SerializedComponent
             {
                 const auto* tc = static_cast<const TagComponent*>(comp);
                 SerializedComponent sc;
                 sc.typeName = "TagComponent";
-                // Serialize tags as comma-separated string
                 std::string tagList;
                 bool first = true;
                 for (const auto& tag : tc->tags)
@@ -549,8 +285,7 @@ namespace Spark
                 }
             });
 
-        // ActiveComponent
-        Register(
+        reg.Register(
             "ActiveComponent",
             [](const void* comp) -> SerializedComponent
             {
@@ -566,8 +301,268 @@ namespace Spark
                 auto it = data.properties.find("active");
                 ac.active = (it == data.properties.end()) || (it->second != "0");
             });
+    }
 
-        // Auto-register reflection-driven serializers for all remaining reflected types
+    static void RegisterPhysicsSerializers(ComponentSerializerRegistry& reg)
+    {
+        reg.Register(
+            "RigidBodyComponent",
+            [](const void* comp) -> SerializedComponent
+            {
+                const auto* rb = static_cast<const RigidBodyComponent*>(comp);
+                SerializedComponent sc;
+                sc.typeName = "RigidBodyComponent";
+                sc.properties["type"] = std::to_string(static_cast<int>(rb->type));
+                sc.properties["mass"] = std::to_string(rb->mass);
+                sc.properties["friction"] = std::to_string(rb->friction);
+                sc.properties["restitution"] = std::to_string(rb->restitution);
+                sc.properties["linearDamping"] = std::to_string(rb->linearDamping);
+                sc.properties["angularDamping"] = std::to_string(rb->angularDamping);
+                sc.properties["isTrigger"] = rb->isTrigger ? "1" : "0";
+                sc.properties["lvx"] = std::to_string(rb->linearVelocity.x);
+                sc.properties["lvy"] = std::to_string(rb->linearVelocity.y);
+                sc.properties["lvz"] = std::to_string(rb->linearVelocity.z);
+                sc.properties["avx"] = std::to_string(rb->angularVelocity.x);
+                sc.properties["avy"] = std::to_string(rb->angularVelocity.y);
+                sc.properties["avz"] = std::to_string(rb->angularVelocity.z);
+                return sc;
+            },
+            [](World& world, EntityID entity, const SerializedComponent& data)
+            {
+                auto& rb = world.AddComponent<RigidBodyComponent>(entity);
+                auto& p = data.properties;
+                rb.type = static_cast<RigidBodyComponent::Type>(static_cast<int>(SafeGetFloat(p, "type", 2)));
+                rb.mass = SafeGetFloat(p, "mass", 1.0f);
+                rb.friction = SafeGetFloat(p, "friction", 0.5f);
+                rb.restitution = SafeGetFloat(p, "restitution", 0.1f);
+                rb.linearDamping = SafeGetFloat(p, "linearDamping", 0.1f);
+                rb.angularDamping = SafeGetFloat(p, "angularDamping", 0.1f);
+                rb.isTrigger = SafeGetString(p, "isTrigger") == "1";
+                rb.linearVelocity = {SafeGetFloat(p, "lvx", 0), SafeGetFloat(p, "lvy", 0), SafeGetFloat(p, "lvz", 0)};
+                rb.angularVelocity = {SafeGetFloat(p, "avx", 0), SafeGetFloat(p, "avy", 0), SafeGetFloat(p, "avz", 0)};
+                rb.physicsBodyHandle = nullptr;
+            });
+
+        reg.Register(
+            "ColliderComponent",
+            [](const void* comp) -> SerializedComponent
+            {
+                const auto* col = static_cast<const ColliderComponent*>(comp);
+                SerializedComponent sc;
+                sc.typeName = "ColliderComponent";
+                sc.properties["shape"] = std::to_string(static_cast<int>(col->shape));
+                sc.properties["hex"] = std::to_string(col->halfExtents.x);
+                sc.properties["hey"] = std::to_string(col->halfExtents.y);
+                sc.properties["hez"] = std::to_string(col->halfExtents.z);
+                sc.properties["radius"] = std::to_string(col->radius);
+                sc.properties["height"] = std::to_string(col->height);
+                sc.properties["ox"] = std::to_string(col->offset.x);
+                sc.properties["oy"] = std::to_string(col->offset.y);
+                sc.properties["oz"] = std::to_string(col->offset.z);
+                return sc;
+            },
+            [](World& world, EntityID entity, const SerializedComponent& data)
+            {
+                auto& col = world.AddComponent<ColliderComponent>(entity);
+                auto& p = data.properties;
+                col.shape = static_cast<ColliderComponent::Shape>(static_cast<int>(SafeGetFloat(p, "shape", 0)));
+                col.halfExtents = {SafeGetFloat(p, "hex", 0.5f), SafeGetFloat(p, "hey", 0.5f),
+                                   SafeGetFloat(p, "hez", 0.5f)};
+                col.radius = SafeGetFloat(p, "radius", 0.5f);
+                col.height = SafeGetFloat(p, "height", 1.0f);
+                col.offset = {SafeGetFloat(p, "ox", 0), SafeGetFloat(p, "oy", 0), SafeGetFloat(p, "oz", 0)};
+            });
+    }
+
+    static void RegisterGameplaySerializers(ComponentSerializerRegistry& reg)
+    {
+        reg.Register(
+            "HealthComponent",
+            [](const void* comp) -> SerializedComponent
+            {
+                const auto* h = static_cast<const HealthComponent*>(comp);
+                SerializedComponent sc;
+                sc.typeName = "HealthComponent";
+                sc.properties["health"] = std::to_string(h->health);
+                sc.properties["maxHealth"] = std::to_string(h->maxHealth);
+                sc.properties["isDead"] = h->isDead ? "1" : "0";
+                return sc;
+            },
+            [](World& world, EntityID entity, const SerializedComponent& data)
+            {
+                auto& h = world.AddComponent<HealthComponent>(entity);
+                auto& p = data.properties;
+                h.health = SafeGetFloat(p, "health", 100.0f);
+                h.maxHealth = SafeGetFloat(p, "maxHealth", 100.0f);
+                h.isDead = SafeGetString(p, "isDead") == "1";
+            });
+
+        reg.Register(
+            "LightComponent",
+            [](const void* comp) -> SerializedComponent
+            {
+                const auto* l = static_cast<const LightComponent*>(comp);
+                SerializedComponent sc;
+                sc.typeName = "LightComponent";
+                sc.properties["type"] = std::to_string(static_cast<int>(l->type));
+                sc.properties["cr"] = std::to_string(l->color.x);
+                sc.properties["cg"] = std::to_string(l->color.y);
+                sc.properties["cb"] = std::to_string(l->color.z);
+                sc.properties["intensity"] = std::to_string(l->intensity);
+                sc.properties["range"] = std::to_string(l->range);
+                sc.properties["castShadows"] = l->castShadows ? "1" : "0";
+                return sc;
+            },
+            [](World& world, EntityID entity, const SerializedComponent& data)
+            {
+                auto& l = world.AddComponent<LightComponent>(entity);
+                auto& p = data.properties;
+                l.type = static_cast<LightComponent::Type>(static_cast<int>(SafeGetFloat(p, "type", 1)));
+                l.color = {SafeGetFloat(p, "cr", 1), SafeGetFloat(p, "cg", 1), SafeGetFloat(p, "cb", 1)};
+                l.intensity = SafeGetFloat(p, "intensity", 1.0f);
+                l.range = SafeGetFloat(p, "range", 10.0f);
+                l.castShadows = SafeGetString(p, "castShadows") == "1";
+            });
+
+        reg.Register(
+            "AudioSourceComponent",
+            [](const void* comp) -> SerializedComponent
+            {
+                const auto* a = static_cast<const AudioSourceComponent*>(comp);
+                SerializedComponent sc;
+                sc.typeName = "AudioSourceComponent";
+                sc.properties["soundName"] = a->soundName;
+                sc.properties["volume"] = std::to_string(a->volume);
+                sc.properties["is3D"] = a->is3D ? "1" : "0";
+                sc.properties["loop"] = a->loop ? "1" : "0";
+                sc.properties["playOnAwake"] = a->playOnAwake ? "1" : "0";
+                return sc;
+            },
+            [](World& world, EntityID entity, const SerializedComponent& data)
+            {
+                auto& a = world.AddComponent<AudioSourceComponent>(entity);
+                auto& p = data.properties;
+                a.soundName = SafeGetString(p, "soundName");
+                a.volume = SafeGetFloat(p, "volume", 1.0f);
+                a.is3D = SafeGetString(p, "is3D") != "0";
+                a.loop = SafeGetString(p, "loop") == "1";
+                a.playOnAwake = SafeGetString(p, "playOnAwake") == "1";
+            });
+
+        reg.Register(
+            "ParticleEmitterComponent",
+            [](const void* comp) -> SerializedComponent
+            {
+                const auto* pe = static_cast<const ParticleEmitterComponent*>(comp);
+                SerializedComponent sc;
+                sc.typeName = "ParticleEmitterComponent";
+                sc.properties["effectName"] = pe->effectName;
+                sc.properties["autoPlay"] = pe->autoPlay ? "1" : "0";
+                sc.properties["isPlaying"] = pe->isPlaying ? "1" : "0";
+                sc.properties["emissionRate"] = std::to_string(pe->emissionRate);
+                sc.properties["lifetime"] = std::to_string(pe->lifetime);
+                sc.properties["scr"] = std::to_string(pe->startColor.x);
+                sc.properties["scg"] = std::to_string(pe->startColor.y);
+                sc.properties["scb"] = std::to_string(pe->startColor.z);
+                sc.properties["sca"] = std::to_string(pe->startColor.w);
+                sc.properties["startSize"] = std::to_string(pe->startSize);
+                sc.properties["startSpeed"] = std::to_string(pe->startSpeed);
+                return sc;
+            },
+            [](World& world, EntityID entity, const SerializedComponent& data)
+            {
+                auto& pe = world.AddComponent<ParticleEmitterComponent>(entity);
+                auto& p = data.properties;
+                pe.effectName = SafeGetString(p, "effectName");
+                pe.autoPlay = SafeGetString(p, "autoPlay") != "0";
+                pe.isPlaying = SafeGetString(p, "isPlaying") == "1";
+                pe.emissionRate = SafeGetFloat(p, "emissionRate", 10.0f);
+                pe.lifetime = SafeGetFloat(p, "lifetime", 1.0f);
+                pe.startColor = {SafeGetFloat(p, "scr", 1), SafeGetFloat(p, "scg", 1), SafeGetFloat(p, "scb", 1),
+                                 SafeGetFloat(p, "sca", 1)};
+                pe.startSize = SafeGetFloat(p, "startSize", 0.1f);
+                pe.startSpeed = SafeGetFloat(p, "startSpeed", 1.0f);
+                pe.emitterHandle = nullptr;
+            });
+
+        reg.Register(
+            "AnimationController",
+            [](const void* comp) -> SerializedComponent
+            {
+                const auto* ac = static_cast<const AnimationController*>(comp);
+                SerializedComponent sc;
+                sc.typeName = "AnimationController";
+                sc.properties["currentAnimation"] = ac->currentAnimation;
+                sc.properties["defaultAnimation"] = ac->defaultAnimation;
+                sc.properties["playbackSpeed"] = std::to_string(ac->playbackSpeed);
+                sc.properties["currentTime"] = std::to_string(ac->currentTime);
+                sc.properties["playing"] = ac->playing ? "1" : "0";
+                sc.properties["loop"] = ac->loop ? "1" : "0";
+                std::string animList;
+                for (size_t i = 0; i < ac->availableAnimations.size(); ++i)
+                {
+                    if (i > 0)
+                        animList += ",";
+                    animList += ac->availableAnimations[i];
+                }
+                sc.properties["availableAnimations"] = animList;
+                return sc;
+            },
+            [](World& world, EntityID entity, const SerializedComponent& data)
+            {
+                auto& ac = world.AddComponent<AnimationController>(entity);
+                auto& p = data.properties;
+                ac.currentAnimation = SafeGetString(p, "currentAnimation");
+                ac.defaultAnimation = SafeGetString(p, "defaultAnimation");
+                ac.playbackSpeed = SafeGetFloat(p, "playbackSpeed", 1.0f);
+                ac.currentTime = SafeGetFloat(p, "currentTime", 0.0f);
+                ac.playing = SafeGetString(p, "playing") != "0";
+                ac.loop = SafeGetString(p, "loop") != "0";
+                std::string animList = SafeGetString(p, "availableAnimations");
+                if (!animList.empty())
+                {
+                    std::istringstream iss(animList);
+                    std::string anim;
+                    while (std::getline(iss, anim, ','))
+                    {
+                        if (!anim.empty())
+                            ac.availableAnimations.push_back(anim);
+                    }
+                }
+                ac.animInstanceHandle = nullptr;
+            });
+
+        reg.Register(
+            "NetworkIdentity",
+            [](const void* comp) -> SerializedComponent
+            {
+                const auto* ni = static_cast<const NetworkIdentity*>(comp);
+                SerializedComponent sc;
+                sc.typeName = "NetworkIdentity";
+                sc.properties["networkID"] = std::to_string(ni->networkID);
+                sc.properties["ownerClientID"] = std::to_string(ni->ownerClientID);
+                sc.properties["isLocalAuthority"] = ni->isLocalAuthority ? "1" : "0";
+                sc.properties["replicateTransform"] = ni->replicateTransform ? "1" : "0";
+                sc.properties["replicateHealth"] = ni->replicateHealth ? "1" : "0";
+                return sc;
+            },
+            [](World& world, EntityID entity, const SerializedComponent& data)
+            {
+                auto& ni = world.AddComponent<NetworkIdentity>(entity);
+                auto& p = data.properties;
+                ni.networkID = SafeGetUint32(p, "networkID", 0);
+                ni.ownerClientID = SafeGetUint32(p, "ownerClientID", 0);
+                ni.isLocalAuthority = SafeGetString(p, "isLocalAuthority") == "1";
+                ni.replicateTransform = SafeGetString(p, "replicateTransform") != "0";
+                ni.replicateHealth = SafeGetString(p, "replicateHealth") != "0";
+            });
+    }
+
+    void ComponentSerializerRegistry::RegisterBuiltins()
+    {
+        RegisterCoreSerializers(*this);
+        RegisterPhysicsSerializers(*this);
+        RegisterGameplaySerializers(*this);
         RegisterReflectedSerializers();
     }
 
@@ -786,6 +781,17 @@ namespace Spark
         return fs::exists(GetSavePath(slotName));
     }
 
+    template <typename T>
+    static void TrySerialize(World& world, entt::entity entity, const ComponentSerializerRegistry& reg,
+                             const char* typeName, std::vector<SerializedComponent>& out)
+    {
+        if (auto* comp = world.GetComponent<T>(entity))
+        {
+            if (reg.HasSerializer(typeName))
+                out.push_back(reg.Serialize(typeName, comp));
+        }
+    }
+
     SaveData SaveSystem::SerializeWorld(World& world, const SaveMetadata& metadata) const
     {
         SaveData data;
@@ -806,103 +812,22 @@ namespace Spark
             auto* name = world.GetComponent<NameComponent>(entity);
             se.name = name ? name->name : "";
 
-            // Serialize Transform
-            if (auto* t = world.GetComponent<Transform>(entity))
-            {
-                if (serializerRegistry.HasSerializer("Transform"))
-                    se.components.push_back(serializerRegistry.Serialize("Transform", t));
-            }
-
-            // Serialize MeshRenderer
-            if (auto* m = world.GetComponent<MeshRenderer>(entity))
-            {
-                if (serializerRegistry.HasSerializer("MeshRenderer"))
-                    se.components.push_back(serializerRegistry.Serialize("MeshRenderer", m));
-            }
-
-            // Serialize HealthComponent
-            if (auto* h = world.GetComponent<HealthComponent>(entity))
-            {
-                if (serializerRegistry.HasSerializer("HealthComponent"))
-                    se.components.push_back(serializerRegistry.Serialize("HealthComponent", h));
-            }
-
-            // Serialize LightComponent
-            if (auto* l = world.GetComponent<LightComponent>(entity))
-            {
-                if (serializerRegistry.HasSerializer("LightComponent"))
-                    se.components.push_back(serializerRegistry.Serialize("LightComponent", l));
-            }
-
-            // Serialize AudioSourceComponent
-            if (auto* a = world.GetComponent<AudioSourceComponent>(entity))
-            {
-                if (serializerRegistry.HasSerializer("AudioSourceComponent"))
-                    se.components.push_back(serializerRegistry.Serialize("AudioSourceComponent", a));
-            }
-
-            // Serialize Camera
-            if (auto* c = world.GetComponent<Camera>(entity))
-            {
-                if (serializerRegistry.HasSerializer("Camera"))
-                    se.components.push_back(serializerRegistry.Serialize("Camera", c));
-            }
-
-            // Serialize Script
-            if (auto* s = world.GetComponent<Script>(entity))
-            {
-                if (serializerRegistry.HasSerializer("Script"))
-                    se.components.push_back(serializerRegistry.Serialize("Script", s));
-            }
-
-            // Serialize RigidBodyComponent
-            if (auto* rb = world.GetComponent<RigidBodyComponent>(entity))
-            {
-                if (serializerRegistry.HasSerializer("RigidBodyComponent"))
-                    se.components.push_back(serializerRegistry.Serialize("RigidBodyComponent", rb));
-            }
-
-            // Serialize ColliderComponent
-            if (auto* col = world.GetComponent<ColliderComponent>(entity))
-            {
-                if (serializerRegistry.HasSerializer("ColliderComponent"))
-                    se.components.push_back(serializerRegistry.Serialize("ColliderComponent", col));
-            }
-
-            // Serialize ParticleEmitterComponent
-            if (auto* pe = world.GetComponent<ParticleEmitterComponent>(entity))
-            {
-                if (serializerRegistry.HasSerializer("ParticleEmitterComponent"))
-                    se.components.push_back(serializerRegistry.Serialize("ParticleEmitterComponent", pe));
-            }
-
-            // Serialize AnimationController
-            if (auto* ac = world.GetComponent<AnimationController>(entity))
-            {
-                if (serializerRegistry.HasSerializer("AnimationController"))
-                    se.components.push_back(serializerRegistry.Serialize("AnimationController", ac));
-            }
-
-            // Serialize NetworkIdentity
-            if (auto* ni = world.GetComponent<NetworkIdentity>(entity))
-            {
-                if (serializerRegistry.HasSerializer("NetworkIdentity"))
-                    se.components.push_back(serializerRegistry.Serialize("NetworkIdentity", ni));
-            }
-
-            // Serialize TagComponent
-            if (auto* tc = world.GetComponent<TagComponent>(entity))
-            {
-                if (serializerRegistry.HasSerializer("TagComponent"))
-                    se.components.push_back(serializerRegistry.Serialize("TagComponent", tc));
-            }
-
-            // Serialize ActiveComponent
-            if (auto* ac = world.GetComponent<ActiveComponent>(entity))
-            {
-                if (serializerRegistry.HasSerializer("ActiveComponent"))
-                    se.components.push_back(serializerRegistry.Serialize("ActiveComponent", ac));
-            }
+            TrySerialize<Transform>(world, entity, serializerRegistry, "Transform", se.components);
+            TrySerialize<MeshRenderer>(world, entity, serializerRegistry, "MeshRenderer", se.components);
+            TrySerialize<HealthComponent>(world, entity, serializerRegistry, "HealthComponent", se.components);
+            TrySerialize<LightComponent>(world, entity, serializerRegistry, "LightComponent", se.components);
+            TrySerialize<AudioSourceComponent>(world, entity, serializerRegistry, "AudioSourceComponent",
+                                               se.components);
+            TrySerialize<Camera>(world, entity, serializerRegistry, "Camera", se.components);
+            TrySerialize<Script>(world, entity, serializerRegistry, "Script", se.components);
+            TrySerialize<RigidBodyComponent>(world, entity, serializerRegistry, "RigidBodyComponent", se.components);
+            TrySerialize<ColliderComponent>(world, entity, serializerRegistry, "ColliderComponent", se.components);
+            TrySerialize<ParticleEmitterComponent>(world, entity, serializerRegistry, "ParticleEmitterComponent",
+                                                   se.components);
+            TrySerialize<AnimationController>(world, entity, serializerRegistry, "AnimationController", se.components);
+            TrySerialize<NetworkIdentity>(world, entity, serializerRegistry, "NetworkIdentity", se.components);
+            TrySerialize<TagComponent>(world, entity, serializerRegistry, "TagComponent", se.components);
+            TrySerialize<ActiveComponent>(world, entity, serializerRegistry, "ActiveComponent", se.components);
 
             if (!se.components.empty())
                 data.entities.push_back(se);

--- a/SparkEngine/Source/Graphics/UpscalingShaders.h
+++ b/SparkEngine/Source/Graphics/UpscalingShaders.h
@@ -1,0 +1,690 @@
+#pragma once
+
+/**
+ * @file UpscalingShaders.h
+ * @brief Inline HLSL compute shader source strings for the upscaling system
+ *
+ * Contains FSR 1.0 EASU/RCAS, temporal upscaling (FSR 2.0-style), and
+ * SparkSR native temporal upscaling shader source.  Extracted from
+ * UpscalingSystem.cpp to keep the translation unit focused on logic.
+ */
+
+namespace Spark::UpscalingShaders
+{
+
+    // -------------------------------------------------------------------------
+    // FSR 1.0 EASU — Edge Adaptive Spatial Upsampling (Compute Shader)
+    //
+    // Simplified approximation of AMD's FidelityFX EASU pass.  Performs a
+    // 12-tap directional filter in a 3x3 neighbourhood, detecting local edges
+    // to steer an anisotropic Lanczos-like kernel.  Thread group: 8x8.
+    // -------------------------------------------------------------------------
+    inline constexpr const char* kFSR1_EASU_CS = R"(
+// FSR 1.0 EASU — Edge Adaptive Spatial Upsampling
+// Approximate implementation for SparkEngine
+
+cbuffer EASUConstants : register(b0)
+{
+    float4 Const0; // (inputWidth, inputHeight, outputWidth, outputHeight)
+    float4 Const1; // (inputOffsetX, inputOffsetY, inputRegionW, inputRegionH)
+    float4 Const2; // (1/inputWidth, 1/inputHeight, 1/outputWidth, 1/outputHeight)
+    float4 Const3; // reserved
+};
+
+Texture2D<float4> InputTexture : register(t0);
+RWTexture2D<float4> OutputTexture : register(u0);
+SamplerState LinearClamp : register(s0);
+
+// Compute Lanczos2 weight
+float Lanczos2(float x)
+{
+    if (abs(x) < 1e-5)
+        return 1.0;
+    if (abs(x) >= 2.0)
+        return 0.0;
+
+    float pi = 3.14159265358979;
+    float piX = pi * x;
+    float piXHalf = piX * 0.5;
+    return (sin(piX) / piX) * (sin(piXHalf) / piXHalf);
+}
+
+// Bilinear fetch with offset in texels
+float3 FetchTexel(float2 baseUV, float2 offsetTexels)
+{
+    float2 uv = baseUV + offsetTexels * Const2.xy;
+    return InputTexture.SampleLevel(LinearClamp, uv, 0.0).rgb;
+}
+
+// Compute local edge direction from a 3x3 neighbourhood
+float2 ComputeEdgeDirection(float3 n, float3 s, float3 e, float3 w,
+                            float3 ne, float3 nw, float3 se, float3 sw)
+{
+    // Luminance approximation
+    float lumN  = dot(n,  float3(0.299, 0.587, 0.114));
+    float lumS  = dot(s,  float3(0.299, 0.587, 0.114));
+    float lumE  = dot(e,  float3(0.299, 0.587, 0.114));
+    float lumW  = dot(w,  float3(0.299, 0.587, 0.114));
+    float lumNE = dot(ne, float3(0.299, 0.587, 0.114));
+    float lumNW = dot(nw, float3(0.299, 0.587, 0.114));
+    float lumSE = dot(se, float3(0.299, 0.587, 0.114));
+    float lumSW = dot(sw, float3(0.299, 0.587, 0.114));
+
+    // Sobel-like gradient
+    float dx = -lumNW - 2.0 * lumW - lumSW + lumNE + 2.0 * lumE + lumSE;
+    float dy = -lumNW - 2.0 * lumN - lumNE + lumSW + 2.0 * lumS + lumSE;
+
+    float len = max(sqrt(dx * dx + dy * dy), 1e-6);
+    return float2(dx / len, dy / len);
+}
+
+[numthreads(8, 8, 1)]
+void CSMain(uint3 dtid : SV_DispatchThreadID)
+{
+    float2 outputSize = Const0.zw;
+
+    if (dtid.x >= (uint)outputSize.x || dtid.y >= (uint)outputSize.y)
+        return;
+
+    // Map output pixel to input UV
+    float2 outputPixel = float2(dtid.x, dtid.y) + 0.5;
+    float2 inputUV = outputPixel * Const2.zw; // output pixel / output size
+    // Scale to input space
+    float2 srcUV = inputUV; // maps [0,1] -> [0,1]
+
+    // Gather 3x3 neighbourhood
+    float3 c  = FetchTexel(srcUV, float2( 0.0,  0.0));
+    float3 n  = FetchTexel(srcUV, float2( 0.0, -1.0));
+    float3 s  = FetchTexel(srcUV, float2( 0.0,  1.0));
+    float3 e  = FetchTexel(srcUV, float2( 1.0,  0.0));
+    float3 w  = FetchTexel(srcUV, float2(-1.0,  0.0));
+    float3 ne = FetchTexel(srcUV, float2( 1.0, -1.0));
+    float3 nw = FetchTexel(srcUV, float2(-1.0, -1.0));
+    float3 se = FetchTexel(srcUV, float2( 1.0,  1.0));
+    float3 sw = FetchTexel(srcUV, float2(-1.0,  1.0));
+
+    // Compute edge direction for anisotropic filtering
+    float2 edgeDir = ComputeEdgeDirection(n, s, e, w, ne, nw, se, sw);
+
+    // Fractional position within the source texel for sub-pixel offset
+    float2 srcTexel = srcUV * Const0.xy; // UV -> texel coordinates
+    float2 frac_pos = frac(srcTexel) - 0.5;
+
+    // 12-tap directional Lanczos-like filter
+    // Taps aligned along and perpendicular to the edge direction
+    float2 along = edgeDir;
+    float2 perp  = float2(-edgeDir.y, edgeDir.x);
+
+    float3 result = float3(0.0, 0.0, 0.0);
+    float totalWeight = 0.0;
+
+    // Sample offsets: 4 along edge, 4 perpendicular, 4 diagonal
+    static const float2 offsets[12] = {
+        float2( 0.0,  0.0),
+        float2( 1.0,  0.0),
+        float2(-1.0,  0.0),
+        float2( 0.0,  1.0),
+        float2( 0.0, -1.0),
+        float2( 1.0,  1.0),
+        float2(-1.0, -1.0),
+        float2( 1.0, -1.0),
+        float2(-1.0,  1.0),
+        float2( 0.5,  0.0),
+        float2(-0.5,  0.0),
+        float2( 0.0,  0.5)
+    };
+
+    [unroll]
+    for (int i = 0; i < 12; i++)
+    {
+        float2 offset = offsets[i];
+        float2 samplePos = offset - frac_pos;
+
+        // Project onto edge-aligned axes for anisotropic weighting
+        float distAlong = abs(dot(samplePos, along));
+        float distPerp  = abs(dot(samplePos, perp));
+
+        // Lanczos weight with edge-aware stretch
+        float wAlong = Lanczos2(distAlong);
+        float wPerp  = Lanczos2(distPerp * 1.5); // Tighter filtering across edges
+        float weight  = wAlong * wPerp;
+
+        float3 tap = FetchTexel(srcUV, offset);
+        result += tap * weight;
+        totalWeight += weight;
+    }
+
+    result /= max(totalWeight, 1e-6);
+
+    OutputTexture[dtid.xy] = float4(result, 1.0);
+}
+)";
+
+    // -------------------------------------------------------------------------
+    // FSR 1.0 RCAS — Robust Contrast Adaptive Sharpening (Compute Shader)
+    //
+    // Simplified CAS pass: applies contrast-adaptive sharpening that avoids
+    // amplifying noise in low-contrast areas.  Thread group: 8x8.
+    // -------------------------------------------------------------------------
+    inline constexpr const char* kFSR1_RCAS_CS = R"(
+// FSR 1.0 RCAS — Robust Contrast Adaptive Sharpening
+// Approximate implementation for SparkEngine
+
+cbuffer RCASConstants : register(b0)
+{
+    float4 Const0; // (attenuation, 0, 0, 0)
+};
+
+Texture2D<float4> InputTexture : register(t0);
+RWTexture2D<float4> OutputTexture : register(u0);
+
+float Luma(float3 color)
+{
+    return dot(color, float3(0.299, 0.587, 0.114));
+}
+
+[numthreads(8, 8, 1)]
+void CSMain(uint3 dtid : SV_DispatchThreadID)
+{
+    uint width, height;
+    InputTexture.GetDimensions(width, height);
+
+    if (dtid.x >= width || dtid.y >= height)
+        return;
+
+    int2 pos = int2(dtid.xy);
+
+    // Load centre and 4-connected neighbours
+    float3 c = InputTexture.Load(int3(pos, 0)).rgb;
+    float3 n = InputTexture.Load(int3(pos + int2( 0, -1), 0)).rgb;
+    float3 s = InputTexture.Load(int3(pos + int2( 0,  1), 0)).rgb;
+    float3 e = InputTexture.Load(int3(pos + int2( 1,  0), 0)).rgb;
+    float3 w = InputTexture.Load(int3(pos + int2(-1,  0), 0)).rgb;
+
+    // Compute min / max luma in cross neighbourhood
+    float lumC = Luma(c);
+    float lumN = Luma(n);
+    float lumS = Luma(s);
+    float lumE = Luma(e);
+    float lumW = Luma(w);
+
+    float minLuma = min(lumC, min(min(lumN, lumS), min(lumE, lumW)));
+    float maxLuma = max(lumC, max(max(lumN, lumS), max(lumE, lumW)));
+
+    // Local contrast ratio drives sharpening strength
+    float contrast = maxLuma - minLuma;
+    float peakRange = max(maxLuma, 1e-6);
+    float ratio = contrast / peakRange;
+
+    // Attenuation maps [0,2]: 0 = full sharpen, 2 = no sharpen
+    float attenuation = Const0.x;
+
+    // Sharpening weight: high contrast => sharpen, attenuated by user control
+    float sharpWeight = max(0.0, 1.0 - ratio * attenuation);
+    sharpWeight = sharpWeight * sharpWeight; // Smooth falloff
+
+    // Clamp to a reasonable range to avoid halos
+    sharpWeight = min(sharpWeight, 0.5);
+
+    // Compute unsharp mask: centre - average of neighbours
+    float3 avg = (n + s + e + w) * 0.25;
+    float3 detail = c - avg;
+
+    // Apply sharpening
+    float3 result = c + detail * sharpWeight;
+
+    // Clamp to prevent ringing
+    float3 minNeighbour = min(c, min(min(n, s), min(e, w)));
+    float3 maxNeighbour = max(c, max(max(n, s), max(e, w)));
+    result = clamp(result, minNeighbour, maxNeighbour);
+
+    OutputTexture[dtid.xy] = float4(result, 1.0);
+}
+)";
+
+    // -------------------------------------------------------------------------
+    // Temporal Upscaling Compute Shader (simplified FSR 2.0-style)
+    //
+    // Single-pass temporal upscaler that reprojects the previous frame using
+    // motion vectors, performs disocclusion detection via depth comparison,
+    // and blends temporal history with the current frame.  Thread group: 8x8.
+    // -------------------------------------------------------------------------
+    inline constexpr const char* kTemporalUpscaling_CS = R"(
+// Simplified temporal upscaling (FSR 2.0 style)
+// Single-pass approximation for SparkEngine
+
+cbuffer TemporalConstants : register(b0)
+{
+    float4 InputOutputSize;    // (renderW, renderH, displayW, displayH)
+    float4 InputSizeRcp;       // (1/renderW, 1/renderH, 1/displayW, 1/displayH)
+    float4 JitterOffset;       // (jitterX, jitterY, motionScaleX, motionScaleY)
+    float4 TemporalParams;     // (deltaTime, nearPlane, farPlane, verticalFOV)
+    float4 Flags;              // (resetAccumulation, frameIndex, 0, 0)
+};
+
+Texture2D<float4> ColorInput        : register(t0);
+Texture2D<float>  DepthInput        : register(t1);
+Texture2D<float2> MotionVectors     : register(t2);
+Texture2D<float>  ExposureInput     : register(t3);
+Texture2D<float>  ReactiveMask      : register(t4);
+Texture2D<float4> HistoryTexture    : register(t5);
+RWTexture2D<float4> OutputTexture   : register(u0);
+SamplerState LinearClamp            : register(s0);
+
+float Luminance(float3 c)
+{
+    return dot(c, float3(0.2126, 0.7152, 0.0722));
+}
+
+float LinearizeDepth(float d, float nearZ, float farZ)
+{
+    return nearZ * farZ / (farZ - d * (farZ - nearZ));
+}
+
+// Catmull-Rom weight for high-quality history sampling
+float CatmullRomWeight(float x)
+{
+    float ax = abs(x);
+    if (ax < 1.0)
+        return 0.5 * (2.0 + ax * ax * (-5.0 + ax * 3.0));
+    if (ax < 2.0)
+        return 0.5 * (4.0 + ax * (-8.0 + ax * (5.0 - ax)));
+    return 0.0;
+}
+
+// Sample history with Catmull-Rom 4-tap (separable)
+float3 SampleHistoryCatmullRom(float2 uv)
+{
+    float2 texelSize = InputSizeRcp.zw;
+    float2 samplePos = uv / texelSize - 0.5;
+    float2 f = frac(samplePos);
+    float2 texelBase = (floor(samplePos) + 0.5) * texelSize;
+
+    float3 result = float3(0.0, 0.0, 0.0);
+    float totalWeight = 0.0;
+
+    [unroll]
+    for (int y = -1; y <= 2; y++)
+    {
+        float wy = CatmullRomWeight(f.y - (float)y);
+        [unroll]
+        for (int x = -1; x <= 2; x++)
+        {
+            float wx = CatmullRomWeight(f.x - (float)x);
+            float weight = wx * wy;
+            float2 offset = float2((float)x, (float)y) * texelSize;
+            float3 tap = HistoryTexture.SampleLevel(LinearClamp, texelBase + offset, 0.0).rgb;
+            result += tap * weight;
+            totalWeight += weight;
+        }
+    }
+
+    return result / max(totalWeight, 1e-6);
+}
+
+[numthreads(8, 8, 1)]
+void CSMain(uint3 dtid : SV_DispatchThreadID)
+{
+    float displayW = InputOutputSize.z;
+    float displayH = InputOutputSize.w;
+
+    if (dtid.x >= (uint)displayW || dtid.y >= (uint)displayH)
+        return;
+
+    float2 outputUV = (float2(dtid.xy) + 0.5) * InputSizeRcp.zw;
+
+    // Map output pixel back to input space (accounting for resolution difference)
+    float2 inputUV = outputUV;
+    float2 jitteredUV = inputUV - JitterOffset.xy * InputSizeRcp.xy;
+
+    // Fetch current frame colour (with jitter removal)
+    float3 currentColor = ColorInput.SampleLevel(LinearClamp, jitteredUV, 0.0).rgb;
+
+    // Fetch motion vector at current position
+    float2 motion = MotionVectors.SampleLevel(LinearClamp, jitteredUV, 0.0).xy;
+    motion *= JitterOffset.zw; // Apply motion vector scale
+
+    // Reproject to find where this pixel was in the previous frame
+    float2 historyUV = outputUV - motion;
+
+    // Fetch depth for disocclusion detection
+    float depth = DepthInput.SampleLevel(LinearClamp, jitteredUV, 0.0).x;
+    float linearDepth = LinearizeDepth(depth, TemporalParams.y, TemporalParams.z);
+
+    // Fetch reactive mask (particles, transparency)
+    float reactive = ReactiveMask.SampleLevel(LinearClamp, jitteredUV, 0.0).x;
+
+    // Read exposure for luminance normalization
+    float exposure = max(ExposureInput.SampleLevel(LinearClamp, float2(0.5, 0.5), 0.0).x, 0.001);
+    currentColor *= exposure;
+
+    // Check if history UV is valid (within screen bounds)
+    bool historyValid = historyUV.x >= 0.0 && historyUV.x <= 1.0 &&
+                        historyUV.y >= 0.0 && historyUV.y <= 1.0;
+
+    // Reset temporal accumulation if requested
+    bool resetAccum = Flags.x > 0.5;
+
+    float3 result;
+
+    if (!historyValid || resetAccum)
+    {
+        // No valid history — use current frame only
+        result = currentColor;
+    }
+    else
+    {
+        // Sample history with high-quality Catmull-Rom filtering
+        float3 historyColor = SampleHistoryCatmullRom(historyUV);
+
+        // Neighbourhood colour clamping to prevent ghosting
+        // Gather a 3x3 neighbourhood around the current input texel
+        float3 minColor = currentColor;
+        float3 maxColor = currentColor;
+
+        [unroll]
+        for (int dy = -1; dy <= 1; dy++)
+        {
+            [unroll]
+            for (int dx = -1; dx <= 1; dx++)
+            {
+                if (dx == 0 && dy == 0)
+                    continue;
+                float2 offset = float2((float)dx, (float)dy) * InputSizeRcp.xy;
+                float3 neighbour = ColorInput.SampleLevel(
+                    LinearClamp, jitteredUV + offset, 0.0).rgb * exposure;
+                minColor = min(minColor, neighbour);
+                maxColor = max(maxColor, neighbour);
+            }
+        }
+
+        // Expand clamp box slightly to reduce flickering
+        float3 boxCenter = (minColor + maxColor) * 0.5;
+        float3 boxExtent = (maxColor - minColor) * 0.5;
+        minColor = boxCenter - boxExtent * 1.25;
+        maxColor = boxCenter + boxExtent * 1.25;
+
+        // Clamp history to the neighbourhood colour box
+        historyColor = clamp(historyColor, minColor, maxColor);
+
+        // Disocclusion detection: compare reprojected depth
+        float historyDepth = DepthInput.SampleLevel(LinearClamp, historyUV, 0.0).x;
+        float historyLinearDepth = LinearizeDepth(historyDepth, TemporalParams.y, TemporalParams.z);
+        float depthDelta = abs(linearDepth - historyLinearDepth) / max(linearDepth, 0.001);
+        float disocclusion = saturate(depthDelta * 10.0);
+
+        // Blend factor: prefer history for stability, bias towards current on disocclusion
+        float blendFactor = lerp(0.05, 1.0, disocclusion);
+
+        // Reactive mask forces use of current colour (particles, alpha-blended objects)
+        blendFactor = lerp(blendFactor, 1.0, reactive);
+
+        // Luminance-based weight adjustment: reduce history when luminance changes sharply
+        float lumCurrent = Luminance(currentColor);
+        float lumHistory = Luminance(historyColor);
+        float lumDelta = abs(lumCurrent - lumHistory) / max(lumCurrent + lumHistory, 0.001);
+        blendFactor = max(blendFactor, lumDelta * 0.5);
+
+        blendFactor = clamp(blendFactor, 0.03, 1.0);
+
+        result = lerp(historyColor, currentColor, blendFactor);
+    }
+
+    // Remove exposure before output
+    result /= exposure;
+
+    OutputTexture[dtid.xy] = float4(max(result, 0.0), 1.0);
+}
+)";
+
+    // -------------------------------------------------------------------------
+    // SparkSR — SparkEngine Native Temporal Upscaling (Compute Shader)
+    //
+    // Engine-native temporal upscaler with no vendor SDK dependency.
+    // Key improvements over the basic temporal upscaler:
+    //   - YCoCg color space for perceptually accurate neighborhood clamping
+    //   - Variance-based clip (mean +/- gamma * stddev) instead of min/max AABB
+    //   - Motion vector confidence weighting (fast motion = less history)
+    //   - Combined depth + motion divergence disocclusion detection
+    //   - Jitter delta tracking for improved sub-pixel reprojection
+    //   - Catmull-Rom 4-tap history sampling
+    // Thread group: 8x8.  Two-pass pipeline: this shader + RCAS sharpening.
+    // -------------------------------------------------------------------------
+    inline constexpr const char* kSparkSR_CS = R"(
+// SparkSR — SparkEngine Native Temporal Upscaling
+// Vendor-independent temporal accumulation with YCoCg variance clip
+
+cbuffer SparkSRConstants : register(b0)
+{
+    float4 RenderSize;     // (renderW, renderH, 1/renderW, 1/renderH)
+    float4 DisplaySize;    // (displayW, displayH, 1/displayW, 1/displayH)
+    float4 JitterOffset;   // (jitterX, jitterY, prevJitterX, prevJitterY)
+    float4 TemporalParams; // (frameIndex, resetFlag, sharpness, blendMin)
+    float4 MotionParams;   // (motionScaleX, motionScaleY, depthThreshold, varianceGamma)
+};
+
+Texture2D<float4> ColorInput        : register(t0);
+Texture2D<float>  DepthInput        : register(t1);
+Texture2D<float2> MotionVectors     : register(t2);
+Texture2D<float>  ExposureInput     : register(t3);
+Texture2D<float>  ReactiveMask      : register(t4);
+Texture2D<float4> HistoryTexture    : register(t5);
+RWTexture2D<float4> OutputTexture   : register(u0);
+SamplerState LinearClamp            : register(s0);
+
+// --- Color space conversion ---
+
+float3 RGBToYCoCg(float3 rgb)
+{
+    float y  = dot(rgb, float3(0.25, 0.5, 0.25));
+    float co = dot(rgb, float3(0.5, 0.0, -0.5));
+    float cg = dot(rgb, float3(-0.25, 0.5, -0.25));
+    return float3(y, co, cg);
+}
+
+float3 YCoCgToRGB(float3 ycocg)
+{
+    float y  = ycocg.x;
+    float co = ycocg.y;
+    float cg = ycocg.z;
+    return float3(y + co - cg, y + cg, y - co - cg);
+}
+
+float Luminance(float3 c)
+{
+    return dot(c, float3(0.2126, 0.7152, 0.0722));
+}
+
+float LinearizeDepth(float d, float nearZ, float farZ)
+{
+    return nearZ * farZ / (farZ - d * (farZ - nearZ));
+}
+
+// --- Variance-based AABB clip ---
+// Clips the history sample toward the center of a variance-derived AABB
+// This is tighter than min/max and reduces ghosting significantly
+
+float3 ClipToVarianceAABB(float3 history, float3 aabbCenter, float3 aabbExtent)
+{
+    float3 offset = history - aabbCenter;
+    float3 absExtent = max(aabbExtent, 0.0001);
+    float3 ts = abs(offset) / absExtent;
+    float maxT = max(ts.x, max(ts.y, ts.z));
+
+    if (maxT > 1.0)
+    {
+        return aabbCenter + offset / maxT;
+    }
+    return history;
+}
+
+// --- Catmull-Rom 4-tap history sampling ---
+
+float CatmullRomWeight(float x)
+{
+    float ax = abs(x);
+    if (ax < 1.0)
+        return 0.5 * (2.0 + ax * ax * (-5.0 + ax * 3.0));
+    if (ax < 2.0)
+        return 0.5 * (4.0 + ax * (-8.0 + ax * (5.0 - ax)));
+    return 0.0;
+}
+
+float3 SampleHistoryCatmullRom(float2 uv)
+{
+    float2 texelSize = DisplaySize.zw;
+    float2 samplePos = uv / texelSize - 0.5;
+    float2 f = frac(samplePos);
+    float2 texelBase = (floor(samplePos) + 0.5) * texelSize;
+
+    float3 result = float3(0.0, 0.0, 0.0);
+    float totalWeight = 0.0;
+
+    [unroll]
+    for (int y = -1; y <= 2; y++)
+    {
+        float wy = CatmullRomWeight(f.y - (float)y);
+        [unroll]
+        for (int x = -1; x <= 2; x++)
+        {
+            float wx = CatmullRomWeight(f.x - (float)x);
+            float weight = wx * wy;
+            float2 offset = float2((float)x, (float)y) * texelSize;
+            float3 tap = HistoryTexture.SampleLevel(LinearClamp, texelBase + offset, 0.0).rgb;
+            result += tap * weight;
+            totalWeight += weight;
+        }
+    }
+
+    return result / max(totalWeight, 1e-6);
+}
+
+[numthreads(8, 8, 1)]
+void CSMain(uint3 dtid : SV_DispatchThreadID)
+{
+    if (dtid.x >= (uint)DisplaySize.x || dtid.y >= (uint)DisplaySize.y)
+        return;
+
+    float2 outputUV = (float2(dtid.xy) + 0.5) * DisplaySize.zw;
+
+    // De-jitter: remove current frame's jitter to get the true sample position
+    float2 inputUV = outputUV;
+    float2 jitteredUV = inputUV - JitterOffset.xy * RenderSize.zw;
+
+    // Fetch current frame color
+    float3 currentColor = ColorInput.SampleLevel(LinearClamp, jitteredUV, 0.0).rgb;
+
+    // Apply exposure normalization
+    float exposure = max(ExposureInput.SampleLevel(LinearClamp, float2(0.5, 0.5), 0.0).x, 0.001);
+    currentColor *= exposure;
+
+    // Fetch motion vector and apply scale
+    float2 motion = MotionVectors.SampleLevel(LinearClamp, jitteredUV, 0.0).xy;
+    motion *= MotionParams.xy;
+
+    // Reproject to find previous frame position
+    float2 historyUV = outputUV - motion;
+
+    // Fetch depth and reactive mask
+    float depth = DepthInput.SampleLevel(LinearClamp, jitteredUV, 0.0).x;
+    float reactive = ReactiveMask.SampleLevel(LinearClamp, jitteredUV, 0.0).x;
+
+    // Check history validity
+    bool historyValid = historyUV.x >= 0.0 && historyUV.x <= 1.0 &&
+                        historyUV.y >= 0.0 && historyUV.y <= 1.0;
+    bool resetAccum = TemporalParams.y > 0.5;
+
+    float3 result;
+
+    if (!historyValid || resetAccum)
+    {
+        result = currentColor;
+    }
+    else
+    {
+        // --- Gather 3x3 neighborhood in YCoCg for variance clip ---
+        float3 m1 = float3(0.0, 0.0, 0.0); // sum
+        float3 m2 = float3(0.0, 0.0, 0.0); // sum of squares
+        float3 currentYCoCg = RGBToYCoCg(currentColor);
+
+        [unroll]
+        for (int dy = -1; dy <= 1; dy++)
+        {
+            [unroll]
+            for (int dx = -1; dx <= 1; dx++)
+            {
+                float2 offset = float2((float)dx, (float)dy) * RenderSize.zw;
+                float3 s = ColorInput.SampleLevel(LinearClamp, jitteredUV + offset, 0.0).rgb * exposure;
+                float3 sYCoCg = RGBToYCoCg(s);
+                m1 += sYCoCg;
+                m2 += sYCoCg * sYCoCg;
+            }
+        }
+
+        // Compute mean and standard deviation
+        float3 mean = m1 / 9.0;
+        float3 variance = abs(m2 / 9.0 - mean * mean);
+        float3 stddev = sqrt(variance);
+
+        // Variance gamma controls how tight the clip box is
+        // Lower gamma = tighter = less ghosting but more flickering
+        float gamma = MotionParams.w; // typically 1.0 - 1.25
+
+        // Sample history with Catmull-Rom for sub-pixel accuracy
+        float3 historyColor = SampleHistoryCatmullRom(historyUV);
+        historyColor *= exposure; // normalize history to current exposure
+        float3 historyYCoCg = RGBToYCoCg(historyColor);
+
+        // Clip history to variance-derived AABB in YCoCg space
+        float3 aabbExtent = stddev * gamma;
+        historyYCoCg = ClipToVarianceAABB(historyYCoCg, mean, aabbExtent);
+        historyColor = YCoCgToRGB(historyYCoCg);
+
+        // --- Disocclusion detection: depth + motion divergence ---
+        float historyDepth = DepthInput.SampleLevel(LinearClamp, historyUV, 0.0).x;
+        float depthDelta = abs(depth - historyDepth);
+        float depthDisocclusion = saturate(depthDelta / max(MotionParams.z, 0.001));
+
+        // Motion divergence: compare motion at current vs reprojected position
+        float2 historyMotion = MotionVectors.SampleLevel(LinearClamp, historyUV, 0.0).xy * MotionParams.xy;
+        float motionDivergence = length(motion - historyMotion);
+        float motionDisocclusion = saturate(motionDivergence * 20.0);
+
+        float disocclusion = max(depthDisocclusion, motionDisocclusion);
+
+        // --- Motion confidence: fast motion = prefer current frame ---
+        float motionLength = length(motion);
+        float motionConfidence = saturate(motionLength * 10.0);
+
+        // --- Compute blend factor ---
+        float blendMin = TemporalParams.w; // minimum blend (e.g. 0.03)
+        float blendFactor = blendMin;
+
+        // Increase blend toward current on disocclusion
+        blendFactor = lerp(blendFactor, 1.0, disocclusion);
+
+        // Increase blend for fast-moving pixels
+        blendFactor = lerp(blendFactor, max(blendFactor, 0.3), motionConfidence);
+
+        // Reactive mask forces use of current color (particles, transparency)
+        blendFactor = lerp(blendFactor, 1.0, reactive);
+
+        // Luminance stability: large luminance shifts bias toward current
+        float lumCurrent = Luminance(currentColor);
+        float lumHistory = Luminance(historyColor);
+        float lumDelta = abs(lumCurrent - lumHistory) / max(lumCurrent + lumHistory, 0.001);
+        blendFactor = max(blendFactor, lumDelta * 0.4);
+
+        blendFactor = clamp(blendFactor, blendMin, 1.0);
+
+        result = lerp(historyColor, currentColor, blendFactor);
+    }
+
+    // Remove exposure normalization before output
+    result /= exposure;
+
+    OutputTexture[dtid.xy] = float4(max(result, 0.0), 1.0);
+}
+)";
+
+} // namespace Spark::UpscalingShaders

--- a/SparkEngine/Source/Graphics/UpscalingSystem.cpp
+++ b/SparkEngine/Source/Graphics/UpscalingSystem.cpp
@@ -18,6 +18,7 @@
 
 #include "../Core/Platform.h"
 #include "UpscalingSystem.h"
+#include "UpscalingShaders.h"
 #include "../Utils/Validate.h"
 
 #ifdef SPARK_PLATFORM_WINDOWS
@@ -40,690 +41,6 @@
 using Microsoft::WRL::ComPtr;
 using namespace DirectX;
 #endif
-
-// =============================================================================
-// HLSL SHADER SOURCES
-// =============================================================================
-
-namespace
-{
-
-    // -------------------------------------------------------------------------
-    // FSR 1.0 EASU — Edge Adaptive Spatial Upsampling (Compute Shader)
-    //
-    // Simplified approximation of AMD's FidelityFX EASU pass.  Performs a
-    // 12-tap directional filter in a 3x3 neighbourhood, detecting local edges
-    // to steer an anisotropic Lanczos-like kernel.  Thread group: 8x8.
-    // -------------------------------------------------------------------------
-    static const char* kFSR1_EASU_CS = R"(
-// FSR 1.0 EASU — Edge Adaptive Spatial Upsampling
-// Approximate implementation for SparkEngine
-
-cbuffer EASUConstants : register(b0)
-{
-    float4 Const0; // (inputWidth, inputHeight, outputWidth, outputHeight)
-    float4 Const1; // (inputOffsetX, inputOffsetY, inputRegionW, inputRegionH)
-    float4 Const2; // (1/inputWidth, 1/inputHeight, 1/outputWidth, 1/outputHeight)
-    float4 Const3; // reserved
-};
-
-Texture2D<float4> InputTexture : register(t0);
-RWTexture2D<float4> OutputTexture : register(u0);
-SamplerState LinearClamp : register(s0);
-
-// Compute Lanczos2 weight
-float Lanczos2(float x)
-{
-    if (abs(x) < 1e-5)
-        return 1.0;
-    if (abs(x) >= 2.0)
-        return 0.0;
-
-    float pi = 3.14159265358979;
-    float piX = pi * x;
-    float piXHalf = piX * 0.5;
-    return (sin(piX) / piX) * (sin(piXHalf) / piXHalf);
-}
-
-// Bilinear fetch with offset in texels
-float3 FetchTexel(float2 baseUV, float2 offsetTexels)
-{
-    float2 uv = baseUV + offsetTexels * Const2.xy;
-    return InputTexture.SampleLevel(LinearClamp, uv, 0.0).rgb;
-}
-
-// Compute local edge direction from a 3x3 neighbourhood
-float2 ComputeEdgeDirection(float3 n, float3 s, float3 e, float3 w,
-                            float3 ne, float3 nw, float3 se, float3 sw)
-{
-    // Luminance approximation
-    float lumN  = dot(n,  float3(0.299, 0.587, 0.114));
-    float lumS  = dot(s,  float3(0.299, 0.587, 0.114));
-    float lumE  = dot(e,  float3(0.299, 0.587, 0.114));
-    float lumW  = dot(w,  float3(0.299, 0.587, 0.114));
-    float lumNE = dot(ne, float3(0.299, 0.587, 0.114));
-    float lumNW = dot(nw, float3(0.299, 0.587, 0.114));
-    float lumSE = dot(se, float3(0.299, 0.587, 0.114));
-    float lumSW = dot(sw, float3(0.299, 0.587, 0.114));
-
-    // Sobel-like gradient
-    float dx = -lumNW - 2.0 * lumW - lumSW + lumNE + 2.0 * lumE + lumSE;
-    float dy = -lumNW - 2.0 * lumN - lumNE + lumSW + 2.0 * lumS + lumSE;
-
-    float len = max(sqrt(dx * dx + dy * dy), 1e-6);
-    return float2(dx / len, dy / len);
-}
-
-[numthreads(8, 8, 1)]
-void CSMain(uint3 dtid : SV_DispatchThreadID)
-{
-    float2 outputSize = Const0.zw;
-
-    if (dtid.x >= (uint)outputSize.x || dtid.y >= (uint)outputSize.y)
-        return;
-
-    // Map output pixel to input UV
-    float2 outputPixel = float2(dtid.x, dtid.y) + 0.5;
-    float2 inputUV = outputPixel * Const2.zw; // output pixel / output size
-    // Scale to input space
-    float2 srcUV = inputUV; // maps [0,1] -> [0,1]
-
-    // Gather 3x3 neighbourhood
-    float3 c  = FetchTexel(srcUV, float2( 0.0,  0.0));
-    float3 n  = FetchTexel(srcUV, float2( 0.0, -1.0));
-    float3 s  = FetchTexel(srcUV, float2( 0.0,  1.0));
-    float3 e  = FetchTexel(srcUV, float2( 1.0,  0.0));
-    float3 w  = FetchTexel(srcUV, float2(-1.0,  0.0));
-    float3 ne = FetchTexel(srcUV, float2( 1.0, -1.0));
-    float3 nw = FetchTexel(srcUV, float2(-1.0, -1.0));
-    float3 se = FetchTexel(srcUV, float2( 1.0,  1.0));
-    float3 sw = FetchTexel(srcUV, float2(-1.0,  1.0));
-
-    // Compute edge direction for anisotropic filtering
-    float2 edgeDir = ComputeEdgeDirection(n, s, e, w, ne, nw, se, sw);
-
-    // Fractional position within the source texel for sub-pixel offset
-    float2 srcTexel = srcUV * Const0.xy; // UV -> texel coordinates
-    float2 frac_pos = frac(srcTexel) - 0.5;
-
-    // 12-tap directional Lanczos-like filter
-    // Taps aligned along and perpendicular to the edge direction
-    float2 along = edgeDir;
-    float2 perp  = float2(-edgeDir.y, edgeDir.x);
-
-    float3 result = float3(0.0, 0.0, 0.0);
-    float totalWeight = 0.0;
-
-    // Sample offsets: 4 along edge, 4 perpendicular, 4 diagonal
-    static const float2 offsets[12] = {
-        float2( 0.0,  0.0),
-        float2( 1.0,  0.0),
-        float2(-1.0,  0.0),
-        float2( 0.0,  1.0),
-        float2( 0.0, -1.0),
-        float2( 1.0,  1.0),
-        float2(-1.0, -1.0),
-        float2( 1.0, -1.0),
-        float2(-1.0,  1.0),
-        float2( 0.5,  0.0),
-        float2(-0.5,  0.0),
-        float2( 0.0,  0.5)
-    };
-
-    [unroll]
-    for (int i = 0; i < 12; i++)
-    {
-        float2 offset = offsets[i];
-        float2 samplePos = offset - frac_pos;
-
-        // Project onto edge-aligned axes for anisotropic weighting
-        float distAlong = abs(dot(samplePos, along));
-        float distPerp  = abs(dot(samplePos, perp));
-
-        // Lanczos weight with edge-aware stretch
-        float wAlong = Lanczos2(distAlong);
-        float wPerp  = Lanczos2(distPerp * 1.5); // Tighter filtering across edges
-        float weight  = wAlong * wPerp;
-
-        float3 tap = FetchTexel(srcUV, offset);
-        result += tap * weight;
-        totalWeight += weight;
-    }
-
-    result /= max(totalWeight, 1e-6);
-
-    OutputTexture[dtid.xy] = float4(result, 1.0);
-}
-)";
-
-    // -------------------------------------------------------------------------
-    // FSR 1.0 RCAS — Robust Contrast Adaptive Sharpening (Compute Shader)
-    //
-    // Simplified CAS pass: applies contrast-adaptive sharpening that avoids
-    // amplifying noise in low-contrast areas.  Thread group: 8x8.
-    // -------------------------------------------------------------------------
-    static const char* kFSR1_RCAS_CS = R"(
-// FSR 1.0 RCAS — Robust Contrast Adaptive Sharpening
-// Approximate implementation for SparkEngine
-
-cbuffer RCASConstants : register(b0)
-{
-    float4 Const0; // (attenuation, 0, 0, 0)
-};
-
-Texture2D<float4> InputTexture : register(t0);
-RWTexture2D<float4> OutputTexture : register(u0);
-
-float Luma(float3 color)
-{
-    return dot(color, float3(0.299, 0.587, 0.114));
-}
-
-[numthreads(8, 8, 1)]
-void CSMain(uint3 dtid : SV_DispatchThreadID)
-{
-    uint width, height;
-    InputTexture.GetDimensions(width, height);
-
-    if (dtid.x >= width || dtid.y >= height)
-        return;
-
-    int2 pos = int2(dtid.xy);
-
-    // Load centre and 4-connected neighbours
-    float3 c = InputTexture.Load(int3(pos, 0)).rgb;
-    float3 n = InputTexture.Load(int3(pos + int2( 0, -1), 0)).rgb;
-    float3 s = InputTexture.Load(int3(pos + int2( 0,  1), 0)).rgb;
-    float3 e = InputTexture.Load(int3(pos + int2( 1,  0), 0)).rgb;
-    float3 w = InputTexture.Load(int3(pos + int2(-1,  0), 0)).rgb;
-
-    // Compute min / max luma in cross neighbourhood
-    float lumC = Luma(c);
-    float lumN = Luma(n);
-    float lumS = Luma(s);
-    float lumE = Luma(e);
-    float lumW = Luma(w);
-
-    float minLuma = min(lumC, min(min(lumN, lumS), min(lumE, lumW)));
-    float maxLuma = max(lumC, max(max(lumN, lumS), max(lumE, lumW)));
-
-    // Local contrast ratio drives sharpening strength
-    float contrast = maxLuma - minLuma;
-    float peakRange = max(maxLuma, 1e-6);
-    float ratio = contrast / peakRange;
-
-    // Attenuation maps [0,2]: 0 = full sharpen, 2 = no sharpen
-    float attenuation = Const0.x;
-
-    // Sharpening weight: high contrast => sharpen, attenuated by user control
-    float sharpWeight = max(0.0, 1.0 - ratio * attenuation);
-    sharpWeight = sharpWeight * sharpWeight; // Smooth falloff
-
-    // Clamp to a reasonable range to avoid halos
-    sharpWeight = min(sharpWeight, 0.5);
-
-    // Compute unsharp mask: centre - average of neighbours
-    float3 avg = (n + s + e + w) * 0.25;
-    float3 detail = c - avg;
-
-    // Apply sharpening
-    float3 result = c + detail * sharpWeight;
-
-    // Clamp to prevent ringing
-    float3 minNeighbour = min(c, min(min(n, s), min(e, w)));
-    float3 maxNeighbour = max(c, max(max(n, s), max(e, w)));
-    result = clamp(result, minNeighbour, maxNeighbour);
-
-    OutputTexture[dtid.xy] = float4(result, 1.0);
-}
-)";
-
-    // -------------------------------------------------------------------------
-    // Temporal Upscaling Compute Shader (simplified FSR 2.0-style)
-    //
-    // Single-pass temporal upscaler that reprojects the previous frame using
-    // motion vectors, performs disocclusion detection via depth comparison,
-    // and blends temporal history with the current frame.  Thread group: 8x8.
-    // -------------------------------------------------------------------------
-    static const char* kTemporalUpscaling_CS = R"(
-// Simplified temporal upscaling (FSR 2.0 style)
-// Single-pass approximation for SparkEngine
-
-cbuffer TemporalConstants : register(b0)
-{
-    float4 InputOutputSize;    // (renderW, renderH, displayW, displayH)
-    float4 InputSizeRcp;       // (1/renderW, 1/renderH, 1/displayW, 1/displayH)
-    float4 JitterOffset;       // (jitterX, jitterY, motionScaleX, motionScaleY)
-    float4 TemporalParams;     // (deltaTime, nearPlane, farPlane, verticalFOV)
-    float4 Flags;              // (resetAccumulation, frameIndex, 0, 0)
-};
-
-Texture2D<float4> ColorInput        : register(t0);
-Texture2D<float>  DepthInput        : register(t1);
-Texture2D<float2> MotionVectors     : register(t2);
-Texture2D<float>  ExposureInput     : register(t3);
-Texture2D<float>  ReactiveMask      : register(t4);
-Texture2D<float4> HistoryTexture    : register(t5);
-RWTexture2D<float4> OutputTexture   : register(u0);
-SamplerState LinearClamp            : register(s0);
-
-float Luminance(float3 c)
-{
-    return dot(c, float3(0.2126, 0.7152, 0.0722));
-}
-
-float LinearizeDepth(float d, float nearZ, float farZ)
-{
-    return nearZ * farZ / (farZ - d * (farZ - nearZ));
-}
-
-// Catmull-Rom weight for high-quality history sampling
-float CatmullRomWeight(float x)
-{
-    float ax = abs(x);
-    if (ax < 1.0)
-        return 0.5 * (2.0 + ax * ax * (-5.0 + ax * 3.0));
-    if (ax < 2.0)
-        return 0.5 * (4.0 + ax * (-8.0 + ax * (5.0 - ax)));
-    return 0.0;
-}
-
-// Sample history with Catmull-Rom 4-tap (separable)
-float3 SampleHistoryCatmullRom(float2 uv)
-{
-    float2 texelSize = InputSizeRcp.zw;
-    float2 samplePos = uv / texelSize - 0.5;
-    float2 f = frac(samplePos);
-    float2 texelBase = (floor(samplePos) + 0.5) * texelSize;
-
-    float3 result = float3(0.0, 0.0, 0.0);
-    float totalWeight = 0.0;
-
-    [unroll]
-    for (int y = -1; y <= 2; y++)
-    {
-        float wy = CatmullRomWeight(f.y - (float)y);
-        [unroll]
-        for (int x = -1; x <= 2; x++)
-        {
-            float wx = CatmullRomWeight(f.x - (float)x);
-            float weight = wx * wy;
-            float2 offset = float2((float)x, (float)y) * texelSize;
-            float3 tap = HistoryTexture.SampleLevel(LinearClamp, texelBase + offset, 0.0).rgb;
-            result += tap * weight;
-            totalWeight += weight;
-        }
-    }
-
-    return result / max(totalWeight, 1e-6);
-}
-
-[numthreads(8, 8, 1)]
-void CSMain(uint3 dtid : SV_DispatchThreadID)
-{
-    float displayW = InputOutputSize.z;
-    float displayH = InputOutputSize.w;
-
-    if (dtid.x >= (uint)displayW || dtid.y >= (uint)displayH)
-        return;
-
-    float2 outputUV = (float2(dtid.xy) + 0.5) * InputSizeRcp.zw;
-
-    // Map output pixel back to input space (accounting for resolution difference)
-    float2 inputUV = outputUV;
-    float2 jitteredUV = inputUV - JitterOffset.xy * InputSizeRcp.xy;
-
-    // Fetch current frame colour (with jitter removal)
-    float3 currentColor = ColorInput.SampleLevel(LinearClamp, jitteredUV, 0.0).rgb;
-
-    // Fetch motion vector at current position
-    float2 motion = MotionVectors.SampleLevel(LinearClamp, jitteredUV, 0.0).xy;
-    motion *= JitterOffset.zw; // Apply motion vector scale
-
-    // Reproject to find where this pixel was in the previous frame
-    float2 historyUV = outputUV - motion;
-
-    // Fetch depth for disocclusion detection
-    float depth = DepthInput.SampleLevel(LinearClamp, jitteredUV, 0.0).x;
-    float linearDepth = LinearizeDepth(depth, TemporalParams.y, TemporalParams.z);
-
-    // Fetch reactive mask (particles, transparency)
-    float reactive = ReactiveMask.SampleLevel(LinearClamp, jitteredUV, 0.0).x;
-
-    // Read exposure for luminance normalization
-    float exposure = max(ExposureInput.SampleLevel(LinearClamp, float2(0.5, 0.5), 0.0).x, 0.001);
-    currentColor *= exposure;
-
-    // Check if history UV is valid (within screen bounds)
-    bool historyValid = historyUV.x >= 0.0 && historyUV.x <= 1.0 &&
-                        historyUV.y >= 0.0 && historyUV.y <= 1.0;
-
-    // Reset temporal accumulation if requested
-    bool resetAccum = Flags.x > 0.5;
-
-    float3 result;
-
-    if (!historyValid || resetAccum)
-    {
-        // No valid history — use current frame only
-        result = currentColor;
-    }
-    else
-    {
-        // Sample history with high-quality Catmull-Rom filtering
-        float3 historyColor = SampleHistoryCatmullRom(historyUV);
-
-        // Neighbourhood colour clamping to prevent ghosting
-        // Gather a 3x3 neighbourhood around the current input texel
-        float3 minColor = currentColor;
-        float3 maxColor = currentColor;
-
-        [unroll]
-        for (int dy = -1; dy <= 1; dy++)
-        {
-            [unroll]
-            for (int dx = -1; dx <= 1; dx++)
-            {
-                if (dx == 0 && dy == 0)
-                    continue;
-                float2 offset = float2((float)dx, (float)dy) * InputSizeRcp.xy;
-                float3 neighbour = ColorInput.SampleLevel(
-                    LinearClamp, jitteredUV + offset, 0.0).rgb * exposure;
-                minColor = min(minColor, neighbour);
-                maxColor = max(maxColor, neighbour);
-            }
-        }
-
-        // Expand clamp box slightly to reduce flickering
-        float3 boxCenter = (minColor + maxColor) * 0.5;
-        float3 boxExtent = (maxColor - minColor) * 0.5;
-        minColor = boxCenter - boxExtent * 1.25;
-        maxColor = boxCenter + boxExtent * 1.25;
-
-        // Clamp history to the neighbourhood colour box
-        historyColor = clamp(historyColor, minColor, maxColor);
-
-        // Disocclusion detection: compare reprojected depth
-        float historyDepth = DepthInput.SampleLevel(LinearClamp, historyUV, 0.0).x;
-        float historyLinearDepth = LinearizeDepth(historyDepth, TemporalParams.y, TemporalParams.z);
-        float depthDelta = abs(linearDepth - historyLinearDepth) / max(linearDepth, 0.001);
-        float disocclusion = saturate(depthDelta * 10.0);
-
-        // Blend factor: prefer history for stability, bias towards current on disocclusion
-        float blendFactor = lerp(0.05, 1.0, disocclusion);
-
-        // Reactive mask forces use of current colour (particles, alpha-blended objects)
-        blendFactor = lerp(blendFactor, 1.0, reactive);
-
-        // Luminance-based weight adjustment: reduce history when luminance changes sharply
-        float lumCurrent = Luminance(currentColor);
-        float lumHistory = Luminance(historyColor);
-        float lumDelta = abs(lumCurrent - lumHistory) / max(lumCurrent + lumHistory, 0.001);
-        blendFactor = max(blendFactor, lumDelta * 0.5);
-
-        blendFactor = clamp(blendFactor, 0.03, 1.0);
-
-        result = lerp(historyColor, currentColor, blendFactor);
-    }
-
-    // Remove exposure before output
-    result /= exposure;
-
-    OutputTexture[dtid.xy] = float4(max(result, 0.0), 1.0);
-}
-)";
-
-    // -------------------------------------------------------------------------
-    // SparkSR — SparkEngine Native Temporal Upscaling (Compute Shader)
-    //
-    // Engine-native temporal upscaler with no vendor SDK dependency.
-    // Key improvements over the basic temporal upscaler:
-    //   - YCoCg color space for perceptually accurate neighborhood clamping
-    //   - Variance-based clip (mean ± gamma * stddev) instead of min/max AABB
-    //   - Motion vector confidence weighting (fast motion = less history)
-    //   - Combined depth + motion divergence disocclusion detection
-    //   - Jitter delta tracking for improved sub-pixel reprojection
-    //   - Catmull-Rom 4-tap history sampling
-    // Thread group: 8x8.  Two-pass pipeline: this shader + RCAS sharpening.
-    // -------------------------------------------------------------------------
-    static const char* kSparkSR_CS = R"(
-// SparkSR — SparkEngine Native Temporal Upscaling
-// Vendor-independent temporal accumulation with YCoCg variance clip
-
-cbuffer SparkSRConstants : register(b0)
-{
-    float4 RenderSize;     // (renderW, renderH, 1/renderW, 1/renderH)
-    float4 DisplaySize;    // (displayW, displayH, 1/displayW, 1/displayH)
-    float4 JitterOffset;   // (jitterX, jitterY, prevJitterX, prevJitterY)
-    float4 TemporalParams; // (frameIndex, resetFlag, sharpness, blendMin)
-    float4 MotionParams;   // (motionScaleX, motionScaleY, depthThreshold, varianceGamma)
-};
-
-Texture2D<float4> ColorInput        : register(t0);
-Texture2D<float>  DepthInput        : register(t1);
-Texture2D<float2> MotionVectors     : register(t2);
-Texture2D<float>  ExposureInput     : register(t3);
-Texture2D<float>  ReactiveMask      : register(t4);
-Texture2D<float4> HistoryTexture    : register(t5);
-RWTexture2D<float4> OutputTexture   : register(u0);
-SamplerState LinearClamp            : register(s0);
-
-// --- Color space conversion ---
-
-float3 RGBToYCoCg(float3 rgb)
-{
-    float y  = dot(rgb, float3(0.25, 0.5, 0.25));
-    float co = dot(rgb, float3(0.5, 0.0, -0.5));
-    float cg = dot(rgb, float3(-0.25, 0.5, -0.25));
-    return float3(y, co, cg);
-}
-
-float3 YCoCgToRGB(float3 ycocg)
-{
-    float y  = ycocg.x;
-    float co = ycocg.y;
-    float cg = ycocg.z;
-    return float3(y + co - cg, y + cg, y - co - cg);
-}
-
-float Luminance(float3 c)
-{
-    return dot(c, float3(0.2126, 0.7152, 0.0722));
-}
-
-float LinearizeDepth(float d, float nearZ, float farZ)
-{
-    return nearZ * farZ / (farZ - d * (farZ - nearZ));
-}
-
-// --- Variance-based AABB clip ---
-// Clips the history sample toward the center of a variance-derived AABB
-// This is tighter than min/max and reduces ghosting significantly
-
-float3 ClipToVarianceAABB(float3 history, float3 aabbCenter, float3 aabbExtent)
-{
-    float3 offset = history - aabbCenter;
-    float3 absExtent = max(aabbExtent, 0.0001);
-    float3 ts = abs(offset) / absExtent;
-    float maxT = max(ts.x, max(ts.y, ts.z));
-
-    if (maxT > 1.0)
-    {
-        return aabbCenter + offset / maxT;
-    }
-    return history;
-}
-
-// --- Catmull-Rom 4-tap history sampling ---
-
-float CatmullRomWeight(float x)
-{
-    float ax = abs(x);
-    if (ax < 1.0)
-        return 0.5 * (2.0 + ax * ax * (-5.0 + ax * 3.0));
-    if (ax < 2.0)
-        return 0.5 * (4.0 + ax * (-8.0 + ax * (5.0 - ax)));
-    return 0.0;
-}
-
-float3 SampleHistoryCatmullRom(float2 uv)
-{
-    float2 texelSize = DisplaySize.zw;
-    float2 samplePos = uv / texelSize - 0.5;
-    float2 f = frac(samplePos);
-    float2 texelBase = (floor(samplePos) + 0.5) * texelSize;
-
-    float3 result = float3(0.0, 0.0, 0.0);
-    float totalWeight = 0.0;
-
-    [unroll]
-    for (int y = -1; y <= 2; y++)
-    {
-        float wy = CatmullRomWeight(f.y - (float)y);
-        [unroll]
-        for (int x = -1; x <= 2; x++)
-        {
-            float wx = CatmullRomWeight(f.x - (float)x);
-            float weight = wx * wy;
-            float2 offset = float2((float)x, (float)y) * texelSize;
-            float3 tap = HistoryTexture.SampleLevel(LinearClamp, texelBase + offset, 0.0).rgb;
-            result += tap * weight;
-            totalWeight += weight;
-        }
-    }
-
-    return result / max(totalWeight, 1e-6);
-}
-
-[numthreads(8, 8, 1)]
-void CSMain(uint3 dtid : SV_DispatchThreadID)
-{
-    if (dtid.x >= (uint)DisplaySize.x || dtid.y >= (uint)DisplaySize.y)
-        return;
-
-    float2 outputUV = (float2(dtid.xy) + 0.5) * DisplaySize.zw;
-
-    // De-jitter: remove current frame's jitter to get the true sample position
-    float2 inputUV = outputUV;
-    float2 jitteredUV = inputUV - JitterOffset.xy * RenderSize.zw;
-
-    // Fetch current frame color
-    float3 currentColor = ColorInput.SampleLevel(LinearClamp, jitteredUV, 0.0).rgb;
-
-    // Apply exposure normalization
-    float exposure = max(ExposureInput.SampleLevel(LinearClamp, float2(0.5, 0.5), 0.0).x, 0.001);
-    currentColor *= exposure;
-
-    // Fetch motion vector and apply scale
-    float2 motion = MotionVectors.SampleLevel(LinearClamp, jitteredUV, 0.0).xy;
-    motion *= MotionParams.xy;
-
-    // Reproject to find previous frame position
-    float2 historyUV = outputUV - motion;
-
-    // Fetch depth and reactive mask
-    float depth = DepthInput.SampleLevel(LinearClamp, jitteredUV, 0.0).x;
-    float reactive = ReactiveMask.SampleLevel(LinearClamp, jitteredUV, 0.0).x;
-
-    // Check history validity
-    bool historyValid = historyUV.x >= 0.0 && historyUV.x <= 1.0 &&
-                        historyUV.y >= 0.0 && historyUV.y <= 1.0;
-    bool resetAccum = TemporalParams.y > 0.5;
-
-    float3 result;
-
-    if (!historyValid || resetAccum)
-    {
-        result = currentColor;
-    }
-    else
-    {
-        // --- Gather 3x3 neighborhood in YCoCg for variance clip ---
-        float3 m1 = float3(0.0, 0.0, 0.0); // sum
-        float3 m2 = float3(0.0, 0.0, 0.0); // sum of squares
-        float3 currentYCoCg = RGBToYCoCg(currentColor);
-
-        [unroll]
-        for (int dy = -1; dy <= 1; dy++)
-        {
-            [unroll]
-            for (int dx = -1; dx <= 1; dx++)
-            {
-                float2 offset = float2((float)dx, (float)dy) * RenderSize.zw;
-                float3 s = ColorInput.SampleLevel(LinearClamp, jitteredUV + offset, 0.0).rgb * exposure;
-                float3 sYCoCg = RGBToYCoCg(s);
-                m1 += sYCoCg;
-                m2 += sYCoCg * sYCoCg;
-            }
-        }
-
-        // Compute mean and standard deviation
-        float3 mean = m1 / 9.0;
-        float3 variance = abs(m2 / 9.0 - mean * mean);
-        float3 stddev = sqrt(variance);
-
-        // Variance gamma controls how tight the clip box is
-        // Lower gamma = tighter = less ghosting but more flickering
-        float gamma = MotionParams.w; // typically 1.0 - 1.25
-
-        // Sample history with Catmull-Rom for sub-pixel accuracy
-        float3 historyColor = SampleHistoryCatmullRom(historyUV);
-        historyColor *= exposure; // normalize history to current exposure
-        float3 historyYCoCg = RGBToYCoCg(historyColor);
-
-        // Clip history to variance-derived AABB in YCoCg space
-        float3 aabbExtent = stddev * gamma;
-        historyYCoCg = ClipToVarianceAABB(historyYCoCg, mean, aabbExtent);
-        historyColor = YCoCgToRGB(historyYCoCg);
-
-        // --- Disocclusion detection: depth + motion divergence ---
-        float historyDepth = DepthInput.SampleLevel(LinearClamp, historyUV, 0.0).x;
-        float depthDelta = abs(depth - historyDepth);
-        float depthDisocclusion = saturate(depthDelta / max(MotionParams.z, 0.001));
-
-        // Motion divergence: compare motion at current vs reprojected position
-        float2 historyMotion = MotionVectors.SampleLevel(LinearClamp, historyUV, 0.0).xy * MotionParams.xy;
-        float motionDivergence = length(motion - historyMotion);
-        float motionDisocclusion = saturate(motionDivergence * 20.0);
-
-        float disocclusion = max(depthDisocclusion, motionDisocclusion);
-
-        // --- Motion confidence: fast motion = prefer current frame ---
-        float motionLength = length(motion);
-        float motionConfidence = saturate(motionLength * 10.0);
-
-        // --- Compute blend factor ---
-        float blendMin = TemporalParams.w; // minimum blend (e.g. 0.03)
-        float blendFactor = blendMin;
-
-        // Increase blend toward current on disocclusion
-        blendFactor = lerp(blendFactor, 1.0, disocclusion);
-
-        // Increase blend for fast-moving pixels
-        blendFactor = lerp(blendFactor, max(blendFactor, 0.3), motionConfidence);
-
-        // Reactive mask forces use of current color (particles, transparency)
-        blendFactor = lerp(blendFactor, 1.0, reactive);
-
-        // Luminance stability: large luminance shifts bias toward current
-        float lumCurrent = Luminance(currentColor);
-        float lumHistory = Luminance(historyColor);
-        float lumDelta = abs(lumCurrent - lumHistory) / max(lumCurrent + lumHistory, 0.001);
-        blendFactor = max(blendFactor, lumDelta * 0.4);
-
-        blendFactor = clamp(blendFactor, blendMin, 1.0);
-
-        result = lerp(historyColor, currentColor, blendFactor);
-    }
-
-    // Remove exposure normalization before output
-    result /= exposure;
-
-    OutputTexture[dtid.xy] = float4(max(result, 0.0), 1.0);
-}
-)";
-
-} // anonymous namespace
 
 // =============================================================================
 // UPSCALING UTILITIES — Cross-platform helpers
@@ -1009,7 +326,7 @@ namespace Spark
  */
             const char* GetFSR1EASUShaderSource()
             {
-                return kFSR1_EASU_CS;
+                return Spark::UpscalingShaders::kFSR1_EASU_CS;
             }
 
             /**
@@ -1018,7 +335,7 @@ namespace Spark
  */
             const char* GetFSR1RCASShaderSource()
             {
-                return kFSR1_RCAS_CS;
+                return Spark::UpscalingShaders::kFSR1_RCAS_CS;
             }
 
             /**
@@ -1027,7 +344,7 @@ namespace Spark
  */
             const char* GetTemporalUpscalingShaderSource()
             {
-                return kTemporalUpscaling_CS;
+                return Spark::UpscalingShaders::kTemporalUpscaling_CS;
             }
 
             /**
@@ -1036,7 +353,7 @@ namespace Spark
              */
             const char* GetSparkSRShaderSource()
             {
-                return kSparkSR_CS;
+                return Spark::UpscalingShaders::kSparkSR_CS;
             }
 
             // -------------------------------------------------------------------------
@@ -1117,12 +434,12 @@ namespace Spark
                     return false;
                 }
 
-                if (!CompileComputeShader(device, kFSR1_EASU_CS, "CSMain", outEASU))
+                if (!CompileComputeShader(device, Spark::UpscalingShaders::kFSR1_EASU_CS, "CSMain", outEASU))
                 {
                     return false;
                 }
 
-                if (!CompileComputeShader(device, kFSR1_RCAS_CS, "CSMain", outRCAS))
+                if (!CompileComputeShader(device, Spark::UpscalingShaders::kFSR1_RCAS_CS, "CSMain", outRCAS))
                 {
                     if (*outEASU)
                     {
@@ -1149,7 +466,8 @@ namespace Spark
                     return false;
                 }
 
-                return CompileComputeShader(device, kTemporalUpscaling_CS, "CSMain", outShader);
+                return CompileComputeShader(device, Spark::UpscalingShaders::kTemporalUpscaling_CS, "CSMain",
+                                            outShader);
             }
 
             /**
@@ -1166,7 +484,7 @@ namespace Spark
                     return false;
                 }
 
-                return CompileComputeShader(device, kSparkSR_CS, "CSMain", outShader);
+                return CompileComputeShader(device, Spark::UpscalingShaders::kSparkSR_CS, "CSMain", outShader);
             }
 
 #endif // SPARK_PLATFORM_WINDOWS

--- a/SparkEngine/Source/Input/InputManager.cpp
+++ b/SparkEngine/Source/Input/InputManager.cpp
@@ -1,186 +1,199 @@
-// InputManager.cpp — Win32 implementation
+/**
+ * @file InputManager.cpp
+ * @brief Input handling implementation — shared logic + platform-specific backends
+ *
+ * Shared code (key queries, console integration, key mapping) is defined once
+ * before the platform-specific sections to avoid duplication.
+ */
+
 #include "../Core/Platform.h"
-#ifdef SPARK_PLATFORM_WINDOWS
 #include "InputManager.h"
 #include "Utils/Assert.h"
 #include "../Utils/Validate.h"
 #include "../Utils/SparkConsole.h"
-#include <windows.h>
-#include <windowsx.h> // GET_X_LPARAM, GET_Y_LPARAM
 #include <cstring>
 #include <cmath>
 #include <iostream>
 #include <sstream>
 #include <iomanip>
 #include <algorithm>
-#include <unordered_map>
 #include <thread>
 #include <chrono>
+#include <unordered_map>
 
-InputManager::InputManager()
-    : m_mouseX(0), m_mouseY(0), m_prevMouseX(0), m_prevMouseY(0), m_mouseDeltaX(0), m_mouseDeltaY(0), m_hwnd(nullptr),
-      m_mouseCaptured(false), m_mouseSensitivity(1.0f), m_mouseDeadZone(0.0f), m_mouseAcceleration(false),
-      m_invertMouseY(false), m_rawMouseInput(false), m_inputLogging(false), m_keyPressCount(0), m_mousePressCount(0),
-      m_totalMouseDistance(0.0f)
+#ifdef SPARK_PLATFORM_WINDOWS
+#include <windows.h>
+#include <windowsx.h>
+#else
+#ifdef SPARK_SDL2_AVAILABLE
+#include <SDL.h>
+#endif
+#endif
+
+// ============================================================================
+// SHARED KEY MAPPING TABLES
+// ============================================================================
+
+static const std::unordered_map<std::string, int>& GetKeyNameToVKMap()
 {
-    ZeroMemory(m_mouseButtons, sizeof(m_mouseButtons));
-    ZeroMemory(m_prevMouseButtons, sizeof(m_prevMouseButtons));
-
-    // Reserve space for recent events
-    m_recentInputEvents.reserve(100);
-
-    SPARK_LOG_INFO(Spark::LogCategory::Input, "InputManager constructed (Windows)");
-    Spark::SimpleConsole::GetInstance().Log("InputManager constructed with console integration.", "INFO");
+    static const std::unordered_map<std::string, int> keyMapping = {{"A", 'A'},
+                                                                    {"B", 'B'},
+                                                                    {"C", 'C'},
+                                                                    {"D", 'D'},
+                                                                    {"E", 'E'},
+                                                                    {"F", 'F'},
+                                                                    {"G", 'G'},
+                                                                    {"H", 'H'},
+                                                                    {"I", 'I'},
+                                                                    {"J", 'J'},
+                                                                    {"K", 'K'},
+                                                                    {"L", 'L'},
+                                                                    {"M", 'M'},
+                                                                    {"N", 'N'},
+                                                                    {"O", 'O'},
+                                                                    {"P", 'P'},
+                                                                    {"Q", 'Q'},
+                                                                    {"R", 'R'},
+                                                                    {"S", 'S'},
+                                                                    {"T", 'T'},
+                                                                    {"U", 'U'},
+                                                                    {"V", 'V'},
+                                                                    {"W", 'W'},
+                                                                    {"X", 'X'},
+                                                                    {"Y", 'Y'},
+                                                                    {"Z", 'Z'},
+                                                                    {"0", '0'},
+                                                                    {"1", '1'},
+                                                                    {"2", '2'},
+                                                                    {"3", '3'},
+                                                                    {"4", '4'},
+                                                                    {"5", '5'},
+                                                                    {"6", '6'},
+                                                                    {"7", '7'},
+                                                                    {"8", '8'},
+                                                                    {"9", '9'},
+                                                                    {"SPACE", VK_SPACE},
+                                                                    {"ENTER", VK_RETURN},
+                                                                    {"ESCAPE", VK_ESCAPE},
+                                                                    {"TAB", VK_TAB},
+                                                                    {"SHIFT", VK_SHIFT},
+                                                                    {"CTRL", VK_CONTROL},
+                                                                    {"ALT", VK_MENU},
+                                                                    {"F1", VK_F1},
+                                                                    {"F2", VK_F2},
+                                                                    {"F3", VK_F3},
+                                                                    {"F4", VK_F4},
+                                                                    {"F5", VK_F5},
+                                                                    {"F6", VK_F6},
+                                                                    {"F7", VK_F7},
+                                                                    {"F8", VK_F8},
+                                                                    {"F9", VK_F9},
+                                                                    {"F10", VK_F10},
+                                                                    {"F11", VK_F11},
+                                                                    {"F12", VK_F12},
+                                                                    {"UP", VK_UP},
+                                                                    {"DOWN", VK_DOWN},
+                                                                    {"LEFT", VK_LEFT},
+                                                                    {"RIGHT", VK_RIGHT},
+                                                                    {"BACKSPACE", VK_BACK},
+                                                                    {"DELETE", VK_DELETE},
+                                                                    {"INSERT", VK_INSERT},
+                                                                    {"HOME", VK_HOME},
+                                                                    {"END", VK_END},
+                                                                    {"PAGEUP", VK_PRIOR},
+                                                                    {"PAGEDOWN", VK_NEXT}};
+    return keyMapping;
 }
 
-InputManager::~InputManager()
+static const std::unordered_map<int, std::string>& GetVKToKeyNameMap()
 {
-    SPARK_LOG_INFO(Spark::LogCategory::Input, "InputManager shutting down");
-    Spark::SimpleConsole::GetInstance().Log("InputManager destructor called.", "INFO");
-    if (m_mouseCaptured)
-        CaptureMouse(false);
-
-    // Join any pending timed key-release threads to avoid use-after-free
-    for (auto& t : m_pendingTimedThreads)
-    {
-        if (t.joinable())
-        {
-            t.join();
-        }
-    }
-    m_pendingTimedThreads.clear();
+    static const std::unordered_map<int, std::string> reverseMapping = {{'A', "A"},
+                                                                        {'B', "B"},
+                                                                        {'C', "C"},
+                                                                        {'D', "D"},
+                                                                        {'E', "E"},
+                                                                        {'F', "F"},
+                                                                        {'G', "G"},
+                                                                        {'H', "H"},
+                                                                        {'I', "I"},
+                                                                        {'J', "J"},
+                                                                        {'K', "K"},
+                                                                        {'L', "L"},
+                                                                        {'M', "M"},
+                                                                        {'N', "N"},
+                                                                        {'O', "O"},
+                                                                        {'P', "P"},
+                                                                        {'Q', "Q"},
+                                                                        {'R', "R"},
+                                                                        {'S', "S"},
+                                                                        {'T', "T"},
+                                                                        {'U', "U"},
+                                                                        {'V', "V"},
+                                                                        {'W', "W"},
+                                                                        {'X', "X"},
+                                                                        {'Y', "Y"},
+                                                                        {'Z', "Z"},
+                                                                        {'0', "0"},
+                                                                        {'1', "1"},
+                                                                        {'2', "2"},
+                                                                        {'3', "3"},
+                                                                        {'4', "4"},
+                                                                        {'5', "5"},
+                                                                        {'6', "6"},
+                                                                        {'7', "7"},
+                                                                        {'8', "8"},
+                                                                        {'9', "9"},
+                                                                        {VK_SPACE, "Space"},
+                                                                        {VK_RETURN, "Enter"},
+                                                                        {VK_ESCAPE, "Escape"},
+                                                                        {VK_TAB, "Tab"},
+                                                                        {VK_SHIFT, "Shift"},
+                                                                        {VK_CONTROL, "Ctrl"},
+                                                                        {VK_MENU, "Alt"},
+                                                                        {VK_F1, "F1"},
+                                                                        {VK_F2, "F2"},
+                                                                        {VK_F3, "F3"},
+                                                                        {VK_F4, "F4"},
+                                                                        {VK_F5, "F5"},
+                                                                        {VK_F6, "F6"},
+                                                                        {VK_F7, "F7"},
+                                                                        {VK_F8, "F8"},
+                                                                        {VK_F9, "F9"},
+                                                                        {VK_F10, "F10"},
+                                                                        {VK_F11, "F11"},
+                                                                        {VK_F12, "F12"},
+                                                                        {VK_UP, "Up"},
+                                                                        {VK_DOWN, "Down"},
+                                                                        {VK_LEFT, "Left"},
+                                                                        {VK_RIGHT, "Right"},
+                                                                        {VK_BACK, "Backspace"},
+                                                                        {VK_DELETE, "Delete"},
+                                                                        {VK_INSERT, "Insert"},
+                                                                        {VK_HOME, "Home"},
+                                                                        {VK_END, "End"},
+                                                                        {VK_PRIOR, "PageUp"},
+                                                                        {VK_NEXT, "PageDown"}};
+    return reverseMapping;
 }
 
-void InputManager::Initialize(HWND hwnd)
+// ============================================================================
+// SHARED IMPLEMENTATIONS (platform-independent)
+// ============================================================================
+
+int InputManager::KeyNameToVirtualKey(const std::string& keyName) const
 {
-    SPARK_TRACE_ENTER(Spark::LogCategory::Input);
-    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Input, hwnd);
-    m_hwnd = hwnd;
-
-    RECT rect;
-    GetClientRect(hwnd, &rect);
-    POINT center = {(rect.right - rect.left) / 2, (rect.bottom - rect.top) / 2};
-    ClientToScreen(hwnd, &center);
-    SetCursorPos(center.x, center.y);
-
-    m_mouseX = m_prevMouseX = center.x;
-    m_mouseY = m_prevMouseY = center.y;
-
-    SPARK_LOG_INFO(Spark::LogCategory::Input, "InputManager initialized (Windows)");
-    Spark::SimpleConsole::GetInstance().Log("InputManager initialized with console integration.", "SUCCESS");
+    std::string upperKeyName = keyName;
+    std::transform(upperKeyName.begin(), upperKeyName.end(), upperKeyName.begin(), ::toupper);
+    auto& map = GetKeyNameToVKMap();
+    auto it = map.find(upperKeyName);
+    return (it != map.end()) ? it->second : 0;
 }
 
-void InputManager::Update()
+std::string InputManager::VirtualKeyToKeyName(int virtualKey) const
 {
-    static bool firstFrame = true;
-    if (firstFrame)
-    {
-        Spark::SimpleConsole::GetInstance().Log("InputManager::Update - First frame started with console integration",
-                                                "INFO");
-        firstFrame = false;
-    }
-
-    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, m_hwnd != nullptr, "InputManager::Update - hwnd not initialized");
-
-    m_prevKeyStates = m_keyStates;
-    memcpy(m_prevMouseButtons, m_mouseButtons, sizeof(m_mouseButtons));
-
-    m_prevMouseX = m_mouseX;
-    m_prevMouseY = m_mouseY;
-
-    if (m_mouseCaptured)
-    {
-        POINT cursor;
-        GetCursorPos(&cursor);
-        ScreenToClient(m_hwnd, &cursor);
-
-        m_mouseDeltaX = cursor.x - m_prevMouseX;
-        m_mouseDeltaY = cursor.y - m_prevMouseY;
-
-        // Apply console-controlled processing
-        ProcessMouseDelta(m_mouseDeltaX, m_mouseDeltaY);
-
-        RECT rect;
-        GetClientRect(m_hwnd, &rect);
-        POINT center = {(rect.right - rect.left) / 2, (rect.bottom - rect.top) / 2};
-        ClientToScreen(m_hwnd, &center);
-        SetCursorPos(center.x, center.y);
-
-        m_mouseX = center.x;
-        m_mouseY = center.y;
-
-        // Track total mouse movement for metrics
-        float distance = sqrtf(static_cast<float>(m_mouseDeltaX * m_mouseDeltaX + m_mouseDeltaY * m_mouseDeltaY));
-        m_totalMouseDistance.fetch_add(distance, std::memory_order_relaxed);
-    }
-    else
-    {
-        m_mouseDeltaX = m_mouseX - m_prevMouseX;
-        m_mouseDeltaY = m_mouseY - m_prevMouseY;
-        ProcessMouseDelta(m_mouseDeltaX, m_mouseDeltaY);
-    }
-}
-
-void InputManager::HandleMouseButtonMessage(int button, bool isDown)
-{
-    // Mouse button event codes start at 1000 (1000=LMB, 1001=RMB, 1002=MMB)
-    UpdateMouseButton(button, isDown);
-    if (m_inputLogging)
-    {
-        LogInputEvent(1000 + button, isDown);
-    }
-    if (isDown)
-    {
-        m_mousePressCount++;
-    }
-}
-
-void InputManager::HandleMessage(UINT message, WPARAM wParam, LPARAM lParam)
-{
-    switch (message)
-    {
-    case WM_KEYDOWN:
-        UpdateKeyState(static_cast<int>(wParam), true);
-        if (m_inputLogging)
-        {
-            LogInputEvent(static_cast<int>(wParam), true);
-        }
-        m_keyPressCount++;
-        break;
-    case WM_KEYUP:
-        UpdateKeyState(static_cast<int>(wParam), false);
-        if (m_inputLogging)
-        {
-            LogInputEvent(static_cast<int>(wParam), false);
-        }
-        break;
-    case WM_LBUTTONDOWN:
-        HandleMouseButtonMessage(0, true);
-        if (!m_mouseCaptured)
-            CaptureMouse(true);
-        break;
-    case WM_LBUTTONUP:
-        HandleMouseButtonMessage(0, false);
-        break;
-    case WM_RBUTTONDOWN:
-        HandleMouseButtonMessage(1, true);
-        break;
-    case WM_RBUTTONUP:
-        HandleMouseButtonMessage(1, false);
-        break;
-    case WM_MBUTTONDOWN:
-        HandleMouseButtonMessage(2, true);
-        break;
-    case WM_MBUTTONUP:
-        HandleMouseButtonMessage(2, false);
-        break;
-    case WM_MOUSEMOVE:
-        if (!m_mouseCaptured)
-            UpdateMousePosition(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
-        break;
-    default:
-        break;
-    }
+    auto& map = GetVKToKeyNameMap();
+    auto it = map.find(virtualKey);
+    return (it != map.end()) ? it->second : "Unknown(" + std::to_string(virtualKey) + ")";
 }
 
 bool InputManager::IsKeyDown(int key) const
@@ -239,32 +252,59 @@ MousePoint InputManager::GetMousePosition() const
     return {m_mouseX, m_mouseY};
 }
 
-void InputManager::CaptureMouse(bool capture)
+void InputManager::UpdateMouseButton(int button, bool isDown)
 {
-    if (capture)
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, button >= 0 && button < 3, "UpdateMouseButton - invalid button");
+    m_mouseButtons[button] = isDown;
+}
+
+void InputManager::UpdateMousePosition(int x, int y)
+{
+    m_mouseX = x;
+    m_mouseY = y;
+}
+
+void InputManager::ProcessMouseDelta(int& deltaX, int& deltaY) const
+{
+    float distance = sqrtf(static_cast<float>(deltaX * deltaX + deltaY * deltaY));
+    if (distance < m_mouseDeadZone)
     {
-        if (!m_mouseCaptured)
-        {
-            SetCapture(m_hwnd);
-            ShowCursor(FALSE);
-            m_mouseCaptured = true;
-            Spark::SimpleConsole::GetInstance().Log("Mouse captured.", "INFO");
-        }
+        deltaX = deltaY = 0;
+        return;
     }
-    else
+
+    deltaX = static_cast<int>(deltaX * m_mouseSensitivity);
+    deltaY = static_cast<int>(deltaY * m_mouseSensitivity);
+
+    if (m_invertMouseY)
+        deltaY = -deltaY;
+
+    if (m_mouseAcceleration && distance > 5.0f)
     {
-        if (m_mouseCaptured)
-        {
-            ReleaseCapture();
-            ShowCursor(TRUE);
-            m_mouseCaptured = false;
-            Spark::SimpleConsole::GetInstance().Log("Mouse capture released.", "INFO");
-        }
+        float accelFactor = 1.0f + (distance - 5.0f) * 0.01f;
+        deltaX = static_cast<int>(deltaX * accelFactor);
+        deltaY = static_cast<int>(deltaY * accelFactor);
     }
 }
 
+void InputManager::LogInputEvent(int key, bool isPressed)
+{
+    if (m_recentInputEvents.size() >= 100)
+    {
+        // O(n) erase on small bounded buffer (max 100 entries) — acceptable for input event rate
+        m_recentInputEvents.erase(m_recentInputEvents.begin());
+    }
+    m_recentInputEvents.emplace_back(key, isPressed);
+}
+
+void InputManager::NotifyStateChange()
+{
+    if (m_stateCallback)
+        m_stateCallback();
+}
+
 // ============================================================================
-// CONSOLE INTEGRATION IMPLEMENTATIONS
+// SHARED CONSOLE INTEGRATION
 // ============================================================================
 
 void InputManager::Console_SetMouseSensitivity(float sensitivity)
@@ -331,9 +371,7 @@ void InputManager::Console_SetInputLogging(bool enabled)
     std::lock_guard<std::mutex> lock(m_inputMutex);
     m_inputLogging = enabled;
     if (enabled)
-    {
         m_recentInputEvents.clear();
-    }
     NotifyStateChange();
     Spark::SimpleConsole::GetInstance().Log(
         "Input logging " + std::string(enabled ? "enabled" : "disabled") + " via console", "SUCCESS");
@@ -350,7 +388,6 @@ bool InputManager::Console_BindKey(const std::string& action, const std::string&
         return false;
     }
 
-    // Remove any existing binding for this action
     auto existingIt = m_keyBindings.find(action);
     if (existingIt != m_keyBindings.end())
     {
@@ -391,24 +428,15 @@ std::string InputManager::Console_ListKeyBindings() const
 {
     std::lock_guard<std::mutex> lock(m_inputMutex);
 
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "Key Bindings (" << m_keyBindings.size() << " total):\n";
     ss << "==========================================\n";
 
-    for (const auto& pair : m_keyBindings)
-    {
-        std::string keyName = VirtualKeyToKeyName(pair.second);
-        ss << "  " << std::left << std::setw(20) << pair.first << " -> " << keyName << " (" << pair.second << ")\n";
-    }
+    for (const auto& [name, key] : m_keyBindings)
+        ss << "  " << std::left << std::setw(20) << name << " -> " << VirtualKeyToKeyName(key) << " (" << key << ")\n";
 
     if (m_keyBindings.empty())
-    {
         ss << "  No key bindings configured\n";
-        ss << "\nExample usage:\n";
-        ss << "  input_bind move_forward W\n";
-        ss << "  input_bind jump Space\n";
-        ss << "  input_bind pause Escape\n";
-    }
 
     return ss.str();
 }
@@ -422,67 +450,44 @@ void InputManager::Console_SimulateKeyPress(const std::string& keyName, int dura
         return;
     }
 
-    // Simulate key press immediately
     UpdateKeyState(virtualKey, true);
     if (m_inputLogging)
-    {
         LogInputEvent(virtualKey, true);
-    }
 
     if (duration == 0)
     {
-        // Single press - immediately release
         UpdateKeyState(virtualKey, false);
         if (m_inputLogging)
-        {
             LogInputEvent(virtualKey, false);
-        }
-        Spark::SimpleConsole::GetInstance().Log("Simulated single key press: " + keyName, "SUCCESS");
     }
     else
     {
-        // Timed release: schedule a delayed key release using a background thread
-        // The key is already pressed above; we schedule the release after 'duration' ms
-        // Clean up any finished threads first to avoid unbounded growth
         m_pendingTimedThreads.erase(std::remove_if(m_pendingTimedThreads.begin(), m_pendingTimedThreads.end(),
-                                                   [](std::thread& t)
-                                                   {
-                                                       // Can't query if a thread is done without joining, so we skip
-                                                       // non-joinable (already joined/moved) entries
-                                                       return !t.joinable();
-                                                   }),
+                                                   [](std::thread& t) { return !t.joinable(); }),
                                     m_pendingTimedThreads.end());
 
         m_pendingTimedThreads.emplace_back(
-            [this, virtualKey, keyName, duration]()
+            [this, virtualKey, duration]()
             {
                 std::this_thread::sleep_for(std::chrono::milliseconds(duration));
                 {
                     std::lock_guard<std::mutex> lock(m_inputMutex);
                     UpdateKeyState(virtualKey, false);
                     if (m_inputLogging)
-                    {
                         LogInputEvent(virtualKey, false);
-                    }
                 }
-                Spark::SimpleConsole::GetInstance().Log(
-                    "Timed key release: " + keyName + " after " + std::to_string(duration) + "ms", "SUCCESS");
             });
-        Spark::SimpleConsole::GetInstance().Log(
-            "Simulated sustained key press: " + keyName + " (duration: " + std::to_string(duration) + "ms)", "SUCCESS");
     }
 }
 
 void InputManager::Console_ClearInputStates()
 {
     std::lock_guard<std::mutex> lock(m_inputMutex);
-
     m_keyStates.clear();
     m_prevKeyStates.clear();
-    ZeroMemory(m_mouseButtons, sizeof(m_mouseButtons));
-    ZeroMemory(m_prevMouseButtons, sizeof(m_prevMouseButtons));
+    memset(m_mouseButtons, 0, sizeof(m_mouseButtons));
+    memset(m_prevMouseButtons, 0, sizeof(m_prevMouseButtons));
     m_recentInputEvents.clear();
-
     Spark::SimpleConsole::GetInstance().Log("All input states cleared via console", "SUCCESS");
 }
 
@@ -490,36 +495,20 @@ std::string InputManager::Console_GetRecentEvents(int count) const
 {
     std::lock_guard<std::mutex> lock(m_inputMutex);
 
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "Recent Input Events (last " << std::min(count, static_cast<int>(m_recentInputEvents.size())) << "):\n";
-    ss << "==========================================\n";
 
     int startIndex = std::max(0, static_cast<int>(m_recentInputEvents.size()) - count);
     for (int i = startIndex; i < static_cast<int>(m_recentInputEvents.size()); ++i)
     {
         const auto& event = m_recentInputEvents[i];
-        std::string keyName;
-
-        if (event.first >= 1000)
-        {
-            // Mouse button
-            int mouseButton = event.first - 1000;
-            keyName = "Mouse" + std::to_string(mouseButton);
-        }
-        else
-        {
-            keyName = VirtualKeyToKeyName(event.first);
-        }
-
-        ss << "  " << std::setw(3) << (i + 1) << ": " << keyName << " " << (event.second ? "PRESSED" : "RELEASED")
-           << "\n";
+        std::string name =
+            (event.first >= 1000) ? "Mouse" + std::to_string(event.first - 1000) : VirtualKeyToKeyName(event.first);
+        ss << "  " << name << " " << (event.second ? "PRESSED" : "RELEASED") << "\n";
     }
 
     if (m_recentInputEvents.empty())
-    {
         ss << "  No input events recorded\n";
-        ss << "  Enable input logging with: input_logging on\n";
-    }
 
     return ss.str();
 }
@@ -527,14 +516,45 @@ std::string InputManager::Console_GetRecentEvents(int count) const
 bool InputManager::Console_IsActionActive(const std::string& action) const
 {
     std::lock_guard<std::mutex> lock(m_inputMutex);
-
     auto it = m_keyBindings.find(action);
-    if (it != m_keyBindings.end())
+    if (it == m_keyBindings.end())
+        return false;
+    return IsKeyDown(it->second);
+}
+
+InputManager::InputMetrics InputManager::GetMetricsThreadSafe() const
+{
+    std::lock_guard<std::mutex> lock(m_inputMutex);
+
+    InputMetrics metrics;
+    metrics.keyPressCount = m_keyPressCount;
+    metrics.mousePressCount = m_mousePressCount;
+    metrics.totalMouseDistance = m_totalMouseDistance;
+
+    metrics.activeKeys = 0;
+    for (const auto& pair : m_keyStates)
     {
-        return IsKeyDown(it->second);
+        if (pair.second)
+            metrics.activeKeys++;
     }
 
-    return false;
+    metrics.activeMouseButtons = 0;
+    for (int i = 0; i < 3; ++i)
+    {
+        if (m_mouseButtons[i])
+            metrics.activeMouseButtons++;
+    }
+
+    metrics.mouseCaptured = m_mouseCaptured;
+    metrics.mouseSensitivity = m_mouseSensitivity;
+    metrics.mouseDeadZone = m_mouseDeadZone;
+    metrics.mouseAcceleration = m_mouseAcceleration;
+    metrics.invertMouseY = m_invertMouseY;
+    metrics.rawMouseInput = m_rawMouseInput;
+    metrics.inputLogging = m_inputLogging;
+    metrics.totalKeyBindings = m_keyBindings.size();
+
+    return metrics;
 }
 
 InputManager::InputMetrics InputManager::Console_GetMetrics() const
@@ -570,12 +590,9 @@ void InputManager::Console_ApplySettings(const InputSettings& settings)
     m_inputLogging = settings.inputLogging;
     m_keyBindings = settings.keyBindings;
 
-    // Rebuild reverse bindings
     m_reverseBindings.clear();
     for (const auto& pair : m_keyBindings)
-    {
         m_reverseBindings[pair.second] = pair.first;
-    }
 
     NotifyStateChange();
     Spark::SimpleConsole::GetInstance().Log("Input settings applied via console", "SUCCESS");
@@ -602,23 +619,170 @@ void InputManager::Console_ResetToDefaults()
 void InputManager::Console_RegisterStateCallback(std::function<void()> callback)
 {
     std::lock_guard<std::mutex> lock(m_inputMutex);
-    m_stateCallback = callback;
+    m_stateCallback = std::move(callback);
     Spark::SimpleConsole::GetInstance().Log("Input state callback registered", "INFO");
 }
 
 void InputManager::Console_RefreshInput()
 {
     Spark::SimpleConsole::GetInstance().Log("Input system refresh requested via console", "INFO");
-
-    // Force input state update
     Update();
-
     Spark::SimpleConsole::GetInstance().Log("Input system refresh complete", "SUCCESS");
 }
 
 // ============================================================================
-// PRIVATE HELPER METHODS
+// WINDOWS PLATFORM-SPECIFIC
 // ============================================================================
+#ifdef SPARK_PLATFORM_WINDOWS
+
+InputManager::InputManager()
+    : m_mouseX(0), m_mouseY(0), m_prevMouseX(0), m_prevMouseY(0), m_mouseDeltaX(0), m_mouseDeltaY(0), m_hwnd(nullptr),
+      m_mouseCaptured(false), m_mouseSensitivity(1.0f), m_mouseDeadZone(0.0f), m_mouseAcceleration(false),
+      m_invertMouseY(false), m_rawMouseInput(false), m_inputLogging(false), m_keyPressCount(0), m_mousePressCount(0),
+      m_totalMouseDistance(0.0f)
+{
+    ZeroMemory(m_mouseButtons, sizeof(m_mouseButtons));
+    ZeroMemory(m_prevMouseButtons, sizeof(m_prevMouseButtons));
+    m_recentInputEvents.reserve(100);
+    SPARK_LOG_INFO(Spark::LogCategory::Input, "InputManager constructed (Windows)");
+    Spark::SimpleConsole::GetInstance().Log("InputManager constructed with console integration.", "INFO");
+}
+
+InputManager::~InputManager()
+{
+    SPARK_LOG_INFO(Spark::LogCategory::Input, "InputManager shutting down");
+    Spark::SimpleConsole::GetInstance().Log("InputManager destructor called.", "INFO");
+    if (m_mouseCaptured)
+        CaptureMouse(false);
+
+    for (auto& t : m_pendingTimedThreads)
+    {
+        if (t.joinable())
+            t.join();
+    }
+    m_pendingTimedThreads.clear();
+}
+
+void InputManager::Initialize(HWND hwnd)
+{
+    SPARK_TRACE_ENTER(Spark::LogCategory::Input);
+    SPARK_REQUIRE_NOT_NULL(Spark::LogCategory::Input, hwnd);
+    m_hwnd = hwnd;
+
+    RECT rect;
+    GetClientRect(hwnd, &rect);
+    POINT center = {(rect.right - rect.left) / 2, (rect.bottom - rect.top) / 2};
+    ClientToScreen(hwnd, &center);
+    SetCursorPos(center.x, center.y);
+
+    m_mouseX = m_prevMouseX = center.x;
+    m_mouseY = m_prevMouseY = center.y;
+
+    SPARK_LOG_INFO(Spark::LogCategory::Input, "InputManager initialized (Windows)");
+    Spark::SimpleConsole::GetInstance().Log("InputManager initialized with console integration.", "SUCCESS");
+}
+
+void InputManager::Update()
+{
+    static bool firstFrame = true;
+    if (firstFrame)
+    {
+        Spark::SimpleConsole::GetInstance().Log("InputManager::Update - First frame started with console integration",
+                                                "INFO");
+        firstFrame = false;
+    }
+
+    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, m_hwnd != nullptr, "InputManager::Update - hwnd not initialized");
+
+    m_prevKeyStates = m_keyStates;
+    memcpy(m_prevMouseButtons, m_mouseButtons, sizeof(m_mouseButtons));
+
+    m_prevMouseX = m_mouseX;
+    m_prevMouseY = m_mouseY;
+
+    if (m_mouseCaptured)
+    {
+        POINT cursor;
+        GetCursorPos(&cursor);
+        ScreenToClient(m_hwnd, &cursor);
+
+        m_mouseDeltaX = cursor.x - m_prevMouseX;
+        m_mouseDeltaY = cursor.y - m_prevMouseY;
+
+        ProcessMouseDelta(m_mouseDeltaX, m_mouseDeltaY);
+
+        RECT rect;
+        GetClientRect(m_hwnd, &rect);
+        POINT center = {(rect.right - rect.left) / 2, (rect.bottom - rect.top) / 2};
+        ClientToScreen(m_hwnd, &center);
+        SetCursorPos(center.x, center.y);
+
+        m_mouseX = center.x;
+        m_mouseY = center.y;
+
+        float distance = sqrtf(static_cast<float>(m_mouseDeltaX * m_mouseDeltaX + m_mouseDeltaY * m_mouseDeltaY));
+        m_totalMouseDistance.fetch_add(distance, std::memory_order_relaxed);
+    }
+    else
+    {
+        m_mouseDeltaX = m_mouseX - m_prevMouseX;
+        m_mouseDeltaY = m_mouseY - m_prevMouseY;
+        ProcessMouseDelta(m_mouseDeltaX, m_mouseDeltaY);
+    }
+}
+
+void InputManager::HandleMouseButtonMessage(int button, bool isDown)
+{
+    UpdateMouseButton(button, isDown);
+    if (m_inputLogging)
+        LogInputEvent(1000 + button, isDown);
+    if (isDown)
+        m_mousePressCount++;
+}
+
+void InputManager::HandleMessage(UINT message, WPARAM wParam, LPARAM lParam)
+{
+    switch (message)
+    {
+    case WM_KEYDOWN:
+        UpdateKeyState(static_cast<int>(wParam), true);
+        if (m_inputLogging)
+            LogInputEvent(static_cast<int>(wParam), true);
+        m_keyPressCount++;
+        break;
+    case WM_KEYUP:
+        UpdateKeyState(static_cast<int>(wParam), false);
+        if (m_inputLogging)
+            LogInputEvent(static_cast<int>(wParam), false);
+        break;
+    case WM_LBUTTONDOWN:
+        HandleMouseButtonMessage(0, true);
+        if (!m_mouseCaptured)
+            CaptureMouse(true);
+        break;
+    case WM_LBUTTONUP:
+        HandleMouseButtonMessage(0, false);
+        break;
+    case WM_RBUTTONDOWN:
+        HandleMouseButtonMessage(1, true);
+        break;
+    case WM_RBUTTONUP:
+        HandleMouseButtonMessage(1, false);
+        break;
+    case WM_MBUTTONDOWN:
+        HandleMouseButtonMessage(2, true);
+        break;
+    case WM_MBUTTONUP:
+        HandleMouseButtonMessage(2, false);
+        break;
+    case WM_MOUSEMOVE:
+        if (!m_mouseCaptured)
+            UpdateMousePosition(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
+        break;
+    default:
+        break;
+    }
+}
 
 void InputManager::UpdateKeyState(int key, bool isDown)
 {
@@ -628,187 +792,36 @@ void InputManager::UpdateKeyState(int key, bool isDown)
         CaptureMouse(false);
 }
 
-void InputManager::UpdateMouseButton(int button, bool isDown)
+void InputManager::CaptureMouse(bool capture)
 {
-    SPARK_REQUIRE_MSG(Spark::LogCategory::Input, button >= 0 && button < 3, "UpdateMouseButton - invalid button");
-    m_mouseButtons[button] = isDown;
-}
-
-void InputManager::UpdateMousePosition(int x, int y)
-{
-    m_mouseX = x;
-    m_mouseY = y;
-}
-
-void InputManager::ProcessMouseDelta(int& deltaX, int& deltaY) const
-{
-    // Apply dead zone
-    float distance = sqrtf(static_cast<float>(deltaX * deltaX + deltaY * deltaY));
-    if (distance < m_mouseDeadZone)
+    if (capture)
     {
-        deltaX = deltaY = 0;
-        return;
+        if (!m_mouseCaptured)
+        {
+            SetCapture(m_hwnd);
+            ShowCursor(FALSE);
+            m_mouseCaptured = true;
+            Spark::SimpleConsole::GetInstance().Log("Mouse captured.", "INFO");
+        }
     }
-
-    // Apply sensitivity
-    deltaX = static_cast<int>(deltaX * m_mouseSensitivity);
-    deltaY = static_cast<int>(deltaY * m_mouseSensitivity);
-
-    // Apply Y inversion
-    if (m_invertMouseY)
+    else
     {
-        deltaY = -deltaY;
+        if (m_mouseCaptured)
+        {
+            ReleaseCapture();
+            ShowCursor(TRUE);
+            m_mouseCaptured = false;
+            Spark::SimpleConsole::GetInstance().Log("Mouse capture released.", "INFO");
+        }
     }
-
-    // Apply acceleration (simplified)
-    if (m_mouseAcceleration && distance > 5.0f)
-    {
-        float accelFactor = 1.0f + (distance - 5.0f) * 0.01f;
-        deltaX = static_cast<int>(deltaX * accelFactor);
-        deltaY = static_cast<int>(deltaY * accelFactor);
-    }
-}
-
-int InputManager::KeyNameToVirtualKey(const std::string& keyName) const
-{
-    // Create a mapping of common key names to virtual key codes
-    static std::unordered_map<std::string, int> keyMapping = {
-        {"A", 'A'},          {"B", 'B'},           {"C", 'C'},
-        {"D", 'D'},          {"E", 'E'},           {"F", 'F'},
-        {"G", 'G'},          {"H", 'H'},           {"I", 'I'},
-        {"J", 'J'},          {"K", 'K'},           {"L", 'L'},
-        {"M", 'M'},          {"N", 'N'},           {"O", 'O'},
-        {"P", 'P'},          {"Q", 'Q'},           {"R", 'R'},
-        {"S", 'S'},          {"T", 'T'},           {"U", 'U'},
-        {"V", 'V'},          {"W", 'W'},           {"X", 'X'},
-        {"Y", 'Y'},          {"Z", 'Z'},           {"0", '0'},
-        {"1", '1'},          {"2", '2'},           {"3", '3'},
-        {"4", '4'},          {"5", '5'},           {"6", '6'},
-        {"7", '7'},          {"8", '8'},           {"9", '9'},
-        {"SPACE", VK_SPACE}, {"ENTER", VK_RETURN}, {"ESCAPE", VK_ESCAPE},
-        {"TAB", VK_TAB},     {"SHIFT", VK_SHIFT},  {"CTRL", VK_CONTROL},
-        {"ALT", VK_MENU},    {"F1", VK_F1},        {"F2", VK_F2},
-        {"F3", VK_F3},       {"F4", VK_F4},        {"F5", VK_F5},
-        {"F6", VK_F6},       {"F7", VK_F7},        {"F8", VK_F8},
-        {"F9", VK_F9},       {"F10", VK_F10},      {"F11", VK_F11},
-        {"F12", VK_F12},     {"UP", VK_UP},        {"DOWN", VK_DOWN},
-        {"LEFT", VK_LEFT},   {"RIGHT", VK_RIGHT}};
-
-    std::string upperKeyName = keyName;
-    std::transform(upperKeyName.begin(), upperKeyName.end(), upperKeyName.begin(), ::toupper);
-
-    auto it = keyMapping.find(upperKeyName);
-    return (it != keyMapping.end()) ? it->second : 0;
-}
-
-std::string InputManager::VirtualKeyToKeyName(int virtualKey) const
-{
-    // Reverse mapping from virtual key codes to names
-    static std::unordered_map<int, std::string> reverseMapping = {
-        {'A', "A"},          {'B', "B"},           {'C', "C"},
-        {'D', "D"},          {'E', "E"},           {'F', "F"},
-        {'G', "G"},          {'H', "H"},           {'I', "I"},
-        {'J', "J"},          {'K', "K"},           {'L', "L"},
-        {'M', "M"},          {'N', "N"},           {'O', "O"},
-        {'P', "P"},          {'Q', "Q"},           {'R', "R"},
-        {'S', "S"},          {'T', "T"},           {'U', "U"},
-        {'V', "V"},          {'W', "W"},           {'X', "X"},
-        {'Y', "Y"},          {'Z', "Z"},           {'0', "0"},
-        {'1', "1"},          {'2', "2"},           {'3', "3"},
-        {'4', "4"},          {'5', "5"},           {'6', "6"},
-        {'7', "7"},          {'8', "8"},           {'9', "9"},
-        {VK_SPACE, "Space"}, {VK_RETURN, "Enter"}, {VK_ESCAPE, "Escape"},
-        {VK_TAB, "Tab"},     {VK_SHIFT, "Shift"},  {VK_CONTROL, "Ctrl"},
-        {VK_MENU, "Alt"},    {VK_F1, "F1"},        {VK_F2, "F2"},
-        {VK_F3, "F3"},       {VK_F4, "F4"},        {VK_F5, "F5"},
-        {VK_F6, "F6"},       {VK_F7, "F7"},        {VK_F8, "F8"},
-        {VK_F9, "F9"},       {VK_F10, "F10"},      {VK_F11, "F11"},
-        {VK_F12, "F12"},     {VK_UP, "Up"},        {VK_DOWN, "Down"},
-        {VK_LEFT, "Left"},   {VK_RIGHT, "Right"}};
-
-    auto it = reverseMapping.find(virtualKey);
-    return (it != reverseMapping.end()) ? it->second : "Unknown(" + std::to_string(virtualKey) + ")";
-}
-
-void InputManager::LogInputEvent(int key, bool isPressed)
-{
-    if (m_recentInputEvents.size() >= 100)
-    {
-        // O(n) erase on small bounded buffer (max 100 entries) — acceptable for input event rate
-        m_recentInputEvents.erase(m_recentInputEvents.begin());
-    }
-    m_recentInputEvents.emplace_back(key, isPressed);
-}
-
-void InputManager::NotifyStateChange()
-{
-    if (m_stateCallback)
-    {
-        m_stateCallback();
-    }
-}
-
-InputManager::InputMetrics InputManager::GetMetricsThreadSafe() const
-{
-    std::lock_guard<std::mutex> lock(m_inputMutex);
-
-    InputMetrics metrics;
-    metrics.keyPressCount = m_keyPressCount;
-    metrics.mousePressCount = m_mousePressCount;
-    metrics.totalMouseDistance = m_totalMouseDistance;
-
-    // Count active inputs
-    metrics.activeKeys = 0;
-    for (const auto& pair : m_keyStates)
-    {
-        if (pair.second)
-            metrics.activeKeys++;
-    }
-
-    metrics.activeMouseButtons = 0;
-    for (int i = 0; i < 3; ++i)
-    {
-        if (m_mouseButtons[i])
-            metrics.activeMouseButtons++;
-    }
-
-    metrics.mouseCaptured = m_mouseCaptured;
-    metrics.mouseSensitivity = m_mouseSensitivity;
-    metrics.mouseDeadZone = m_mouseDeadZone;
-    metrics.mouseAcceleration = m_mouseAcceleration;
-    metrics.invertMouseY = m_invertMouseY;
-    metrics.rawMouseInput = m_rawMouseInput;
-    metrics.inputLogging = m_inputLogging;
-    metrics.totalKeyBindings = m_keyBindings.size();
-
-    return metrics;
 }
 
 #endif // SPARK_PLATFORM_WINDOWS
 
 // ============================================================================
-// Non-Windows (Linux/macOS) InputManager implementation
-// Provides the same public API as the Windows version, processing input via
-// HandleMessage() which is called by the SDL2 event loop in SparkEngine.cpp.
+// LINUX/macOS PLATFORM-SPECIFIC
 // ============================================================================
 #ifndef SPARK_PLATFORM_WINDOWS
-
-#include "InputManager.h"
-#include "Utils/Assert.h"
-#include "../Utils/Validate.h"
-#include "../Utils/SparkConsole.h"
-#include <cstring>
-#include <cmath>
-#include <iostream>
-#include <sstream>
-#include <algorithm>
-#include <thread>
-#include <chrono>
-
-#ifdef SPARK_SDL2_AVAILABLE
-#include <SDL.h>
-#endif
-#include <iomanip>
 
 InputManager::InputManager()
     : m_mouseX(0), m_mouseY(0), m_prevMouseX(0), m_prevMouseY(0), m_mouseDeltaX(0), m_mouseDeltaY(0), m_hwnd(nullptr),
@@ -885,83 +898,6 @@ void InputManager::HandleMessage(UINT message, WPARAM wParam, LPARAM lParam)
     }
 }
 
-bool InputManager::IsKeyDown(int key) const
-{
-    auto it = m_keyStates.find(key);
-    return it != m_keyStates.end() && it->second;
-}
-
-bool InputManager::IsKeyUp(int key) const
-{
-    return !IsKeyDown(key);
-}
-
-bool InputManager::WasKeyPressed(int key) const
-{
-    bool curr = IsKeyDown(key);
-    auto it = m_prevKeyStates.find(key);
-    bool prev = (it != m_prevKeyStates.end()) && it->second;
-    return curr && !prev;
-}
-
-bool InputManager::WasKeyReleased(int key) const
-{
-    bool curr = IsKeyDown(key);
-    auto it = m_prevKeyStates.find(key);
-    bool prev = (it != m_prevKeyStates.end()) && it->second;
-    return !curr && prev;
-}
-
-bool InputManager::IsMouseButtonDown(int button) const
-{
-    if (button < 0 || button >= 3)
-        return false;
-    return m_mouseButtons[button];
-}
-
-bool InputManager::WasMouseButtonPressed(int button) const
-{
-    if (button < 0 || button >= 3)
-        return false;
-    return m_mouseButtons[button] && !m_prevMouseButtons[button];
-}
-
-bool InputManager::WasMouseButtonReleased(int button) const
-{
-    if (button < 0 || button >= 3)
-        return false;
-    return !m_mouseButtons[button] && m_prevMouseButtons[button];
-}
-
-MousePoint InputManager::GetMouseDelta() const
-{
-    int deltaX = static_cast<int>(m_mouseDeltaX * m_mouseSensitivity);
-    int deltaY = static_cast<int>(m_mouseDeltaY * m_mouseSensitivity);
-    if (m_invertMouseY)
-        deltaY = -deltaY;
-    return {deltaX, deltaY};
-}
-
-MousePoint InputManager::GetMousePosition() const
-{
-    return {m_mouseX, m_mouseY};
-}
-
-void InputManager::CaptureMouse(bool capture)
-{
-    if (capture == m_mouseCaptured)
-        return;
-
-    m_mouseCaptured = capture;
-
-#ifdef SPARK_SDL2_AVAILABLE
-    // Relative mouse mode hides the cursor, grabs input, and reports delta movement
-    SDL_SetRelativeMouseMode(capture ? SDL_TRUE : SDL_FALSE);
-#endif
-
-    Spark::SimpleConsole::GetInstance().Log(capture ? "Mouse captured." : "Mouse capture released.", "INFO");
-}
-
 void InputManager::UpdateKeyState(int key, bool isDown)
 {
     SPARK_REQUIRE_MSG(Spark::LogCategory::Input, key >= 0, "UpdateKeyState - invalid key code");
@@ -973,366 +909,18 @@ void InputManager::UpdateKeyState(int key, bool isDown)
     NotifyStateChange();
 }
 
-void InputManager::UpdateMouseButton(int button, bool isDown)
+void InputManager::CaptureMouse(bool capture)
 {
-    SPARK_WARN_IF(Spark::LogCategory::Input, button < 0 || button >= 3, "UpdateMouseButton - invalid button index");
-    if (button >= 0 && button < 3)
-    {
-        m_mouseButtons[button] = isDown;
-        if (isDown)
-            ++m_mousePressCount;
-    }
-}
-
-void InputManager::UpdateMousePosition(int x, int y)
-{
-    m_mouseX = x;
-    m_mouseY = y;
-}
-
-void InputManager::ProcessMouseDelta(int& deltaX, int& deltaY) const
-{
-    float dx = static_cast<float>(deltaX) * m_mouseSensitivity;
-    float dy = static_cast<float>(deltaY) * m_mouseSensitivity;
-    if (m_invertMouseY)
-        dy = -dy;
-    if (std::abs(dx) < m_mouseDeadZone)
-        dx = 0.0f;
-    if (std::abs(dy) < m_mouseDeadZone)
-        dy = 0.0f;
-    deltaX = static_cast<int>(dx);
-    deltaY = static_cast<int>(dy);
-}
-
-// Console integration
-void InputManager::Console_SetMouseSensitivity(float s)
-{
-    m_mouseSensitivity = std::max(0.1f, std::min(s, 10.0f));
-}
-void InputManager::Console_SetMouseDeadZone(float d)
-{
-    m_mouseDeadZone = std::max(0.0f, std::min(d, 10.0f));
-}
-void InputManager::Console_SetMouseAcceleration(bool e)
-{
-    m_mouseAcceleration = e;
-}
-void InputManager::Console_SetInvertMouseY(bool e)
-{
-    m_invertMouseY = e;
-}
-void InputManager::Console_SetRawMouseInput(bool e)
-{
-    m_rawMouseInput = e;
-}
-void InputManager::Console_SetInputLogging(bool e)
-{
-    m_inputLogging = e;
-}
-bool InputManager::Console_BindKey(const std::string& action, const std::string& keyName)
-{
-    int vk = KeyNameToVirtualKey(keyName);
-    if (vk == 0)
-        return false;
-    m_keyBindings[action] = vk;
-    m_reverseBindings[vk] = action;
-    return true;
-}
-void InputManager::Console_UnbindKey(const std::string& action)
-{
-    auto it = m_keyBindings.find(action);
-    if (it != m_keyBindings.end())
-    {
-        m_reverseBindings.erase(it->second);
-        m_keyBindings.erase(it);
-    }
-}
-std::string InputManager::Console_ListKeyBindings() const
-{
-    std::ostringstream ss;
-    ss << "Key Bindings (" << m_keyBindings.size() << " total):\n";
-    ss << "==========================================\n";
-    for (const auto& [name, key] : m_keyBindings)
-        ss << "  " << std::left << std::setw(20) << name << " -> " << VirtualKeyToKeyName(key) << " (" << key << ")\n";
-    if (m_keyBindings.empty())
-        ss << "  No key bindings configured\n";
-    return ss.str();
-}
-void InputManager::Console_SimulateKeyPress(const std::string& keyName, int duration)
-{
-    int virtualKey = KeyNameToVirtualKey(keyName);
-    if (virtualKey == 0)
+    if (capture == m_mouseCaptured)
         return;
 
-    UpdateKeyState(virtualKey, true);
-    if (duration == 0)
-    {
-        UpdateKeyState(virtualKey, false);
-    }
-    else
-    {
-        // Schedule timed release via background thread
-        m_pendingTimedThreads.erase(std::remove_if(m_pendingTimedThreads.begin(), m_pendingTimedThreads.end(),
-                                                   [](std::thread& t) { return !t.joinable(); }),
-                                    m_pendingTimedThreads.end());
+    m_mouseCaptured = capture;
 
-        m_pendingTimedThreads.emplace_back(
-            [this, virtualKey, duration]()
-            {
-                std::this_thread::sleep_for(std::chrono::milliseconds(duration));
-                UpdateKeyState(virtualKey, false);
-            });
-    }
-}
-void InputManager::Console_ClearInputStates()
-{
-    m_keyStates.clear();
-    m_prevKeyStates.clear();
-    memset(m_mouseButtons, 0, sizeof(m_mouseButtons));
-    memset(m_prevMouseButtons, 0, sizeof(m_prevMouseButtons));
-    m_recentInputEvents.clear();
-}
-std::string InputManager::Console_GetRecentEvents(int count) const
-{
-    std::ostringstream ss;
-    ss << "Recent Input Events (last " << std::min(count, static_cast<int>(m_recentInputEvents.size())) << "):\n";
-    int startIndex = std::max(0, static_cast<int>(m_recentInputEvents.size()) - count);
-    for (int i = startIndex; i < static_cast<int>(m_recentInputEvents.size()); ++i)
-    {
-        const auto& event = m_recentInputEvents[i];
-        std::string name =
-            (event.first >= 1000) ? "Mouse" + std::to_string(event.first - 1000) : VirtualKeyToKeyName(event.first);
-        ss << "  " << name << " " << (event.second ? "PRESSED" : "RELEASED") << "\n";
-    }
-    if (m_recentInputEvents.empty())
-        ss << "  No input events recorded\n";
-    return ss.str();
-}
-bool InputManager::Console_IsActionActive(const std::string& action) const
-{
-    auto it = m_keyBindings.find(action);
-    if (it == m_keyBindings.end())
-        return false;
-    return IsKeyDown(it->second);
-}
-InputManager::InputMetrics InputManager::Console_GetMetrics() const
-{
-    InputMetrics m{};
-    m.keyPressCount = m_keyPressCount;
-    m.mousePressCount = m_mousePressCount;
-    m.totalMouseDistance = m_totalMouseDistance;
-    m.mouseCaptured = m_mouseCaptured;
-    m.mouseSensitivity = m_mouseSensitivity;
-    m.mouseDeadZone = m_mouseDeadZone;
-    m.mouseAcceleration = m_mouseAcceleration;
-    m.invertMouseY = m_invertMouseY;
-    m.rawMouseInput = m_rawMouseInput;
-    m.inputLogging = m_inputLogging;
-    m.totalKeyBindings = m_keyBindings.size();
-    return m;
-}
-InputManager::InputSettings InputManager::Console_GetSettings() const
-{
-    InputSettings s{};
-    s.mouseSensitivity = m_mouseSensitivity;
-    s.mouseDeadZone = m_mouseDeadZone;
-    s.mouseAcceleration = m_mouseAcceleration;
-    s.invertMouseY = m_invertMouseY;
-    s.rawMouseInput = m_rawMouseInput;
-    s.inputLogging = m_inputLogging;
-    s.keyBindings = m_keyBindings;
-    return s;
-}
-void InputManager::Console_ApplySettings(const InputSettings& s)
-{
-    m_mouseSensitivity = s.mouseSensitivity;
-    m_mouseDeadZone = s.mouseDeadZone;
-    m_mouseAcceleration = s.mouseAcceleration;
-    m_invertMouseY = s.invertMouseY;
-    m_rawMouseInput = s.rawMouseInput;
-    m_inputLogging = s.inputLogging;
-}
-void InputManager::Console_ResetToDefaults()
-{
-    m_mouseSensitivity = 1.0f;
-    m_mouseDeadZone = 0.0f;
-    m_mouseAcceleration = false;
-    m_invertMouseY = false;
-    m_rawMouseInput = false;
-}
-void InputManager::Console_RegisterStateCallback(std::function<void()> cb)
-{
-    m_stateCallback = std::move(cb);
-}
-void InputManager::Console_RefreshInput()
-{
-    Update();
-}
-int InputManager::KeyNameToVirtualKey(const std::string& keyName) const
-{
-    // Cross-platform key name mapping using Platform.h VK_ constants
-    static const std::unordered_map<std::string, int> keyMapping = {{"A", 'A'},
-                                                                    {"B", 'B'},
-                                                                    {"C", 'C'},
-                                                                    {"D", 'D'},
-                                                                    {"E", 'E'},
-                                                                    {"F", 'F'},
-                                                                    {"G", 'G'},
-                                                                    {"H", 'H'},
-                                                                    {"I", 'I'},
-                                                                    {"J", 'J'},
-                                                                    {"K", 'K'},
-                                                                    {"L", 'L'},
-                                                                    {"M", 'M'},
-                                                                    {"N", 'N'},
-                                                                    {"O", 'O'},
-                                                                    {"P", 'P'},
-                                                                    {"Q", 'Q'},
-                                                                    {"R", 'R'},
-                                                                    {"S", 'S'},
-                                                                    {"T", 'T'},
-                                                                    {"U", 'U'},
-                                                                    {"V", 'V'},
-                                                                    {"W", 'W'},
-                                                                    {"X", 'X'},
-                                                                    {"Y", 'Y'},
-                                                                    {"Z", 'Z'},
-                                                                    {"0", '0'},
-                                                                    {"1", '1'},
-                                                                    {"2", '2'},
-                                                                    {"3", '3'},
-                                                                    {"4", '4'},
-                                                                    {"5", '5'},
-                                                                    {"6", '6'},
-                                                                    {"7", '7'},
-                                                                    {"8", '8'},
-                                                                    {"9", '9'},
-                                                                    {"SPACE", VK_SPACE},
-                                                                    {"ENTER", VK_RETURN},
-                                                                    {"ESCAPE", VK_ESCAPE},
-                                                                    {"TAB", VK_TAB},
-                                                                    {"SHIFT", VK_SHIFT},
-                                                                    {"CTRL", VK_CONTROL},
-                                                                    {"ALT", VK_MENU},
-                                                                    {"F1", VK_F1},
-                                                                    {"F2", VK_F2},
-                                                                    {"F3", VK_F3},
-                                                                    {"F4", VK_F4},
-                                                                    {"F5", VK_F5},
-                                                                    {"F6", VK_F6},
-                                                                    {"F7", VK_F7},
-                                                                    {"F8", VK_F8},
-                                                                    {"F9", VK_F9},
-                                                                    {"F10", VK_F10},
-                                                                    {"F11", VK_F11},
-                                                                    {"F12", VK_F12},
-                                                                    {"UP", VK_UP},
-                                                                    {"DOWN", VK_DOWN},
-                                                                    {"LEFT", VK_LEFT},
-                                                                    {"RIGHT", VK_RIGHT},
-                                                                    {"BACKSPACE", VK_BACK},
-                                                                    {"DELETE", VK_DELETE},
-                                                                    {"INSERT", VK_INSERT},
-                                                                    {"HOME", VK_HOME},
-                                                                    {"END", VK_END},
-                                                                    {"PAGEUP", VK_PRIOR},
-                                                                    {"PAGEDOWN", VK_NEXT}};
+#ifdef SPARK_SDL2_AVAILABLE
+    SDL_SetRelativeMouseMode(capture ? SDL_TRUE : SDL_FALSE);
+#endif
 
-    std::string upperKeyName = keyName;
-    std::transform(upperKeyName.begin(), upperKeyName.end(), upperKeyName.begin(), ::toupper);
-
-    auto it = keyMapping.find(upperKeyName);
-    return (it != keyMapping.end()) ? it->second : 0;
-}
-std::string InputManager::VirtualKeyToKeyName(int virtualKey) const
-{
-    static const std::unordered_map<int, std::string> reverseMapping = {{'A', "A"},
-                                                                        {'B', "B"},
-                                                                        {'C', "C"},
-                                                                        {'D', "D"},
-                                                                        {'E', "E"},
-                                                                        {'F', "F"},
-                                                                        {'G', "G"},
-                                                                        {'H', "H"},
-                                                                        {'I', "I"},
-                                                                        {'J', "J"},
-                                                                        {'K', "K"},
-                                                                        {'L', "L"},
-                                                                        {'M', "M"},
-                                                                        {'N', "N"},
-                                                                        {'O', "O"},
-                                                                        {'P', "P"},
-                                                                        {'Q', "Q"},
-                                                                        {'R', "R"},
-                                                                        {'S', "S"},
-                                                                        {'T', "T"},
-                                                                        {'U', "U"},
-                                                                        {'V', "V"},
-                                                                        {'W', "W"},
-                                                                        {'X', "X"},
-                                                                        {'Y', "Y"},
-                                                                        {'Z', "Z"},
-                                                                        {'0', "0"},
-                                                                        {'1', "1"},
-                                                                        {'2', "2"},
-                                                                        {'3', "3"},
-                                                                        {'4', "4"},
-                                                                        {'5', "5"},
-                                                                        {'6', "6"},
-                                                                        {'7', "7"},
-                                                                        {'8', "8"},
-                                                                        {'9', "9"},
-                                                                        {VK_SPACE, "Space"},
-                                                                        {VK_RETURN, "Enter"},
-                                                                        {VK_ESCAPE, "Escape"},
-                                                                        {VK_TAB, "Tab"},
-                                                                        {VK_SHIFT, "Shift"},
-                                                                        {VK_CONTROL, "Ctrl"},
-                                                                        {VK_MENU, "Alt"},
-                                                                        {VK_F1, "F1"},
-                                                                        {VK_F2, "F2"},
-                                                                        {VK_F3, "F3"},
-                                                                        {VK_F4, "F4"},
-                                                                        {VK_F5, "F5"},
-                                                                        {VK_F6, "F6"},
-                                                                        {VK_F7, "F7"},
-                                                                        {VK_F8, "F8"},
-                                                                        {VK_F9, "F9"},
-                                                                        {VK_F10, "F10"},
-                                                                        {VK_F11, "F11"},
-                                                                        {VK_F12, "F12"},
-                                                                        {VK_UP, "Up"},
-                                                                        {VK_DOWN, "Down"},
-                                                                        {VK_LEFT, "Left"},
-                                                                        {VK_RIGHT, "Right"},
-                                                                        {VK_BACK, "Backspace"},
-                                                                        {VK_DELETE, "Delete"},
-                                                                        {VK_INSERT, "Insert"},
-                                                                        {VK_HOME, "Home"},
-                                                                        {VK_END, "End"},
-                                                                        {VK_PRIOR, "PageUp"},
-                                                                        {VK_NEXT, "PageDown"}};
-
-    auto it = reverseMapping.find(virtualKey);
-    return (it != reverseMapping.end()) ? it->second : "Unknown(" + std::to_string(virtualKey) + ")";
-}
-void InputManager::LogInputEvent(int key, bool isPressed)
-{
-    if (m_recentInputEvents.size() >= 100)
-    {
-        // O(n) erase on small bounded buffer (max 100 entries) — acceptable for input event rate
-        m_recentInputEvents.erase(m_recentInputEvents.begin());
-    }
-    m_recentInputEvents.emplace_back(key, isPressed);
-}
-void InputManager::NotifyStateChange()
-{
-    if (m_stateCallback)
-        m_stateCallback();
-}
-InputManager::InputMetrics InputManager::GetMetricsThreadSafe() const
-{
-    return Console_GetMetrics();
+    Spark::SimpleConsole::GetInstance().Log(capture ? "Mouse captured." : "Mouse capture released.", "INFO");
 }
 
 #endif // !SPARK_PLATFORM_WINDOWS

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -123,12 +123,12 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 <!-- AUTO:stats -->
 | Metric | Count |
 |--------|-------|
-| Header files | 537 |
+| Header files | 538 |
 | ECS Components | 79 |
 | ECS Systems | 64 |
 | Editor Panels | 52 |
 | Test files | 225 |
 | Test cases | 2885+ |
 | Wiki pages | 66 |
-| *Last synced* | *2026-03-31 08:15* |
+| *Last synced* | *2026-03-31 08:50* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
…ons (~1100 lines net)

- SaveSystem.cpp: Split RegisterBuiltins() (425 lines) into 3 domain functions (RegisterCoreSerializers, RegisterPhysicsSerializers, RegisterGameplaySerializers); refactor SerializeWorld() with TrySerialize<T> template helper (1350→1274 lines)
- InputManager.cpp: Consolidate duplicated Windows/Linux code — shared key mapping tables, query methods, and console integration defined once (1338→840 lines, -37%)
- UpscalingSystem.cpp: Extract ~640 lines of inline HLSL shader strings to new UpscalingShaders.h header (1335→652 lines, -51%)
- ConsoleApp.cpp: Split oversized Run/ReadEngineInput/ReadUserInput into focused private helpers (functions now under 60-line guideline)
- SparkEngine.cpp: Refactor RunHeadlessWindows to reuse existing helper functions

https://claude.ai/code/session_01L79mnXhwzxh1P45QoEAXMd