### PR TITLE
Add 13 wiki pages for undocumented engine subsystems and broad topics

### DIFF
--- a/.claude/index.md
+++ b/.claude/index.md
@@ -24,7 +24,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 | Rendering pipeline (all 12 stubs now implemented) | [knowledge/rendering-pipeline-status.md](knowledge/rendering-pipeline-status.md) | Observation | **Resolved** | 2026-03-22 |
 | Engine systems (29+ working, all wired) | [knowledge/gameplay-systems-status.md](knowledge/gameplay-systems-status.md) | Observation | Active | 2026-03-22 |
 | SparkGame module (AI enemies now wired) | [knowledge/sparkgame-module-status.md](knowledge/sparkgame-module-status.md) | Observation | Active | 2026-03-22 |
-| Documentation coverage (64 wiki pages, 99.6% Doxygen) | [knowledge/documentation-coverage-audit.md](knowledge/documentation-coverage-audit.md) | Observation | Active | 2026-03-24 |
+| Documentation coverage (83 wiki pages, 99.6% Doxygen) | [knowledge/documentation-coverage-audit.md](knowledge/documentation-coverage-audit.md) | Observation | Active | 2026-04-02 |
 | ThirdParty dependencies | [knowledge/thirdparty-dependencies-audit.md](knowledge/thirdparty-dependencies-audit.md) | Observation | Active | 2026-03-17 |
 | Load test baseline (frame/CPU/memory benchmarks) | [knowledge/load-test-baseline.md](knowledge/load-test-baseline.md) | Observation | Active | 2026-03-26 |
 | Live editor testing (Xvfb + Mesa llvmpipe) | [knowledge/live-editor-testing.md](knowledge/live-editor-testing.md) | Pattern | Active | 2026-03-28 |

--- a/.claude/knowledge/documentation-coverage-audit.md
+++ b/.claude/knowledge/documentation-coverage-audit.md
@@ -1,31 +1,46 @@
 # Documentation Coverage Audit
 
-**Last updated:** 2026-03-24
+**Last updated:** 2026-04-02
 **Type:** Observation
 **Status:** Active
 **Severity:** Low
 
 ## Description
 
-64 wiki pages (including new Codebase-Statistics and Codebase-Health pages), 245/246 headers with Doxygen comments, near-complete API coverage. All analysis data consolidated from docs/ into wiki pages.
+83 wiki pages (excluding _Sidebar.md), 245/246 headers with Doxygen comments, near-complete API coverage. Added 13 new wiki pages covering advanced graphics subsystems, tween system, error handling patterns, and hot-reload overview.
 
 ---
 
-## Wiki Coverage (64 pages)
+## Wiki Coverage (83 pages)
 
 ### Statistics
-- **Total pages**: 64 (excluding _Sidebar.md)
-- **Key new pages**: Codebase-Statistics.md, Codebase-Health.md
-- All 25+ engine subsystems have wiki pages
-- Test counts updated to 1,989 cases across 170 files
+- **Total pages**: 83 (excluding _Sidebar.md)
+- All engine subsystems have wiki pages (including Tween System, previously missing)
+- All major graphics subsystems documented (Render Graph, GPU Particles, GPU-Driven Rendering, Volumetric Fog, Global Illumination, Virtual Texturing, Water Rendering, Clustered Lighting, Mesh Shaders, Shader Graph)
+- Broad topic pages added: Error Handling Patterns, Hot Reload Overview
 
-### Consolidated Analysis Data (2026-03-24)
+### New Pages Added (2026-04-02)
 
-The following docs/ files were merged into wiki pages and removed:
-- `docs/codebase-analysis/` (19 documents) → merged into wiki/Codebase-Statistics.md and subsystem wiki pages
-- `docs/gap-analysis/` (4 documents) → merged into wiki/Codebase-Health.md
-- `docs/ARCHITECTURE_ANALYSIS.md` → merged into wiki/Architecture-Overview.md and wiki/Codebase-Health.md
-- `docs/defensive-offensive-programming-analysis.md` → merged into wiki/Codebase-Health.md
+| Page | Category | Coverage |
+|------|----------|----------|
+| `Tween-System.md` | Engine Subsystems | Handle-based tween system with sequencing, composition, easing |
+| `Render-Graph.md` | Graphics | Declarative render pipeline, StandardPipelineBuilder, transient resources |
+| `Shader-Graph.md` | Graphics | Node-based material authoring, 35+ node types, HLSL compilation |
+| `GPU-Particles.md` | Graphics | D3D11 compute particle system, 1M particles, indirect draw |
+| `GPU-Driven-Rendering.md` | Graphics | Compute culling, HiZ occlusion, indirect rendering |
+| `Volumetric-Fog.md` | Graphics | Froxel-based fog, Henyey-Greenstein, Beer-Lambert |
+| `Global-Illumination.md` | Graphics | DDGI probes + Adaptive Probe Volumes, L2 SH |
+| `Virtual-Texturing.md` | Graphics | Feedback-driven page streaming, LRU cache |
+| `Water-Rendering.md` | Graphics | Gerstner wave simulation, height queries |
+| `Clustered-Lighting.md` | Graphics | 3D frustum grid light culling |
+| `Mesh-Shaders.md` | Graphics | Meshlet rendering, amplification shaders, D3D12 SM6.5 |
+| `Error-Handling-Patterns.md` | Advanced | Unified error handling reference across subsystems |
+| `Hot-Reload-Overview.md` | Advanced | Shader, script, module, material, asset hot-reload |
+
+### Sidebar Updated
+- "Graphics Backends" renamed to "Graphics" with 10 new entries
+- "Engine Subsystems" gained Tween System
+- "Advanced" gained Error Handling Patterns and Hot Reload Overview
 
 ---
 
@@ -46,30 +61,38 @@ docs/
 ├── auto-update.sh
 ├── generate-api-docs.sh
 ├── generate-docs.sh
