### PR TITLE
Add comprehensive error handling: HRESULT checks, null guards, string parse safety

### DIFF
--- a/GameModules/SparkGameFPS/Source/Core/Main.cpp
+++ b/GameModules/SparkGameFPS/Source/Core/Main.cpp
@@ -633,7 +633,15 @@ void SparkGameModule::RegisterGameConsoleCommands()
         {
             if (args.size() < 2)
                 return "Usage: audio_volume <master|sfx|music> <0.0-1.0>";
-            float vol = std::stof(args[1]);
+            float vol;
+            try
+            {
+                vol = std::stof(args[1]);
+            }
+            catch (const std::exception&)
+            {
+                return "Invalid volume value: " + args[1];
+            }
             auto& mixer = Spark::Audio::AudioBusMixer::GetInstance();
             if (args[0] == "master")
                 mixer.SetBusVolume(Spark::Audio::AudioBus::Master, vol);
@@ -738,7 +746,15 @@ void SparkGameModule::RegisterGameConsoleCommands()
             if (args.empty())
                 return "Usage: destroy <entity_id>";
             auto& destruction = Spark::DestructionSystem::GetInstance();
-            uint32_t entityId = static_cast<uint32_t>(std::stoul(args[0]));
+            uint32_t entityId;
+            try
+            {
+                entityId = static_cast<uint32_t>(std::stoul(args[0]));
+            }
+            catch (const std::exception&)
+            {
+                return "Invalid entity ID: " + args[0];
+            }
             destruction.ForceDestroy(entityId, 50.0f);
             return "Force-destroyed entity " + args[0];
         },
@@ -798,7 +814,14 @@ void SparkGameModule::RegisterGameConsoleCommands()
             auto* seq = Spark::Cinematic::SequencerManager::GetInstance().GetSequence(args[0]);
             if (!seq)
                 return "Sequence not found: " + args[0];
-            seq->SetTime(std::stof(args[1]));
+            try
+            {
+                seq->SetTime(std::stof(args[1]));
+            }
+            catch (const std::exception&)
+            {
+                return "Invalid time value: " + args[1];
+            }
             return "Seeked " + args[0] + " to " + args[1] + "s";
         },
         "Seek a sequence to a specific time");
@@ -875,7 +898,15 @@ void SparkGameModule::RegisterGameConsoleCommands()
         {
             if (args.empty())
                 return "Usage: replay_seek <seconds>";
-            float t = std::stof(args[0]);
+            float t;
+            try
+            {
+                t = std::stof(args[0]);
+            }
+            catch (const std::exception&)
+            {
+                return "Invalid time value: " + args[0];
+            }
             Spark::ReplaySystem::GetInstance().SeekTo(t);
             return "Seeked to " + args[0] + "s";
         },
@@ -887,7 +918,15 @@ void SparkGameModule::RegisterGameConsoleCommands()
         {
             if (args.empty())
                 return "Usage: replay_speed <multiplier>";
-            float speed = std::stof(args[0]);
+            float speed;
+            try
+            {
+                speed = std::stof(args[0]);
+            }
+            catch (const std::exception&)
+            {
+                return "Invalid speed value: " + args[0];
+            }
             Spark::ReplaySystem::GetInstance().SetPlaybackSpeed(speed);
             return "Playback speed set to " + std::to_string(speed) + "x";
         },
@@ -928,7 +967,18 @@ void SparkGameModule::RegisterGameConsoleCommands()
             auto* ws = game->GetWaveSpawner();
             if (!ws)
                 return "Wave spawner not initialized";
-            int wave = args.empty() ? ws->GetCurrentWave() + 1 : std::stoi(args[0]);
+            int wave = ws->GetCurrentWave() + 1;
+            if (!args.empty())
+            {
+                try
+                {
+                    wave = std::stoi(args[0]);
+                }
+                catch (const std::exception&)
+                {
+                    return "Invalid wave number: " + args[0];
+                }
+            }
             ws->SkipToWave(wave);
             return "Skipping to wave " + std::to_string(wave);
         },
