### PR TITLE
fix: remove unused variables causing compilation errors

### DIFF
--- a/SparkEngine/Source/Engine/Networking/NetworkManager.cpp
+++ b/SparkEngine/Source/Engine/Networking/NetworkManager.cpp
@@ -666,7 +666,6 @@ namespace Spark::Net
             XMVECTOR bmin = XMLoadFloat3(&entity.boundsMin);
             XMVECTOR bmax = XMLoadFloat3(&entity.boundsMax);
 
-            XMVECTOR invDir;
             XMFLOAT3 dir;
             XMStoreFloat3(&dir, direction);
             float invDirX = (dir.x != 0.0f) ? (1.0f / dir.x) : 1e30f;

--- a/SparkEngine/Source/Engine/Security/MemoryIntegrity.cpp
+++ b/SparkEngine/Source/Engine/Security/MemoryIntegrity.cpp
@@ -473,7 +473,6 @@ namespace Spark::Security
         if (hModule == nullptr)
             return;
 
-        MODULEINFO modInfo{};
         // GetModuleInformation requires psapi — use VirtualQuery walk instead
         auto baseAddr = reinterpret_cast<const uint8_t*>(hModule);
         MEMORY_BASIC_INFORMATION mbi{};


### PR DESCRIPTION
Remove unused `MODULEINFO modInfo` in MemoryIntegrity.cpp (undeclared identifier since psapi header isn't included — VirtualQuery walk is used instead) and unused `XMVECTOR invDir` in NetworkManager.cpp.

https://claude.ai/code/session_01M9dHeUJaed39qPvqZAbvs9