-└── sync-wiki.sh
+├── generate-flowchart.sh
+├── generate-flowchart-content.py
+├── sync-wiki.sh
+├── plans/
+│   └── hardware-acceleration-plan.md
+└── specs/
+    ├── asset-format.md
+    ├── networking-wire-format.md
+    └── plugin-abi-guide.md
 ```
-
-Analysis files and gap analyses have been consolidated into wiki pages.
 
 ---
 
 ## Top Documentation Gaps (remaining)
 
-| Priority | Gap | Impact |
-|----------|-----|--------|
-| 1 | **Networking protocol wire format** | Can't build external clients |
-| 2 | **Asset format specifications** | Can't build external tools |
-| 3 | **Plugin ABI stability & versioning** | Breaking module changes |
-| 4 | **Save system binary layout** | Version migration unclear |
-| 5 | **Physics solver tuning guide** | Instability in complex scenes |
+| Priority | Gap | Impact | Status |
+|----------|-----|--------|--------|
+| 1 | ~~Networking protocol wire format~~ | ~~Can't build external clients~~ | **Resolved** (wiki page exists) |
+| 2 | ~~Asset format specifications~~ | ~~Can't build external tools~~ | **Resolved** (wiki page exists) |
+| 3 | ~~Plugin ABI stability & versioning~~ | ~~Breaking module changes~~ | **Resolved** (wiki page exists) |
+| 4 | **Physics solver tuning guide** | Instability in complex scenes | Partially covered in Physics.md |
+| 5 | **Migration/upgrade guide** | No formal version upgrade path | Not yet documented |
 
 ---
 
 ## What's Done Right
 
-- 64 wiki pages covering all major subsystems
+- 83 wiki pages covering all major subsystems and advanced graphics
 - 99.6% header Doxygen coverage
-- Codebase-Statistics.md with comprehensive metrics (~371K LOC)
-- Codebase-Health.md with system maturity status for all subsystems
+- Codebase-Statistics.md with comprehensive metrics
+- Codebase-Health.md with system maturity status
+- Unified error handling and hot-reload documentation
 - README badges for all platforms, compilers, and quality tools
 - All analysis data lives in wiki (no orphan docs/ files)
+- docs/specs/ contains detailed wire format, asset format, and plugin ABI specs

--- a/wiki/Clustered-Lighting.md
+++ b/wiki/Clustered-Lighting.md
@@ -1,0 +1,209 @@
+# Clustered Lighting
+
+SparkEngine uses GPU-based clustered light culling to efficiently determine which lights affect each region of the screen. The camera frustum is subdivided into a 3D grid of clusters, and each light is assigned to the clusters it overlaps, enabling O(1) light lookups per pixel during shading.
+
+**Source:** `SparkEngine/Source/Graphics/ClusteredLightCulling.h`, `SparkEngine/Source/Graphics/ClusteredLightGPU.h`
+**Namespace:** `Spark::Graphics`
+**Tests:** `Tests/TestClusteredLightGPU.cpp` (7 test cases)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Cluster Grid](#cluster-grid)
+- [Light Assignment](#light-assignment)
+- [API Reference](#api-reference)
+- [GPU Buffers](#gpu-buffers)
+- [Usage Example](#usage-example)
+- [Integration](#integration)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+With many lights in a scene, testing every light for every pixel is prohibitively expensive. Clustered lighting divides the frustum into a 3D grid and pre-computes which lights affect each cell, so the pixel shader only evaluates a small subset of lights.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                     Camera Frustum                       │
+│                                                          │
+│  Near ──────────────────────────────────────────── Far   │
+│  ┌────┬────┬────┬────┬────┬────┬────┬────┐  ← Y slices │
+│  │ C0 │ C1 │ C2 │ C3 │ C4 │ C5 │ C6 │ C7 │             │
+│  ├────┼────┼────┼────┼────┼────┼────┼────┤              │
+│  │ C8 │ C9 │C10 │C11 │C12 │C13 │C14 │C15 │  ← gridY   │
+│  └────┴────┴────┴────┴────┴────┴────┴────┘              │
+│  ↑                                         ↑             │
+│  gridX                              gridZ (depth)        │
+│                                                          │
+│  Each cluster stores:                                    │
+│    - light count                                         │
+│    - list of light indices                               │
+│                                                          │
+│  Pixel shader: cluster = f(screenXY, depth)              │
+│                lights = clusterLightList[cluster]        │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Cluster Grid
+
+### Configuration
+
+```cpp
+struct ClusterConfig
+{
+    uint32_t gridX = 16;                  // Clusters along screen X
+    uint32_t gridY = 8;                   // Clusters along screen Y
+    uint32_t gridZ = 24;                  // Clusters along depth
+    uint32_t maxLightsPerCluster = 200;   // Light index list capacity
+    uint32_t maxTotalLights = 1000;       // Maximum active lights
+};
+```
+
+Default grid: 16 x 8 x 24 = **3,072 clusters**.
+
+### Cluster AABBs
+
+Each cluster is represented as an axis-aligned bounding box in view space:
+
+```cpp
+struct ClusterAABB
+{
+    XMFLOAT3 minBounds;
+    XMFLOAT3 maxBounds;
+};
+```
+
+Cluster AABBs are rebuilt when the projection matrix changes (e.g., FOV or aspect ratio change).
+
+---
+
+## Light Assignment
+
+### Light Data
+
+```cpp
+struct LightData
+{
+    XMFLOAT3 position;
+    float radius;
+    XMFLOAT3 color;
+    float intensity;
+    uint32_t type;  // 0 = point, 1 = spot
+};
+```
+
+### Assignment Algorithm
+
+`Update()` performs two steps:
+
+1. **Rebuild grid** (`RebuildClusterGrid`): Compute cluster AABBs from the projection matrix, near/far planes, and grid dimensions. Depth slices use logarithmic distribution for higher near-camera resolution.
+
+2. **Assign lights** (`AssignLightsToClusters`): For each light, transform its position to view space and test its bounding sphere against each cluster's AABB. If they intersect, the light's index is added to that cluster's light list.
+
+The sphere-AABB intersection test is conservative — it may include a few extra lights per cluster, but never misses one.
+
+---
+
+## API Reference
+
+| Method | Description |
+|--------|-------------|
+| `GetInstance()` | Singleton access |
+| `Initialize(config)` | Create grid with given dimensions |
+| `Shutdown()` | Release all resources |
+| `AddLight(light)` | Add a light for the next Update |
+| `ClearLights()` | Remove all lights |
+| `Update(viewMatrix, projMatrix, nearZ, farZ)` | Rebuild grid and assign lights |
+| `GetClusterCount()` | Total clusters (gridX * gridY * gridZ) |
+| `GetActiveLightCount()` | Lights in the active list |
+| `GetConfig()` | Current grid configuration |
+| `GetClusterLightCount(index)` | Light count for a specific cluster |
+| `GetClusterLightIndices(index)` | Light index array for a cluster |
+| `Console_GetStatus()` | Formatted debug string |
+
+---
+
+## GPU Buffers
+
+Upload cluster data for use in pixel shaders:
+
+```cpp
+culling.CreateGPUBuffers(rhiDevice);
+
+// After Update() each frame:
+culling.UploadToGPU(rhiDevice);
+
+// Bind in shader
+auto* clusterBuf = culling.GetClusterBuffer();       // Per-cluster light counts
+auto* lightIdxBuf = culling.GetLightIndexBuffer();    // Flat light index array
+```
+
+The pixel shader determines its cluster from screen position and depth, reads the light count, and iterates only over assigned lights.
+
+---
+
+## Usage Example
+
+```cpp
+using namespace Spark::Graphics;
+
+auto& culling = ClusteredLightCulling::GetInstance();
+
+ClusterConfig config;
+config.gridX = 16;
+config.gridY = 8;
+config.gridZ = 32;
+config.maxLightsPerCluster = 128;
+culling.Initialize(config);
+
+// Each frame:
+culling.ClearLights();
+
+// Add scene lights
+for (const auto& light : sceneLights)
+{
+    LightData ld;
+    ld.position = light.GetPosition();
+    ld.radius = light.GetRadius();
+    ld.color = light.GetColor();
+    ld.intensity = light.GetIntensity();
+    ld.type = light.IsSpot() ? 1 : 0;
+    culling.AddLight(ld);
+}
+
+// Build clusters
+XMFLOAT4X4 view, proj;
+XMStoreFloat4x4(&view, camera.GetViewMatrix());
+XMStoreFloat4x4(&proj, camera.GetProjectionMatrix());
+culling.Update(view, proj, camera.GetNearZ(), camera.GetFarZ());
+
+// Upload to GPU
+culling.UploadToGPU(rhiDevice);
+
+LOG_INFO("Clustered lighting: {} lights in {} clusters",
+         culling.GetActiveLightCount(), culling.GetClusterCount());
+```
+
+---
+
+## Integration
+
+- **LightingSystem**: Feeds lights into clustered culling each frame
+- **LightManager**: Provides the scene's active light list
+- **Deferred Lighting Pass**: The lighting pass uses cluster data to evaluate only relevant lights per pixel
+- **Volumetric Fog**: The fog scattering pass can reuse the clustered light list. See [Volumetric Fog](Volumetric-Fog)
+- **Forward Rendering**: Clustered lighting also works with forward rendering by reading cluster data in the forward pixel shader
+
+---
+
+## See Also
+
+- [Rendering and Graphics](Rendering-and-Graphics) — Overall lighting pipeline
+- [Volumetric Fog](Volumetric-Fog) — Light scattering uses the same light data
+- [Global Illumination](Global-Illumination) — Indirect lighting complements direct clustered lighting
+- [GPU-Driven Rendering](GPU-Driven-Rendering) — GPU culling for geometry (parallel concept)

--- a/wiki/Error-Handling-Patterns.md
+++ b/wiki/Error-Handling-Patterns.md
@@ -1,0 +1,277 @@
+# Error Handling Patterns
+
+SparkEngine uses multiple error handling strategies across its subsystems, chosen based on the boundary type and failure severity. This page documents the conventions, when to use each pattern, and how errors propagate through the engine.
+
+**Relevant headers:** `SparkEngine/Source/Utils/Assert.h`, `SparkEngine/Source/Utils/Logger.h`, `SparkEngine/Source/Core/Platform.h`
+**Namespace:** `Spark`
+
+---
+
+## Table of Contents
+
+- [Philosophy](#philosophy)
+- [Error Handling Strategies](#error-handling-strategies)
+  - [bool Return Values](#bool-return-values)
+  - [HRESULT (D3D11/COM)](#hresult-d3d11com)
+  - [std::expected (C++23)](#stdexpected-c23)
+  - [Assertions](#assertions)
+  - [Error Callbacks](#error-callbacks)
+- [When to Use What](#when-to-use-what)
+- [Error Logging](#error-logging)
+- [Error Propagation Patterns](#error-propagation-patterns)
+- [Subsystem Conventions](#subsystem-conventions)
+- [See Also](#see-also)
+
+---
+
+## Philosophy
+
+SparkEngine follows these principles for error handling:
+
+1. **Fail loudly in development, gracefully in production** — Assertions catch programmer errors during development; runtime error paths handle user/environment failures
+2. **Validate at system boundaries** — Validate user input, file I/O, network data, and API calls. Trust internal engine code
+3. **Return errors, don't throw exceptions** — SparkEngine does not use C++ exceptions. All error paths use return values
+4. **Log before returning** — Every error return should be accompanied by a `LOG_ERROR` or `LOG_WARN` so failures are always visible
+
+---
+
+## Error Handling Strategies
+
+### bool Return Values
+
+The most common pattern across the engine. `Initialize()`, `LoadAsset()`, and similar functions return `true` on success:
+
+```cpp
+bool AudioEngine::Initialize()
+{
+    if (!CreateXAudioDevice())
+    {
+        LOG_ERROR("Failed to create XAudio2 device");
+        return false;
+    }
+
+    m_initialized = true;
+    return true;
+}
+```
+
+**Use for**: Engine subsystem initialization, resource loading, operations with a clear pass/fail outcome.
+
+### HRESULT (D3D11/COM)
+
+Windows graphics and COM APIs return `HRESULT`. SparkEngine propagates these directly in graphics code:
+
+```cpp
+HRESULT GraphicsEngine::CreateDevice()
+{
+    HRESULT hr = D3D11CreateDevice(/* ... */);
+    if (FAILED(hr))
+    {
+        LOG_ERROR("D3D11CreateDevice failed: 0x{:08X}", static_cast<uint32_t>(hr));
+        return hr;
+    }
+    return S_OK;
+}
+```
+
+**Use for**: D3D11/D3D12 resource creation, shader compilation, any COM interop. Always log the hex HRESULT value for debugging.
+
+### std::expected (C++23)
+
+For operations that can fail with a meaningful error value, `std::expected` provides a type-safe result-or-error:
+
+```cpp
+std::expected<Mesh, std::string> LoadMesh(const std::string& path)
+{
+    auto data = ReadFile(path);
+    if (!data)
+    {
+        return std::unexpected("File not found: " + path);
+    }
+
+    Mesh mesh = ParseMeshData(*data);
+    if (mesh.vertices.empty())
+    {
+        return std::unexpected("Empty mesh: " + path);
+    }
+
+    return mesh;
+}
+
+// Caller:
+auto result = LoadMesh("models/hero.fbx");
+if (result)
+{
+    UseModel(*result);
+}
+else
+{
+    LOG_ERROR("{}", result.error());
+}
+```
+
+**Use for**: Operations where the caller needs to know *what* went wrong, not just that it failed. Preferred for new code over raw bool returns when error context matters.
+
+### Assertions
+
+Assertions catch programming errors — conditions that should never occur if the code is correct:
+
+```cpp
+#include "Utils/Assert.h"
+
+void PhysicsSystem::AddBody(PhysicsBody* body)
+{
+    SPARK_ASSERT(body != nullptr);
+    SPARK_ASSERT(m_initialized && "PhysicsSystem not initialized");
+
+    m_bodies.push_back(body);
+}
+```
+
+**Rules:**
+- Assertions are **enabled in Debug**, **disabled in Release**
+- Never put side effects inside an assertion expression
+- Use assertions for programmer errors (null pointers, invalid states, violated preconditions)
+- Do NOT use assertions for runtime failures (file not found, network error, user input)
+
+### Error Callbacks
+
+Some subsystems use callback-based error reporting, especially for async operations:
+
+```cpp
+// AngelScript compilation errors
+scriptEngine.SetMessageCallback([](const std::string& msg, int line)
+{
+    LOG_ERROR("Script error at line {}: {}", line, msg);
+});
+
+// Network error handling
+networkManager.SetErrorHandler([](NetworkError error, const std::string& detail)
+{
+    LOG_ERROR("Network error {}: {}", static_cast<int>(error), detail);
+});
+```
+
+**Use for**: Async operations, third-party library integration, situations where errors are reported to a different context than the caller.
+
+---
+
+## When to Use What
+
+| Situation | Pattern | Example |
+|-----------|---------|---------|
+| Subsystem `Initialize()` | `bool` return | `AudioEngine::Initialize()` |
+| D3D11/COM API call | `HRESULT` | `CreateBuffer()`, `CompileShader()` |
+| File/asset loading | `std::expected` or `bool` | `LoadMesh()`, `LoadTexture()` |
+| Programmer error (impossible state) | `SPARK_ASSERT` | Null pointer, uninitialized system |
+| Network message parsing | `bool` with `HasError()` | `NetBuffer::ReadString()` |
+| Script compilation | Error callback | `SetMessageCallback()` |
+| Configuration validation | `bool` + `LOG_WARN` | Invalid settings clamped to valid range |
+
+---
+
+## Error Logging
+
+All errors should be logged through the `Logger` system:
+
+```cpp
+#include "Utils/Logger.h"
+
+LOG_ERROR("Failed to load texture: {}", path);    // Errors (something broke)
+LOG_WARN("Texture format unsupported, using fallback");  // Warnings (degraded but functional)
+LOG_INFO("Loaded {} textures", count);             // Info (normal operation)
+```
+
+**Guidelines:**
+- `LOG_ERROR`: Something failed and the operation cannot complete
+- `LOG_WARN`: Something unexpected happened but the engine can continue (e.g., fallback used)
+- `LOG_INFO`: Normal operational messages (use sparingly in hot paths)
+- Include context in the message: file paths, counts, error codes
+- Never log inside tight loops — guard with `if` or rate-limit
+
+---
+
+## Error Propagation Patterns
+
+### Early Return
+
+The predominant pattern. Check each operation and return immediately on failure:
+
+```cpp
+bool Scene::Load(const std::string& path)
+{
+    auto data = ReadFile(path);
+    if (!data) return false;
+
+    if (!ParseHeader(*data)) return false;
+    if (!LoadEntities(*data)) return false;
+    if (!LoadLighting(*data)) return false;
+
+    return true;
+}
+```
+
+### Accumulate and Report
+
+For operations that should try to complete even with partial failures:
+
+```cpp
+ShaderGraphOutput ShaderGraphCompiler::Compile(const ShaderGraphInput& graph)
+{
+    ShaderGraphOutput output;
+
+    if (graph.nodes.empty())
+    {
+        output.errors.push_back("Graph has no nodes");
+    }
+
+    // Continue checking...
+    if (!FindOutputNode(graph))
+    {
+        output.errors.push_back("No output node found");
+    }
+
+    output.success = output.errors.empty();
+    return output;
+}
+```
+
+### NetBuffer Overflow Protection
+
+Network buffers track an internal error flag:
+
+```cpp
+NetBuffer buf(receivedData);
+uint32_t id = buf.ReadUInt32();
+std::string name = buf.ReadString();
+
+if (buf.HasError())
+{
+    LOG_WARN("Malformed packet: buffer overflow");
+    return;
+}
+```
+
+---
+
+## Subsystem Conventions
+
+| Subsystem | Primary Pattern | Notes |
+|-----------|----------------|-------|
+| Graphics (D3D11) | `HRESULT` | COM convention, always check `FAILED()` |
+| Physics (Jolt) | `bool` + assertions | Jolt uses assertions internally |
+| Audio (XAudio2) | `HRESULT` | COM-based API |
+| Networking | `bool` + `HasError()` | NetBuffer overflow tracking |
+| Scripting | Error callbacks | AngelScript message callback |
+| ECS | Assertions | Invalid entity/component access |
+| Asset Loading | `bool` or `std::expected` | File I/O at system boundary |
+| Scene Management | `bool` early return | Chain of loading steps |
+
+---
+
+## See Also
+
+- [Utilities](Utilities) — Logger and Assert implementations
+- [Testing](Testing) — How errors are tested
+- [Profiler and Debugging](Profiler-and-Debugging) — Runtime diagnostics
+- [Contributing](Contributing) — Coding standards for new code

--- a/wiki/GPU-Driven-Rendering.md
+++ b/wiki/GPU-Driven-Rendering.md
@@ -1,0 +1,217 @@
+# GPU-Driven Rendering
+
+SparkEngine implements a GPU-driven rendering pipeline that performs frustum and hierarchical Z-buffer (HiZ) occlusion culling entirely on the GPU via compute shaders, then issues geometry draws through indirect dispatch. This eliminates CPU-side per-object visibility checks for scenes with thousands of instances.
+
+**Source:** `SparkEngine/Source/Graphics/GPUDrivenRenderer.h`, `SparkEngine/Source/Graphics/GPUOcclusionCulling.h`
+**Namespace:** `Spark::Graphics`
+**Tests:** `Tests/TestGPUDrivenRenderer.cpp` (13 test cases)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Pipeline](#pipeline)
+- [GPUDrivenRenderer](#gpudrivenrenderer)
+  - [Cull Settings](#cull-settings)
+  - [Statistics](#statistics)
+  - [GPU Instance Data](#gpu-instance-data)
+  - [API Reference](#api-reference)
+- [GPU Occlusion Culling](#gpu-occlusion-culling)
+  - [HiZ Pyramid](#hiz-pyramid)
+  - [Occlusion Testing](#occlusion-testing)
+  - [Batch Culling](#batch-culling)
+- [Usage Example](#usage-example)
+- [Integration](#integration)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+Traditional rendering tests each object's visibility on the CPU, which becomes a bottleneck with thousands of draw calls. GPU-driven rendering uploads all instance bounding boxes to the GPU, runs a compute shader to cull invisible instances, and writes draw arguments directly — the CPU never touches per-instance visibility.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Frame N-1: Render scene → depth buffer                      │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+                            v
+┌─────────────────────────────────────────────────────────────┐
+│ BeginFrame(): Build HiZ mip chain from depth buffer         │
+│                                                             │
+│  Mip 0 (full res) → Mip 1 (half) → ... → Mip N (1x1)     │
+│  Each mip stores the MAX depth of the 2x2 parent region    │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+                            v
+┌─────────────────────────────────────────────────────────────┐
+│ CullAndDraw():                                              │
+│  1. Upload instance AABBs to GPU structured buffer          │
+│  2. Dispatch cull compute shader:                           │
+│     - Frustum plane test                                    │
+│     - HiZ occlusion test (project AABB → screen rect →     │
+│       sample HiZ at appropriate mip)                        │
+│  3. Write indirect draw args for visible instances          │
+│  4. DrawIndexedInstancedIndirect                            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Pipeline
+
+Each frame follows two stages:
+
+### Stage 1: BeginFrame
+
+Builds the HiZ mip chain from the previous frame's depth buffer. Each mip level stores the maximum depth of its parent 2x2 region, creating a conservative depth pyramid.
+
+### Stage 2: CullAndDraw
+
+1. **Upload**: Instance AABBs are uploaded to a GPU structured buffer
+2. **Cull dispatch**: A compute shader tests each AABB against:
+   - **Frustum planes**: 6-plane frustum test eliminates objects fully outside the view
+   - **HiZ occlusion**: Projects the AABB to a screen-space rectangle, selects the HiZ mip level matching the rectangle size, and compares the AABB's nearest depth against the stored maximum depth
+3. **Indirect args**: Visible instances write their draw arguments to an indirect buffer
+4. **Draw**: `DrawIndexedInstancedIndirect` renders all visible geometry in one call
+
+A 1-frame-deferred readback avoids CPU-GPU sync stalls when reading back statistics.
+
+---
+
+## GPUDrivenRenderer
+
+### Cull Settings
+
+```cpp
+struct CullSettings
+{
+    bool enableFrustumCull = true;  // Frustum plane culling
+    bool enableHiZCull = true;      // Hierarchical Z-buffer occlusion
+    bool freezeCulling = false;     // Debug: freeze at current camera
+};
+```
+
+### Statistics
+
+```cpp
+struct CullStatistics
+{
+    uint32_t totalInstances;    // Submitted for culling
+    uint32_t visibleInstances;  // Passed all tests
+    uint32_t culledByFrustum;   // Removed by frustum
+    uint32_t culledByHiZ;       // Removed by occlusion
+};
+```
+
+### GPU Instance Data
+
+```cpp
+struct alignas(16) GPUInstanceAABB
+{
+    float minX, minY, minZ;
+    float padding0;
+    float maxX, maxY, maxZ;
+    float padding1;
+};
+```
+
+16-byte aligned for GPU structured buffer compatibility.
+
+### API Reference
+
+| Method | Description |
+|--------|-------------|
+| `Initialize(device, context, maxInstances)` | Create GPU resources. Default max: 8192 instances |
+| `Shutdown()` | Release all GPU resources |
+| `BeginFrame(depthSRV, width, height)` | Build HiZ mip chain from depth buffer |
+| `CullAndDraw(aabbs, count, view, proj, ib, vb, stride, indexCount)` | Cull and draw |
+| `GetVisibleCount()` | Visible instances from last frame |
+| `GetStatistics()` | Full `CullStatistics` struct |
+| `GetSettings()` / `SetSettings()` | Read/write `CullSettings` |
+| `Console_GetStatus()` | Formatted debug string |
+
+---
+
+## GPU Occlusion Culling
+
+The `GPUOcclusionCuller` provides a standalone HiZ occlusion testing API, usable independently of the full GPU-driven renderer.
+
+### HiZ Pyramid
+
+```cpp
+struct HiZPyramid
+{
+    static constexpr int kMaxMips = 12;  // Up to 4096x4096
+
+    void Build(const float* depthBuffer, uint32_t w, uint32_t h);
+    float Sample(int mip, uint32_t x, uint32_t y) const;
+};
+```
+
+The pyramid stores maximum depth values at progressively coarser resolutions. A bounding box is occluded if its nearest depth is greater than the HiZ value at its screen extent.
+
+### Occlusion Testing
+
+```cpp
+bool IsVisible(float screenMinX, float screenMinY,
+               float screenMaxX, float screenMaxY,
+               float nearDepth) const;
+```
+
+Projects screen-space bounds and tests against the appropriate HiZ mip level.
+
+### Batch Culling
+
+```cpp
+std::vector<uint32_t> CullBatch(
+    const std::vector<OcclusionAABB>& objects,
+    const float* viewProjMatrix) const;
+```
+
+Tests multiple world-space AABBs at once, returning indices of visible objects.
+
+---
+
+## Usage Example
+
+```cpp
+auto& renderer = GPUDrivenRenderer::GetInstance();
+renderer.Initialize(device, context, 16384);
+
+// Each frame:
+renderer.BeginFrame(depthSRV, screenWidth, screenHeight);
+
+// Prepare instance AABBs
+std::vector<GPUInstanceAABB> aabbs = BuildAABBs(sceneObjects);
+
+renderer.CullAndDraw(
+    aabbs.data(), static_cast<uint32_t>(aabbs.size()),
+    viewMatrix, projMatrix,
+    indexBuffer, vertexBuffer, vertexStride, totalIndexCount);
+
+// Check stats
+const auto& stats = renderer.GetStatistics();
+LOG_INFO("Visible: {}/{} (frustum culled: {}, HiZ culled: {})",
+         stats.visibleInstances, stats.totalInstances,
+         stats.culledByFrustum, stats.culledByHiZ);
+```
+
+---
+
+## Integration
+
+- **GraphicsEngine**: Can be used alongside or instead of CPU frustum culling
+- **MeshClusterSystem**: Provides meshlet-level AABBs for fine-grained culling. See [Mesh Shaders](Mesh-Shaders)
+- **GPU Scene Buffer**: Shared GPU buffer for instance transforms and material IDs
+- **Platform**: Requires D3D11 compute shaders. CPU reference implementation available via `GPUOcclusionCuller`
+
+---
+
+## See Also
+
+- [Rendering and Graphics](Rendering-and-Graphics) — Overall rendering architecture
+- [Mesh Shaders](Mesh-Shaders) — Meshlet-based rendering with per-meshlet culling
+- [GPU Particles](GPU-Particles) — Related GPU compute pipeline
+- [Clustered Lighting](Clustered-Lighting) — 3D frustum grid for light culling

--- a/wiki/GPU-Particles.md
+++ b/wiki/GPU-Particles.md
@@ -1,0 +1,254 @@
+# GPU Particles
+
+SparkEngine provides a GPU-accelerated particle system that runs emission, simulation, sorting, and rendering entirely on the GPU via D3D11 compute shaders. Each emitter supports up to 1 million particles with bitonic sort for correct alpha blending.
+
+**Source:** `SparkEngine/Source/Graphics/GPUParticleSystem.h`, `SparkEngine/Source/Graphics/GPUParticleTypes.h`
+**Namespace:** Global (classes prefixed with `GPU`)
+**Tests:** `Tests/TestGPUParticleSystem.cpp` (11 test cases)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Pipeline](#pipeline)
+- [Emitter Configuration](#emitter-configuration)
+- [GPU Data Layout](#gpu-data-layout)
+  - [GPUParticleData](#gpuparticledata)
+  - [GPUParticleEmitterCB](#gpuparticleemittercb)
+  - [Buffer Architecture](#buffer-architecture)
+- [API Reference](#api-reference)
+  - [Initialization](#initialization)
+  - [Emitter Management](#emitter-management)
+  - [Simulation and Rendering](#simulation-and-rendering)
+  - [Emitter Control](#emitter-control)
+- [Usage Example](#usage-example)
+- [Performance](#performance)
+- [Integration](#integration)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+The GPU particle system offloads all particle work to compute shaders, freeing the CPU for gameplay logic. The CPU only manages emitter configuration and issues dispatch calls.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         CPU Side                            │
+│  CreateEmitter() → configure desc → Update(dt) → Render()  │
+├─────────────────────────────────────────────────────────────┤
+│                         GPU Side                            │
+│  ┌──────────────┐  ┌────────────────┐  ┌─────────────────┐ │
+│  │ ParticleEmit │→│ParticleSimulate│→│ParticleBitonic  │ │
+│  │ .hlsl        │  │ .hlsl          │  │ Sort.hlsl       │ │
+│  │              │  │                │  │                 │ │
+│  │ Pop dead     │  │ Integrate vel  │  │ Sort alive by   │ │
+│  │ Init new     │  │ Kill expired   │  │ camera distance │ │
+│  │ particles    │  │ Compact alive  │  │                 │ │
+│  └──────────────┘  └────────────────┘  └─────────────────┘ │
+│                           |                                 │
+│                           v                                 │
+│                  DrawInstancedIndirect                       │
+│                  (alive list + particle pool SRVs)           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `kMaxGPUParticlesPerEmitter` | 1,048,576 (1M) | Hard maximum particles per emitter |
+| `kDefaultGPUParticleCapacity` | 65,536 (64K) | Default capacity if not specified |
+| `kParticleThreadGroupSize` | 256 | Compute shader thread group size |
+
+---
+
+## Pipeline
+
+Each frame, `Update(deltaTime)` dispatches three compute shader passes per emitter:
+
+1. **Emit** (`ParticleEmit.hlsl`): Pops indices from the dead list, initializes new particles with position, velocity, lifetime, color, and rotation based on emitter settings
+2. **Simulate** (`ParticleSimulate.hlsl`): Integrates velocity with gravity and drag, ages particles, kills expired ones (push to dead list), and compacts the alive list
+3. **Bitonic Sort** (`ParticleBitonicSort.hlsl`): Sorts the alive list by camera distance for correct back-to-front alpha blending
+4. **Update indirect args**: Writes the alive count into the indirect draw argument buffer
+
+`Render(view, projection)` then binds the alive list SRV and particle pool SRV and issues `DrawInstancedIndirect`.
+
+---
+
+## Emitter Configuration
+
+The `ParticleEmitterDesc` (defined in `GPUParticleTypes.h`) configures emitter behavior:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `string` | `""` | Debug identifier |
+| `emissionRate` | `float` | 100.0 | Particles emitted per second |
+| `emitterShape` | `EmitterShape` | Point | Point, Sphere, Cone, Box |
+| `shapeRadius` | `float` | 1.0 | Radius for Sphere/Cone shapes |
+| `coneAngle` | `float` | 45.0 | Half-angle in degrees for Cone |
+| `gravity` | `XMFLOAT3` | {0,-9.8,0} | Gravity acceleration |
+| `drag` | `float` | 0.0 | Velocity damping per second |
+| `gravityMultiplier` | `float` | 1.0 | Scale factor for gravity |
+| `lifetimeRange` | x=min, y=max | 1.0-3.0 | Random lifetime range (seconds) |
+| `sizeRange` | x=min, y=max | 0.1-0.5 | Random particle size range |
+| `rotSpeedRange` | x=min, y=max | 0.0-0.0 | Random rotation speed (rad/s) |
+
+---
+
+## GPU Data Layout
+
+### GPUParticleData
+
+The per-particle structured buffer layout (16-byte aligned):
+
+```cpp
+struct alignas(16) GPUParticleData
+{
+    XMFLOAT3 position;
+    float age;
+    XMFLOAT3 velocity;
+    float lifetime;
+    XMFLOAT4 color;
+    float size;
+    float rotation;
+    float rotationSpeed;
+    uint32_t alive;     // 1 = alive, 0 = dead
+};
+```
+
+### GPUParticleEmitterCB
+
+Per-emitter constant buffer sent to compute shaders each frame:
+
+```cpp
+struct alignas(16) GPUParticleEmitterCB
+{
+    XMFLOAT3 emitterPosition;
+    float deltaTime;
+    XMFLOAT3 gravity;
+    float drag;
+    float emissionRate;
+    float shapeRadius;
+    float coneAngle;
+    uint32_t maxParticles;
+    XMFLOAT4 lifetimeRange;  // x=min, y=max, z=speedMin, w=speedMax
+    XMFLOAT4 sizeRange;      // x=sizeMin, y=sizeMax, z=rotMin, w=rotMax
+    XMFLOAT4 rotSpeedRange;  // x=min, y=max
+    uint32_t emitCount;       // particles to emit this frame
+    uint32_t emitterShape;
+    float gravityMultiplier;
+    float totalTime;
+};
+```
+
+### Buffer Architecture
+
+Each emitter owns seven GPU buffers:
+
+| Buffer | Type | Description |
+|--------|------|-------------|
+| `particleBuffer` | RW Structured | Pool of all particle data |
+| `deadListBuffer` | Append/Consume | Available particle indices |
+| `aliveListBuffer` | RW Structured | This frame's alive particle indices |
+| `aliveListSwapBuffer` | RW Structured | Previous frame's alive indices (double-buffered) |
+| `sortKeysBuffer` | RW Structured | Camera distance keys for bitonic sort |
+| `indirectArgsBuffer` | Indirect | `DrawInstancedIndirect` arguments |
+| `emitterCBBuffer` | Constant | Per-emitter constants |
+
+---
+
+## API Reference
+
+### Initialization
+
+```cpp
+auto& gpu = GPUParticleSystem::GetInstance();
+
+// Windows (D3D11)
+HRESULT hr = gpu.Initialize(device, context);
+
+// Non-Windows (stub)
+bool ok = gpu.Initialize();
+```
+
+### Emitter Management
+
+```cpp
+// Create with custom capacity
+uint32_t id = gpu.CreateEmitter(desc, 100000);  // 100K particles
+
+// Destroy single emitter
+gpu.DestroyEmitter(id);
+
+// Destroy all emitters
+gpu.DestroyAllEmitters();
+```
+
+### Simulation and Rendering
+
+```cpp
+// Each frame
+gpu.Update(deltaTime);
+gpu.Render(viewMatrix, projMatrix);
+```
+
+### Emitter Control
+
+```cpp
+gpu.SetEmitterPosition(id, {10.0f, 5.0f, 0.0f});
+gpu.SetEmitterPlaying(id, false);  // pause emission
+
+uint32_t count = gpu.GetEmitterCount();
+std::string status = gpu.GetStatus();
+```
+
+---
+
+## Usage Example
+
+```cpp
+auto& gpuParticles = GPUParticleSystem::GetInstance();
+gpuParticles.Initialize(device, context);
+
+ParticleEmitterDesc desc;
+desc.name = "campfire";
+desc.emissionRate = 500.0f;
+desc.gravity = {0.0f, 2.0f, 0.0f};  // upward drift
+desc.drag = 0.5f;
+desc.shapeRadius = 0.3f;
+
+uint32_t fireId = gpuParticles.CreateEmitter(desc, 50000);
+gpuParticles.SetEmitterPosition(fireId, {5.0f, 0.0f, 10.0f});
+
+// In render loop
+gpuParticles.Update(deltaTime);
+gpuParticles.Render(camera.GetViewMatrix(), camera.GetProjectionMatrix());
+```
+
+---
+
+## Performance
+
+- **Thread group size**: 256 threads per group (must match HLSL `[numthreads]`)
+- **Dispatch count**: `ceil(maxParticles / 256)` groups per emitter per compute pass
+- **Sorting**: Bitonic sort is O(n log^2 n) but runs entirely on GPU with high parallelism
+- **Memory**: Each particle is 64 bytes (GPUParticleData). 1M particles = ~64 MB per emitter
+- **Indirect draw**: Zero CPU readback during normal rendering — the GPU writes draw args directly
+
+---
+
+## Integration
+
+- **GraphicsEngine**: Calls `Update()` and `Render()` as part of the main render pipeline
+- **CPU ParticleSystem**: The existing `ParticleSystem` class handles CPU-side particles; GPU particles are a separate, higher-performance path for large counts
+- **Platform**: Requires D3D11 compute shader support. Non-Windows platforms get a no-op stub
+
+---
+
+## See Also
+
+- [Rendering and Graphics](Rendering-and-Graphics) — Overall graphics pipeline
+- [GPU-Driven Rendering](GPU-Driven-Rendering) — Related GPU compute pipeline for geometry culling
+- [Shader Pipeline](Shader-Pipeline) — Compute shader compilation

--- a/wiki/Global-Illumination.md
+++ b/wiki/Global-Illumination.md
@@ -1,0 +1,356 @@
+# Global Illumination
+
+SparkEngine provides two complementary probe-based global illumination systems: **DDGI** (Dynamic Diffuse Global Illumination) for regular-grid irradiance probes, and **Adaptive Probe Volumes** (APV) for hierarchical brick-based probes with geometry-aware subdivision. Both use L2 spherical harmonics for compact irradiance storage.
+
+**Source:** `SparkEngine/Source/Graphics/DDGIProbeSystem.h`, `SparkEngine/Source/Graphics/AdaptiveProbeVolumes.h`
+**Namespace:** `Spark::Graphics`
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [DDGI Probe System](#ddgi-probe-system)
+  - [Grid Configuration](#grid-configuration)
+  - [Probe Data (Spherical Harmonics)](#probe-data-spherical-harmonics)
+  - [Probe Update Pipeline](#probe-update-pipeline)
+  - [Probe Relocation](#probe-relocation)
+  - [Irradiance Queries](#irradiance-queries)
+  - [DDGI API](#ddgi-api)
+- [Adaptive Probe Volumes](#adaptive-probe-volumes)
+  - [Brick Hierarchy](#brick-hierarchy)
+  - [LOD Levels](#lod-levels)
+  - [Adaptive Subdivision](#adaptive-subdivision)
+  - [Virtual Offsets](#virtual-offsets)
+  - [Camera-Based Streaming](#camera-based-streaming)
+  - [APV API](#apv-api)
+- [DDGI vs APV](#ddgi-vs-apv)
+- [GPU Resources](#gpu-resources)
+- [Usage Examples](#usage-examples)
+- [Integration](#integration)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+Both systems compute indirect diffuse lighting by placing probe grids in the scene, capturing irradiance from ray-cast samples, and interpolating the results at shading time.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Scene Geometry                           │
+│                                                             │
+│   ● ─── ● ─── ● ─── ●       DDGI: Regular 3D grid         │
+│   |     |     |     |       of probes at fixed spacing      │
+│   ● ─── ● ─── ● ─── ●                                      │
+│   |     |     |     |                                       │
+│   ● ─── ● ─── ● ─── ●                                      │
+│                                                             │
+│   ┌────┐                     APV: Brick-based hierarchy     │
+│   │●●●●│ ┌──┐               Fine bricks near geometry,     │
+│   │●●●●│ │●●│               coarse bricks in open areas    │
+│   │●●●●│ │●●│                                              │
+│   │●●●●│ └──┘                                              │
+│   └────┘                                                    │
+│                                                             │
+│   Each probe stores L2 SH (9 coefficients x 3 RGB channels)│
+│   = 27 floats per probe                                     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Constants
+
+| Constant | DDGI | APV |
+|----------|------|-----|
+| SH coefficients per channel | 9 (L2) | 9 (L2) |
+| Floats per probe | 27 | 27 |
+| Probes per brick | N/A | 64 (4x4x4) |
+
+---
+
+## DDGI Probe System
+
+A regular 3D grid of irradiance probes with real-time updates via ray casting.
+
+### Grid Configuration
+
+```cpp
+struct DDGISettings
+{
+    float spacingX = 2.0f, spacingY = 2.0f, spacingZ = 2.0f;
+    uint32_t countX = 8, countY = 4, countZ = 8;
+    float originX = 0.0f, originY = 0.0f, originZ = 0.0f;
+    int raysPerProbe = 128;
+    float hysteresis = 0.97f;
+    float maxRayDistance = 50.0f;
+    float normalBias = 0.25f;
+    float relocationThreshold = 0.5f;
+    float relocationMaxOffset = 1.0f;
+};
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `spacing` | 2m | Distance between probes on each axis |
+| `count` | 8x4x8 = 256 | Number of probes per axis |
+| `raysPerProbe` | 128 | Rays cast per probe per update cycle |
+| `hysteresis` | 0.97 | Temporal blend factor (higher = smoother, slower) |
+| `maxRayDistance` | 50m | Ray trace distance limit |
+| `normalBias` | 0.25m | Bias along surface normal to prevent self-shadowing |
+
+### Probe Data (Spherical Harmonics)
+
+Each probe stores irradiance as L2 spherical harmonics — 9 basis functions per color channel:
+
+```cpp
+struct DDGIProbe
+{
+    std::array<float, 9> r{};  // 9 SH coefficients for red
+    std::array<float, 9> g{};  // 9 SH coefficients for green
+    std::array<float, 9> b{};  // 9 SH coefficients for blue
+    float offsetX, offsetY, offsetZ;  // Relocation offset
+    bool relocated;
+};
+```
+
+SH basis functions are evaluated using `EvaluateSHBasis()` with a normalized direction vector, producing 9 basis values that are dot-multiplied with the stored coefficients to reconstruct irradiance.
+
+### Probe Update Pipeline
+
+```cpp
+// For each probe in the grid:
+DDGIRayResult rays[128];
+// ... cast rays using cosine-weighted hemisphere sampling ...
+
+system.UpdateProbe(ix, iy, iz, rays, 128);
+system.UpdateProbeBorders();
+```
+
+`UpdateProbe()` performs:
+1. **SH projection**: Each ray's radiance is projected into SH basis functions using spherical Fibonacci sampling for quasi-uniform direction distribution
+2. **Hysteresis blending**: New SH coefficients are blended with existing values: `new = lerp(current, incoming, 1 - hysteresis)`
+3. **Border copy**: `UpdateProbeBorders()` copies edge texels for seamless hardware bilinear filtering in the GPU texture atlas
+
+### Probe Relocation
+
+Probes inside or very close to geometry produce biased irradiance. Relocation nudges them along the surface normal:
+
+```cpp
+system.RelocateProbe(ix, iy, iz,
+    closestHitDistance, hitNormalX, hitNormalY, hitNormalZ);
+```
+
+Relocation is limited to `relocationMaxOffset` (default 1m) to keep probes near their grid position.
+
+### Irradiance Queries
+
+```cpp
+DDGIIrradiance result = system.QueryIrradiance(
+    worldX, worldY, worldZ,
+    normalX, normalY, normalZ);
+```
+
+Performs trilinear interpolation of the 8 nearest probes. Each probe's SH is evaluated at the given surface normal before interpolation.
+
+### DDGI API
+
+| Method | Description |
+|--------|-------------|
+| `Initialize(settings)` | Create probe grid |
+| `Shutdown()` | Release probe data |
+| `GetProbePosition(ix, iy, iz)` | World position of a grid probe |
+| `UpdateProbe(ix, iy, iz, rays, count)` | Update one probe with ray results |
+| `UpdateProbeBorders()` | Copy border texels for filtering |
+| `RelocateProbe(ix, iy, iz, ...)` | Push probe away from geometry |
+| `QueryIrradiance(pos, normal)` | Trilinear SH interpolation |
+| `GetProbeCount()` | Total probes (countX * countY * countZ) |
+| `CreateGPUResources(device)` | Create structured buffer for SH data |
+| `UploadProbeDataToGPU(device)` | Upload SH to GPU |
+
+---
+
+## Adaptive Probe Volumes
+
+A brick-based hierarchical system that adapts probe density to scene geometry, inspired by Unity's Adaptive Probe Volumes.
+
+### Brick Hierarchy
+
+Probes are organized in **bricks** of 4x4x4 = 64 probes each. Bricks are sparse — only regions of interest are populated.
+
+```cpp
+struct APVBrick
+{
+    BrickID id;
+    std::array<APVProbeData, 64> probes;  // 4x4x4
+    float originX, originY, originZ;       // World-space corner
+    float spacing;                         // Probe spacing within brick
+    bool loaded;
+    bool subdivided;
+};
+```
+
+### LOD Levels
+
+| LOD | Spacing | Use Case |
+|-----|---------|----------|
+| `Fine` (0) | 1m | Near geometry surfaces |
+| `Medium` (1) | 2m | Transitional areas |
+| `Coarse` (2) | 4m | Open areas, far from camera |
+
+### Adaptive Subdivision
+
+Coarse bricks near geometry can be subdivided into 8 finer bricks:
+
+```cpp
+system.SubdivideBrick(gridX, gridY, gridZ, BrickLOD::Coarse);
+// Creates 8 Medium bricks; their probes are interpolated from the parent
+```
+
+The parent brick is marked as `subdivided` and its data is preserved for fallback. Child bricks inherit initial SH values via interpolation.
+
+### Virtual Offsets
+
+Like DDGI relocation, but per-probe within each brick:
+
+```cpp
+system.ApplyVirtualOffsets(brickId, geometryDistances, geometryNormals);
+```
+
+Probes too close to (or inside) geometry are pushed away along the surface normal by up to `virtualOffsetDistance` (default 0.25m).
+
+### Camera-Based Streaming
+
+```cpp
+system.UpdateStreaming(cameraPosX, cameraPosY, cameraPosZ);
+```
+
+Loads bricks within `streamingDistance` of the camera and unloads distant ones, keeping memory usage bounded.
+
+### APV API
+
+| Method | Description |
+|--------|-------------|
+| `Initialize(settings)` | Set up with `APVSettings` |
+| `Shutdown()` | Release all brick data |
+| `CreateBrick(x, y, z, lod)` | Create a brick at grid position |
+| `SubdivideBrick(x, y, z, parentLOD)` | Split into 8 finer bricks |
+| `ApplyVirtualOffsets(id, distances, normals)` | Push probes from surfaces |
+| `UpdateStreaming(camPos)` | Load/unload bricks by distance |
+| `SetProbeData(id, px, py, pz, shR, shG, shB)` | Store baked SH data |
+| `SampleIrradiance(pos, normal)` | Query irradiance at world position |
+| `GetLoadedBrickCount()` | Active bricks in memory |
+| `GetTotalProbeCount()` | brickCount * 64 |
+| `CreateGPUResources(device)` | Create structured buffer for bricks |
+| `UploadBrickDataToGPU(device)` | Upload active bricks to GPU |
+
+---
+
+## DDGI vs APV
+
+| Feature | DDGI | Adaptive Probe Volumes |
+|---------|------|----------------------|
+| Grid type | Regular 3D | Sparse brick hierarchy |
+| Probe density | Uniform everywhere | Adaptive (fine near geometry) |
+| Memory | Fixed (countX * countY * countZ) | Dynamic (loaded bricks only) |
+| Streaming | No | Yes (camera distance) |
+| Subdivision | No | Yes (3 LOD levels) |
+| Real-time update | Yes (per-probe ray cast) | Typically baked, can update |
+| Best for | Small-medium dynamic scenes | Large worlds with baked lighting |
+| Virtual offsets | Probe relocation | Per-probe virtual offsets |
+
+**Use DDGI** for fully dynamic lighting in contained areas (e.g., interiors, arenas).
+**Use APV** for large open worlds where baked GI with streaming is needed.
+
+---
+
+## GPU Resources
+
+Both systems create GPU structured buffers for shader access:
+
+```cpp
+// DDGI
+ddgi.CreateGPUResources(device);
+ddgi.UploadProbeDataToGPU(device);
+auto* probeBuffer = ddgi.GetProbeBuffer();  // SH data structured buffer
+
+// APV
+apv.CreateGPUResources(device);
+apv.UploadBrickDataToGPU(device);
+auto* brickBuffer = apv.GetBrickBuffer();   // Brick SH data
+```
+
+---
+
+## Usage Examples
+
+### DDGI Setup
+
+```cpp
+DDGIProbeSystem ddgi;
+
+DDGISettings settings;
+settings.countX = 12; settings.countY = 6; settings.countZ = 12;
+settings.spacingX = 3.0f; settings.spacingY = 2.0f; settings.spacingZ = 3.0f;
+settings.raysPerProbe = 64;
+ddgi.Initialize(settings);
+
+// Update loop: update a subset of probes each frame
+for (int i = 0; i < probesPerFrame; ++i)
+{
+    auto [ix, iy, iz] = GetNextProbeToUpdate();
+    DDGIRayResult rays[64];
+    CastProbeRays(ddgi, ix, iy, iz, rays, 64);
+    ddgi.UpdateProbe(ix, iy, iz, rays, 64);
+}
+ddgi.UpdateProbeBorders();
+
+// Query in shader setup
+DDGIIrradiance irr = ddgi.QueryIrradiance(
+    fragWorldPos.x, fragWorldPos.y, fragWorldPos.z,
+    fragNormal.x, fragNormal.y, fragNormal.z);
+```
+
+### APV Setup
+
+```cpp
+AdaptiveProbeVolumes apv;
+
+APVSettings settings;
+settings.streamingDistance = 80.0f;
+settings.subdivisionGeometryThreshold = 1.5f;
+apv.Initialize(settings);
+
+// Create coarse bricks covering the scene
+for (int z = -5; z <= 5; ++z)
+    for (int y = 0; y <= 2; ++y)
+        for (int x = -5; x <= 5; ++x)
+            apv.CreateBrick(x, y, z, BrickLOD::Coarse);
+
+// Subdivide near a building
+apv.SubdivideBrick(0, 0, 0, BrickLOD::Coarse);
+
+// Each frame
+apv.UpdateStreaming(cameraPos.x, cameraPos.y, cameraPos.z);
+
+// Query
+APVIrradiance irr = apv.SampleIrradiance(
+    worldX, worldY, worldZ, normalX, normalY, normalZ);
+```
+
+---
+
+## Integration
+
+- **LightingSystem**: GI results are combined with direct lighting in the deferred lighting pass
+- **Render Graph**: DDGI probe updates can be scheduled as compute passes
+- **Large World Support**: APV streaming pairs well with [Large World Support](Large-World-Support) for seamless area transitions
+- **Day-Night Cycle**: DDGI probes update dynamically with changing light conditions
+
+---
+
+## See Also
+
+- [Rendering and Graphics](Rendering-and-Graphics) — Overall lighting architecture
+- [Volumetric Fog](Volumetric-Fog) — Volumetric scattering that complements GI
+- [Clustered Lighting](Clustered-Lighting) — Direct light culling system
+- [Large World Support](Large-World-Support) — World streaming for APV integration

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -129,6 +129,6 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Editor Panels | 54 |
 | Test files | 238 |
 | Test cases | 3109+ |