@@ -945,7 +995,15 @@ void SparkGameModule::RegisterGameConsoleCommands()
             auto* ws = game->GetWaveSpawner();
             if (!ws)
                 return "Wave spawner not initialized";
-            float scale = std::stof(args[0]);
+            float scale;
+            try
+            {
+                scale = std::stof(args[0]);
+            }
+            catch (const std::exception&)
+            {
+                return "Invalid scale value: " + args[0];
+            }
             ws->SetDifficultyScale(scale);
             return "Difficulty scale set to " + std::to_string(scale);
         },
@@ -977,7 +1035,15 @@ void SparkGameModule::RegisterGameConsoleCommands()
             auto* prog = game->GetProgression();
             if (!prog)
                 return "Progression not initialized";
-            int amount = std::stoi(args[0]);
+            int amount;
+            try
+            {
+                amount = std::stoi(args[0]);
+            }
+            catch (const std::exception&)
+            {
+                return "Invalid XP amount: " + args[0];
+            }
             prog->AwardXP(amount, "console");
             return "Awarded " + std::to_string(amount) + " XP (level " + std::to_string(prog->GetLevel()) + ")";
         },
@@ -1049,10 +1115,17 @@ void SparkGameModule::RegisterGameConsoleCommands()
                 return "Game not available";
             uint16_t port = 27015;
             int maxClients = 32;
-            if (!args.empty())
-                port = static_cast<uint16_t>(std::stoi(args[0]));
-            if (args.size() > 1)
-                maxClients = std::stoi(args[1]);
+            try
+            {
+                if (!args.empty())
+                    port = static_cast<uint16_t>(std::stoi(args[0]));
+                if (args.size() > 1)
+                    maxClients = std::stoi(args[1]);
+            }
+            catch (const std::exception&)
+            {
+                return "Invalid port or max_clients value";
+            }
             return game->StartServer(port, maxClients) ? "Server started" : "Failed to start server";
         },
         "Host a server (net_host [port] [max_clients])");
@@ -1067,7 +1140,16 @@ void SparkGameModule::RegisterGameConsoleCommands()
                 return "Game not available";
             uint16_t port = 27015;
             if (args.size() > 1)
-                port = static_cast<uint16_t>(std::stoi(args[1]));
+            {
+                try
+                {
+                    port = static_cast<uint16_t>(std::stoi(args[1]));
+                }
+                catch (const std::exception&)
+                {
+                    return "Invalid port value: " + args[1];
+                }
+            }
             return game->ConnectToServer(args[0], port) ? "Connecting..." : "Failed to connect";
         },
         "Connect to a server (net_connect <address> [port])");

--- a/GameModules/SparkGameMMO/Source/Core/Main.cpp
+++ b/GameModules/SparkGameMMO/Source/Core/Main.cpp
@@ -510,7 +510,15 @@ void SparkGameMMOModule::RegisterConsoleCommands()
                             {
                                 if (args.empty())
                                     return "Usage: mmo_boss_spawn <boss_id>";
-                                uint32_t id = static_cast<uint32_t>(std::stoi(args[0]));
+                                uint32_t id;
+                                try
+                                {
+                                    id = static_cast<uint32_t>(std::stoi(args[0]));
+                                }
+                                catch (const std::exception&)
+                                {
+                                    return "Invalid boss ID: " + args[0];
+                                }
                                 return m_worldBossSystem->SpawnBoss(id) ? "Boss spawned!" : "Spawn failed";
                             });
 
@@ -575,7 +583,15 @@ void SparkGameMMOModule::RegisterConsoleCommands()
                             {
                                 if (args.empty())
                                     return "Usage: mmo_characters <account_id>";
-                                uint32_t acctId = static_cast<uint32_t>(std::stoi(args[0]));
+                                uint32_t acctId;
+                                try
+                                {
+                                    acctId = static_cast<uint32_t>(std::stoi(args[0]));
+                                }
+                                catch (const std::exception&)
+                                {
+                                    return "Invalid account ID: " + args[0];
+                                }
                                 return m_characterSystem->GetCharacterListString(acctId);
                             });
 }

