### PR TITLE
refactor: use ::SceneNode qualifier and include EngineContext.h for T…

### DIFF
--- a/SparkEditor/Source/UndoRedo/EditorCommand.h
+++ b/SparkEditor/Source/UndoRedo/EditorCommand.h
@@ -257,7 +257,7 @@ namespace SparkEditor
             auto* scene = EngineContext::Get() ? EngineContext::Get()->GetSceneManager() : nullptr;
             if (!scene)
                 return;
-            SceneNode node;
+            ::SceneNode node;
             node.name = m_entityName;
             m_createdEntityId = static_cast<uint64_t>(scene->AddNode(node));
         }
@@ -321,7 +321,7 @@ namespace SparkEditor
       private:
         uint64_t m_entityId;
         std::string m_entityName;
-        SceneNode m_savedNode;
+        ::SceneNode m_savedNode;
         // Snapshot of the entity's components for restoration
         std::unordered_map<std::string, std::unordered_map<std::string, PropertyValue>> m_componentSnapshot;
     };

--- a/SparkEngine/Source/Core/Reflection.h
+++ b/SparkEngine/Source/Core/Reflection.h
@@ -42,17 +42,9 @@
 #include <unordered_map>
 #include <vector>
 
-// Reuse the EngineContext TypeId pattern
-#ifndef SPARK_TYPEID_DEFINED
-#define SPARK_TYPEID_DEFINED
-using TypeId = const void*;
-
-template <typename T> TypeId GetTypeId()
-{
-    static const char id = 0;
-    return &id;
-}
-#endif
+// TypeId and GetTypeId are defined in EngineContext.h — include it rather than
+// duplicating the definition, which causes "already defined" errors on MSVC.
+#include "Core/EngineContext.h"
 
 namespace Spark
 {


### PR DESCRIPTION
…ypeId

- EditorCommand.h: Use ::SceneNode for unambiguous global namespace lookup
- Reflection.h: Include EngineContext.h instead of duplicating TypeId definition

https://claude.ai/code/session_01Bp73AWt15yadTN42NstkaV