### PR TITLE
Fix UBSan signed integer overflow in test busy-wait loops

### DIFF
--- a/Tests/TestChromeTracing.cpp
+++ b/Tests/TestChromeTracing.cpp
@@ -43,8 +43,8 @@ TEST(ChromeTracing_ScopeGuard)
     {
         SPARK_CHROME_TRACE_SCOPE("ScopedTest");
         // Some work
-        volatile int x = 0;
-        for (int i = 0; i < 100; i++)
+        volatile unsigned int x = 0;
+        for (unsigned int i = 0; i < 100; i++)
             x += i;
     }
 

--- a/Tests/TestDebugUtilities.cpp
+++ b/Tests/TestDebugUtilities.cpp
@@ -27,8 +27,8 @@ TEST(CpuDebugger_BasicTiming)
 
     cd.BeginSection("TestSection", "General", __FILE__, __LINE__, __FUNCTION__);
     // Small busy-wait to ensure measurable time
-    volatile int x = 0;
-    for (int i = 0; i < 10000; ++i)
+    volatile unsigned int x = 0;
+    for (unsigned int i = 0; i < 10000; ++i)
         x += i;
     cd.EndSection("TestSection");
 
@@ -48,8 +48,8 @@ TEST(CpuDebugger_SectionStats)
     for (int i = 0; i < 10; ++i)
     {
         cd.BeginSection("Repeated", "Test");
-        volatile int x = 0;
-        for (int j = 0; j < 1000; ++j)
+        volatile unsigned int x = 0;
+        for (unsigned int j = 0; j < 1000; ++j)
             x += j;
         cd.EndSection("Repeated");
     }
@@ -72,8 +72,8 @@ TEST(CpuDebugger_HotSpots)
     cd.EndSection("FastSection");
 
     cd.BeginSection("SlowSection", "General", "fileB.cpp", 20, "funcB");
-    volatile int x = 0;
-    for (int i = 0; i < 100000; ++i)
+    volatile unsigned int x = 0;
+    for (unsigned int i = 0; i < 100000; ++i)
         x += i;
     cd.EndSection("SlowSection");
 
@@ -89,8 +89,8 @@ TEST(CpuDebugger_ScopedSection)
 
     {
         Spark::ScopedCpuSection section("ScopedTest", "General", __FILE__, __LINE__, __FUNCTION__);
-        volatile int x = 0;
-        for (int i = 0; i < 1000; ++i)
+        volatile unsigned int x = 0;
+        for (unsigned int i = 0; i < 1000; ++i)
             x += i;
     }
 
@@ -137,8 +137,8 @@ TEST(CpuDebugger_P99Calculation)
     for (int i = 0; i < 100; ++i)
     {
         cd.BeginSection("P99Test", "Test");
-        volatile int x = 0;
-        for (int j = 0; j < 1000; ++j)
+        volatile unsigned int x = 0;
+        for (unsigned int j = 0; j < 1000; ++j)
             x += j;
         cd.EndSection("P99Test");
     }
@@ -469,8 +469,8 @@ TEST(ThreadDebugger_ContentionTracking)
     // Simulate a mutex wait
     td.RecordMutexWaitBegin("RenderMutex", __FILE__, __LINE__);
     // Small delay to simulate contention
-    volatile int x = 0;
-    for (int i = 0; i < 10000; ++i)
+    volatile unsigned int x = 0;
+    for (unsigned int i = 0; i < 10000; ++i)
         x += i;
     td.RecordMutexWaitEnd("RenderMutex");
 

--- a/Tests/TestProfiler.cpp
+++ b/Tests/TestProfiler.cpp
@@ -66,8 +66,8 @@ TEST(Profiler_BeginEndSection)
     p.BeginSection("TestSection", ProfileCategory::GameLogic);
 
     // Small busy-wait to ensure measurable time
-    volatile int x = 0;
-    for (int i = 0; i < 100000; ++i)
+    volatile unsigned int x = 0;
+    for (unsigned int i = 0; i < 100000; ++i)
         x += i;
 
     p.EndSection("TestSection");
@@ -111,8 +111,8 @@ TEST(Profiler_BeginEndFrame)
 
     p.BeginFrame();
 
-    volatile int x = 0;
-    for (int i = 0; i < 10000; ++i)
+    volatile unsigned int x = 0;
+    for (unsigned int i = 0; i < 10000; ++i)
         x += i;
 
     p.EndFrame();
@@ -181,8 +181,8 @@ TEST(Profiler_CategoryTimeMs)
     p.SetEnabled(true);
 
     p.BeginSection("RenderWork", ProfileCategory::Render);
-    volatile int x = 0;
-    for (int i = 0; i < 10000; ++i)
+    volatile unsigned int x = 0;
+    for (unsigned int i = 0; i < 10000; ++i)
         x += i;
     p.EndSection("RenderWork");
 
@@ -291,8 +291,8 @@ TEST(Profiler_ScopedProfileTimer)
 
     {
         ScopedProfileTimer timer("ScopedTest", ProfileCategory::GameLogic);
-        volatile int x = 0;
-        for (int i = 0; i < 10000; ++i)
+        volatile unsigned int x = 0;
+        for (unsigned int i = 0; i < 10000; ++i)
             x += i;
     }
 


### PR DESCRIPTION
The busy-wait pattern `volatile int x = 0; for (int i = 0; i < N; ++i) x += i` overflows signed int when N=100000 (sum ~5 billion). Changed all test busy-loop variables to unsigned int across TestDebugUtilities, TestProfiler, and TestChromeTracing to eliminate UBSan runtime errors.

https://claude.ai/code/session_013pbpQmtyuFCcGPZ7ZBGxPw