--- a/GameModules/SparkGameMMO/Source/Persistence/MMOPersistenceSystem.cpp
+++ b/GameModules/SparkGameMMO/Source/Persistence/MMOPersistenceSystem.cpp
@@ -236,20 +236,28 @@ namespace MMO
 
                 if (tokens.size() >= 14)
                 {
-                    outData.name = tokens[0];
-                    outData.level = std::stoi(tokens[1]);
-                    outData.xp = std::stoi(tokens[2]);
-                    outData.areaId = static_cast<uint32_t>(std::stoi(tokens[3]));
-                    outData.posX = std::stof(tokens[4]);
-                    outData.posY = std::stof(tokens[5]);
-                    outData.posZ = std::stof(tokens[6]);
-                    outData.rotY = std::stof(tokens[7]);
-                    outData.health = std::stof(tokens[8]);
-                    outData.maxHealth = std::stof(tokens[9]);
-                    outData.mana = std::stof(tokens[10]);
-                    outData.maxMana = std::stof(tokens[11]);
-                    outData.playTime = std::stof(tokens[12]);
-                    outData.inventory.currency = std::stoi(tokens[13]);
+                    try
+                    {
+                        outData.name = tokens[0];
+                        outData.level = std::stoi(tokens[1]);
+                        outData.xp = std::stoi(tokens[2]);
+                        outData.areaId = static_cast<uint32_t>(std::stoi(tokens[3]));
+                        outData.posX = std::stof(tokens[4]);
+                        outData.posY = std::stof(tokens[5]);
+                        outData.posZ = std::stof(tokens[6]);
+                        outData.rotY = std::stof(tokens[7]);
+                        outData.health = std::stof(tokens[8]);
+                        outData.maxHealth = std::stof(tokens[9]);
+                        outData.mana = std::stof(tokens[10]);
+                        outData.maxMana = std::stof(tokens[11]);
+                        outData.playTime = std::stof(tokens[12]);
+                        outData.inventory.currency = std::stoi(tokens[13]);
+                    }
+                    catch (const std::exception&)
+                    {
+                        SPARK_LOG_ERROR(Spark::LogCategory::Game, "MMOPersistence: corrupt character data for ID %u",
+                                        characterId);
+                    }
                 }
             }
         }
@@ -363,8 +371,15 @@ namespace MMO
                     if (key.starts_with("character_"))
                     {
                         auto idStr = key.substr(10);
-                        uint32_t charId = static_cast<uint32_t>(std::stoul(idStr));
-                        result.emplace_back(charId, idStr);
+                        try
+                        {
+                            uint32_t charId = static_cast<uint32_t>(std::stoul(idStr));
+                            result.emplace_back(charId, idStr);
+                        }
+                        catch (const std::exception&)
+                        {
+                            continue;
+                        }
                     }
                 }
             }
@@ -409,11 +424,18 @@ namespace MMO
                     auto sep = val.find('|');
                     if (sep != std::string::npos)
                     {
-                        ItemStack stack;
-                        stack.itemDefId = static_cast<uint32_t>(std::stoul(val.substr(0, sep)));
-                        stack.count = std::stoi(val.substr(sep + 1));
-                        if (!stack.IsEmpty())
-                            inv.slots.push_back(stack);
+                        try
+                        {
+                            ItemStack stack;
+                            stack.itemDefId = static_cast<uint32_t>(std::stoul(val.substr(0, sep)));
+                            stack.count = std::stoi(val.substr(sep + 1));
+                            if (!stack.IsEmpty())
+                                inv.slots.push_back(stack);
+                        }
+                        catch (const std::exception&)
+                        {
+                            continue;
+                        }
                     }
                 }
             }
