### PR TITLE
Exclude ThirdParty from CodeQL scanning and enable Copilot Autofix

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: "SparkEngine CodeQL Config"
+
+# Exclude third-party libraries from code scanning analysis.
+# These are vendored dependencies we don't maintain — alerts in them
+# are noise and should not block PRs.
+paths-ignore:
+  - "ThirdParty"
+  - "ThirdParty/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -110,11 +110,3 @@ jobs:
       uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"
-        output: sarif-results
-
-    - name: Copilot Autofix
-      if: github.event_name == 'pull_request'
-      uses: github/codeql-action/autofix@v4
-      with:
-        category: "/language:${{matrix.language}}"
-        output: autofix-results

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,9 @@ jobs:
       actions: read
       contents: read
 
+      # required for Copilot Autofix to propose pull request suggestions
+      pull-requests: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -81,10 +84,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
+        config-file: ./.github/codeql/codeql-config.yml
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
@@ -110,3 +110,11 @@ jobs:
       uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"
+        output: sarif-results
+
+    - name: Copilot Autofix
+      if: github.event_name == 'pull_request'
+      uses: github/codeql-action/autofix@v4
+      with:
+        category: "/language:${{matrix.language}}"
+        output: autofix-results


### PR DESCRIPTION
- Add .github/codeql/codeql-config.yml with paths-ignore for ThirdParty/
- Reference config in CodeQL init step to suppress alerts from vendored deps
- Add Copilot Autofix step (runs on PRs) to auto-suggest fixes for findings
- Grant pull-requests: write permission required by the autofix action

https://claude.ai/code/session_01LwFpJtW8drWnZMmPgaHyEz