### PR TITLE
Fix 3 engine stability issues: headless test-frames, SIGPIPE crash, O…

### DIFF
--- a/.github/badges/files.json
+++ b/.github/badges/files.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": 1,
-  "label": "source files",
-  "message": "1452",
-  "color": "green"
+    "schemaVersion": 1,
+    "label": "source files",
+    "message": "1452",
+    "color": "green"
 }

--- a/.github/badges/loc-breakdown.json
+++ b/.github/badges/loc-breakdown.json
@@ -1,11 +1,11 @@
 {
-  "schemaVersion": 1,
-  "total": 469357,
-  "files": 1452,
-  "engine": 240439,
-  "editor": 82887,
-  "game": 57421,
-  "tests": 86219,
-  "tools": 2391,
-  "updated": "2026-04-04T10:58:19Z"
+    "schemaVersion": 1,
+    "total": 469407,
+    "files": 1452,
+    "engine": 240489,
+    "editor": 82887,
+    "game": 57421,
+    "tests": 86219,
+    "tools": 2391,
+    "updated": "2026-04-04T12:34:09Z"
 }

--- a/.github/badges/loc.json
+++ b/.github/badges/loc.json
@@ -1,8 +1,8 @@
 {
-  "schemaVersion": 1,
-  "label": "C++ lines of code",
-  "message": "469357",
-  "color": "blue",
-  "namedLogo": "cplusplus",
-  "logoColor": "white"
+    "schemaVersion": 1,
+    "label": "C++ lines of code",
+    "message": "469407",
+    "color": "blue",
+    "namedLogo": "cplusplus",
+    "logoColor": "white"
 }

--- a/SparkEngine/Source/Core/SparkEngine.cpp
+++ b/SparkEngine/Source/Core/SparkEngine.cpp
@@ -1350,8 +1350,19 @@ static int RunHeadlessLinux(int argc, char* argv[])
     console.LogInfo("Starting headless server loop (60 Hz)...");
     console.LogInfo("Press Ctrl+C to stop.");
 
+    if (g_testFrameLimit > 0)
+        console.LogInfo(std::format("Test mode: will exit after {} frames", g_testFrameLimit));
+
+    int frameCount = 0;
+
     while (!g_shutdownRequested)
     {
+        if (g_testFrameLimit > 0 && frameCount >= g_testFrameLimit)
+        {
+            console.LogInfo(std::format("[TEST] Frame limit reached ({} frames). Exiting.", g_testFrameLimit));
+            break;
+        }
+
         SPARK_HEARTBEAT();
         auto tickStart = std::chrono::steady_clock::now();
         float dt = g_timer ? g_timer->GetDeltaTime() : (1.0f / 60.0f);
@@ -1372,6 +1383,8 @@ static int RunHeadlessLinux(int argc, char* argv[])
             Spark::ConsoleProcessManager::GetInstance().ProcessCommands();
             console.Update();
         });
+
+        ++frameCount;
 
         auto elapsed = std::chrono::steady_clock::now() - tickStart;
         if (elapsed < TICK_INTERVAL)