@@ -425,7 +447,16 @@ namespace MMO
         {
             const auto& val = currResult.rows[0].columns[0];
             if (std::holds_alternative<std::string>(val))
-                inv.currency = std::stoi(std::get<std::string>(val));
+            {
+                try
+                {
+                    inv.currency = std::stoi(std::get<std::string>(val));
+                }
+                catch (const std::exception&)
+                {
+                    inv.currency = 0;
+                }
+            }
             else if (std::holds_alternative<int64_t>(val))
                 inv.currency = static_cast<int>(std::get<int64_t>(val));
         }
@@ -458,21 +489,27 @@ namespace MMO
                     auto prefix = "rep_" + std::to_string(charId) + "_";
                     if (key.starts_with(prefix))
                     {
-                        uint32_t factionId = static_cast<uint32_t>(std::stoul(key.substr(prefix.size())));
-                        // Load the actual value
-                        auto valResult =
-                            m_db->SyncQuery(sid(MMOStmtId::SaveReputation), {MakeInt(charId), MakeInt(factionId)});
-                        if (valResult.success && !valResult.rows.empty())
+                        try
                         {
-                            FactionStanding standing;
-                            standing.factionId = factionId;
-                            const auto& val = valResult.rows[0].columns[0];
-                            if (std::holds_alternative<int64_t>(val))
-                                standing.reputation = static_cast<int>(std::get<int64_t>(val));
-                            else if (std::holds_alternative<std::string>(val))
-                                standing.reputation = std::stoi(std::get<std::string>(val));
-                            standing.tier = FactionStanding::GetTierForValue(standing.reputation);
-                            state.standings[factionId] = standing;
+                            uint32_t factionId = static_cast<uint32_t>(std::stoul(key.substr(prefix.size())));
+                            auto valResult =
+                                m_db->SyncQuery(sid(MMOStmtId::SaveReputation), {MakeInt(charId), MakeInt(factionId)});
+                            if (valResult.success && !valResult.rows.empty())
+                            {
+                                FactionStanding standing;
+                                standing.factionId = factionId;
+                                const auto& val = valResult.rows[0].columns[0];
+                                if (std::holds_alternative<int64_t>(val))
+                                    standing.reputation = static_cast<int>(std::get<int64_t>(val));
+                                else if (std::holds_alternative<std::string>(val))
+                                    standing.reputation = std::stoi(std::get<std::string>(val));
+                                standing.tier = FactionStanding::GetTierForValue(standing.reputation);
+                                state.standings[factionId] = standing;
+                            }
+                        }
+                        catch (const std::exception&)
+                        {
+                            continue;
                         }
                     }
                 }
@@ -513,8 +550,15 @@ namespace MMO
                     auto prefix = "ach_" + std::to_string(charId) + "_";
                     if (key.starts_with(prefix))
                     {
-                        uint32_t achId = static_cast<uint32_t>(std::stoul(key.substr(prefix.size())));
-                        state.completedIds.insert(achId);
+                        try
+                        {
+                            uint32_t achId = static_cast<uint32_t>(std::stoul(key.substr(prefix.size())));
+                            state.completedIds.insert(achId);
+                        }
+                        catch (const std::exception&)
+                        {
+                            continue;
+                        }
                     }
                 }
             }
@@ -541,7 +585,16 @@ namespace MMO
                             if (std::holds_alternative<int64_t>(val))
                                 state.stats[statKey] = static_cast<int>(std::get<int64_t>(val));
                             else if (std::holds_alternative<std::string>(val))
-                                state.stats[statKey] = std::stoi(std::get<std::string>(val));
+                            {
+                                try
+                                {
+                                    state.stats[statKey] = std::stoi(std::get<std::string>(val));
+                                }
+                                catch (const std::exception&)
+                                {
+                                    state.stats[statKey] = 0;
+                                }
+                            }
                         }
                     }
                 }