-| Wiki pages | 70 |
-| *Last synced* | *2026-04-02 08:21* |
+| Wiki pages | 83 |
+| *Last synced* | *2026-04-02 09:24* |
 <!-- /AUTO:stats -->

--- a/wiki/Hot-Reload-Overview.md
+++ b/wiki/Hot-Reload-Overview.md
@@ -1,0 +1,226 @@
+# Hot Reload Overview
+
+SparkEngine supports hot-reloading across multiple subsystems: shaders, scripts, game modules, materials, and assets. This page provides a unified overview of all hot-reload capabilities, how they work, and how to use them during development.
+
+**Relevant sources:**
+- `SparkEngine/Source/Graphics/Shader.h` (shader hot-reload)
+- `SparkEngine/Source/Engine/Scripting/ScriptHotReload.h` (script hot-reload)
+- `SparkEngine/Source/Core/ModuleHotReload.h` (module hot-reload)
+- `SparkEngine/Source/Graphics/MaterialSystem.h` (material hot-reload)
+- `SparkEngine/Source/Graphics/AssetPipeline.h` (asset hot-reload)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Shader Hot Reload](#shader-hot-reload)
+- [Script Hot Reload](#script-hot-reload)
+- [Module Hot Reload](#module-hot-reload)
+- [Material Hot Reload](#material-hot-reload)
+- [Asset Hot Reload](#asset-hot-reload)
+- [Comparison](#comparison)
+- [Console Commands](#console-commands)
+- [Best Practices](#best-practices)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+Hot-reloading allows developers to modify assets, code, and data while the engine is running, seeing changes immediately without restarting. Each subsystem uses a similar pattern: monitor files for changes, detect modifications, reload the resource, and swap it into the running engine.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                     Hot Reload Systems                        │
+│                                                              │
+│  ┌─────────────┐  ┌──────────────┐  ┌───────────────────┐   │
+│  │ Shader       │  │ Script        │  │ Module            │   │
+│  │ Hot Reload   │  │ Hot Reload    │  │ Hot Reload        │   │
+│  │              │  │               │  │                   │   │
+│  │ FILETIME     │  │ File watcher  │  │ DLL timestamp     │   │
+│  │ polling      │  │ + debounce    │  │ polling           │   │
+│  │              │  │               │  │                   │   │
+│  │ Recompile    │  │ Recompile     │  │ Unload → Reload   │   │
+│  │ HLSL → swap  │  │ AS → swap     │  │ DLL → reinit      │   │
+│  └─────────────┘  └──────────────┘  └───────────────────┘   │
+│                                                              │
+│  ┌─────────────┐  ┌──────────────┐                           │
+│  │ Material     │  │ Asset         │                          │
+│  │ Hot Reload   │  │ Hot Reload    │                          │
+│  │              │  │               │                          │
+│  │ Material     │  │ File change   │                          │
+│  │ file watch   │  │ detection     │                          │
+│  │ → reparse    │  │ → reimport    │                          │
+│  └─────────────┘  └──────────────┘                           │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Shader Hot Reload
+
+Monitors shader source files (HLSL) for changes and recompiles them at runtime.
+
+**How it works:**
+1. `Shader` tracks each shader file's `FILETIME` (last write time)
+2. Each frame (or on demand), `HotReloadShaders()` checks if any file has been modified
+3. Modified shaders are recompiled via D3DCompile
+4. On success, the old compiled shader is replaced with the new one
+5. On failure, the old shader remains active and an error is logged
+
+**Usage:**
+```cpp
+// Automatic: happens each frame if enabled
+graphicsEngine.SetShaderHotReloadEnabled(true);
+
+// Manual trigger:
+graphicsEngine.HotReloadShaders();
+```
+
+**State preservation:** Shader hot-reload is seamless — constant buffers, render targets, and pipeline state are unaffected. Only the compiled shader bytecode is swapped.
+
+---
+
+## Script Hot Reload
+
+Monitors AngelScript files for changes and recompiles modified scripts.
+
+**How it works:**
+1. `ScriptHotReloadManager` watches directories for file changes (Modified, Created, Deleted, Renamed)
+2. A **debounce timer** (configurable, default ~200ms) prevents recompilation during rapid saves
+3. When the debounce timer expires, the recompile callback fires
+4. The script engine recompiles the modified file
+5. A `RecompileResult` reports success/failure and error details
+
+**Usage:**
+```cpp
+ScriptHotReloadManager hotReload;
+hotReload.AddWatchDirectory("Scripts/");
+hotReload.SetRecompileCallback([&](const std::string& file)
+{
+    scriptEngine.CompileFile(file);
+});
+hotReload.Start();
+
+// In main loop:
+hotReload.PollChanges();
+```
+
+**State preservation:** Script global variables and object state may be lost on reload. Design scripts to re-initialize from component data rather than relying on persistent script-side state.
+
+**File change types:**
+
+| Type | Action |
+|------|--------|
+| `Modified` | Recompile the changed file |
+| `Created` | Compile and register the new script |
+| `Deleted` | Unregister the script (existing instances keep running) |
+| `Renamed` | Treated as delete + create |
+
+---
+
+## Module Hot Reload
+
+Monitors game module DLLs for changes and reloads them via the `ModuleManager`.
+
+**How it works:**
+1. `ModuleHotReloadManager` polls module DLL/SO file timestamps
+2. When a change is detected, the module is unloaded (`IModule::Shutdown`)
+3. The new DLL is loaded and the module is re-initialized (`IModule::Initialize`)
+4. A callback reports success or failure per module
+
+**Usage:**
+```cpp
+ModuleHotReloadManager moduleReload;
+moduleReload.SetCallback([](const std::string& name, bool success)
+{
+    if (success)
+        LOG_INFO("Module '{}' reloaded", name);
+    else
+        LOG_ERROR("Module '{}' reload failed", name);
+});
+
+// In main loop:
+moduleReload.PollChanges();
+```
+
+**State preservation:** Module state is lost on reload. The module must re-register its systems, components, and commands during `Initialize()`. Game state stored in ECS components persists across module reloads.
+
+---
+
+## Material Hot Reload
+
+The `MaterialSystem` monitors material definition files for changes.
+
+**How it works:**
+1. Material files are tracked by timestamp
+2. On change, the material definition is re-parsed
+3. Shader permutations are recompiled if the material's shader references changed
+4. Texture bindings are updated
+5. Objects using the material see the new appearance immediately
+
+**Trigger:** Automatic when shader hot-reload detects material-related changes, or via console command.
+
+---
+
+## Asset Hot Reload
+
+The `AssetPipeline` detects changes to source asset files and re-imports them.
+
+**How it works:**
+1. Source assets (textures, models, audio) are monitored via the `LocalFileCache`
+2. When a source file changes, the asset transitions to a "needs reimport" state
+3. The reimport pipeline processes the asset (compression, format conversion, etc.)
+4. The runtime resource is updated with the new data
+
+**Best for:** Texture iteration, model tweaks, audio adjustments during development.
+
+---
+
+## Comparison
+
+| System | Detection | Debounce | State Preserved | Latency |
+|--------|-----------|----------|-----------------|---------|
+| Shader | FILETIME polling | No | Full (seamless) | ~1 frame |
+| Script | File watcher | Yes (~200ms) | Partial (globals lost) | ~200ms + compile |
+| Module | DLL timestamp | No | None (re-initialize) | ~1s (DLL load) |
+| Material | File timestamp | No | Full (seamless) | ~1 frame + compile |
+| Asset | File cache | No | Full (resource swap) | Varies (reimport) |
+
+---
+
+## Console Commands
+
+| Command | Description |
+|---------|-------------|
+| `shader_reload` | Force reload all modified shaders |
+| `shader_reload_all` | Recompile all shaders regardless of timestamp |
+| `material_reload <name>` | Reload a specific material |
+| `asset_reimport <path>` | Force reimport a specific asset |
+
+---
+
+## Best Practices
+
+### Designing Reload-Safe Code
+
+1. **Store state in ECS components, not in reloadable code.** Script variables and module-side state will be lost. ECS components survive script and module reloads.
+
+2. **Use `Initialize()`/`Shutdown()` for module lifecycle.** Modules must cleanly unregister everything in `Shutdown()` and re-register in `Initialize()`. Leaked registrations cause crashes on reload.
+
+3. **Keep shader interfaces stable.** Changing constant buffer layouts requires all dependent code to update simultaneously. Add fields at the end of constant buffers when possible.
+
+4. **Test with hot-reload during development.** Enable shader and script hot-reload by default in debug builds. Discovering reload issues early is cheaper than fixing them later.
+
+5. **Don't rely on script constructor order.** After script hot-reload, objects may initialize in a different order. Use explicit initialization functions instead.
+
+---
+
+## See Also
+
+- [Shader Pipeline](Shader-Pipeline) — Shader compilation and hot-reload details
+- [Scripting with AngelScript](Scripting-with-AngelScript) — Script engine and hot-reload
+- [Creating a Game Module](Creating-a-Game-Module) — Module lifecycle and DLL boundaries
+- [Asset Pipeline](Asset-Pipeline) — Asset import and caching
+- [SparkEditor](SparkEditor) — Editor integration with hot-reload

--- a/wiki/Mesh-Shaders.md
+++ b/wiki/Mesh-Shaders.md
@@ -1,0 +1,268 @@
+# Mesh Shaders
+
+SparkEngine provides a mesh shader rendering pipeline for meshlet-based geometry using D3D12 Shader Model 6.5. Amplification shaders handle LOD selection and coarse culling, while mesh shaders perform per-meshlet processing with fine-grained backface and frustum culling. The system falls back to the traditional vertex pipeline on D3D11 or unsupported hardware.
+
+**Source:** `SparkEngine/Source/Graphics/MeshShaderPipeline.h`
+**Namespace:** `Spark::Graphics`
+**Tests:** `Tests/TestMeshShaderPipeline.cpp` (9 test cases)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Meshlet Data Structures](#meshlet-data-structures)
+  - [GPUMeshlet](#gpumeshlet)
+  - [GPUMeshletGroup](#gpumeshletgroup)
+  - [MeshletMesh](#meshletmesh)
+- [Pipeline Stages](#pipeline-stages)
+- [Building Meshlets](#building-meshlets)
+- [Rendering](#rendering)
+- [Performance Statistics](#performance-statistics)
+- [API Reference](#api-reference)
+- [Usage Example](#usage-example)
+- [Integration](#integration)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+Traditional vertex shaders process one vertex at a time with no awareness of the surrounding geometry. Mesh shaders process entire meshlets (small clusters of triangles) at once, enabling GPU-driven culling at the meshlet level without CPU intervention.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                Traditional Pipeline                      │
+│  CPU: for each object → draw call                       │
+│  GPU: VS → Rasterizer → PS                             │
+│                                                         │
+│                Mesh Shader Pipeline                      │
+│  CPU: DispatchMesh(groupCount)                          │
+│  GPU: AS → MS → Rasterizer → PS                        │
+│                                                         │
+│  ┌──────────────────┐   ┌──────────────────┐            │
+│  │ Amplification     │   │ Mesh Shader       │           │
+│  │ Shader (AS)       │──│ (MS)              │           │
+│  │                   │   │                   │           │
+│  │ • LOD selection   │   │ • Load meshlet    │           │
+│  │ • Coarse frustum  │   │ • Backface cull   │           │
+│  │   cull per group  │   │ • Frustum cull    │           │
+│  │ • Dispatch visible│   │ • Emit triangles  │           │
+│  │   meshlets        │   │                   │           │
+│  └──────────────────┘   └──────────────────┘            │
+│         ↑                        ↑                       │
+│    MeshletAS.hlsl          MeshletMS.hlsl                │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Meshlet Data Structures
+
+### GPUMeshlet
+
+A single meshlet — a small cluster of vertices and triangles:
+
+```cpp
+struct GPUMeshlet
+{
+    uint32_t vertexOffset;      // Start index in unique vertex array
+    uint32_t triangleOffset;    // Start index in primitive index array
+    uint32_t vertexCount;       // Vertices in this meshlet (max 64)
+    uint32_t triangleCount;     // Triangles in this meshlet (max 124)
+
+    float boundCenter[3];       // Bounding sphere center
+    float boundRadius;          // Bounding sphere radius
+
+    float coneAxis[3];          // Normal cone axis
+    float coneCutoff;           // cos(half_angle + 90°), negative = valid
+};
+```
+
+The **normal cone** enables GPU-side backface culling: if the entire meshlet faces away from the camera, it can be skipped without testing individual triangles. `coneCutoff` encodes the cone's half-angle; negative values indicate a valid cone.
+
+### GPUMeshletGroup
+
+Groups of meshlets for LOD selection by the amplification shader:
+
+```cpp
+struct GPUMeshletGroup
+{
+    uint32_t meshletOffset;     // First meshlet index in this group
+    uint32_t meshletCount;      // Meshlets in this group
+    float lodError;             // Screen-space error for this LOD
+    float parentLodError;       // Parent group's error (for smooth transitions)
+
+    float boundCenter[3];       // Group bounding sphere center
+    float boundRadius;          // Group bounding sphere radius
+};
+```
+
+### MeshletMesh
+
+A complete mesh converted to meshlet format:
+
+```cpp
+struct MeshletMesh
+{
+    std::string name;
+    std::vector<GPUMeshlet> meshlets;
+    std::vector<GPUMeshletGroup> groups;
+    std::vector<uint32_t> uniqueVertexIndices;  // Meshlet-local → mesh-global
+    std::vector<uint32_t> primitiveIndices;     // Packed triangle indices
+    uint32_t totalVertices;
+    uint32_t totalTriangles;
+};
+```
+
+---
+
+## Pipeline Stages
+
+### 1. Amplification Shader (AS)
+
+One thread group per meshlet group. Each group:
+- Evaluates LOD by comparing `lodError` against the group's screen-space size
+- Performs coarse frustum culling using the group's bounding sphere
+- Dispatches visible meshlets to the mesh shader stage
+
+### 2. Mesh Shader (MS)
+
+One thread group per meshlet. Each meshlet:
+- Loads its vertices from the unique vertex index array
+- Performs **backface culling** using the normal cone (if `coneCutoff < 0`)
+- Performs **fine frustum culling** using the bounding sphere
+- Emits visible triangles to the rasterizer
+
+### 3. Fallback Path
+
+On D3D11 or when mesh shaders are unavailable, the system falls back to traditional `DrawIndexed` calls using the original vertex/index buffers.
+
+---
+
+## Building Meshlets
+
+Convert a traditional mesh to meshlet format:
+
+```cpp
+auto& pipeline = MeshShaderPipeline::GetInstance();
+
+MeshletMesh meshletMesh = pipeline.BuildMeshlets(
+    vertexPositions,       // float3 per vertex
+    vertexCount,
+    indexBuffer,
+    indexCount,
+    64,                    // max vertices per meshlet (default)
+    124                    // max triangles per meshlet (default)
+);
+```
+
+The build process:
+1. Groups triangles into meshlets of at most 64 vertices and 124 triangles
+2. Computes bounding spheres for frustum culling
+3. Computes normal cones for backface culling
+4. Builds unique vertex index and packed primitive index arrays
+5. Groups meshlets for LOD selection
+
+---
+
+## Rendering
+
+```cpp
+pipeline.RenderMeshletMesh(
+    meshletMesh,
+    worldViewProjection,   // float[16]
+    worldMatrix,           // float[16]
+    cameraPosition         // float[3]
+);
+```
+
+Internally dispatches `DispatchMesh()` with one group per meshlet group.
+
+---
+
+## Performance Statistics
+
+```cpp
+struct MeshShaderStats
+{
+    uint32_t totalMeshlets;
+    uint32_t visibleMeshlets;
+    uint32_t culledByBackface;
+    uint32_t culledByFrustum;
+    uint32_t totalTriangles;
+    uint32_t dispatchCount;
+    bool meshShadersAvailable;
+};
+
+const auto& stats = pipeline.GetStats();
+```
+
+---
+
+## API Reference
+
+| Method | Description |
+|--------|-------------|
+| `GetInstance()` | Singleton access |
+| `CheckMeshShaderSupport()` | Static check for hardware support |
+| `Initialize(device)` | Init pipeline (returns false if fallback) |
+| `Shutdown()` | Release resources |
+| `BuildMeshlets(verts, vCount, indices, iCount, ...)` | Convert mesh to meshlet format |
+| `RenderMeshletMesh(mesh, wvp, world, camPos)` | Render via mesh shaders |
+| `IsUsingMeshShaders()` | True if mesh shaders active (not fallback) |
+| `GetStats()` | Performance statistics |
+| `Console_GetStatus()` | Formatted debug string |
+
+---
+
+## Usage Example
+
+```cpp
+using namespace Spark::Graphics;
+
+auto& pipeline = MeshShaderPipeline::GetInstance();
+
+if (pipeline.Initialize(d3d12Device))
+{
+    LOG_INFO("Mesh shaders enabled");
+}
+else
+{
+    LOG_INFO("Falling back to vertex pipeline");
+}
+
+// Convert static meshes at load time
+MeshletMesh buildingMesh = pipeline.BuildMeshlets(
+    building.positions.data(), building.vertexCount,
+    building.indices.data(), building.indexCount);
+
+LOG_INFO("Building: {} meshlets, {} triangles",
+         buildingMesh.meshlets.size(), buildingMesh.totalTriangles);
+
+// Each frame:
+pipeline.RenderMeshletMesh(buildingMesh, wvp, world, camPos);
+
+const auto& stats = pipeline.GetStats();
+LOG_INFO("Visible: {}/{} meshlets (backface: {}, frustum: {})",
+         stats.visibleMeshlets, stats.totalMeshlets,
+         stats.culledByBackface, stats.culledByFrustum);
+```
+
+---
+
+## Integration
+
+- **MeshClusterSystem**: Provides meshlet-level data for GPU-driven rendering. See [GPU-Driven Rendering](GPU-Driven-Rendering)
+- **D3D12 Backend**: Mesh shaders require D3D12 SM6.5 support. See [D3D12 Backend](D3D12-Backend)
+- **Asset Pipeline**: Meshlet conversion can be done at asset import time. See [Asset Pipeline](Asset-Pipeline)
+- **LOD System**: Meshlet groups integrate with the existing mesh LOD system. See [Rendering and Graphics](Rendering-and-Graphics)
+
+---
+
+## See Also
+
+- [GPU-Driven Rendering](GPU-Driven-Rendering) — Compute-based culling for traditional geometry
+- [D3D12 Backend](D3D12-Backend) — D3D12 feature tiers and mesh shader capability
+- [Rendering and Graphics](Rendering-and-Graphics) — Overall rendering architecture
+- [RHI Abstraction Layer](RHI-Abstraction-Layer) — Cross-backend abstraction

--- a/wiki/Render-Graph.md
+++ b/wiki/Render-Graph.md
@@ -1,0 +1,329 @@
+# Render Graph
+
+SparkEngine uses a declarative render graph (frame graph) system to define the rendering pipeline each frame. Passes declare their resource dependencies, and the graph compiler performs topological sorting, dead-code elimination, lifetime analysis, and resource aliasing automatically.
+
+**Source:** `SparkEngine/Source/Graphics/RenderGraph.h` (umbrella), `SparkEngine/Source/Graphics/RenderGraph/`
+**Namespace:** `Spark::Graphics`
+**Tests:** `Tests/TestRenderGraph.cpp` (25 test cases)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Core Concepts](#core-concepts)
+  - [Passes](#passes)
+  - [Resources](#resources)
+  - [Blackboard](#blackboard)
+- [RenderGraph API](#rendergraph-api)
+  - [AddPass](#addpass)
+  - [Compile](#compile)
+  - [Execute](#execute)
+- [StandardPipelineBuilder](#standardpipelinebuilder)
+  - [Pass Dependency Chain](#pass-dependency-chain)
+  - [Pipeline Configuration](#pipeline-configuration)
+  - [Frame Data](#frame-data)
+  - [Callbacks](#callbacks)
+  - [Usage](#usage)
+- [Transient Resource Pool](#transient-resource-pool)
+- [GraphViz Export](#graphviz-export)
+- [Integration](#integration)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+The render graph replaces a hardcoded render loop with a data-driven pipeline. Instead of manually managing render targets, barriers, and pass ordering, each pass declares what it reads and writes. The graph compiler resolves the optimal execution order and resource lifetimes.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    StandardPipelineBuilder                       │
+│  (Builds the standard deferred pipeline from configuration)     │
+├─────────────────────────────────────────────────────────────────┤
+│                         RenderGraph                             │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐       │
+│  │ Shadow   │──│ GBuffer  │──│ Lighting │──│ PostProc │──...   │
+│  │ Pass     │  │ Pass     │  │ Pass     │  │ Pass     │        │
+│  └──────────┘  └──────────┘  └──────────┘  └──────────┘        │
+│        |              |             |              |             │
+│        v              v             v              v             │
+│  [shadowAtlas]  [albedo,norm]  [hdrColor]    [ldrColor]        │
+│                 [material,mv]                [bloom,ssao]       │
+│                 [depth]                                         │
+├─────────────────────────────────────────────────────────────────┤
+│                    TransientResourcePool                        │
+│          (age-based GPU resource recycling)                     │
+├─────────────────────────────────────────────────────────────────┤
+│                    RenderGraphBlackboard                        │
+│         (type-erased inter-pass data sharing)                   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Files
+
+| File | Responsibility |
+|------|---------------|
+| `RenderGraph.h` | Umbrella header + `RenderGraph` class (AddPass/Compile/Execute) |
+| `RenderGraphTypes.h` | Resource handles, descriptors, enums, registry, stats |
+| `RenderGraphPass.h` | Pass and builder classes for declaring dependencies |
+| `RenderGraphBlackboard.h` | Type-erased data sharing between passes |
+| `RenderGraph/RenderGraphBuilder.h` | `StandardPipelineBuilder` and pass data structs |
+| `RenderGraph/TransientResourcePool.h` | Age-based GPU resource pooling |
+| `RenderGraph/RenderGraphExporter.h` | GraphViz `.dot` file export for debugging |
+
+---
+
+## Core Concepts
+
+### Passes
+
+A render pass is a unit of GPU work (graphics, compute, copy, or async compute). Each pass declares:
+- **Reads**: Resources consumed (e.g., shadow atlas for lighting)
+- **Writes**: Resources produced (e.g., GBuffer textures)
+- **Creates**: New transient resources allocated for this pass
+- **Side effects**: Passes that write to the backbuffer or perform I/O
+
+Passes with no consumers for their outputs are eliminated during compilation (dead-code elimination).
+
+### Resources
+
+Resources are identified by `RenderGraphResource` handles — lightweight IDs that reference textures or buffers within the graph. Resources can be:
+- **Transient**: Allocated and released within a single frame by the `TransientResourcePool`
+- **Imported**: External resources (e.g., the backbuffer) brought into the graph
+
+Resource descriptors (`RenderGraphTextureDesc`) specify dimensions, format, and usage flags.
+
+### Blackboard
+
+The `RenderGraphBlackboard` provides type-erased data sharing between passes. Each pass can write structured data (e.g., `GBufferPassData`) to the blackboard, and downstream passes read it to access resource handles.
+
+---
+
+## RenderGraph API
+
+### AddPass
+
+```cpp
+RenderGraphPass& AddPass(
+    const std::string& name,
+    RenderGraphPassType type,
+    std::function<void(RenderGraphBuilder&)> setup,
+    std::function<void(const RenderGraphResourceRegistry&)> execute);
+```
+
+The `setup` lambda receives a `RenderGraphBuilder` to declare resource dependencies. The `execute` lambda is called at execution time with a registry to resolve handles to GPU objects.
+
+```cpp
+RenderGraph graph("MainFrame", d3dDevice);
+
+graph.AddPass("ToneMapping", RenderGraphPassType::Compute,
+    [&](RenderGraphBuilder& builder)
+    {
+        hdrInput = builder.Read(hdrInput);
+        ldrOutput = builder.Write(ldrOutput);
+    },
+    [=](const RenderGraphResourceRegistry& registry)
+    {
+        auto* hdr = registry.GetTexture(hdrInput);
+        auto* ldr = registry.GetTexture(ldrOutput);
+        // dispatch tone mapping compute shader ...
+    });
+```
+
+### Compile
+
+```cpp
+graph.Compile();
+```
+
+Compilation performs:
+1. **Topological sort** — Orders passes by dependency
+2. **Dead-code elimination** — Removes passes with no consumers
+3. **Lifetime analysis** — Determines when each resource is first used and last used
+4. **Resource aliasing** — Reuses memory for non-overlapping resources
+5. **Barrier placement** — Inserts resource transitions between passes
+
+### Execute
+
+```cpp
+graph.Execute();
+```
+
+Allocates transient resources via the pool, runs passes in compiled order, and releases transient resources. The graph is single-use — call `Clear()` or destroy it after execution.
+
+---
+
+## StandardPipelineBuilder
+
+The `StandardPipelineBuilder` constructs SparkEngine's canonical deferred rendering pipeline as a `RenderGraph`. It is the primary way most rendering code interacts with the graph system.
+
+### Pass Dependency Chain
+
+```
+ShadowPass
+    |
+    v
+GBufferPass ─────┐
+    |             |
+    v             v
+LightingPass (reads GBuffer + Shadow)
+    |
+    v
+PostProcessPass (reads HDR color, motion, depth)
+    |
+    v
+UIPass (reads LDR color, writes composited output) [side-effect]
+    |
+    v
+DebugPass (optional, reads depth) [side-effect]
+```
+
+### Pipeline Configuration
+
+`PipelineConfig` controls which passes are enabled and their parameters:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `renderWidth` / `renderHeight` | 1920 x 1080 | Output resolution |
+| `renderScale` | 1.0 | Internal resolution multiplier |
+| `shadowsEnabled` | true | Enable shadow pass |
+| `shadowMapSize` | 2048 | Shadow atlas resolution |
+| `shadowCascades` | 3 | Cascade shadow map count |
+| `deferredEnabled` | true | Enable deferred GBuffer pass |
+| `gBufferCount` | 4 | GBuffer targets (Albedo, Normal, Material, Motion) |
+| `hdrEnabled` | true | HDR lighting |
+| `hdrFormat` | RGBA16_FLOAT | HDR render target format |
+| `bloomEnabled` | true | Post-process bloom |
+| `ssaoEnabled` | false | Screen-space ambient occlusion |
+| `taaEnabled` | false | Temporal anti-aliasing |
+| `motionBlurEnabled` | false | Motion blur |
+| `uiEnabled` | true | UI compositing pass |
+| `debugPassEnabled` | false | Debug visualization pass |
+
+### Frame Data
+
+`PipelineFrameData` provides per-frame camera and timing data:
+
+```cpp
+struct PipelineFrameData
+{
+    XMMATRIX viewMatrix;
+    XMMATRIX projMatrix;
+    XMFLOAT3 cameraPosition;
+    float nearPlane;
+    float farPlane;
+    float deltaTime;
+};
+```
+
+### Callbacks
+
+`PipelineCallbacks` holds user-supplied lambdas that perform actual GPU work in each pass:
+
+```cpp
+struct PipelineCallbacks
+{
+    using ExecuteFn = std::function<void(
+        const RenderGraphResourceRegistry&,
+        const PipelineFrameData&)>;
+
+    ExecuteFn shadowExecute;
+    ExecuteFn gBufferExecute;
+    ExecuteFn lightingExecute;
+    ExecuteFn postProcessExecute;
+    ExecuteFn uiExecute;
+    ExecuteFn debugExecute;
+};
+```
+
+### Usage
+
+```cpp
+StandardPipelineBuilder pipelineBuilder;
+pipelineBuilder.Configure(config);
+pipelineBuilder.SetFrameData(frameData);
+pipelineBuilder.SetCallbacks(callbacks);
+
+// Each frame:
+RenderGraph graph("MainFrame", d3dDevice);
+pipelineBuilder.Build(graph);
+graph.Compile();
+graph.Execute();
+```
+
+### Blackboard Data
+
+Each pass writes structured output to the blackboard for downstream passes:
+
+| Struct | Pass | Contents |
+|--------|------|----------|
+| `ShadowPassData` | Shadow | `shadowAtlas`, `cascadeCount` |
+| `GBufferPassData` | GBuffer | `albedo`, `normals`, `material`, `motion`, `depth` |
+| `LightingPassData` | Lighting | `hdrColor` |
+| `PostProcessPassData` | PostProcess | `ldrColor`, `bloom`, `ssao` |
+| `UIPassData` | UI | `composited` |
+
+---
+
+## Transient Resource Pool
+
+The `TransientResourcePool` manages GPU resources that are allocated and released each frame by render graph passes. Resources are recycled based on descriptor matching and garbage-collected when idle.
+
+```cpp
+auto& pool = TransientResourcePool::GetInstance();
+pool.Initialize(4);  // destroy resources idle for 4+ frames
+
+pool.BeginFrame(frameIndex);
+uint64_t handle = pool.AcquireResource(desc);
+// ... use resource ...
+pool.ReleaseResource(handle);
+pool.GarbageCollect();
+```
+
+| Method | Description |
+|--------|-------------|
+| `Initialize(maxIdleFrames)` | Set up pool with idle frame threshold |
+| `BeginFrame(frameIndex)` | Mark start of new frame for age tracking |
+| `AcquireResource(desc)` | Get a matching pooled resource or create new |
+| `ReleaseResource(handle)` | Return resource to pool (not destroyed) |
+| `GarbageCollect()` | Destroy resources idle beyond threshold |
+| `GetPooledResourceCount()` | Total resources in pool |
+| `GetActiveResourceCount()` | Resources currently in use |
+| `GetEstimatedMemoryUsage()` | Approximate VRAM usage in bytes |
+
+Resources are matched by width, height, format, and usage flags. Debug names are ignored during matching.
+
+---
+
+## GraphViz Export
+
+The `RenderGraphExporter` dumps the pass dependency graph as a `.dot` file for visualization:
+
+```cpp
+std::vector<RenderPassInfo> passes = { /* ... */ };
+RenderGraphExporter::ExportGraphViz(passes, "debug/render_graph.dot");
+
+// Or get the DOT string directly:
+std::string dot = RenderGraphExporter::GenerateDotString(passes);
+```
+
+Render the output with `dot -Tpng render_graph.dot -o render_graph.png`.
+
+---
+
+## Integration
+
+- **GraphicsEngine**: Owns the `StandardPipelineBuilder` and calls `Build()`/`Compile()`/`Execute()` each frame
+- **RHI backends**: The graph uses RHI abstractions for resource creation and barrier management
+- **Quality settings**: `PipelineConfig` can be changed between frames when the player adjusts quality
+- **Console**: `GetPipelineSummary()` and `TransientResourcePool::Console_GetStatus()` provide debug output
+
+---
+
+## See Also
+
+- [Rendering and Graphics](Rendering-and-Graphics) — Overall graphics architecture
+- [RHI Abstraction Layer](RHI-Abstraction-Layer) — Hardware abstraction used by the graph
+- [Shader Pipeline](Shader-Pipeline) — Shader compilation and management
+- [Profiler and Debugging](Profiler-and-Debugging) — GPU timing and profiling

--- a/wiki/Shader-Graph.md
+++ b/wiki/Shader-Graph.md
@@ -1,0 +1,266 @@
+# Shader Graph
+
+SparkEngine includes a node-based shader graph compiler that translates visual material graphs into HLSL shader code. Artists and technical designers build materials by connecting nodes in the editor, and the compiler generates optimized vertex and pixel shaders.
+
+**Source:** `SparkEngine/Source/Graphics/ShaderGraph/ShaderGraphCompiler.h`
+**Namespace:** `Spark::Graphics`
+**Tests:** `Tests/TestShaderGraphCompiler.cpp` (5 test cases)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Node Types](#node-types)
+  - [Input Nodes](#input-nodes)
+  - [Math Nodes](#math-nodes)
+  - [Utility Nodes](#utility-nodes)
+  - [Output Nodes](#output-nodes)
+- [Graph Structure](#graph-structure)
+  - [ShaderNode](#shadernode)
+  - [ShaderConnection](#shaderconnection)
+  - [ShaderGraphInput](#shadergraphinput)
+  - [ShaderGraphOutput](#shadergraphoutput)
+- [Compilation Algorithm](#compilation-algorithm)
+- [Usage Example](#usage-example)
+- [Integration](#integration)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+The shader graph system bridges the gap between visual material editing and GPU shader code. The editor (see [SparkEditor](SparkEditor)) provides a node canvas where users connect input, math, and utility nodes to output nodes. The `ShaderGraphCompiler` traverses this graph and emits valid HLSL.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   SparkEditor                           │
+│  ┌────────────┐   ┌─────────┐   ┌───────────────────┐  │
+│  │TextureSample│──│ Multiply │──│ SurfaceOutput     │  │
+│  └────────────┘   └─────────┘   │  .albedo          │  │
+│  ┌────────────┐   ┌─────────┐   │  .normal          │  │
+│  │ WorldNormal│──│ Normalize│──│  .roughness        │  │
+│  └────────────┘   └─────────┘   │  .metalness        │  │
+│                                  └───────────────────┘  │
+├─────────────────────────────────────────────────────────┤
+│              ShaderGraphCompiler::Compile()              │
+│  1. Find output node                                    │
+│  2. Topological sort (backward from output)             │
+│  3. Emit HLSL variable declarations                     │
+│  4. Wire outputs to PBR struct                          │
+├─────────────────────────────────────────────────────────┤
+│              Generated HLSL                              │
+│  vertex shader + pixel shader                           │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Node Types
+
+The `ShaderNodeType` enum defines 35+ node types across four categories.
+
+### Input Nodes
+
+Provide data from the rendering context.
+
+| Node | ID | Output | Description |
+|------|----|--------|-------------|
+| `TextureSample` | 0 | `float4` | Sample a texture at UV coordinates |
+| `ConstantFloat` | 1 | `float` | Scalar constant value |
+| `ConstantVec2` | 2 | `float2` | 2D vector constant |
+| `ConstantVec3` | 3 | `float3` | 3D vector constant |
+| `ConstantVec4` | 4 | `float4` | 4D vector constant |
+| `ConstantColor` | 5 | `float4` | Color picker constant (RGBA) |
+| `Time` | 6 | `float` | Elapsed time for animation |
+| `UVCoords` | 7 | `float2` | Mesh UV coordinates |
+| `WorldPosition` | 8 | `float3` | Fragment world position |
+| `WorldNormal` | 9 | `float3` | Interpolated world normal |
+| `CameraVector` | 10 | `float3` | Camera-to-fragment direction |
+
+### Math Nodes
+
+Perform mathematical operations on inputs.
+
+| Node | ID | Inputs | Output | HLSL |
+|------|----|--------|--------|------|
+| `Add` | 50 | A, B | A + B | `a + b` |
+| `Subtract` | 51 | A, B | A - B | `a - b` |
+| `Multiply` | 52 | A, B | A * B | `a * b` |
+| `Divide` | 53 | A, B | A / B | `a / b` |
+| `DotProduct` | 54 | A, B | `float` | `dot(a, b)` |
+| `CrossProduct` | 55 | A, B | `float3` | `cross(a, b)` |
+| `Normalize` | 56 | V | unit V | `normalize(v)` |
+| `Length` | 57 | V | `float` | `length(v)` |
+| `Distance` | 58 | A, B | `float` | `distance(a, b)` |
+| `Power` | 59 | Base, Exp | Base^Exp | `pow(base, exp)` |
+| `Sqrt` | 60 | V | sqrt(V) | `sqrt(v)` |
+| `Sin` | 61 | V | sin(V) | `sin(v)` |
+| `Cos` | 62 | V | cos(V) | `cos(v)` |
+| `Tan` | 63 | V | tan(V) | `tan(v)` |
+| `Lerp` | 64 | A, B, T | lerp | `lerp(a, b, t)` |
+| `Clamp` | 65 | V, Min, Max | clamped | `clamp(v, min, max)` |
+| `Saturate` | 66 | V | [0,1] | `saturate(v)` |
+
+### Utility Nodes
+
+Higher-level operations.
+
+| Node | ID | Description |
+|------|----|-------------|
+| `Fresnel` | 100 | Fresnel term from view angle and normal |
+| `Noise` | 101 | Procedural noise generation |
+| `SplitVector` | 105 | Split `float3/4` into individual components |
+| `CombineVector` | 106 | Combine scalars into a vector |
+
+### Output Nodes
+
+Terminal nodes that define the material's surface properties.
+
+| Node | ID | Inputs |
+|------|----|--------|
+| `SurfaceOutput` | 200 | Albedo, Normal, Roughness, Metalness, AO, Emissive (PBR) |
+| `UnlitOutput` | 201 | Color, Alpha (unlit / UI materials) |
+
+---
+
+## Graph Structure
+
+### ShaderNode
+
+```cpp
+struct ShaderNode
+{
+    uint32_t id;
+    ShaderNodeType type;
+    std::vector<ShaderNodeInput> inputs;
+    std::unordered_map<std::string, std::string> properties;
+};
+```
+
+Each node has a unique ID, a type, input sockets with default values, and optional string properties (e.g., texture path for `TextureSample`).
+
+### ShaderConnection
+
+```cpp
+struct ShaderConnection
+{
+    uint32_t fromNodeID;
+    uint32_t fromSocketIndex;
+    uint32_t toNodeID;
+    uint32_t toSocketIndex;
+};
+```
+
+A connection wires one node's output socket to another node's input socket.
+
+### ShaderGraphInput
+
+```cpp
+struct ShaderGraphInput
+{
+    std::vector<ShaderNode> nodes;
+    std::vector<ShaderConnection> connections;
+    uint32_t surfaceOutputNodeID;
+    uint32_t unlitOutputNodeID;
+    std::string materialName;
+};
+```
+
+The complete graph description passed to the compiler. Either `surfaceOutputNodeID` or `unlitOutputNodeID` should be set (not both).
+
+### ShaderGraphOutput
+
+```cpp
+struct ShaderGraphOutput
+{
+    std::string vertexShader;
+    std::string pixelShader;
+    std::vector<std::string> errors;
+    int textureSlotCount;
+    bool success;
+};
+```
+
+The compilation result containing generated HLSL code, any error messages, and the number of texture slots used.
+
+---
+
+## Compilation Algorithm
+
+`ShaderGraphCompiler::Compile()` follows a four-step process:
+
+1. **Find the output node** — Locate the `SurfaceOutput` or `UnlitOutput` node in the graph
+2. **Topological sort** — Walk connections backward from the output node to all reachable inputs, producing a dependency-ordered list of nodes
+3. **Emit HLSL** — For each node in topological order, generate a local HLSL variable declaration. Connected inputs resolve to the upstream node's variable; unconnected inputs use default values
+4. **Wire output struct** — Map the output node's inputs to the PBR or unlit output structure fields
+
+Each node generates a uniquely named variable (`_node{id}_out{socket}`) to avoid collisions.
+
+---
+
+## Usage Example
+
+```cpp
+using namespace Spark::Graphics;
+
+ShaderGraphInput graph;
+graph.materialName = "BrickWall";
+
+// Add a texture sample node
+ShaderNode texNode;
+texNode.id = 1;
+texNode.type = ShaderNodeType::TextureSample;
+texNode.properties["texture"] = "textures/brick_diffuse.dds";
+graph.nodes.push_back(texNode);
+
+// Add a surface output node
+ShaderNode outputNode;
+outputNode.id = 2;
+outputNode.type = ShaderNodeType::SurfaceOutput;
+outputNode.inputs.resize(6); // albedo, normal, roughness, metalness, ao, emissive
+graph.nodes.push_back(outputNode);
+graph.surfaceOutputNodeID = 2;
+
+// Connect texture sample → albedo input
+ShaderConnection conn;
+conn.fromNodeID = 1;
+conn.fromSocketIndex = 0;
+conn.toNodeID = 2;
+conn.toSocketIndex = 0; // albedo
+graph.connections.push_back(conn);
+
+// Compile
+ShaderGraphOutput result = ShaderGraphCompiler::Compile(graph);
+if (result.success)
+{
+    // result.vertexShader and result.pixelShader contain valid HLSL
+    LOG_INFO("Generated shaders for {}", graph.materialName);
+    LOG_INFO("Texture slots used: {}", result.textureSlotCount);
+}
+else
+{
+    for (const auto& err : result.errors)
+    {
+        LOG_ERROR("Shader graph error: {}", err);
+    }
+}
+```
+
+---
+
+## Integration
+
+- **SparkEditor**: The material editor panel creates `ShaderGraphInput` from the visual canvas and calls `Compile()`. See [SparkEditor](SparkEditor)
+- **SparkShaderCompiler**: The standalone tool can also compile shader graphs from serialized JSON. See [Shader Pipeline](Shader-Pipeline)
+- **Material System**: Generated HLSL is fed to the shader compilation pipeline and cached. See [Rendering and Graphics](Rendering-and-Graphics)
+- **Thread safety**: Not thread-safe — compile one graph at a time
+
+---
+
+## See Also
+
+- [Visual Scripting](Visual-Scripting) — General visual scripting system (references shader graph as prior art)
+- [Shader Pipeline](Shader-Pipeline) — HLSL compilation, cross-compilation, and hot-reload
+- [Rendering and Graphics](Rendering-and-Graphics) — Material system and PBR pipeline
+- [Asset Pipeline](Asset-Pipeline) — Texture and material asset management

--- a/wiki/Tween-System.md
+++ b/wiki/Tween-System.md
@@ -1,0 +1,351 @@
+# Tween System
+
+SparkEngine provides a handle-based tween system for smoothly interpolating values over time. The system supports sequencing, parallel composition, configurable easing, looping, and lifecycle control — suitable for UI animations, camera movements, gameplay feedback, and any time-driven interpolation.
+
+**Source:** `SparkEngine/Source/Engine/Tween/TweenSystem.h`
+**Namespace:** `Spark`
+**Tests:** `Tests/TestTween.cpp` (14 test cases)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Easing Functions](#easing-functions)
+- [TweenInstance](#tweeninstance)
+  - [Chaining API](#chaining-api)
+  - [Loop Modes](#loop-modes)
+  - [Lifecycle Control](#lifecycle-control)
+- [TweenHandle](#tweenhandle)
+- [TweenSystem](#tweensystem)
+  - [Singleton Access](#singleton-access)
+  - [Creating Tweens](#creating-tweens)
+  - [Convenience Helpers](#convenience-helpers)
+  - [Composition](#composition)
+  - [Update Loop](#update-loop)
+- [Practical Examples](#practical-examples)
+  - [Fade In UI Element](#fade-in-ui-element)
+  - [Camera Dolly](#camera-dolly)
+  - [Sequenced Door Animation](#sequenced-door-animation)
+  - [Looping Pulse Effect](#looping-pulse-effect)
+- [Relationship to Utils/Tween.h](#relationship-to-utilstween-h)
+- [Integration](#integration)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+The tween system solves the problem of time-based value interpolation without scattering timer logic across update functions. Instead of manually tracking elapsed time and computing lerp values, you describe the interpolation once and let the system drive it.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                       Game Code                             │
+│   TweenFloat(), CreateSequence(), CreateParallel()          │
+├─────────────────────────────────────────────────────────────┤
+│                      TweenSystem                            │
+│  ┌──────────────┬──────────────────┬──────────────────────┐ │
+│  │ Handle       │ Update           │ Composition          │ │
+│  │ Registry     │ Loop             │                      │ │
+│  │              │                  │                      │ │
+│  │ Create()     │ Update(dt)       │ CreateSequence()     │ │
+│  │ Get()        │ (drives all      │ CreateParallel()     │ │
+│  │ Cancel()     │  active tweens)  │                      │ │
+│  └──────────────┴──────────────────┴──────────────────────┘ │
+├─────────────────────────────────────────────────────────────┤
+│  TweenInstance          TweenHandle         EaseType        │
+│  (value, callbacks,     (uint32_t ID)       (10 easing      │
+│   easing, loop)                              functions)      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Key Types
+
+| Type | Responsibility |
+|------|---------------|
+| `TweenSystem` | Singleton manager: creates, updates, and destroys tweens by handle |
+| `TweenInstance` | A single interpolation with duration, easing, callbacks, and loop configuration |
+| `TweenHandle` | Lightweight `uint32_t` identifier for referencing a tween |
+| `EaseType` | Enum of 10 easing functions controlling the interpolation curve |
+| `TweenState` | Enum tracking tween lifecycle: Pending, Running, Paused, Completed |
+| `LoopMode` | Enum for loop behavior: None, Loop, PingPong |
+
+---
+
+## Easing Functions
+
+The `EaseType` enum provides 10 built-in easing curves. The `ApplyEase()` free function maps a linear `t` in `[0, 1]` to the eased value.
+
+```cpp
+float ApplyEase(EaseType ease, float t);
+```
+
+| EaseType | Behavior | Best For |
+|----------|----------|----------|
+| `Linear` | Constant speed | Mechanical motion, progress bars |
+| `EaseInQuad` | Slow start, accelerate | Objects starting from rest |
+| `EaseOutQuad` | Fast start, decelerate | Objects coming to rest |
+| `EaseInOutQuad` | Slow start and end | Smooth camera transitions |
+| `EaseInCubic` | Slower start than quad | Dramatic acceleration |
+| `EaseOutCubic` | Slower end than quad | Soft landing effects |
+| `EaseInOutCubic` | Smooth S-curve | Polished UI animations |
+| `EaseInElastic` | Elastic wind-up | Anticipation effects |
+| `EaseOutElastic` | Elastic overshoot | Bouncy UI elements |
+| `EaseOutBounce` | Bouncing at end | Physical bounce effects |
+
+---
+
+## TweenInstance
+
+A `TweenInstance` represents a single interpolation operation. It is created by the `TweenSystem` and configured via a chaining API.
+
+```cpp
+class TweenInstance
+{
+public:
+    using UpdateCallback = std::function<void(float t)>;
+    using CompleteCallback = std::function<void()>;
+
+    TweenInstance(float duration, UpdateCallback onUpdate,
+                  EaseType ease = EaseType::Linear);
+
+    TweenInstance& OnComplete(CompleteCallback callback);
+    TweenInstance& SetLoop(LoopMode mode, int32_t count = -1);
+    TweenInstance& SetDelay(float delay);
+    TweenInstance& SetPlayRate(float rate);
+
+    void Pause();
+    void Resume();
+    void Cancel();
+    void Restart();
+
+    TweenState GetState() const;
+    float GetProgress() const;   // elapsed / duration
+    float GetElapsed() const;
+};
+```
+
+### Chaining API
+
+After creating a tween, configure it with method chaining:
+
+```cpp
+auto handle = tweenSystem.Create(1.0f, [&](float t)
+{
+    opacity = t;  // t is the eased value in [0, 1]
+}, EaseType::EaseOutQuad);
+
+if (auto* tween = tweenSystem.Get(handle))
+{
+    tween->OnComplete([]() { LOG_INFO("Fade complete"); })
+          .SetDelay(0.5f)
+          .SetPlayRate(2.0f);
+}
+```
+
+### Loop Modes
+
+| LoopMode | Behavior |
+|----------|----------|
+| `None` | Play once, then complete |
+| `Loop` | Restart from the beginning after each cycle |
+| `PingPong` | Alternate forward and backward each cycle |
+
+The `count` parameter controls how many times to loop. Pass `-1` for infinite looping.
+
+```cpp
+tween->SetLoop(LoopMode::PingPong, 3);  // 3 cycles: forward, back, forward
+tween->SetLoop(LoopMode::Loop, -1);     // infinite loop
+```
+
+### Lifecycle Control
+
+| Method | Effect |
+|--------|--------|
+| `Pause()` | Freezes the tween at its current progress |
+| `Resume()` | Continues from where it was paused |
+| `Cancel()` | Stops and marks as Completed (no callback) |
+| `Restart()` | Resets elapsed time and resumes from the beginning |
+
+---
+
+## TweenHandle
+
+```cpp
+using TweenHandle = uint32_t;
+constexpr TweenHandle INVALID_TWEEN = 0;
+```
+
+Handles are monotonically increasing IDs starting at 1. Use `INVALID_TWEEN` to check for invalid or uninitialized handles.
+
+---
+
+## TweenSystem
+
+### Singleton Access
+
+```cpp
+auto& ts = TweenSystem::GetInstance();
+ts.Initialize();
+```
+
+### Creating Tweens
+
+```cpp
+// Low-level: create with custom update callback
+TweenHandle Create(float duration, TweenInstance::UpdateCallback onUpdate,
+                   EaseType ease = EaseType::Linear);
+
+// Get the instance for further configuration
+TweenInstance* Get(TweenHandle handle);
+```
+
+### Convenience Helpers
+
+```cpp
+// Interpolate a float reference from start to end
+TweenHandle TweenFloat(float& target, float from, float to,
+                       float duration, EaseType ease = EaseType::Linear);
+
+// Fire a callback after a delay (no interpolation)
+TweenHandle TweenDelay(float delay, TweenInstance::CompleteCallback onComplete);
+```
+
+### Composition
+
+Tweens can be composed into sequences (one after another) or parallel groups (all at once):
+
+```cpp
+// Play tweens one after another
+TweenHandle CreateSequence(std::vector<TweenHandle> tweens);
+
+// Play all tweens simultaneously, complete when the longest finishes
+TweenHandle CreateParallel(std::vector<TweenHandle> tweens);
+```
+
+### Update Loop
+
+Call `Update()` once per frame from the main game loop:
+
+```cpp
+ts.Update(deltaTime);
+```
+
+Completed tweens are automatically removed after their completion callback fires.
+
+| Method | Description |
+|--------|-------------|
+| `Cancel(handle)` | Cancel a specific tween |
+| `CancelAll()` | Cancel all active tweens |
+| `Pause(handle)` | Pause a specific tween |
+| `Resume(handle)` | Resume a paused tween |
+| `GetActiveTweenCount()` | Number of tweens currently active |
+| `Console_GetStatus()` | Formatted status string for debug console |
+
+---
+
+## Practical Examples
+
+### Fade In UI Element
+
+```cpp
+auto& ts = TweenSystem::GetInstance();
+
+float panelOpacity = 0.0f;
+auto handle = ts.TweenFloat(panelOpacity, 0.0f, 1.0f, 0.3f,
+                            EaseType::EaseOutQuad);
+```
+
+### Camera Dolly
+
+```cpp
+auto& ts = TweenSystem::GetInstance();
+
+float cameraZ = 0.0f;
+auto dolly = ts.TweenFloat(cameraZ, 0.0f, 10.0f, 2.0f,
+                           EaseType::EaseInOutCubic);
+
+if (auto* tween = ts.Get(dolly))
+{
+    tween->OnComplete([]()
+    {
+        LOG_INFO("Camera dolly complete");
+    });
+}
+```
+
+### Sequenced Door Animation
+
+```cpp
+auto& ts = TweenSystem::GetInstance();
+
+float doorAngle = 0.0f;
+float lightIntensity = 0.0f;
+
+// Step 1: open the door
+auto openDoor = ts.TweenFloat(doorAngle, 0.0f, 90.0f, 1.0f,
+                              EaseType::EaseOutCubic);
+
+// Step 2: wait 0.5s
+auto pause = ts.TweenDelay(0.5f, nullptr);
+
+// Step 3: fade in the light
+auto fadeLight = ts.TweenFloat(lightIntensity, 0.0f, 1.0f, 0.5f,
+                               EaseType::EaseInQuad);
+
+// Play in order
+auto sequence = ts.CreateSequence({openDoor, pause, fadeLight});
+```
+
+### Looping Pulse Effect
+
+```cpp
+auto& ts = TweenSystem::GetInstance();
+
+float scale = 1.0f;
+auto pulse = ts.Create(0.8f, [&](float t)
+{
+    scale = 1.0f + 0.1f * t;
+}, EaseType::EaseInOutQuad);
+
+if (auto* tween = ts.Get(pulse))
+{
+    tween->SetLoop(LoopMode::PingPong, -1);  // infinite pulse
+}
+```
+
+---
+
+## Relationship to Utils/Tween.h
+
+SparkEngine has two tween systems:
+
+| Feature | `Utils/Tween.h` | `Engine/Tween/TweenSystem.h` |
+|---------|-----------------|------------------------------|
+| Complexity | Simple, standalone | Full-featured singleton |
+| Handle-based | No | Yes |
+| Sequencing | No | Yes (`CreateSequence`) |
+| Parallel groups | No | Yes (`CreateParallel`) |
+| Loop modes | No | Yes (Loop, PingPong) |
+| Delay / play rate | No | Yes |
+| Best for | Quick one-off lerps | Production animation systems |
+
+The `TweenSystem` in `Engine/Tween/` is the production-ready API. `Utils/Tween.h` is a lightweight helper for simple cases where handle management is unnecessary.
+
+---
+
+## Integration
+
+- **Main loop**: `TweenSystem::GetInstance().Update(deltaTime)` must be called each frame
+- **Initialization**: Call `TweenSystem::GetInstance().Initialize()` at engine startup
+- **Shutdown**: Call `TweenSystem::GetInstance().Shutdown()` at engine teardown
+- **Console**: `Console_GetStatus()` provides debug output for the [SparkConsole](SparkConsole)
+
+---
+
+## See Also
+
+- [Coroutine System](Coroutine-System) — For complex async gameplay sequences with branching logic
+- [Animation](Animation) — For skeletal animation and state machines
+- [UI System](UI-System) — Common use case for tween-driven transitions
+- [Event System](Event-System) — Trigger tweens in response to game events

--- a/wiki/Virtual-Texturing.md
+++ b/wiki/Virtual-Texturing.md
@@ -1,0 +1,173 @@
+# Virtual Texturing
+
+SparkEngine includes a virtual texturing system that keeps only the needed texture pages resident in a GPU page cache. A shader-driven feedback buffer reports which pages are visible each frame, and the CPU-side manager loads requested pages and evicts stale ones using LRU.
+
+**Source:** `SparkEngine/Source/Graphics/VirtualTexture.h`
+**Namespace:** `Spark::Graphics`
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Page Cache Architecture](#page-cache-architecture)
+- [Feedback Loop](#feedback-loop)
+- [Configuration](#configuration)
+- [API Reference](#api-reference)
+- [Usage Example](#usage-example)
+- [Integration](#integration)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+Traditional texture streaming loads entire mip levels of each texture. Virtual texturing instead divides textures into tiles (pages) and loads only the tiles visible on screen, dramatically reducing VRAM usage for scenes with many large textures.
+
+```
+┌───────────────────────────────────────────────────────────┐
+│                      GPU Rendering                        │
+│                                                           │
+│  Pixel shader writes to feedback buffer:                  │
+│    "I need texture 5, mip 3 at tile (2, 1)"             │
+│                                                           │
+├───────────────────────────────────────────────────────────┤
+│                      CPU Readback                         │
+│                                                           │
+│  ProcessFeedback():                                       │
+│    - Parse feedback entries                               │
+│    - Mark needed pages as used (update LRU)              │
+│    - Queue missing pages for async loading               │
+│    - Evict stale pages when cache is full                │
+│                                                           │
+├───────────────────────────────────────────────────────────┤
+│                      Page Cache                           │
+│                                                           │
+│  ┌─────┬─────┬─────┬─────┬─────┬─────┐                  │
+│  │ T1  │ T3  │ T5  │ T5  │ T2  │free │  Resident pages  │
+│  │ M0  │ M2  │ M3  │ M1  │ M0  │     │                  │
+│  │(0,0)│(1,0)│(2,1)│(0,0)│(3,2)│     │                  │
+│  └─────┴─────┴─────┴─────┴─────┴─────┘                  │
+│  Max 1024 pages (configurable)                            │
+└───────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Page Cache Architecture
+
+### Virtual Texture Page
+
+Each page is one tile of a specific mip level of a source texture:
+
+```cpp
+struct VirtualTexturePage
+{
+    uint32_t textureId;       // Source texture identifier
+    uint32_t mipLevel;        // Mip level this page belongs to
+    uint32_t tileX;           // Tile column within the mip level
+    uint32_t tileY;           // Tile row within the mip level
+    bool resident;            // True if loaded in the cache
+    uint32_t lastUsedFrame;   // LRU tracking
+};
+```
+
+### Feedback Entry
+
+Shaders write what they need into the feedback buffer:
+
+```cpp
+struct FeedbackEntry
+{
+    uint32_t textureId;     // Texture that was sampled
+    uint32_t requiredMip;   // Mip level needed for this pixel
+};
+```
+
+---
+
+## Feedback Loop
+
+Each frame follows this cycle:
+
+1. **Render**: Pixel shaders sample virtual textures and write `FeedbackEntry` records to a GPU feedback buffer
+2. **Readback**: The feedback buffer is read back to CPU
+3. **ProcessFeedback**: The manager analyzes entries:
+   - Pages already resident get their `lastUsedFrame` updated
+   - Missing pages are queued for async loading
+   - When the cache is full, the least-recently-used pages are evicted
+4. **Upload**: Newly loaded page data is uploaded to the GPU page cache texture
+5. **Update indirection**: The indirection table (maps virtual page → physical cache slot) is updated
+
+---
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `pageCacheSize` | 1024 | Maximum resident pages |
+| `tileSize` | 128 | Pixels per tile edge |
+| `framesToKeep` | 60 | Frames a page stays resident without use |
+
+At default settings: 1024 pages x 128x128 pixels x 4 bytes (RGBA8) = **64 MB** page cache.
+
+---
+
+## API Reference
+
+| Method | Description |
+|--------|-------------|
+| `Initialize(pageCacheSize, tileSize)` | Set up page cache |
+| `Shutdown()` | Release all resources |
+| `ProcessFeedback(feedback, currentFrame)` | Analyze GPU feedback, schedule loads/evictions |
+| `RequestPage(textureId, mip, tileX, tileY)` | Manually request a specific page |
+| `EvictStalePages(currentFrame, framesToKeep)` | Remove unused pages (returns eviction count) |
+| `GetResidentPageCount()` | Pages currently in cache |
+| `GetPendingPageCount()` | Pages queued for loading |
+| `Console_GetStatus()` | Formatted debug string |
+
+---
+
+## Usage Example
+
+```cpp
+using namespace Spark::Graphics;
+
+auto& vtm = VirtualTextureManager::GetInstance();
+vtm.Initialize(2048, 128);  // 2048 pages, 128px tiles
+
+// Each frame after rendering:
+std::vector<FeedbackEntry> feedback = ReadbackFeedbackBuffer();
+vtm.ProcessFeedback(feedback, frameNumber);
+
+// Periodic cleanup (e.g., every 30 frames)
+if (frameNumber % 30 == 0)
+{
+    uint32_t evicted = vtm.EvictStalePages(frameNumber, 60);
+    if (evicted > 0)
+    {
+        LOG_INFO("Evicted {} stale virtual texture pages", evicted);
+    }
+}
+
+// Debug output
+LOG_INFO("VT: {} resident, {} pending", 
+         vtm.GetResidentPageCount(), vtm.GetPendingPageCount());
+```
+
+---
+
+## Integration
+
+- **Asset Pipeline**: Source textures are pre-tiled during asset import. See [Asset Pipeline](Asset-Pipeline)
+- **Material System**: Materials reference virtual texture IDs rather than GPU texture handles
+- **RHI Backend**: The indirection table and page cache physical texture are managed by the RHI layer
+- **Terrain**: Large terrain textures are ideal candidates for virtual texturing. See [Terrain and Procedural Generation](Terrain-and-Procedural-Generation)
+
+---
+
+## See Also
+
+- [Rendering and Graphics](Rendering-and-Graphics) — Texture streaming and material system
+- [Asset Pipeline](Asset-Pipeline) — Asset import and texture processing
+- [Terrain and Procedural Generation](Terrain-and-Procedural-Generation) — Terrain texture streaming

--- a/wiki/Volumetric-Fog.md
+++ b/wiki/Volumetric-Fog.md
@@ -1,0 +1,291 @@
+# Volumetric Fog
+
+SparkEngine implements froxel-based (frustum-voxel) volumetric fog that subdivides the camera frustum into a 3D grid and computes light scattering per cell. The system supports local fog volumes, point light scattering, temporal filtering, and Beer-Lambert transmittance integration.
+
+**Source:** `SparkEngine/Source/Graphics/FroxelVolumetricFog.h`
+**Namespace:** `Spark::Graphics`
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Froxel Grid](#froxel-grid)
+- [Three-Pass Pipeline](#three-pass-pipeline)
+  - [Pass 1: Media Injection](#pass-1-media-injection)
+  - [Pass 2: Light Scattering](#pass-2-light-scattering)
+  - [Pass 3: Temporal Filtering](#pass-3-temporal-filtering)
+  - [Integration](#integration-pass)
+- [Configuration](#configuration)
+- [Local Fog Volumes](#local-fog-volumes)
+- [Querying Fog](#querying-fog)
+- [GPU Resources](#gpu-resources)
+- [API Reference](#api-reference)
+- [Usage Example](#usage-example)
+- [Integration](#integration)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+Traditional distance-based fog applies a single density function along the view ray. Volumetric fog instead evaluates scattering and absorption at every point in a 3D grid aligned to the camera frustum, producing physically-based fog with light shafts, local density variations, and proper light interaction.
+
+```
+┌───────────────────────────────────────────────────────────┐
+│                     Camera Frustum                        │
+│                                                           │
+│  Near ─────────────────────────────────────────── Far     │
+│  ┌──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┐     │
+│  │  │  │  │  │  │  │  │  │  │  │  │  │  │  │  │  │     │
+│  ├──┼──┼──┼──┼──┼──┼──┼──┼──┼──┼──┼──┼──┼──┼──┼──┤     │
+│  │  │  │  │  │  │  │  │  │  │  │  │  │  │  │  │  │     │
+│  └──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┘     │
+│  <-- dense slices -->          <-- sparse slices -->      │
+│  (logarithmic depth distribution)                         │
+│                                                           │
+│  Each cell (froxel) stores:                               │
+│    - inscattered light (RGB)                              │
+│    - extinction coefficient                               │
+└───────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Froxel Grid
+
+The frustum is divided into a 3D grid where depth slices use a blend between linear and logarithmic distribution, giving higher resolution near the camera where fog detail matters most.
+
+| Default Setting | Value | Description |
+|-----------------|-------|-------------|
+| `gridWidth` | 160 | Froxels along X (~1080p / 12) |
+| `gridHeight` | 90 | Froxels along Y (~1080p / 12) |
+| `gridDepth` | 64 | Depth slices |
+| `nearPlane` | 0.1 | Camera near plane |
+| `farPlane` | 200.0 | Maximum fog distance |
+| `logDistribution` | 0.5 | Blend: 0 = linear, 1 = logarithmic |
+
+Total froxels at default: 160 x 90 x 64 = **921,600 cells**.
+
+Depth slice conversion:
+```cpp
+float SliceToDepth(uint32_t slice) const;  // slice index → linear depth
+float DepthToSlice(float depth) const;      // linear depth → fractional slice
+```
+
+---
+
+## Three-Pass Pipeline
+
+### Pass 1: Media Injection
+
+```cpp
+void InjectMedia(const FogVolume* volumes, int volumeCount);
+```
+
+Writes scattering and extinction coefficients into each froxel. Global density is applied everywhere; local `FogVolume` boxes override density in their region. Each froxel accumulates:
+- **Extinction**: How much light is absorbed per unit distance
+- **Inscattering**: Ambient light scattered into the viewing direction
+
+### Pass 2: Light Scattering
+
+```cpp
+void ScatterLight(const FroxelLight* lights, int lightCount,
+                  float cameraPosX, float cameraPosY, float cameraPosZ);
+```
+
+Evaluates point light contributions per froxel using the **Henyey-Greenstein phase function**:
+
+```
+P(cos θ) = (1 - g²) / (4π · (1 + g² - 2g·cos θ)^(3/2))
+```
+
+Where `g` (phaseG setting) controls scattering directionality:
+- `g = 0`: Isotropic scattering (equal in all directions)
+- `g > 0`: Forward scattering (light shafts toward camera)
+- `g < 0`: Back scattering
+
+### Pass 3: Temporal Filtering
+
+```cpp
+void TemporalFilter(float motionScale = 0.0f);
+```
+
+Blends the current frame's froxel grid with the previous frame using exponential history:
+
+```
+result = lerp(current, history, temporalBlend)
+```
+
+Motion rejection (`temporalRejectionThreshold`) discards history samples when the camera moves significantly, preventing ghosting artifacts.
+
+### Integration Pass
+
+```cpp
+void Integrate();
+```
+
+Marches along the depth axis accumulating inscattering and transmittance via **Beer-Lambert law**:
+
+```
+T(d) = exp(-∫ extinction · ds)
+fogColor = ∫ inscattering · T(s) · ds
+finalColor = sceneColor · T(totalDepth) + fogColor
+```
+
+---
+
+## Configuration
+
+```cpp
+struct FroxelFogSettings
+{
+    // Grid dimensions
+    uint32_t gridWidth = 160;
+    uint32_t gridHeight = 90;
+    uint32_t gridDepth = 64;
+    float nearPlane = 0.1f;
+    float farPlane = 200.0f;
+    float logDistribution = 0.5f;
+
+    // Density
+    float globalDensity = 0.02f;
+    float globalScattering = 0.015f;
+    float globalAbsorption = 0.005f;
+
+    // Phase function
+    float phaseG = 0.3f;   // Henyey-Greenstein asymmetry [-1, 1]
+
+    // Ambient inscattering
+    float ambientR = 0.05f;
+    float ambientG = 0.06f;
+    float ambientB = 0.08f;
+
+    // Temporal filtering
+    float temporalBlend = 0.9f;
+    float temporalRejectionThreshold = 0.1f;
+};
+```
+
+---
+
+## Local Fog Volumes
+
+Override fog density in specific regions of the scene:
+
+```cpp
+struct FogVolume
+{
+    float posX, posY, posZ;          // World-space center
+    float extentX, extentY, extentZ; // Half-extents (box shape)
+    float density;                    // Override density
+    float scattering;                 // Override scattering
+    float absorption;                 // Override absorption
+};
+```
+
+Use local volumes for fog under bridges, mist in valleys, or smoke in rooms.
+
+---
+
+## Querying Fog
+
+After integration, query the fog at any screen position:
+
+```cpp
+FroxelFogResult QueryFog(float u, float v, float depth) const;
+```
+
+Returns:
+
+```cpp
+struct FroxelFogResult
+{
+    float fogR, fogG, fogB;   // Inscattered light to blend in
+    float transmittance;       // Scene color multiplier [0, 1]
+};
+```
+
+Apply in the final compositing pass:
+```hlsl
+float3 finalColor = sceneColor * result.transmittance + float3(result.fogR, result.fogG, result.fogB);
+```
+
+---
+
+## GPU Resources
+
+The system creates GPU resources for use in compute shader pipelines:
+
+```cpp
+bool CreateGPUResources(Spark::RHI::IRHIDevice* device);
+void UploadGridToGPU(Spark::RHI::IRHIDevice* device);
+Spark::RHI::IRHITexture* GetFogVolumeTexture() const;
+```
+
+The GPU resource is a 3D texture (`gridWidth x gridHeight x gridDepth`, RGBA16F) containing the integrated froxel grid data.
+
+---
+
+## API Reference
+
+| Method | Description |
+|--------|-------------|
+| `Initialize(settings)` | Create froxel grid buffers |
+| `Shutdown()` | Release all buffers |
+| `InjectMedia(volumes, count)` | Pass 1: Write density per froxel |
+| `ScatterLight(lights, count, camPos)` | Pass 2: Evaluate light contributions |
+| `TemporalFilter(motionScale)` | Pass 3: Blend with history |
+| `Integrate()` | March depth axis, accumulate fog |
+| `QueryFog(u, v, depth)` | Sample fog at screen position |
+| `GetFroxelCount()` | Total grid cells |
+| `CreateGPUResources(device)` | Create 3D texture for GPU pipeline |
+| `UploadGridToGPU(device)` | Upload integrated grid to GPU |
+
+---
+
+## Usage Example
+
+```cpp
+using namespace Spark::Graphics;
+
+FroxelVolumetricFog fog;
+
+FroxelFogSettings settings;
+settings.globalDensity = 0.03f;
+settings.phaseG = 0.4f;       // moderate forward scattering
+settings.farPlane = 150.0f;
+fog.Initialize(settings);
+
+// Each frame:
+FogVolume swampFog;
+swampFog.posX = 50.0f; swampFog.posY = 0.0f; swampFog.posZ = 30.0f;
+swampFog.extentX = 20.0f; swampFog.extentY = 3.0f; swampFog.extentZ = 20.0f;
+swampFog.density = 0.1f;
+fog.InjectMedia(&swampFog, 1);
+
+fog.ScatterLight(lights.data(), lights.size(), camX, camY, camZ);
+fog.TemporalFilter(cameraMotionMagnitude);
+fog.Integrate();
+
+// In compositing shader:
+auto result = fog.QueryFog(screenU, screenV, pixelDepth);
+```
+
+---
+
+## Integration
+
+- **FogSystem**: The simpler distance-based `FogSystem` provides basic height/distance fog; `FroxelVolumetricFog` is the physically-based alternative
+- **LightingSystem**: Point lights from `LightingSystem` feed into the scattering pass
+- **ClusteredLightCulling**: Can share the light list with clustered lighting for efficiency
+- **Day-Night Cycle**: Ambient inscattering colors can be driven by time-of-day
+
+---
+
+## See Also
+
+- [Rendering and Graphics](Rendering-and-Graphics) — Overall rendering pipeline
+- [Clustered Lighting](Clustered-Lighting) — Light culling that shares data with fog scattering
+- [Day Night Cycle and Weather](Day-Night-Cycle-and-Weather) — Weather system integration
+- [Global Illumination](Global-Illumination) — Probe-based lighting that complements fog

--- a/wiki/Water-Rendering.md
+++ b/wiki/Water-Rendering.md
@@ -1,0 +1,252 @@
+# Water Rendering
+
+SparkEngine provides a water rendering system with Gerstner wave simulation for realistic ocean and lake surfaces. Water planes are tessellated grids whose vertices are displaced each frame by a sum of Gerstner wave components, with CPU-side height queries for gameplay interactions like buoyancy and splash effects.
+
+**Source:** `SparkEngine/Source/Graphics/WaterRenderer.h`
+**Namespace:** `Spark::Graphics`
+**Tests:** `Tests/TestWaterRenderer.cpp` (6 test cases)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Water Settings](#water-settings)
+- [Gerstner Waves](#gerstner-waves)
+- [Water Plane Management](#water-plane-management)
+- [Height Queries](#height-queries)
+- [GPU Buffers](#gpu-buffers)
+- [API Reference](#api-reference)
+- [Usage Example](#usage-example)
+- [Integration](#integration)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+The water renderer creates tessellated grid meshes for each water body and animates them using Gerstner wave summation. Gerstner waves produce the characteristic peaked crests and flat troughs of real ocean waves, unlike simple sine waves.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                    WaterRenderer                          │
+│                                                          │
+│  WaterSettings ──► GenerateDefaultWaves()                │
+│                         │                                │
+│                         ▼                                │
+│  ┌─────────────────────────────────────────┐             │
+│  │ Gerstner Wave Components (N waves)      │             │
+│  │  direction, amplitude, wavelength,      │             │
+│  │  speed, steepness                       │             │
+│  └──────────────┬──────────────────────────┘             │
+│                 │                                         │
+│                 ▼                                         │
+│  Update(dt) ──► ComputeGerstnerDisplacement(x, z, t)    │
+│                 ComputeGerstnerNormal(x, z, t)           │
+│                         │                                │
+│                         ▼                                │
+│  ┌─────────────────────────────────────────┐             │
+│  │ WaterPlane (tessellated grid)           │             │
+│  │  vertices[] updated each frame          │             │
+│  │  basePositions[] for undisplaced grid   │             │
+│  └─────────────────────────────────────────┘             │
+│                                                          │
+│  GetWaterHeight(x, z) ──► CPU height query for gameplay  │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Water Settings
+
+```cpp
+struct WaterSettings
+{
+    XMFLOAT3 waterColor = {0.0f, 0.3f, 0.5f};
+    float opacity = 0.8f;
+    float waveAmplitude = 0.3f;
+    float waveFrequency = 1.0f;
+    float waveSpeed = 1.0f;
+    int waveCount = 4;
+    float fresnelPower = 5.0f;
+    float reflectionStrength = 0.5f;
+    float refractionStrength = 0.3f;
+    float specularPower = 64.0f;
+    float rippleSpeed = 1.0f;
+    bool enabled = true;
+};
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `waterColor` | (0, 0.3, 0.5) | Base surface color (linear RGB) |
+| `opacity` | 0.8 | 0 = fully transparent, 1 = fully opaque |
+| `waveAmplitude` | 0.3 | Global amplitude scale for all waves |
+| `waveFrequency` | 1.0 | Global frequency multiplier |
+| `waveSpeed` | 1.0 | Global speed multiplier |
+| `waveCount` | 4 | Number of Gerstner wave components |
+| `fresnelPower` | 5.0 | Fresnel reflection exponent |
+| `reflectionStrength` | 0.5 | Planar reflection blend factor |
+| `refractionStrength` | 0.3 | Refraction distortion strength |
+| `specularPower` | 64.0 | Specular highlight sharpness |
+| `rippleSpeed` | 1.0 | Detail ripple animation speed |
+
+---
+
+## Gerstner Waves
+
+Each wave component is an independent travelling wave:
+
+```cpp
+struct GerstnerWave
+{
+    XMFLOAT2 direction = {1.0f, 0.0f};  // Travel direction (XZ)
+    float amplitude = 0.2f;              // Vertical displacement
+    float wavelength = 10.0f;            // Crest-to-crest distance
+    float speed = 1.0f;                  // Phase velocity
+    float steepness = 0.5f;              // 0 = sine, 1 = sharp peak
+};
+```
+
+The Gerstner wave equation displaces vertices both vertically and horizontally, creating the distinctive peaked-crest shape:
+
+```
+x' = x + Σ (Q_i * A_i * D_i.x * cos(w_i * dot(D_i, [x,z]) + φ_i * t))
+z' = z + Σ (Q_i * A_i * D_i.y * cos(w_i * dot(D_i, [x,z]) + φ_i * t))
+y' = Σ (A_i * sin(w_i * dot(D_i, [x,z]) + φ_i * t))
+```
+
+Where `Q` is steepness, `A` is amplitude, `D` is direction, `w = 2π/wavelength`, and `φ = speed * w`.
+
+Default waves are auto-generated from `WaterSettings` with varied directions and wavelengths.
+
+---
+
+## Water Plane Management
+
+Water bodies are represented as individual planes, each with its own tessellated grid:
+
+```cpp
+auto& water = WaterRenderer::GetInstance();
+water.Initialize();
+
+// Add a 100x100 meter lake centered at (0, 0, 0)
+uint32_t lakeId = water.AddWaterPlane({0.0f, 0.0f, 0.0f}, {100.0f, 100.0f});
+
+// Add a 50x50 river section
+uint32_t riverId = water.AddWaterPlane({200.0f, -1.0f, 0.0f}, {50.0f, 50.0f});
+
+// Remove a water plane
+water.RemoveWaterPlane(riverId);
+```
+
+Each plane generates a grid with `gridResolution` vertices per side (default 32), for 32x32 = 1024 vertices per plane.
+
+---
+
+## Height Queries
+
+Query the animated water surface height at any world position for gameplay logic:
+
+```cpp
+float height = water.GetWaterHeight(playerX, playerZ);
+
+// Buoyancy check
+if (playerY < height)
+{
+    ApplyBuoyancyForce(playerY - height);
+}
+```
+
+Returns 0 if no water plane covers the queried position.
+
+Access the full vertex data for custom rendering:
+
+```cpp
+std::span<const WaterVertex> verts = water.GetMeshVertices(lakeId);
+for (const auto& v : verts)
+{
+    // v.position, v.normal, v.texCoord
+}
+```
+
+---
+
+## GPU Buffers
+
+The renderer can create GPU vertex and index buffers for hardware rendering:
+
+```cpp
+water.CreateGPUBuffers(rhiDevice);
+
+// After Update() each frame:
+water.UpdateGPUBuffers(rhiDevice);
+
+uint32_t vertCount = water.GetGPUVertexCount();
+uint32_t idxCount = water.GetGPUIndexCount();
+```
+
+---
+
+## API Reference
+
+| Method | Description |
+|--------|-------------|
+| `GetInstance()` | Singleton access |
+| `Initialize()` | Create renderer, generate default waves |
+| `Shutdown()` | Release all planes and resources |
+| `SetSettings(settings)` | Update water configuration |
+| `GetSettings()` | Read current settings |
+| `AddWaterPlane(center, size)` | Add a water body, returns ID |
+| `RemoveWaterPlane(id)` | Remove a water body |
+| `Update(deltaTime)` | Advance simulation, displace vertices |
+| `GetWaterHeight(worldX, worldZ)` | CPU height query |
+| `GetMeshVertices(id)` | Access animated vertex data |
+| `GetWaterPlaneCount()` | Number of active water planes |
+| `CreateGPUBuffers(device)` | Create GPU vertex/index buffers |
+| `UpdateGPUBuffers(device)` | Upload displaced vertices to GPU |
+
+---
+
+## Usage Example
+
+```cpp
+using namespace Spark::Graphics;
+
+auto& water = WaterRenderer::GetInstance();
+water.Initialize();
+
+WaterSettings settings;
+settings.waveAmplitude = 0.5f;
+settings.waveCount = 6;
+settings.waveSpeed = 0.8f;
+settings.waterColor = {0.02f, 0.15f, 0.3f};
+water.SetSettings(settings);
+
+uint32_t oceanId = water.AddWaterPlane({0.0f, 0.0f, 0.0f}, {500.0f, 500.0f});
+
+// In render loop:
+water.Update(deltaTime);
+
+// Gameplay: check if boat is floating
+float waterY = water.GetWaterHeight(boat.x, boat.z);
+boat.y = waterY + boat.draft;
+```
+
+---
+
+## Integration
+
+- **Physics**: Use `GetWaterHeight()` for buoyancy forces in [Physics](Physics) simulations
+- **Audio**: Trigger splash sounds when objects enter water. See [Audio](Audio)
+- **Particle System**: Spawn spray particles at wave crests
+- **Sky Atmosphere**: Water color is affected by sky reflection. See [Rendering and Graphics](Rendering-and-Graphics)
+
+---
+
+## See Also
+
+- [Rendering and Graphics](Rendering-and-Graphics) — Overall rendering pipeline
+- [Physics](Physics) — Buoyancy and fluid interaction
+- [Terrain and Procedural Generation](Terrain-and-Procedural-Generation) — Shoreline and riverbed terrain
+- [Day Night Cycle and Weather](Day-Night-Cycle-and-Weather) — Weather affects wave intensity

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -41,6 +41,7 @@
 - [Loading System](Loading-System)
 - [Mod System](Mod-System)
 - [Content Delivery](Content-Delivery)
+- [Tween System](Tween-System)
 
 ### Gameplay & Tools
 - [Gameplay Systems](Gameplay-Systems)
@@ -59,12 +60,22 @@
 - [Mobile Platform](Mobile-Platform)
 - [Cross-Compilation: Wine Testing](Cross-Compilation-Wine-Testing)
 
-### Graphics Backends
+### Graphics
 - [RHI Abstraction Layer](RHI-Abstraction-Layer)
 - [D3D12 Backend](D3D12-Backend)
 - [DXR Raytracing](DXR-Raytracing)
 - [Hybrid Ray Tracing](Hybrid-Ray-Tracing)
 - [Upscaling (DLSS/FSR)](Upscaling-System)
+- [Render Graph](Render-Graph)
+- [Shader Graph](Shader-Graph)
+- [GPU Particles](GPU-Particles)
+- [GPU-Driven Rendering](GPU-Driven-Rendering)
+- [Volumetric Fog](Volumetric-Fog)
+- [Global Illumination](Global-Illumination)
+- [Virtual Texturing](Virtual-Texturing)
+- [Water Rendering](Water-Rendering)
+- [Clustered Lighting](Clustered-Lighting)
+- [Mesh Shaders](Mesh-Shaders)
 
 ### Advanced
 - [Threading Model](Threading-Model)
@@ -76,6 +87,8 @@
 - [Testing](Testing)
 - [Codebase Statistics](Codebase-Statistics)
 - [Codebase Health](Codebase-Health)
+- [Error Handling Patterns](Error-Handling-Patterns)
+- [Hot Reload Overview](Hot-Reload-Overview)
 - [Troubleshooting](Troubleshooting)
 - [Contributing](Contributing)
 


### PR DESCRIPTION
New pages cover advanced graphics (Render Graph, Shader Graph, GPU Particles, GPU-Driven Rendering, Volumetric Fog, Global Illumination, Virtual Texturing, Water Rendering, Clustered Lighting, Mesh Shaders), the Tween System, and two broad topic pages (Error Handling Patterns, Hot Reload Overview). Sidebar updated with all new entries under reorganized Graphics section.

https://claude.ai/code/session_01VFTwwR5bpAUMPeonjtL5ho