@@ -1744,24 +1757,61 @@ int main(int argc, char* argv[])
 {
     std::signal(SIGINT, SignalHandler);
     std::signal(SIGTERM, SignalHandler);
+#ifndef _WIN32
+    std::signal(SIGPIPE, SIG_IGN);
+#endif
 
-    g_testFrameLimit = ParseTestFrameLimitArgs(argc, argv);
-    ParseWindowSizeOverrideArgs(argc, argv);
+    try
+    {
+        g_testFrameLimit = ParseTestFrameLimitArgs(argc, argv);
+        ParseWindowSizeOverrideArgs(argc, argv);
 
 #ifdef SPARK_HEADLESS_SUPPORT
-    bool headless = ParseFlag(argc, argv, "-headless") || ParseFlag(argc, argv, "-dedicated");
-    g_headlessMode = headless;
-    if (headless)
-        return RunHeadlessLinux(argc, argv);
+        bool headless = ParseFlag(argc, argv, "-headless") || ParseFlag(argc, argv, "-dedicated");
+        g_headlessMode = headless;
+        if (headless)
+            return RunHeadlessLinux(argc, argv);
 #endif
 
 #ifdef SPARK_SDL2_AVAILABLE
-    int result = RunSDL2Windowed(argc, argv);
+        int result = RunSDL2Windowed(argc, argv);
 #else
-    int result = RunNoSDL2Fallback(argc, argv);
+        int result = RunNoSDL2Fallback(argc, argv);
 #endif
 
-    Spark::SimpleConsole::GetInstance().LogInfo("Spark Engine shut down cleanly.");
-    return result;
+        Spark::SimpleConsole::GetInstance().LogInfo("Spark Engine shut down cleanly.");
+        return result;
+    }
+    catch (const std::system_error& e)
+    {
+        fprintf(stderr, "[FATAL] System error during engine execution: %s (code: %d)\n", e.what(), e.code().value());
+    }
+    catch (const std::bad_alloc&)
+    {
+        fprintf(stderr, "[FATAL] Out of memory during engine execution\n");
+    }
+    catch (const std::exception& e)
+    {
+        fprintf(stderr, "[FATAL] Unhandled exception: %s\n", e.what());
+    }
+
+    // Emergency cleanup: release globals to prevent segfault during static
+    // destruction. EventBus channels hold vtable pointers into module .so code;
+    // if modules are unloaded first, channel destructors will segfault.
+    // Under resource exhaustion, module shutdown itself may throw (from
+    // destructors calling thread join, etc.), so we leak rather than crash.
+    if (g_eventBus)
+    {
+        try
+        {
+            g_eventBus->ClearAll();
+        }
+        catch (...)
+        {
+        }
+    }
+    g_eventBus.release();
+    g_moduleManager.release();
+    return 1;
 }
 #endif // !SPARK_PLATFORM_WINDOWS

--- a/wiki/Codebase-Statistics.md
+++ b/wiki/Codebase-Statistics.md
@@ -8,13 +8,13 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 
 | Section | Lines |
 |---------|------:|
-| **SparkEngine/Source** | 240439 |
+| **SparkEngine/Source** | 240489 |
 | **SparkEditor/Source** | 82887 |
 | **GameModules** | 57421 |
 | **Tests** | 86219 |
 | **SparkConsole/src** | 1858 |
 | **SparkShaderCompiler/src** | 533 |
-| **Total C++ (excl. ThirdParty)** | **~469357** |
+| **Total C++ (excl. ThirdParty)** | **~469407** |
 
 ### File Counts
 
@@ -43,9 +43,9 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 | Subsystem | Lines | % of Source |
 |-----------|------:|:----------:|
 | Graphics | 95851 | 39.8% |
-| Engine (all subsystems) | 71184 | 29.6% |
+| Engine (all subsystems) | 71184 | 29.5% |
 | Utils | 31706 | 13.1% |
-| Core | 17229 | 7.1% |
+| Core | 17279 | 7.1% |
 | Physics | 10087 | 4.1% |
 | Audio | 5520 | 2.2% |
 | Input | 3345 | 1.3% |
@@ -155,7 +155,7 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 | File | Lines |
 |------|------:|
 | `OpenGLDevice.cpp` | 1932 |
-| `SparkEngine.cpp` | 1767 |
+| `SparkEngine.cpp` | 1817 |
 | `VulkanDevice.cpp` | 1722 |
 | `GraphicsEngine.cpp` | 1569 |
 | `D3D12Device.cpp` | 1558 |

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -182,5 +182,5 @@ SparkEngine is licensed under the [MIT License](https://github.com/Krilliac/Spar
 | Test files | 278 |
 | Test cases | 3511+ |
 | Wiki pages | 101 |
-| *Last synced* | *2026-04-04 09:31* |
+| *Last synced* | *2026-04-04 12:34* |
 <!-- /AUTO:stats -->


### PR DESCRIPTION
…OM segfault

- Headless server loop now respects --test-frames flag (was silently ignored)
- Ignore SIGPIPE on Linux to prevent unexpected termination under fd exhaustion
- Add top-level exception handling in main() for std::system_error/bad_alloc
- Emergency cleanup releases EventBus/ModuleManager to prevent vtable segfault during static destruction when modules are already unloaded

https://claude.ai/code/session_011WwxdqDZNh1bF8vfxZNC7o