@@ -583,12 +636,19 @@ namespace MMO
                     auto prefix = "craft_" + std::to_string(charId) + "_";
                     if (key.starts_with(prefix))
                     {
-                        int discKey = std::stoi(key.substr(prefix.size()));
-                        CraftingSkill skill;
-                        skill.discipline = static_cast<CraftingDiscipline>(discKey);
-                        skill.level = 1;
-                        skill.currentXP = 0;
-                        state.skills[discKey] = skill;
+                        try
+                        {
+                            int discKey = std::stoi(key.substr(prefix.size()));
+                            CraftingSkill skill;
+                            skill.discipline = static_cast<CraftingDiscipline>(discKey);
+                            skill.level = 1;
+                            skill.currentXP = 0;
+                            state.skills[discKey] = skill;
+                        }
+                        catch (const std::exception&)
+                        {
+                            continue;
+                        }
                     }
                 }
             }
@@ -606,8 +666,15 @@ namespace MMO
                     auto prefix = "recipe_" + std::to_string(charId) + "_";
                     if (key.starts_with(prefix))
                     {
-                        uint32_t recipeId = static_cast<uint32_t>(std::stoul(key.substr(prefix.size())));
-                        state.knownRecipes.push_back(recipeId);
+                        try
+                        {
+                            uint32_t recipeId = static_cast<uint32_t>(std::stoul(key.substr(prefix.size())));
+                            state.knownRecipes.push_back(recipeId);
+                        }
+                        catch (const std::exception&)
+                        {
+                            continue;
+                        }
                     }
                 }
             }
@@ -646,11 +713,18 @@ namespace MMO
                         auto sep = rest.find('_');
                         if (sep != std::string::npos)
                         {
-                            LootLockout lo;
-                            lo.dungeonDefId = static_cast<uint32_t>(std::stoul(rest.substr(0, sep)));
-                            lo.difficulty = static_cast<DungeonDifficulty>(std::stoi(rest.substr(sep + 1)));
-                            lo.remaining = 604800.0f; // Default 1 week, actual loaded from value
-                            state.lockouts.push_back(lo);
+                            try
+                            {
+                                LootLockout lo;
+                                lo.dungeonDefId = static_cast<uint32_t>(std::stoul(rest.substr(0, sep)));
+                                lo.difficulty = static_cast<DungeonDifficulty>(std::stoi(rest.substr(sep + 1)));
+                                lo.remaining = 604800.0f; // Default 1 week, actual loaded from value
+                                state.lockouts.push_back(lo);
+                            }
+                            catch (const std::exception&)
+                            {
+                                continue;
+                            }
                         }
                     }
                 }

--- a/GameModules/SparkGamePlatformer/Source/Core/Main.cpp
+++ b/GameModules/SparkGamePlatformer/Source/Core/Main.cpp
@@ -289,7 +289,15 @@ void SparkGamePlatformerModule::RegisterConsoleCommands()
                             {
                                 if (args.empty())
                                     return "Usage: platformer_level <index>";
-                                uint32_t idx = static_cast<uint32_t>(std::stoi(args[0]));
+                                uint32_t idx;
+                                try
+                                {
+                                    idx = static_cast<uint32_t>(std::stoi(args[0]));
+                                }
+                                catch (const std::exception&)
+                                {
+                                    return "Invalid level index: " + args[0];
+                                }
                                 return m_levelSystem->LoadLevel(idx) ? "Level " + std::to_string(idx) + " loaded"
                                                                      : "Failed to load level";
                             });

--- a/GameModules/SparkGameRTS/Source/Core/Main.cpp
+++ b/GameModules/SparkGameRTS/Source/Core/Main.cpp
@@ -317,7 +317,15 @@ void SparkGameRTSModule::RegisterConsoleCommands()
                                     return "Engine systems not initialized";
                                 if (args.empty())
                                     return "Usage: rts_time <0-24>";
-                                float hour = std::stof(args[0]);
+                                float hour;
+                                try
+                                {
+                                    hour = std::stof(args[0]);
+                                }
+                                catch (const std::exception&)
+                                {
+                                    return "Invalid time value: " + args[0];
+                                }
                                 m_engineSystems->SetTimeOfDay(hour);
                                 return "Time set to: " + args[0];
                             });

