### PR TITLE
Fix edge cases: empty container underflow and division by zero

### DIFF
--- a/GameModules/SparkGameARPG/Source/Monster/ARPGMonsterSystem.cpp
+++ b/GameModules/SparkGameARPG/Source/Monster/ARPGMonsterSystem.cpp
@@ -215,6 +215,9 @@ namespace ARPG
 
     std::vector<MonsterData> ARPGMonsterSystem::SpawnElitePack(int level, int packSize)
     {
+        if (m_templates.empty())
+            return {};
+
         // Pick a random template for the pack
         std::uniform_int_distribution<size_t> dist(0, m_templates.size() - 1);
         const auto& tmpl = m_templates[dist(GetMonsterRNG())];

--- a/GameModules/SparkGamePlatformer/Source/Hazard/PlatformerHazardSystem.cpp
+++ b/GameModules/SparkGamePlatformer/Source/Hazard/PlatformerHazardSystem.cpp
@@ -163,9 +163,18 @@ namespace Platformer
             if (hazard.type != HazardType::Crusher)
                 continue;
 
+            if (hazard.crusherSpeed <= 0.0f)
+                continue;
+
             // Simple oscillation between start Y and crusherEndY
             float cycleTime = std::abs(hazard.posY - hazard.crusherEndY) / hazard.crusherSpeed;
+            if (cycleTime <= 0.0f)
+                continue;
+
             float totalCycle = cycleTime * 2.0f + hazard.crusherPauseTime * 2.0f;
+            if (totalCycle <= 0.0f)
+                continue;
+
             float t = std::fmod(m_globalTimer, totalCycle);
 
             float startY = hazard.posY;
@@ -205,7 +214,7 @@ namespace Platformer
             float pathLength = std::sqrt((hazard.pathEndX - hazard.posX) * (hazard.pathEndX - hazard.posX) +
                                          (hazard.pathEndY - hazard.posY) * (hazard.pathEndY - hazard.posY));
 
-            if (pathLength < 0.01f)
+            if (pathLength < 0.01f || hazard.pathSpeed <= 0.0f)
                 continue;
 
             float travelTime = pathLength / hazard.pathSpeed;


### PR DESCRIPTION
- ARPGMonsterSystem::SpawnElitePack: add empty check on m_templates before size()-1 to prevent integer underflow to SIZE_MAX
- PlatformerHazardSystem::UpdateCrushers: guard against zero crusherSpeed, zero cycleTime (when posY==crusherEndY), and zero totalCycle to prevent division by zero and fmod(x,0) producing NaN
- PlatformerHazardSystem::UpdateSawblades: guard against zero pathSpeed to prevent division by zero

https://claude.ai/code/session_01T7ePkcEP6sYrqL6M31EzH7