--- a/SparkEngine/Source/Core/EngineDiagnostics.cpp
+++ b/SparkEngine/Source/Core/EngineDiagnostics.cpp
@@ -375,7 +375,7 @@ namespace Spark
         report.Add(sub, "Non-existent slot check", nonExistent);
 
         // If we have a world, test save/load roundtrip
-        auto* world = Ctx()->GetWorld();
+        auto* world = Ctx() ? Ctx()->GetWorld() : nullptr;
         if (world)
         {
             SaveMetadata meta;

--- a/SparkEngine/Source/Core/SparkEngine.cpp
+++ b/SparkEngine/Source/Core/SparkEngine.cpp
@@ -256,7 +256,14 @@ static int ParseTestFrameLimit(LPWSTR cmdLine)
         ++pos;
     if (pos >= cmd.size())
         return 0;
-    return std::max(0, std::stoi(std::wstring(cmd.substr(pos))));
+    try
+    {
+        return std::max(0, std::stoi(std::wstring(cmd.substr(pos))));
+    }
+    catch (const std::exception&)
+    {
+        return 0;
+    }
 }
 
 /**
@@ -279,8 +286,15 @@ static void ParseWindowSizeOverride(LPWSTR cmdLine)
         xPos = sizeStr.find(L'X');
     if (xPos != std::wstring::npos)
     {
-        g_windowWidthOverride = std::max(320, std::stoi(sizeStr.substr(0, xPos)));
-        g_windowHeightOverride = std::max(240, std::stoi(sizeStr.substr(xPos + 1)));
+        try
+        {
+            g_windowWidthOverride = std::max(320, std::stoi(sizeStr.substr(0, xPos)));
+            g_windowHeightOverride = std::max(240, std::stoi(sizeStr.substr(xPos + 1)));
+        }
+        catch (const std::exception&)
+        {
+            // Ignore malformed window size arguments
+        }
     }
 }
 

--- a/SparkEngine/Source/Engine/Modding/ModSystem.cpp
+++ b/SparkEngine/Source/Engine/Modding/ModSystem.cpp
@@ -267,6 +267,12 @@ namespace Spark
         Json::Value root;
         root["mods"] = std::move(modsArray);
         file << Json::StringifyPretty(root) << "\n";
+        file.close();
+        if (file.fail())
+        {
+            SPARK_LOG_ERROR(Spark::LogCategory::Game, "ModSystem::SaveConfig write failed for '%s'", filePath.c_str());
+            return false;
+        }
         return true;
     }
 

--- a/SparkEngine/Source/Engine/Modding/VirtualFileSystem.cpp
+++ b/SparkEngine/Source/Engine/Modding/VirtualFileSystem.cpp
@@ -59,6 +59,11 @@ namespace Spark
         std::vector<uint8_t> buffer(static_cast<size_t>(size));
         file.seekg(0, std::ios::beg);
         file.read(reinterpret_cast<char*>(buffer.data()), size);
+        if (file.bad())
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Core, "VFS: Read error for '%s'", fullPath.c_str());
+            return {};
+        }
         return buffer;
     }
 

--- a/SparkEngine/Source/Graphics/GraphicsDeviceResources.cpp
+++ b/SparkEngine/Source/Graphics/GraphicsDeviceResources.cpp
@@ -1224,7 +1224,12 @@ void main() {
         desc.bytecodeSize = result.bytecode.size();
         desc.entryPoint = "main";
         desc.debugName = "EmbeddedBasicVS";
-        device->CreateShader(desc);
+        auto shader = device->CreateShader(desc);
+        if (!shader)
+        {
+            SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "Failed to create embedded vertex shader");
+            return E_FAIL;
+        }
     }
 
     return S_OK;
@@ -1280,7 +1285,12 @@ void main() {
         desc.bytecodeSize = result.bytecode.size();
         desc.entryPoint = "main";
         desc.debugName = "EmbeddedBasicPS";
-        device->CreateShader(desc);
+        auto shader = device->CreateShader(desc);
+        if (!shader)
+        {
+            SPARK_LOG_ERROR(Spark::LogCategory::Graphics, "Failed to create embedded pixel shader");
+            return E_FAIL;
+        }
     }
 
     return S_OK;

--- a/SparkEngine/Source/Graphics/MSDFTextRenderer.cpp
+++ b/SparkEngine/Source/Graphics/MSDFTextRenderer.cpp
@@ -184,13 +184,17 @@ float4 main(PS_IN input) : SV_Target {
         cbDesc.Usage = D3D11_USAGE_DYNAMIC;
         cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
         cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
-        m_device->CreateBuffer(&cbDesc, nullptr, &m_constantBuffer);
+        hr = m_device->CreateBuffer(&cbDesc, nullptr, &m_constantBuffer);
+        if (FAILED(hr))
+            return false;
 
         // Sampler
         D3D11_SAMPLER_DESC sampDesc = {};
         sampDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
         sampDesc.AddressU = sampDesc.AddressV = sampDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
-        m_device->CreateSamplerState(&sampDesc, &m_linearSampler);
+        hr = m_device->CreateSamplerState(&sampDesc, &m_linearSampler);
+        if (FAILED(hr))
+            return false;
 
         // Alpha blend state
         D3D11_BLEND_DESC blendDesc = {};
@@ -202,19 +206,25 @@ float4 main(PS_IN input) : SV_Target {
         blendDesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
         blendDesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
         blendDesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
-        m_device->CreateBlendState(&blendDesc, &m_alphaBlendState);
+        hr = m_device->CreateBlendState(&blendDesc, &m_alphaBlendState);
+        if (FAILED(hr))
+            return false;
 
         // Depth stencil state (no depth test for UI text)
         D3D11_DEPTH_STENCIL_DESC dsDesc = {};
         dsDesc.DepthEnable = FALSE;
-        m_device->CreateDepthStencilState(&dsDesc, &m_depthStencilState);
+        hr = m_device->CreateDepthStencilState(&dsDesc, &m_depthStencilState);
+        if (FAILED(hr))
+            return false;
 
         // Rasterizer state
         D3D11_RASTERIZER_DESC rsDesc = {};
         rsDesc.FillMode = D3D11_FILL_SOLID;
         rsDesc.CullMode = D3D11_CULL_NONE;
         rsDesc.ScissorEnable = FALSE;
-        m_device->CreateRasterizerState(&rsDesc, &m_rasterizerState);
+        hr = m_device->CreateRasterizerState(&rsDesc, &m_rasterizerState);
+        if (FAILED(hr))
+            return false;
 
         return true;
     }

--- a/SparkEngine/Source/Graphics/TonemapColorGrading.cpp
+++ b/SparkEngine/Source/Graphics/TonemapColorGrading.cpp
@@ -310,9 +310,15 @@ float4 main(float4 pos : SV_Position, float2 uv : TEXCOORD0) : SV_Target {
             desc.Usage = D3D11_USAGE_DEFAULT;
             desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
 
-            m_device->CreateTexture2D(&desc, nullptr, &m_lumTextures[i]);
-            m_device->CreateRenderTargetView(m_lumTextures[i].Get(), nullptr, &m_lumRTVs[i]);
-            m_device->CreateShaderResourceView(m_lumTextures[i].Get(), nullptr, &m_lumSRVs[i]);
+            HRESULT hr = m_device->CreateTexture2D(&desc, nullptr, &m_lumTextures[i]);
+            if (FAILED(hr))
+                return false;
+            hr = m_device->CreateRenderTargetView(m_lumTextures[i].Get(), nullptr, &m_lumRTVs[i]);
+            if (FAILED(hr))
+                return false;
+            hr = m_device->CreateShaderResourceView(m_lumTextures[i].Get(), nullptr, &m_lumSRVs[i]);
+            if (FAILED(hr))
+                return false;
 
             lumSize = std::max(lumSize / 2, 1u);
         }
@@ -330,9 +336,15 @@ float4 main(float4 pos : SV_Position, float2 uv : TEXCOORD0) : SV_Target {
             desc.Usage = D3D11_USAGE_DEFAULT;
             desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
 
-            m_device->CreateTexture2D(&desc, nullptr, &m_adaptedLum[i]);
-            m_device->CreateRenderTargetView(m_adaptedLum[i].Get(), nullptr, &m_adaptedLumRTV[i]);
-            m_device->CreateShaderResourceView(m_adaptedLum[i].Get(), nullptr, &m_adaptedLumSRV[i]);
+            HRESULT hr = m_device->CreateTexture2D(&desc, nullptr, &m_adaptedLum[i]);
+            if (FAILED(hr))
+                return false;
+            hr = m_device->CreateRenderTargetView(m_adaptedLum[i].Get(), nullptr, &m_adaptedLumRTV[i]);
+            if (FAILED(hr))
+                return false;
+            hr = m_device->CreateShaderResourceView(m_adaptedLum[i].Get(), nullptr, &m_adaptedLumSRV[i]);
+            if (FAILED(hr))
+                return false;
         }
 
         // Constant buffer
@@ -341,16 +353,22 @@ float4 main(float4 pos : SV_Position, float2 uv : TEXCOORD0) : SV_Target {
         cbDesc.Usage = D3D11_USAGE_DYNAMIC;
         cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
         cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
-        m_device->CreateBuffer(&cbDesc, nullptr, &m_constantBuffer);
+        HRESULT hr = m_device->CreateBuffer(&cbDesc, nullptr, &m_constantBuffer);
+        if (FAILED(hr))
+            return false;
 
         // Samplers
         D3D11_SAMPLER_DESC sampDesc = {};
         sampDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
         sampDesc.AddressU = sampDesc.AddressV = sampDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
-        m_device->CreateSamplerState(&sampDesc, &m_linearClampSampler);
+        hr = m_device->CreateSamplerState(&sampDesc, &m_linearClampSampler);
+        if (FAILED(hr))
+            return false;
 
         sampDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
-        m_device->CreateSamplerState(&sampDesc, &m_pointSampler);
+        hr = m_device->CreateSamplerState(&sampDesc, &m_pointSampler);
+        if (FAILED(hr))
+            return false;
 
         return true;
     }

--- a/SparkEngine/Source/Physics/PhysicsSpatialQueries.cpp
+++ b/SparkEngine/Source/Physics/PhysicsSpatialQueries.cpp
@@ -78,7 +78,7 @@ RaycastHit PhysicsSystem::Raycast(const XMFLOAT3& origin, const XMFLOAT3& direct
         {
             // Get surface normal at hit point
             JPH::Body* joltBody = m_joltSystem->GetBodyLockInterface().TryGetBody(hitBodyID);
-            if (joltBody)
+            if (joltBody && joltBody->GetShape())
             {
                 JPH::Vec3 normal =
                     joltBody->GetShape()->GetSurfaceNormal(result.mSubShapeID2, ray.GetPointOnRay(result.mFraction));

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -149,5 +149,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 238 |
 | Test cases | 3109+ |
 | Wiki pages | 88 |
-| *Last synced* | *2026-04-03 00:55* |
+| *Last synced* | *2026-04-03 01:26* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
- Check HRESULT returns for all D3D11 Create* calls in TonemapColorGrading and MSDFTextRenderer
- Validate CreateShader results in GraphicsDeviceResources embedded shader compilation
- Add try-catch for std::stoi/stof in command-line parsing (SparkEngine.cpp)
- Guard Ctx() null dereference in EngineDiagnostics
- Guard GetShape() null dereference in PhysicsSpatialQueries
- Add post-write validation in ModSystem::SaveConfig and VFS ReadFile
- Wrap all unchecked std::stoi/stof/stoul in console commands across FPS, MMO,
  RTS, and Platformer game modules with try-catch and user-friendly error messages
- Wrap MMO persistence data parsing (character data, inventory, reputation,
  achievements, crafting, lockouts) in try-catch to handle corrupt save data

https://claude.ai/code/session_01DYfXviQgCqGwGAhemLj11B