### PR TITLE
Add 8 new wiki pages and fix stale counts across documentation

### DIFF
--- a/.claude/index.md
+++ b/.claude/index.md
@@ -21,7 +21,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 | 66 oversized functions, 7 private-method violations | [knowledge/code-quality-violations.md](knowledge/code-quality-violations.md) | Observation | Active | 2026-03-16 |
 | Engine systems (29+ working, all wired) | [knowledge/gameplay-systems-status.md](knowledge/gameplay-systems-status.md) | Observation | Active | 2026-03-22 |
 | SparkGame module (AI enemies now wired) | [knowledge/sparkgame-module-status.md](knowledge/sparkgame-module-status.md) | Observation | Active | 2026-03-22 |
-| Documentation coverage (89 wiki pages, 100% Doxygen) | [knowledge/documentation-coverage-audit.md](knowledge/documentation-coverage-audit.md) | Observation | Active | 2026-04-04 |
+| Documentation coverage (125 wiki pages, 100% Doxygen) | [knowledge/documentation-coverage-audit.md](knowledge/documentation-coverage-audit.md) | Observation | Active | 2026-04-06 |
 | ThirdParty dependencies | [knowledge/thirdparty-dependencies-audit.md](knowledge/thirdparty-dependencies-audit.md) | Observation | Active | 2026-03-17 |
 | Load test baseline (frame/CPU/memory benchmarks) | [knowledge/load-test-baseline.md](knowledge/load-test-baseline.md) | Observation | Active | 2026-03-26 |
 | Live editor testing (Xvfb + Mesa llvmpipe) | [knowledge/live-editor-testing.md](knowledge/live-editor-testing.md) | Pattern | Active | 2026-03-28 |
@@ -38,7 +38,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 | Memory safety evaluation & C++26 bridge (Contracts, NonNull, SafeCast) | [knowledge/memory-safety-evaluation.md](knowledge/memory-safety-evaluation.md) | Decision | Active | 2026-04-06 |
 ## Quick Reference
 
-### Current Engine State (2026-04-06)
+### Current Engine State (2026-04-07)
 
 - **Physics**: Jolt Physics (migrated from Bullet3). Use `EngineContext::Get()->GetPhysics()`
 - **Networking**: Enabled by default (`ENABLE_NETWORKING=ON`), UDP sockets, no external deps
@@ -50,7 +50,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 - **Game modules**: 10 (SparkGame, FPS, MMO, RPG, ARPG, RTS, Racing, Platformer, OpenWorld, VisualScript)
 - **Infrastructure**: JobSystem wired, DeferredDeletionQueue in RHI, collision layer filtering, EntityEventBus cleanup, archetype spawn overrides
 - **Gameplay**: TimeOfDaySystem, AI enemies in SparkGame, WeatherSystem integration
-- **Codebase**: ~510K lines of C++ across 1574 source files, 117 wiki pages
+- **Codebase**: ~510K lines of C++ across 1574 source files, 125 wiki pages
 
 ### Before Writing Code
 

--- a/.claude/knowledge/documentation-coverage-audit.md
+++ b/.claude/knowledge/documentation-coverage-audit.md
@@ -1,24 +1,37 @@
 # Documentation Coverage Audit
 
-**Last updated:** 2026-04-03
+**Last updated:** 2026-04-06
 **Type:** Observation
 **Status:** Active
 **Severity:** Low
 
 ## Description
 
-88 wiki pages (excluding _Sidebar.md), 245/246 headers with Doxygen comments, near-complete API coverage. Added 5 new user-facing wiki pages: FAQ, Quick-Start Tutorial, Editor Walkthrough, Configuration Reference, Performance Tips. Updated Home.md with role-based reading paths.
+125 wiki pages (excluding _Sidebar.md), 246/246 headers with Doxygen comments, complete API coverage. Added 8 new graphics/rendering wiki pages: Post-Processing, Neural Rendering, Material System, Decal System, Particle System, Sky and Atmosphere, Shadow System, Foliage System. Fixed stale counts across README, PROJECT_STATUS, FEATURE_ROADMAP, CHANGELOG, and editor references (57→59 panels, test counts updated to 4290).
 
 ---
 
-## Wiki Coverage (83 pages)
+## Wiki Coverage (125 pages)
 
 ### Statistics
-- **Total pages**: 88 (excluding _Sidebar.md)
-- All engine subsystems have wiki pages (including Tween System, previously missing)
-- All major graphics subsystems documented (Render Graph, GPU Particles, GPU-Driven Rendering, Volumetric Fog, Global Illumination, Virtual Texturing, Water Rendering, Clustered Lighting, Mesh Shaders, Shader Graph)
-- Broad topic pages added: Error Handling Patterns, Hot Reload Overview
-- User-facing docs added: FAQ, Quick-Start Tutorial, Editor Walkthrough, Configuration Reference, Performance Tips
+- **Total pages**: 125 (excluding _Sidebar.md)
+- All engine subsystems have wiki pages
+- All graphics subsystems documented (Render Graph, GPU Particles, GPU-Driven Rendering, Volumetric Fog, Global Illumination, Virtual Texturing, Water Rendering, Clustered Lighting, Mesh Shaders, Shader Graph, Post-Processing, Neural Rendering, Material System, Decal System, Particle System, Sky and Atmosphere, Shadow System, Foliage System)
+- Broad topic pages: Error Handling Patterns, Hot Reload Overview
+- User-facing docs: FAQ, Quick-Start Tutorial, Editor Walkthrough, Configuration Reference, Performance Tips
+
+### New Pages Added (2026-04-06)
+
+| Page | Category | Coverage |
+|------|----------|----------|
+| `Post-Processing.md` | Graphics | 14-pass pipeline, per-effect settings, performance metrics |
+| `Neural-Rendering.md` | Graphics | Inference engine, radiance cache, NTC, neural denoiser/SR |
+| `Material-System.md` | Graphics | PBR metallic/roughness, 18 texture slots, advanced properties |
+| `Decal-System.md` | Graphics | Deferred decals, surface types, weapon integration |
+| `Particle-System.md` | Graphics | CPU particles, emitter shapes, blend modes |
+| `Sky-and-Atmosphere.md` | Graphics | Preetham sky model, turbidity, sun direction |
+| `Shadow-System.md` | Graphics | Shadow atlas, PCSS, temporal caching |
+| `Foliage-System.md` | Graphics | Instanced vegetation, terrain-aware placement |
 
 ### New Pages Added (2026-04-03)
 
@@ -99,8 +112,8 @@ docs/
 
 ## What's Done Right
 
-- 83 wiki pages covering all major subsystems and advanced graphics
-- 99.6% header Doxygen coverage
+- 125 wiki pages covering all major subsystems, graphics, and rendering
+- 100% header Doxygen coverage (246/246)
 - Codebase-Statistics.md with comprehensive metrics
 - Codebase-Health.md with system maturity status
 - Unified error handling and hot-reload documentation

--- a/.claude/knowledge/engine-viability-evaluation.md
+++ b/.claude/knowledge/engine-viability-evaluation.md
@@ -103,7 +103,7 @@ wWinMain() / main()
 Save system, UI, dialogue, ability system (WoW-style), scripting (conditional on SDK),
 weather, destruction, modding (VFS + SparkPak), coroutines, events
 
-### 11. Editor -- EXTENSIVE (57 panels, collaborative editing)
+### 11. Editor -- EXTENSIVE (59 panels, collaborative editing)
 
 ### 12. Tests -- 211 files, 2,577 tests (all pass on Linux)
 

--- a/.github/badges/loc-breakdown.json
+++ b/.github/badges/loc-breakdown.json
@@ -1,11 +1,11 @@
 {
     "schemaVersion": 1,
-    "total": 510938,
+    "total": 510916,
     "files": 1574,
     "engine": 261074,
     "editor": 85303,
-    "game": 57841,
-    "tests": 104329,
+    "game": 57813,
+    "tests": 104335,
     "tools": 2391,
-    "updated": "2026-04-06T14:24:43Z"
+    "updated": "2026-04-07T00:07:30Z"
 }

--- a/.github/badges/loc.json
+++ b/.github/badges/loc.json
@@ -1,7 +1,7 @@
 {
     "schemaVersion": 1,
     "label": "C++ lines of code",
-    "message": "510938",
+    "message": "510916",
     "color": "blue",
     "namedLogo": "cplusplus",
     "logoColor": "white"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Animation system (skeletal, blend spaces, IK, retargeting)
 - UDP networking with entity replication, prediction, lag compensation
 - EnTT-based ECS with 75 component types and 25 systems
-- Dear ImGui editor with 57 panels and collaborative editing
+- Dear ImGui editor with 59 panels and collaborative editing
 - Audio system (XAudio2, OpenAL, null backend)
 - AngelScript + Lua scripting with hot-reload
 - 10 game modules (FPS, RPG, MMO, ARPG, RTS, Racing, Platformer, OpenWorld, VisualScript)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 
 ### Why Spark Engine?
 
-- **Complete game engine** — rendering (6 backends), physics, audio, AI, animation, networking, scripting, visual scripting, and a 57-panel editor all in one package
+- **Complete game engine** — rendering (6 backends), physics, audio, AI, animation, networking, scripting, visual scripting, and a 59-panel editor all in one package
 - **General-purpose** — FPS, RPG, MMO, battle royale, open-world, RTS, racing, platformer — build any genre with 10 built-in game module templates
 - **Advanced rendering** — global illumination (DDGI/APV), GPU-driven rendering, mesh shaders, virtual texturing, DXR ray tracing, Shader Graph, and RenderGraph
 - **Scalable multiplayer** — from single-player to MMO-scale via HeroEngine-inspired area-based server architecture with seamless entity migration
@@ -64,7 +64,7 @@
 
 ## Editor Preview
 
-![SparkEditor — ImGui-based visual editor with 57 dockable panels](docs/screenshots/editor-overview.png)
+![SparkEditor — ImGui-based visual editor with 59 dockable panels](docs/screenshots/editor-overview.png)
 
 *SparkEditor default layout — Hierarchy, Scene View, Inspector, Console, and Asset Browser. Additional panels available from the Window menu. Spark Professional dark theme.*
 
@@ -75,7 +75,7 @@
 
 ![Welcome screen](docs/screenshots/editor-welcome.png)
 
-**Window Menu** (57 panels available)
+**Window Menu** (59 panels available)
 
 ![Window menu](docs/screenshots/editor-window-menu.png)
 
@@ -181,7 +181,7 @@ AngelScript with Unity-style hot-reload (file watcher with debouncing and state 
 
 ### Editor
 
-ImGui-powered visual editor with 57 specialized dockable panels: scene hierarchy, inspector, asset browser, game viewport, gizmos (ImGuizmo), node graphs (imnodes), animation timeline, material editor with Shader Graph, visual script editor (node-based, compiles to AngelScript), terrain editing, weapon editor, profiler, AI editor/debugger, physics debug, cinematic sequencer, dialogue editor, ability/condition/trigger editors, destruction editor, 2D/sprite/tilemap editors, FPS tools, audio mixer, replay panel, save system panel, dedicated server panel, version control integration, build/deployment pipeline, level streaming, search panel, command palette (Ctrl+P), prefab system, event monitor, coroutine debugger, collaboration panel, project management, scene statistics, accessibility settings, VR configuration, and theming. Collaborative multi-user editing (HeroEngine-inspired node locking, edit broadcasting, peer presence awareness). Full undo/redo support, play-mode editing, and plugin system (built-in + DLL).
+ImGui-powered visual editor with 59 specialized dockable panels: scene hierarchy, inspector, asset browser, game viewport, gizmos (ImGuizmo), node graphs (imnodes), animation timeline, material editor with Shader Graph, visual script editor (node-based, compiles to AngelScript), terrain editing, weapon editor, profiler, AI editor/debugger, physics debug, cinematic sequencer, dialogue editor, ability/condition/trigger editors, destruction editor, 2D/sprite/tilemap editors, FPS tools, audio mixer, replay panel, save system panel, dedicated server panel, version control integration, build/deployment pipeline, level streaming, search panel, command palette (Ctrl+P), prefab system, event monitor, coroutine debugger, collaboration panel, project management, scene statistics, accessibility settings, VR configuration, and theming. Collaborative multi-user editing (HeroEngine-inspired node locking, edit broadcasting, peer presence awareness). Full undo/redo support, play-mode editing, and plugin system (built-in + DLL).
 
 ### Procedural Generation
 
@@ -310,7 +310,7 @@ Standalone debug console application that communicates with SparkEngine via name
 |                   |                   |                   |
 |  AngelScript VM   |  InputManager     |  EnTT ECS (75+)   |
 |  Visual Scripting |  Gamepad / SDL2   |  SceneManager     |
-|  Hot Reload / Lua |  ImGui Editor(57) |  AssetPipeline    |
+|  Hot Reload / Lua |  ImGui Editor(59) |  AssetPipeline    |
 +-------------------+-------------------+-------------------+
 |    Gameplay       |    AI & Nav       |    Networking     |
 |                   |                   |                   |
@@ -385,7 +385,7 @@ SparkEngine/
 |       |-- SceneManager/    # Scene and level management
 |       |-- Utils/           # Logging, profiler, crash handler, console, debug tools
 |-- SparkEditor/
-|   |-- Source/              # ImGui editor (57 panels, collaborative editing)
+|   |-- Source/              # ImGui editor (59 panels, collaborative editing)
 |-- SparkConsole/
 |   |-- src/                 # Standalone debug console application
 |-- SparkShaderCompiler/
@@ -417,7 +417,7 @@ SparkEngine/
 |   |-- SparkBuild.exe       # Pre-built SparkBuild binary
 |   |-- update-sparkbuild.*  # Manual update scripts (ps1/sh)
 |-- docs/                    # Doxygen docs, wiki, API reference
-|-- wiki/                    # 117 wiki pages covering all subsystems
+|-- wiki/                    # 125 wiki pages covering all subsystems
 |-- cmake/                   # CMake utility modules
 |-- .github/
 |   |-- workflows/          # CI/CD (build + release)

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -34,7 +34,7 @@ Features being evaluated but not yet committed to.
 |---------|-------|
 | **WebGPU Backend** | Browser-based rendering via WebGPU API. |
 | **Additional VR Runtimes** | Beyond OpenXR (native Oculus, SteamVR). |
-| **Machine Learning Integration** | Neural rendering, AI upscaling, procedural content via ML. |
+| **Machine Learning Integration** | **Shipped** (v1.0.0) — Neural texture compression, radiance cache, denoiser, super-resolution. See `ENABLE_NEURAL_RENDERING`. |
 | **Deterministic Lockstep Networking** | Alternative to current snapshot-based replication. |
 
 ## Completed (v1.0.0)
@@ -50,12 +50,12 @@ Major features shipped in the initial release:
 - Shader Graph (35+ nodes, HLSL generation)
 - Visual Scripting (60 node types, compiles to AngelScript)
 - HeroEngine-inspired MMO networking (AreaServers, WorldServer, seamless migration)
-- 57-panel ImGui editor with collaborative multi-user editing
+- 59-panel ImGui editor with collaborative multi-user editing
 - Jolt Physics (vehicles, ragdoll, cloth, destruction)
 - 10 game module templates (FPS, MMO, RPG, ARPG, RTS, Racing, Platformer, OpenWorld, VisualScript, Base)
 - Accessibility (colorblind modes, subtitles, reduced motion, one-handed input)
-- 3727 unit tests, 5 sanitizer CI jobs, code coverage
+- 4290 unit tests across 338 files, 5 sanitizer CI jobs, code coverage
 
 ---
 
-*Last updated: 2026-04-05*
+*Last updated: 2026-04-06*

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -111,7 +111,7 @@ Current status of all major subsystems as of v1.0.0 (April 2026).
 
 | System | Status | Notes |
 |--------|--------|-------|
-| Panel System | **Stable** | 57 dockable panels, layout save/load |
+| Panel System | **Stable** | 59 dockable panels, layout save/load |
 | Gizmos | **Stable** | Translate/rotate/scale (ImGuizmo) |
 | Node Graphs | **Stable** | Visual scripting, shader graph (imnodes) |
 | Command Palette | **Stable** | Ctrl+P quick access |
@@ -151,7 +151,7 @@ Current status of all major subsystems as of v1.0.0 (April 2026).
 
 | System | Status | Notes |
 |--------|--------|-------|
-| Unit Tests | **Stable** | 3727 tests, 303 files |
+| Unit Tests | **Stable** | 4290 tests, 338 files |
 | ASan / UBSan / LSan | **Stable** | CI enforced |
 | TSan | **Stable** | CI enforced |
 | MSan | Experimental | Advisory (uninstru mented libc++) |
@@ -162,4 +162,4 @@ Current status of all major subsystems as of v1.0.0 (April 2026).
 
 ---
 
-*Last updated: 2026-04-05*
+*Last updated: 2026-04-06*

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ This `docs/` directory also contains tooling for Doxygen-based API documentation
 | Directory | Description |
 |-----------|-------------|
 | `SparkEngine/Source/` | Core engine library (all subsystems) |
-| `SparkEditor/Source/` | ImGui visual editor (57 panels) |
+| `SparkEditor/Source/` | ImGui visual editor (59 panels) |
 | `SparkConsole/src/` | Standalone debug console application |
 | `SparkShaderCompiler/src/` | Offline shader compilation tool |
 | `GameModules/*/Source/` | 10 game modules (FPS, MMO, RPG, ARPG, RTS, Racing, Platformer, OpenWorld, VisualScript) |

--- a/wiki/Codebase-Health.md
+++ b/wiki/Codebase-Health.md
@@ -118,7 +118,7 @@ Status legend: **DONE** = fully implemented and wired in | **PARTIAL** = core wo
 
 | System | Status | Notes |
 |--------|:------:|-------|
-| ImGui editor core | **DONE** | 57 panel classes, docking, theming |
+| ImGui editor core | **DONE** | 59 panel classes, docking, theming |
 | Scene hierarchy | **DONE** | Tree view with drag-drop |
 | Inspector | **DONE** | Component renderers |
 | Material editor | **DONE** | PBR material editing |

--- a/wiki/Codebase-Statistics.md
+++ b/wiki/Codebase-Statistics.md
@@ -1,6 +1,6 @@
 # Codebase Statistics
 
-Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-06.
+Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-07.
 
 ## Code Volume
 
@@ -10,11 +10,11 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 |---------|------:|
 | **SparkEngine/Source** | 261074 |
 | **SparkEditor/Source** | 85303 |
-| **GameModules** | 57841 |
-| **Tests** | 104329 |
+| **GameModules** | 57813 |
+| **Tests** | 104335 |
 | **SparkConsole/src** | 1858 |
 | **SparkShaderCompiler/src** | 533 |
-| **Total C++ (excl. ThirdParty)** | **~510938** |
+| **Total C++ (excl. ThirdParty)** | **~510916** |
 
 ### File Counts
 
@@ -26,7 +26,7 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 | GLSL shader files | 14 |
 | AngelScript files (.as) | 1 |
 | Test files (.cpp) | 338 |
-| Wiki pages (.md) | 117 |
+| Wiki pages (.md) | 125 |
 
 ### Code Density
 

--- a/wiki/Decal-System.md
+++ b/wiki/Decal-System.md
@@ -1,0 +1,290 @@
+# Decal System
+
+SparkEngine's decal system provides deferred decal projection for FPS visual feedback -- bullet holes, scorch marks, blood splatters, and other environmental detail projected onto scene surfaces. Decals are surface-type aware, automatically selecting the right material based on whether a bullet hits concrete, metal, wood, or flesh.
+
+**Source:** `SparkEngine/Source/Graphics/DecalSystem.h`
+
+---
+
+## Overview
+
+The `DecalSystem` is a singleton that manages a fixed-size pool of projected decals. Each decal is an oriented bounding box (OBB) projected onto the surface at a hit point, combining albedo, normal, and roughness textures to blend seamlessly with the underlying geometry. The system integrates with the weapon/raycast pipeline: when a projectile hits a surface, the system spawns the appropriate decal based on the `DecalType` and `SurfaceType` at the impact point.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     Weapon System                        │
+│           (raycast hit -> position, normal, surface)     │
+├─────────────────────────────────────────────────────────┤
+│                      DecalSystem                         │
+│  ┌──────────────┬────────────────┬────────────────────┐ │
+│  │ Material     │ Surface-Decal  │ Decal Pool         │ │
+│  │ Registry     │ Mapping Table  │ (spawn, fade, cull)│ │
+│  │              │                │                    │ │
+│  │ RegisterMaterial()  RegisterSurfaceMapping()       │ │
+│  │ GetMaterial()       SpawnDecal()  Update()         │ │
+│  └──────────────┴────────────────┴────────────────────┘ │
+├─────────────────────────────────────────────────────────┤
+│  DecalMaterial       Decal           SurfaceDecalMapping │
+│  (textures,          (OBB, fade,     (surface -> material│
+│   opacity, flags)     lifetime)       + size range)      │
+├─────────────────────────────────────────────────────────┤
+│              Deferred Rendering Pass                      │
+│         (project OBBs into G-buffer)                     │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Namespace
+
+All decal types reside in `namespace Spark::Graphics`.
+
+---
+
+## Decal Types and Surface Types
+
+### DecalType
+
+Identifies the category of decal to spawn. The system uses this together with `SurfaceType` to look up the correct material and size range.
+
+| Value | Description |
+|-------|-------------|
+| `BulletHole` | Small impact mark from projectile hits |
+| `ScorchMark` | Burn or explosion residue |
+| `BloodSplatter` | Organic impact effect |
+| `Footprint` | Character or creature footprints |
+| `TireTrack` | Vehicle tire marks |
+| `Crack` | Structural damage cracks |
+| `Custom` | User-defined decal with explicit material |
+
+### SurfaceType
+
+Identifies the physical material of the surface that was hit. Different surfaces produce different decal sizes and materials (e.g., bullet holes are smaller on metal than on wood).
+
+| Value | Description |
+|-------|-------------|
+| `Default` | Fallback surface type |
+| `Concrete` | Stone, cement, brick |
+| `Metal` | Steel, iron, aluminum |
+| `Wood` | Timber, planks, furniture |
+| `Glass` | Windows, bottles |
+| `Dirt` | Soil, gravel, sand |
+| `Flesh` | Organic targets |
+| `Water` | Liquid surfaces |
+| `Foliage` | Leaves, grass, vegetation |
+
+### Default Surface Mappings
+
+The system registers these mappings during `Initialize()`:
+
+| Surface | Decal Type | Material | Size Range |
+|---------|-----------|----------|------------|
+| Concrete | BulletHole | `decal_bullet_hole` | 0.05 -- 0.15 |
+| Metal | BulletHole | `decal_bullet_hole` | 0.03 -- 0.08 |
+| Wood | BulletHole | `decal_bullet_hole` | 0.04 -- 0.12 |
+| Default | ScorchMark | `decal_scorch` | 0.3 -- 0.8 |
+| Default | BloodSplatter | `decal_blood` | 0.2 -- 0.5 |
+
+Custom mappings can be registered at runtime via `RegisterSurfaceMapping()`.
+
+---
+
+## DecalMaterial Configuration
+
+A `DecalMaterial` defines the visual appearance of a decal through PBR textures and blending controls:
+
+```cpp
+struct DecalMaterial
+{
+    std::string name;              // Unique identifier (e.g. "decal_bullet_hole")
+    std::string albedoTexture;     // Color/albedo texture path
+    std::string normalTexture;     // Normal map path (optional)
+    std::string roughnessTexture;  // Roughness map path (optional)
+    float opacity = 1.0f;          // Base opacity (0.0 - 1.0)
+    bool affectsNormals = true;    // Whether to write to G-buffer normals
+    bool affectsRoughness = true;  // Whether to write to G-buffer roughness
+};
+```
+
+| Field | Purpose |
+|-------|---------|
+| `name` | Lookup key used by surface mappings and `SpawnDecalWithMaterial()` |
+| `albedoTexture` | Diffuse color texture (e.g. `Textures/Decals/bullet_hole.dds`) |
+| `normalTexture` | Perturbs surface normals for depth effect (e.g. indent around bullet hole) |
+| `roughnessTexture` | Overrides surface roughness (e.g. scorch marks are rougher) |
+| `opacity` | Base opacity before fade-out is applied |
+| `affectsNormals` | Set to `false` for flat decals like scorch marks that should not alter normals |
+| `affectsRoughness` | Set to `false` for decals that should preserve the underlying surface roughness |
+
+### Default Materials
+
+Three materials are registered during `Initialize()`:
+
+| Name | Albedo | Normal | Affects Normals |
+|------|--------|--------|----------------|
+| `decal_bullet_hole` | `Textures/Decals/bullet_hole.dds` | `Textures/Decals/bullet_hole_normal.dds` | Yes |
+| `decal_scorch` | `Textures/Decals/scorch_mark.dds` | -- | No |
+| `decal_blood` | `Textures/Decals/blood_splatter.dds` | -- | No |
+
+---
+
+## Pooling and Lifecycle
+
+The decal system uses a fixed-capacity object pool to avoid dynamic allocation during gameplay.
+
+### Pool Behavior
+
+1. **Spawn request** -- `SpawnDecal()` or `SpawnDecalWithMaterial()` is called.
+2. **Find inactive slot** -- The pool is scanned for the first `active == false` entry.
+3. **Grow if room** -- If no inactive slot exists and `m_decals.size() < m_maxDecals`, a new entry is appended.
+4. **Recycle oldest** -- If the pool is full, the oldest active decal is immediately deactivated and its slot is reused.
+
+### Fade-Out Timeline
+
+Each decal follows a two-phase lifetime:
+
+```
+|<---- fadeTimer ---->|<-- fadeDuration -->|
+       Full opacity         Fading            Deactivated
+     (default 15s)       (default 3s)
+```
+
+- **`fadeTimer`** (default 15 seconds) -- The decal remains at full opacity.
+- **`fadeDuration`** (default 3 seconds) -- Opacity linearly interpolates from full to zero.
+- Once `age >= fadeTimer + fadeDuration`, the decal is marked `active = false` and its slot becomes available for reuse.
+
+The current opacity at any point is computed by `Decal::GetCurrentOpacity()`:
+
+```cpp
+if (age < fadeTimer) return opacity;
+float fadeProgress = min(1.0f, (age - fadeTimer) / fadeDuration);
+return opacity * (1.0f - fadeProgress);
+```
+
+### Configuration
+
+| Method | Default | Description |
+|--------|---------|-------------|
+| `SetMaxDecals(uint32_t)` | 512 | Maximum number of decals in the pool |
+| `SetDefaultFadeTime(float)` | 15.0s | Seconds before fade-out begins |
+| `SetDefaultFadeDuration(float)` | 3.0s | Seconds for the fade-out transition |
+| `ClearAllDecals()` | -- | Immediately deactivates all decals |
+
+---
+
+## Code Example
+
+### Spawning a decal from a weapon hit
+
+```cpp
+#include "Graphics/DecalSystem.h"
+
+using namespace Spark::Graphics;
+
+// After a raycast hit:
+void OnWeaponHit(const XMFLOAT3& hitPos, const XMFLOAT3& hitNormal, SurfaceType surface)
+{
+    auto& decals = DecalSystem::GetInstance();
+
+    // Automatic material selection based on surface type
+    Decal* decal = decals.SpawnDecal(hitPos, hitNormal, DecalType::BulletHole, surface);
+
+    // Or spawn with an explicit material and size
+    Decal* custom = decals.SpawnDecalWithMaterial(hitPos, hitNormal, "decal_scorch", 0.5f);
+}
+```
+
+### Registering a custom material and surface mapping
+
+```cpp
+// Register a new decal material
+DecalMaterial laserBurn;
+laserBurn.name = "decal_laser_burn";
+laserBurn.albedoTexture = "Textures/Decals/laser_burn.dds";
+laserBurn.normalTexture = "Textures/Decals/laser_burn_normal.dds";
+laserBurn.affectsRoughness = true;
+DecalSystem::GetInstance().RegisterMaterial(laserBurn);
+
+// Map it to a surface + decal type combination
+SurfaceDecalMapping mapping;
+mapping.surface = SurfaceType::Metal;
+mapping.decalType = DecalType::ScorchMark;
+mapping.materialName = "decal_laser_burn";
+mapping.sizeRange = {0.1f, 0.25f};
+mapping.rotationVariance = MathUtils::PI;
+DecalSystem::GetInstance().RegisterSurfaceMapping(mapping);
+```
+
+### Rendering loop integration
+
+```cpp
+// In engine initialization
+DecalSystem::GetInstance().Initialize(512);
+
+// In the main update loop
+DecalSystem::GetInstance().Update(deltaTime);
+
+// In the render pass — retrieve active decals for deferred projection
+const auto& activeDecals = DecalSystem::GetInstance().GetActiveDecals();
+for (const auto& decal : activeDecals)
+{
+    if (!decal.active) continue;
+    XMMATRIX world = decal.GetWorldMatrix();
+    float opacity = decal.GetCurrentOpacity();
+    // Submit OBB to deferred decal pass...
+}
+
+// At shutdown
+DecalSystem::GetInstance().Shutdown();
+```
+
+---
+
+## Console Commands
+
+The `DecalSystem` exposes three console integration methods:
+
+| Method | Description |
+|--------|-------------|
+| `Console_GetStatus()` | Returns a status string with active/total decal count, material count, surface mapping count, and fade configuration |
+| `Console_SetMaxDecals(uint32_t)` | Changes the maximum pool size at runtime |
+| `Console_SpawnTestDecal(float x, float y, float z)` | Spawns a test bullet hole decal at the given world position (concrete surface, 0.15 size, upward normal) |
+
+### Example console output
+
+```
+=== Decal System ===
+Active: 12/128 (Max: 512)
+Materials: 3
+Surface Mappings: 5
+Fade Time: 15s + 3s fade
+```
+
+---
+
+## Editor
+
+The **DecalEditorPanel** (`SparkEditor/Source/Panels/DecalEditorPanel.h`) provides an ImGui-based interface for authoring decal materials and surface mappings at edit time. It exposes:
+
+- **Material list** -- Browse and select registered decal materials.
+- **Material details** -- Edit albedo/normal/roughness texture paths, opacity, fade time, and the `affectsNormals`/`affectsRoughness` flags.
+- **Surface mappings** -- Configure which surface types map to which decal materials.
+- **Pool status** -- Displays active decal count and max pool size.
+
+---
+
+## Source Files
+
+| File | Description |
+|------|-------------|
+| `SparkEngine/Source/Graphics/DecalSystem.h` | Enums, structs, and `DecalSystem` class declaration |
+| `SparkEngine/Source/Graphics/DecalSystem.cpp` | Implementation (Windows + Linux stub) |
+| `SparkEditor/Source/Panels/DecalEditorPanel.h` | Editor panel declaration |
+| `SparkEditor/Source/Panels/DecalEditorPanel.cpp` | Editor panel implementation |
+| `Tests/TestDecalSystem.cpp` | Unit tests (7 tests) |
+
+---
+
+## See Also
+
+- [Rendering and Graphics](Rendering-and-Graphics) -- Parent rendering system and G-buffer pipeline
+- [Physics](Physics) -- Surface type detection from physics materials
+- [Gameplay Systems](Gameplay-Systems) -- Weapon system that triggers decal spawning

--- a/wiki/Engine-Architecture-Flowchart.md
+++ b/wiki/Engine-Architecture-Flowchart.md
@@ -3,7 +3,7 @@
 > Complete visual guide to how SparkEngine works, from boot to shutdown.
 
 <!-- AUTO:flowchart_stats -->
-_Generated 2026-04-06 from 611 headers, 398 source files, 79 ECS components, 11 ECS systems, 59 editor panels, 6 RHI backends._
+_Generated 2026-04-07 from 611 headers, 398 source files, 79 ECS components, 11 ECS systems, 59 editor panels, 6 RHI backends._
 <!-- /AUTO:flowchart_stats -->
 
 ---

--- a/wiki/Foliage-System.md
+++ b/wiki/Foliage-System.md
@@ -1,0 +1,211 @@
+# Foliage System
+
+SparkEngine's foliage system handles procedural and painted vegetation placement within scatter volumes. Each volume defines bounds, density, and a list of vegetation species with terrain constraints, scale randomization, and wind influence. Instance transforms are generated at placement time and rendered via GPU instancing for optimal performance.
+
+**Source:** `SparkEngine/Source/Graphics/FoliageSystem.h`
+**Namespace:** `Spark::Graphics`
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Species Configuration](#species-configuration)
+- [Volume Placement](#volume-placement)
+- [GPU Instancing](#gpu-instancing)
+- [Code Example](#code-example)
+- [Source Files](#source-files)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+The foliage system populates large outdoor environments with vegetation (grass, bushes, trees, flowers) without manually placing each instance. Artists define foliage volumes that specify where vegetation can appear, and the system procedurally scatters instances within those volumes based on species rules and terrain constraints.
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                        Scene Setup                             │
+│                                                                │
+│  FoliageVolumeData               FoliageSpecies (per volume)   │
+│  ┌─────────────────┐             ┌──────────────────────────┐  │
+│  │ halfExtents      │             │ meshPath, materialPath    │  │
+│  │ seed             │             │ density, scale range      │  │
+│  │ globalDensityScale│            │ slope/altitude limits     │  │
+│  │ enabled          │             │ windInfluence, cullDist   │  │
+│  └────────┬─────────┘             └────────────┬─────────────┘  │
+│           └───────────────┬────────────────────┘               │
+│                           ▼                                    │
+│                  ┌─────────────────┐                           │
+│                  │ FoliageManager  │                           │
+│                  │ (singleton)     │                           │
+│                  │ AddVolume()     │                           │
+│                  │ RemoveVolume()  │                           │
+│                  └────────┬────────┘                           │
+│                           │                                    │
+│                           ▼                                    │
+│                  Instance Transforms                           │
+│                  → GPU Instance Buffer                         │
+│                  → Draw Instanced                              │
+└────────────────────────────────────────────────────────────────┘
+```
+
+Key features:
+
+- **Procedural scattering** based on density, random seed, and terrain constraints
+- **Terrain-aware placement** respecting slope angle and altitude limits
+- **Surface alignment** to terrain normals with optional random Y-axis rotation
+- **Distance culling** per species for LOD-friendly rendering
+- **Wind sway** multiplier for integration with the wind system
+- **Shadow casting** toggle per species
+- **Deterministic** placement via configurable random seed
+
+---
+
+## Architecture
+
+| Class/Struct | Responsibility |
+|-------------|----------------|
+| `FoliageManager` | Singleton that owns all foliage volumes and manages instance generation |
+| `FoliageVolumeData` | Defines a region where vegetation is placed (bounds, seed, density scale) |
+| `FoliageSpecies` | Describes a single vegetation type (mesh, material, density, constraints) |
+
+`FoliageManager` is accessed via `FoliageManager::GetInstance()`. Call `Initialize()` at startup and `Shutdown()` at teardown.
+
+---
+
+## Species Configuration
+
+Each `FoliageSpecies` defines a vegetation type with mesh, material, and placement rules:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `meshPath` | `std::string` | -- | Mesh asset path for this species |
+| `materialPath` | `std::string` | -- | Material asset path |
+| `density` | `float` | 1.0 | Instances per square meter |
+| `minScale` | `float` | 0.8 | Minimum random scale factor |
+| `maxScale` | `float` | 1.2 | Maximum random scale factor |
+| `minSlopeAngle` | `float` | 0.0 | Minimum terrain slope for placement (degrees) |
+| `maxSlopeAngle` | `float` | 45.0 | Maximum terrain slope for placement (degrees) |
+| `minAltitude` | `float` | -1000.0 | Minimum placement altitude |
+| `maxAltitude` | `float` | 1000.0 | Maximum placement altitude |
+| `alignToSurface` | `bool` | true | Align instance up-vector to terrain normal |
+| `randomRotation` | `bool` | true | Apply random Y-axis rotation |
+| `castShadows` | `bool` | true | Whether instances cast shadows |
+| `windInfluence` | `float` | 1.0 | Wind sway multiplier [0, 2]. 0 = no wind, 2 = exaggerated sway. |
+| `cullDistance` | `float` | 100.0 | Distance beyond which instances are culled |
+
+**Slope and altitude constraints** allow species to be restricted to specific terrain regions. For example, grass might be limited to slopes under 30 degrees, while mossy rocks could be placed only on steep slopes above 40 degrees.
+
+**Scale randomization** between `minScale` and `maxScale` prevents uniform-looking vegetation. The random value is seeded deterministically from the volume seed and instance index.
+
+---
+
+## Volume Placement
+
+A `FoliageVolumeData` defines the spatial bounds and global parameters for a scatter region:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `halfExtents` | `XMFLOAT3` | (50, 50, 50) | Half-extents of the placement volume |
+| `seed` | `int` | 0 | Random seed for reproducible placement |
+| `globalDensityScale` | `float` | 1.0 | Multiplier applied to all species densities in this volume |
+| `enabled` | `bool` | true | Whether the volume generates instances |
+
+Volumes are registered with `FoliageManager::AddVolume(center, halfExtents)`, which returns a volume ID for later removal via `RemoveVolume(volumeId)`.
+
+The placement algorithm:
+
+1. Iterate the volume bounds at intervals determined by species density
+2. For each candidate point, sample the terrain height and normal
+3. Reject points outside the species slope and altitude constraints
+4. Compute a deterministic random scale and Y-rotation from the seed
+5. If `alignToSurface` is true, orient the instance to match the terrain normal
+6. Emit the instance transform (position, rotation, scale) to the instance buffer
+
+The `globalDensityScale` multiplier allows runtime density adjustment (e.g., reducing foliage density on lower-end hardware).
+
+---
+
+## GPU Instancing
+
+Foliage instances are rendered using GPU instancing to minimize draw calls. All instances of the same species sharing the same mesh and material are batched into a single instanced draw call.
+
+The per-instance data typically includes:
+
+- **World transform** (4x3 matrix: position, rotation, uniform scale)
+- **Wind phase offset** (derived from position, so nearby instances sway together)
+
+**Distance culling** is applied per-species using the `cullDistance` field. Instances beyond this distance are excluded from the instance buffer before upload to the GPU.
+
+For large volumes, the system can subdivide the volume into chunks and cull entire chunks against the view frustum before processing individual instances.
+
+---
+
+## Code Example
+
+```cpp
+using namespace Spark::Graphics;
+
+// Initialize the foliage manager
+auto& foliage = FoliageManager::GetInstance();
+foliage.Initialize();
+
+// Define a species: grass
+FoliageSpecies grass;
+grass.meshPath = "Assets/Meshes/Grass_Clump.mesh";
+grass.materialPath = "Assets/Materials/Grass.mat";
+grass.density = 8.0f;              // 8 clumps per square meter
+grass.minScale = 0.7f;
+grass.maxScale = 1.3f;
+grass.maxSlopeAngle = 30.0f;       // Only on gentle slopes
+grass.windInfluence = 1.5f;        // Sways heavily in wind
+grass.cullDistance = 50.0f;         // Cull beyond 50 meters
+grass.castShadows = false;         // Skip shadow pass for grass
+
+// Define a species: tree
+FoliageSpecies tree;
+tree.meshPath = "Assets/Meshes/Pine_Tree.mesh";
+tree.materialPath = "Assets/Materials/Pine.mat";
+tree.density = 0.05f;              // 1 tree per 20 square meters
+tree.minScale = 0.8f;
+tree.maxScale = 1.5f;
+tree.maxSlopeAngle = 25.0f;
+tree.windInfluence = 0.3f;         // Slight trunk sway
+tree.cullDistance = 200.0f;        // Visible at longer range
+tree.castShadows = true;
+
+// Add a volume
+XMFLOAT3 center = {0.0f, 0.0f, 0.0f};
+XMFLOAT3 halfExtents = {100.0f, 50.0f, 100.0f};
+uint32_t volumeId = foliage.AddVolume(center, halfExtents);
+
+// Query state
+uint32_t count = foliage.GetVolumeCount(); // 1
+
+// Remove when no longer needed
+foliage.RemoveVolume(volumeId);
+
+// Shutdown
+foliage.Shutdown();
+```
+
+---
+
+## Source Files
+
+| File | Description |
+|------|-------------|
+| `SparkEngine/Source/Graphics/FoliageSystem.h` | `FoliageManager`, `FoliageSpecies`, `FoliageVolumeData` |
+
+---
+
+## See Also
+
+- [Terrain and Procedural Generation](Terrain-and-Procedural-Generation) -- Terrain system that provides height and normal data for foliage placement
+- [Rendering and Graphics](Rendering-and-Graphics) -- Instanced rendering pipeline used by the foliage system
+- [GPU-Driven Rendering](GPU-Driven-Rendering) -- Indirect draw and GPU culling for large instance counts
+- [Day Night Cycle and Weather](Day-Night-Cycle-and-Weather) -- Wind system that drives foliage sway
+- [Shadow System](Shadow-System) -- Shadow rendering for foliage instances with `castShadows` enabled
+- [HLOD and World Partition](HLOD-And-World-Partition) -- World partitioning that manages foliage LOD transitions

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,6 +1,6 @@
 # Spark Engine
 
-**Spark Engine** is a free, open-source 3D game engine written in C++23. Originally designed for first-person shooters, Spark Engine is evolving into a general-purpose engine supporting FPS, RPG, MMO, open-world, and other genres. It ships with a multi-backend RHI (DirectX 11/12, Vulkan, OpenGL, Metal, NullRHI), global illumination, GPU-driven rendering, mesh shaders, DXR ray tracing, Jolt Physics, XAudio2 spatial audio, AngelScript hot-reload scripting with visual scripting and Shader Graph, an EnTT-based ECS architecture (75 component types), an ImGui visual editor with 57 dockable panels, and HeroEngine-inspired features including seamless world streaming, area-based server architecture, and collaborative multi-user editing.
+**Spark Engine** is a free, open-source 3D game engine written in C++23. Originally designed for first-person shooters, Spark Engine is evolving into a general-purpose engine supporting FPS, RPG, MMO, open-world, and other genres. It ships with a multi-backend RHI (DirectX 11/12, Vulkan, OpenGL, Metal, NullRHI), global illumination, GPU-driven rendering, mesh shaders, DXR ray tracing, Jolt Physics, XAudio2 spatial audio, AngelScript hot-reload scripting with visual scripting and Shader Graph, an EnTT-based ECS architecture (75 component types), an ImGui visual editor with 59 dockable panels, and HeroEngine-inspired features including seamless world streaming, area-based server architecture, and collaborative multi-user editing.
 
 > **v1.0.0 Released** — SparkEngine's first official release. Production-ready core systems with active feature development.
 
@@ -26,7 +26,7 @@
 - **Animation** — Skeletal animation, state machines, multi-layer blending, IK (two-bone, look-at, FABRIK), root motion, retargeting, ragdoll blending, cloth simulation, [cinematic sequencer](Cinematic-Sequencer), FBX/glTF import.
 - **Scripting** — AngelScript with hot-reload, lifecycle callbacks, full engine API bindings, client/server separation. [Visual scripting](Visual-Scripting) with 60 node types that compiles to AngelScript. Lua also supported. [Mod system](Mod-System).
 - **Networking** — UDP client/server, entity replication, client-side prediction, lag compensation (hitbox rewinding), delta snapshots. [HeroEngine-inspired MMO architecture](Area-Server-Architecture) with AreaServers, WorldServer, seamless entity migration, and dynamic load balancing.
-- **Editor** — ImGui-powered visual editor with 57 dockable panels: scene hierarchy, inspector, gizmos, [Shader Graph](Shader-Graph) material editor, [visual script editor](Visual-Scripting), cinematic sequencer, dialogue editor, AI debugger, command palette (Ctrl+P), collaborative multi-user editing, and 200+ debug console commands.
+- **Editor** — ImGui-powered visual editor with 59 dockable panels: scene hierarchy, inspector, gizmos, [Shader Graph](Shader-Graph) material editor, [visual script editor](Visual-Scripting), cinematic sequencer, dialogue editor, AI debugger, command palette (Ctrl+P), collaborative multi-user editing, and 200+ debug console commands.
 
 ## Downloads
 
@@ -184,6 +184,6 @@ SparkEngine is licensed under the [Spark Open License](https://github.com/Krilli
 | Editor Panels | 59 |
 | Test files | 337 |
 | Test cases | 4290+ |
-| Wiki pages | 117 |
-| *Last synced* | *2026-04-06 14:23* |
+| Wiki pages | 125 |
+| *Last synced* | *2026-04-07 00:10* |
 <!-- /AUTO:stats -->

--- a/wiki/Material-System.md
+++ b/wiki/Material-System.md
@@ -1,0 +1,320 @@
+# Material System
+
+SparkEngine uses a physically-based rendering (PBR) material system built on the metallic/roughness workflow. Materials are GPU-compiled objects that encapsulate surface properties, texture bindings, blend/cull state, and shader permutations. The system supports 18 texture slots, advanced shading models (subsurface scattering, clearcoat, anisotropy, transmission, sheen, iridescence), material variants for shader permutations, hot-reload, and thread-safe caching.
+
+**Source:** `SparkEngine/Source/Graphics/MaterialSystem.h`
+
+## Overview
+
+```
+MaterialSystem (singleton manager)
+    ├── Material cache           (thread-safe, keyed by name)
+    ├── Texture cache            (shared SRVs, deduplicated by path)
+    ├── Sampler cache            (hashed TextureSampling → ID3D11SamplerState)
+    ├── Default material         (white dielectric, roughness 0.5)
+    └── Error material           (magenta fallback for missing materials)
+
+Material (individual asset)
+    ├── PBRProperties            (albedo, metallic, roughness, normal, AO, emissive, IOR)
+    ├── AdvancedProperties       (SSS, clearcoat, anisotropy, transmission, sheen, iridescence)
+    ├── MaterialRenderState      (blend mode, cull mode, depth, shadows, render queue)
+    ├── MaterialTexture[18]      (SRV + sampling + tiling/offset per slot)
+    ├── Variants                 (named shader define sets)
+    └── Compiled pipeline state  (BlendState, DepthStencilState, RasterizerState, CB)
+```
+
+Materials are compiled once via `CompileMaterial()`, which creates the D3D11 blend, depth-stencil, and rasterizer states along with a GPU-aligned constant buffer (`MaterialConstants`). Binding a material sets all texture SRVs, samplers, the constant buffer, and pipeline states on the device context.
+
+## PBR Workflow
+
+The material system implements the metallic/roughness PBR model. Core surface parameters are stored in `PBRProperties` and uploaded to the GPU via a 16-byte-aligned constant buffer:
+
+```cpp
+struct alignas(16) MaterialConstants
+{
+    XMFLOAT4 albedoColor;    // Base color (RGBA)
+    float metallicFactor;    // 0 = dielectric, 1 = metallic
+    float roughnessFactor;   // 0 = mirror, 1 = fully rough
+    float normalScale;       // Normal map intensity
+    float occlusionStrength; // Ambient occlusion strength
+    XMFLOAT3 emissiveColor;  // Emissive RGB
+    float emissiveFactor;    // Emissive intensity multiplier
+    float alphaCutoff;       // Alpha test threshold
+    float indexOfRefraction; // IOR for dielectrics (default 1.5)
+    float pad0, pad1;        // Padding to 16-byte alignment
+};
+```
+
+| Property | Range | Default | Description |
+|----------|-------|---------|-------------|
+| `albedoColor` | RGBA [0,1] | (1, 1, 1, 1) | Base surface color |
+| `metallicFactor` | [0, 1] | 0.0 | Metal vs. dielectric response |
+| `roughnessFactor` | [0, 1] | 0.5 | Microsurface roughness |
+| `normalScale` | any | 1.0 | Normal map intensity multiplier |
+| `occlusionStrength` | [0, 1] | 1.0 | Ambient occlusion strength |
+| `emissiveColor` | RGB [0,+inf) | (0, 0, 0) | Self-illumination color |
+| `emissiveFactor` | [0, +inf) | 0.0 | Emissive intensity |
+| `alphaCutoff` | [0, 1] | 0.5 | Alpha test discard threshold |
+| `indexOfRefraction` | (0, +inf) | 1.5 | Fresnel IOR for dielectrics |
+
+All scalar PBR properties are validated at set-time via `Material::ValidatePBRProperties()`.
+
+## Texture Slots
+
+Each material supports up to 18 texture slots. Every slot carries its own SRV, sampling parameters, UV tiling/offset, intensity, and enable flag.
+
+| Slot | Enum | Description |
+|------|------|-------------|
+| 0 | `Albedo` | Base color / albedo map |
+| 1 | `Normal` | Tangent-space normal map |
+| 2 | `Metallic` | Metallic map (grayscale) |
+| 3 | `Roughness` | Roughness map (grayscale) |
+| 4 | `Occlusion` | Ambient occlusion map |
+| 5 | `Emissive` | Emissive map |
+| 6 | `Height` | Height / displacement map |
+| 7 | `DetailAlbedo` | Detail albedo (tiled overlay) |
+| 8 | `DetailNormal` | Detail normal map |
+| 9 | `Subsurface` | Subsurface scattering color map |
+| 10 | `Transmission` | Transmission map |
+| 11 | `Clearcoat` | Clearcoat layer intensity map |
+| 12 | `ClearcoatRoughness` | Clearcoat roughness map |
+| 13 | `Anisotropy` | Anisotropy direction map |
+| 14 | `Custom0` | Custom texture slot 0 |
+| 15 | `Custom1` | Custom texture slot 1 |
+| 16 | `Custom2` | Custom texture slot 2 |
+| 17 | `Custom3` | Custom texture slot 3 |
+
+### Texture Sampling
+
+Each slot has independent sampling parameters:
+
+```cpp
+struct TextureSampling
+{
+    D3D11_FILTER filter = D3D11_FILTER_ANISOTROPIC;  // Default: anisotropic
+    D3D11_TEXTURE_ADDRESS_MODE addressU = D3D11_TEXTURE_ADDRESS_WRAP;
+    D3D11_TEXTURE_ADDRESS_MODE addressV = D3D11_TEXTURE_ADDRESS_WRAP;
+    D3D11_TEXTURE_ADDRESS_MODE addressW = D3D11_TEXTURE_ADDRESS_WRAP;
+    UINT maxAnisotropy = 16;                          // 16x anisotropic filtering
+    float mipLODBias = 0.0f;
+    float minLOD = 0.0f;
+    float maxLOD = D3D11_FLOAT32_MAX;
+    XMFLOAT4 borderColor = {0, 0, 0, 0};
+};
+```
+
+Sampler states are cached by hash so identical sampling configurations share the same `ID3D11SamplerState`.
+
+## Advanced Properties
+
+Advanced shading models are toggled individually and extend the base PBR model. Each feature adds shader permutation defines when enabled.
+
+### Subsurface Scattering
+
+Simulates light transport through translucent materials (skin, wax, marble).
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `subsurfaceEnabled` | false | Enable SSS |
+| `subsurfaceColor` | (1, 1, 1) | Scattering color tint |
+| `subsurfaceRadius` | 1.0 | Scattering radius (world units) |
+
+### Clearcoat
+
+Adds a secondary specular lobe for lacquered or coated surfaces (car paint, varnished wood).
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `clearcoatEnabled` | false | Enable clearcoat layer |
+| `clearcoatFactor` | 0.0 | Layer strength [0, 1] |
+| `clearcoatRoughness` | 0.0 | Layer roughness [0, 1] |
+
+### Anisotropy
+
+Stretches specular highlights along a direction (brushed metal, hair, silk).
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `anisotropyEnabled` | false | Enable anisotropic reflections |
+| `anisotropyFactor` | 0.0 | Anisotropy strength |
+| `anisotropyDirection` | (1, 0) | Tangent-space direction |
+
+### Transmission
+
+Light passing through thin or translucent surfaces (glass, leaves, thin fabric).
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `transmissionEnabled` | false | Enable transmission |
+| `transmissionFactor` | 0.0 | Transmission strength [0, 1] |
+| `transmissionColor` | (1, 1, 1) | Transmission color tint |
+
+### Sheen
+
+Fabric-like soft highlight at grazing angles (velvet, cloth).
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `sheenEnabled` | false | Enable sheen |
+| `sheenColor` | (0, 0, 0) | Sheen color |
+| `sheenRoughness` | 0.0 | Sheen roughness |
+
+### Iridescence
+
+Thin-film interference effects (soap bubbles, oil slicks, beetle shells).
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `iridescenceEnabled` | false | Enable iridescence |
+| `iridescenceFactor` | 0.0 | Effect strength [0, 1] |
+| `iridescenceIOR` | 1.3 | Thin-film IOR |
+| `iridescenceThickness` | 100.0 | Film thickness in nanometers |
+
+## Blend Modes
+
+The `BlendMode` enum controls how a material composites with the framebuffer:
+
+| Mode | Description | Typical use |
+|------|-------------|-------------|
+| `Opaque` | No blending, full depth write | Solid geometry (default) |
+| `AlphaTest` | Binary alpha via `alphaCutoff` | Foliage, fences, hair cards |
+| `Transparent` | Standard alpha blending | Glass, windows, UI elements |
+| `Additive` | Source added to destination | Particles, fire, glow |
+| `Multiply` | Source multiplied with destination | Shadow decals, tinting |
+| `Screen` | Inverse multiply (brightening) | Light overlays, bloom |
+
+`CullMode` controls face culling: `None` (double-sided), `Front`, or `Back` (default). The `MaterialRenderState` struct also exposes `depthTest`, `depthWrite`, `castShadows`, `receiveShadows`, `renderQueue`, and `doubleSided`.
+
+## Material Variants
+
+Variants represent named shader permutation sets. Each variant stores a list of preprocessor defines that alter the compiled shader:
+
+```cpp
+// Create a variant with specific defines
+material->CreateVariant("Wet", {"ENABLE_WETNESS", "RAIN_RIPPLES"});
+material->CreateVariant("Snow", {"ENABLE_SNOW_COVERAGE"});
+
+// Switch active variant at runtime
+material->SetActiveVariant("Wet");
+
+// Query current permutation
+auto defines = material->GetShaderPermutation();
+```
+
+Variants enable material-level shader customization without duplicating material assets.
+
+## Code Example
+
+```cpp
+// Create and configure a PBR material
+auto& matSystem = GetMaterialSystem();
+auto mat = matSystem.CreateMaterial("BrushedSteel");
+
+// Set PBR surface properties
+PBRProperties pbr;
+pbr.albedoColor = {0.9f, 0.9f, 0.92f, 1.0f};
+pbr.metallicFactor = 1.0f;
+pbr.roughnessFactor = 0.35f;
+pbr.indexOfRefraction = 2.5f;
+mat->SetPBRProperties(pbr);
+
+// Enable anisotropy for brushed-metal highlights
+AdvancedProperties adv;
+adv.anisotropyEnabled = true;
+adv.anisotropyFactor = 0.8f;
+adv.anisotropyDirection = {1.0f, 0.0f};
+mat->SetAdvancedProperties(adv);
+
+// Load textures
+mat->LoadTexture(MaterialTextureType::Albedo, "textures/steel_albedo.dds", device);
+mat->LoadTexture(MaterialTextureType::Normal, "textures/steel_normal.dds", device);
+mat->LoadTexture(MaterialTextureType::Metallic, "textures/steel_metallic.dds", device);
+mat->LoadTexture(MaterialTextureType::Roughness, "textures/steel_roughness.dds", device);
+mat->LoadTexture(MaterialTextureType::Anisotropy, "textures/steel_aniso_dir.dds", device);
+
+// Configure render state
+MaterialRenderState state;
+state.blendMode = BlendMode::Opaque;
+state.cullMode = CullMode::Back;
+mat->SetRenderState(state);
+
+// Compile pipeline state (blend, depth-stencil, rasterizer, CB)
+mat->CompileMaterial(device);
+
+// Bind for rendering
+matSystem.BindMaterial("BrushedSteel");
+
+// Hot-reload: watch for texture changes on disk
+matSystem.EnableHotReload(true);
+// Call each frame to pick up file changes:
+matSystem.UpdateHotReload();
+```
+
+## Console Commands
+
+The `MaterialSystem` exposes console integration methods for runtime inspection and editing. These are accessed through the `Console_*` methods on `MaterialSystem`:
+
+| Method | Description |
+|--------|-------------|
+| `Console_GetMetrics()` | Material count, texture memory, bind stats, load times |
+| `Console_ListMaterials()` | List all loaded material names |
+| `Console_GetMaterialInfo(name)` | Detailed info for a specific material |
+| `Console_ReloadMaterial(name)` | Reload a single material from disk |
+| `Console_ReloadAllMaterials()` | Reload every loaded material |
+| `Console_CreateVariant(name, variant, defines)` | Create a shader variant |
+| `Console_ListMaterialVariants(name)` | List variants for a material |
+| `Console_SetMaterialProperty(name, prop, value)` | Set a float property at runtime |
+| `Console_SetMaterialColor(name, prop, r, g, b)` | Set a color property at runtime |
+| `Console_SetHotReload(enabled)` | Enable/disable hot-reload |
+| `Console_SetTextureQuality(quality)` | Set texture quality level |
+| `Console_GetTextureMemoryInfo()` | Texture memory usage breakdown |
+| `Console_LoadTextureToSlot(name, type, path)` | Load a texture into a material slot |
+| `Console_UnloadTextureFromSlot(name, type)` | Unload a texture from a slot |
+| `Console_ListTextureTypes()` | List all available texture slot types |
+| `Console_ClearCache()` | Clear texture and sampler caches |
+| `Console_GarbageCollect()` | Remove unused materials |
+| `Console_ValidateMaterials()` | Validate all loaded materials |
+| `Console_DumpMaterialDetails(name)` | Dump full material details |
+| `Console_ExportMaterial(name, path)` | Export material to file |
+| `Console_ImportMaterial(path)` | Import material from file |
+
+## Editor Integration
+
+The **MaterialEditorPanel** (`SparkEditor/Source/Panels/MaterialEditorPanel.h`) provides a node-graph-style visual editor for creating and editing materials. It supports:
+
+- PBR parameter sliders and color pickers grouped by category (Surface, Normal, Emission)
+- Texture slot assignment with drag-and-drop
+- Render state configuration (blend mode, cull mode, depth settings)
+- Live preview with scene lighting
+- Shader Graph integration for custom material logic
+
+## Source Files
+
+| File | Description |
+|------|-------------|
+| `SparkEngine/Source/Graphics/MaterialSystem.h` | Material, MaterialSystem, all data structures |
+| `SparkEngine/Source/Graphics/MaterialSystem.cpp` | MaterialSystem lifecycle, CRUD, texture loading |
+| `SparkEngine/Source/Graphics/PBRMaterial.cpp` | Material class implementation |
+| `SparkEngine/Source/Graphics/PBRMaterialBinding.cpp` | Material binding to the GPU pipeline |
+| `SparkEngine/Source/Graphics/PBRMaterialLighting.cpp` | PBR lighting calculations |
+| `SparkEngine/Source/Graphics/MaterialConsoleOps.cpp` | Console inspection, listing, validation |
+| `SparkEngine/Source/Graphics/MaterialConsoleEdit.cpp` | Console editing, texture, hot-reload |
+| `SparkEngine/Source/Graphics/MaterialTextureLoading.cpp` | Texture loading from disk |
+| `SparkEngine/Source/Graphics/MaterialLoader.h` | Material file loading interface |
+| `SparkEngine/Source/Graphics/MaterialLoader.cpp` | Material file loading implementation |
+| `SparkEngine/Source/Graphics/MaterialDefinition.h` | Material definition data structures |
+| `SparkEngine/Source/Graphics/MaterialPropertyHandle.h` | Type-safe property handle access |
+| `SparkEngine/Source/Graphics/MaterialPropertyHandle.cpp` | Property handle implementation |
+| `SparkEngine/Source/Graphics/PersistentMaterialCB.h` | Persistent constant buffer management |
+| `SparkEditor/Source/Panels/MaterialEditorPanel.h` | Editor panel header |
+| `SparkEditor/Source/Panels/MaterialEditorPanel.cpp` | Editor panel implementation |
+| `SparkEditor/Source/Panels/MaterialEditorParameters.cpp` | Parameter editing UI |
+| `SparkEditor/Source/Panels/MaterialEditorPreview.cpp` | Live preview rendering |
+| `SparkEditor/Source/MaterialEditor/MaterialEditor.h` | Standalone material editor |
+| `SparkEditor/Source/MaterialEditor/MaterialEditor.cpp` | Standalone material editor implementation |
+
+## See Also
+
+- [Shader Graph](Shader-Graph) — Node-based shader authoring
+- [Shader Pipeline](Shader-Pipeline) — Shader compilation and management
+- [Rendering and Graphics](Rendering-and-Graphics) — Graphics engine overview

--- a/wiki/Migration-Guide.md
+++ b/wiki/Migration-Guide.md
@@ -72,7 +72,7 @@ Asset files contain a version header. When the engine loads an asset:
 2. If the version is older than current, `AssetMigration` runs automatic upgrade
 3. Upgraded assets are written back to disk (or cached in memory)
 
-See `SparkEngine/Source/Graphics/AssetMigration.h` for the migration registry and `docs/specs/asset-format.md` for format details.
+See `SparkEngine/Source/Core/AssetMigration.h` for the migration registry and `docs/specs/asset-format.md` for format details.
 
 ### Forcing re-migration
 

--- a/wiki/Neural-Rendering.md
+++ b/wiki/Neural-Rendering.md
@@ -1,0 +1,391 @@
+# Neural Rendering
+
+SparkEngine's neural rendering subsystem uses small multi-layer perceptrons (MLPs) evaluated via GPU compute shaders to accelerate and enhance several rendering tasks: indirect lighting caching, texture compression, denoising, and super-resolution. The entire subsystem is self-contained with **zero external ML framework dependencies** -- all inference runs through a custom compute shader dispatch pipeline backed by D3D11 structured buffers, with an SSE2/AVX2 CPU fallback for headless and NullRHI modes.
+
+**Source:** `SparkEngine/Source/Graphics/Neural/`
+**Namespace:** `Spark::Graphics::Neural`
+**CMake toggle:** `ENABLE_NEURAL_RENDERING=ON` (defines `SPARK_NEURAL_RENDERING=1`)
+
+---
+
+## Table of Contents
+
+- [Architecture Overview](#architecture-overview)
+- [Neural Inference Engine](#neural-inference-engine)
+  - [GPU Path](#gpu-path)
+  - [CPU Fallback](#cpu-fallback)
+  - [Network Lifecycle](#network-lifecycle)
+- [Neural Radiance Cache](#neural-radiance-cache)
+  - [Hash Grid Encoding](#hash-grid-encoding)
+  - [Training Loop](#training-loop)
+  - [Querying Radiance](#querying-radiance)
+- [Neural Texture Compression (NTC)](#neural-texture-compression-ntc)
+  - [Compression Pipeline](#compression-pipeline)
+  - [Quality Levels](#quality-levels)
+  - [.ntex File Format](#ntex-file-format)
+- [Neural Post-Processing](#neural-post-processing)
+  - [Neural Denoiser](#neural-denoiser)
+  - [Neural Super-Resolution](#neural-super-resolution)
+- [Weight Serialization (.nnw)](#weight-serialization-nnw)
+- [Console Commands](#console-commands)
+- [Source Files](#source-files)
+- [See Also](#see-also)
+
+---
+
+## Architecture Overview
+
+All neural rendering components share a common inference backbone. Networks are described by `NetworkDesc` / `LayerDesc` structs, uploaded once, and evaluated in batches via the singleton `NeuralInferenceEngine`.
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                        Neural Rendering Subsystem                        │
+├──────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  ┌─────────────────────┐  ┌──────────────────────┐  ┌────────────────┐  │
+│  │ NeuralRadianceCache  │  │ NeuralTextureCompr.  │  │ NeuralPostProc │  │
+│  │                      │  │                      │  │                │  │
+│  │  Hash Grid (16 lvl)  │  │  Per-block MLPs      │  │  Denoiser      │  │
+│  │  + MLP decoder       │  │  (u,v) -> RGBA       │  │  Super-Res     │  │
+│  └──────────┬───────────┘  └──────────┬───────────┘  └───────┬────────┘  │
+│             │                         │                      │           │
+│             └─────────────┬───────────┘──────────────────────┘           │
+│                           ▼                                              │
+│              ┌─────────────────────────────┐                             │
+│              │   NeuralInferenceEngine     │                             │
+│              │   (Singleton)               │                             │
+│              ├─────────────────────────────┤                             │
+│              │  CreateNetwork()            │                             │
+│              │  UploadWeights()            │                             │
+│              │  Evaluate()   ─── GPU ──▶  Compute Shader (D3D11 CS)     │
+│              │  EvaluateCPU() ── CPU ──▶  CpuNeuralInference (SIMD)     │
+│              └─────────────────────────────┘                             │
+│                           │                                              │
+│              ┌────────────┴────────────┐                                 │
+│              │     NeuralWeights       │                                 │
+│              │  SaveWeights / Load     │                                 │
+│              │  (.nnw binary format)   │                                 │
+│              └─────────────────────────┘                                 │
+│                                                                          │
+│  Shared types: NeuralTypes.h (ActivationType, LayerDesc, NetworkDesc,   │
+│                NetworkHandle, NeuralInferenceCB)                          │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+**Key design constraints:**
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `kMaxNetworkLayers` | 8 | Max layers per network (shader constant buffer) |
+| `kMaxNeuronsPerLayer` | 256 | Shared memory limit in compute shader |
+| `kNeuralThreadGroupSize` | 64 | Thread group size for inference dispatch |
+
+---
+
+## Neural Inference Engine
+
+`NeuralInferenceEngine` is the core singleton that owns all GPU-resident networks and dispatches MLP evaluation. It is initialized at engine startup (see `SparkEngine.cpp`) and registered with `EngineContext`.
+
+### GPU Path
+
+On D3D11, the engine compiles an HLSL compute shader at initialization. Each `Evaluate()` call:
+
+1. Binds the network's weight structured buffer as an SRV
+2. Fills a `NeuralInferenceCB` constant buffer with layer sizes, activations, and weight offsets
+3. Dispatches `ceil(batchSize / 64)` thread groups
+4. Writes results to the output UAV
+
+### CPU Fallback
+
+When no GPU is available (NullRHI, headless mode), inference falls back to `CpuNeuralInference`, which provides:
+
+- **SIMD acceleration:** Weights are repacked into `AlignedWeightLayout` with rows padded to 8-float alignment for aligned AVX2/SSE2 loads
+- **Multi-threaded batching:** Batches of 16+ samples are split across JobSystem workers
+- **ISA auto-detection:** `CpuNeuralInference::Initialize()` probes the CPU and binds the fastest kernel (SSE2 or AVX2)
+
+### Network Lifecycle
+
+```cpp
+// 1. Get the singleton (initialized at engine startup)
+auto& engine = NeuralInferenceEngine::GetInstance();
+
+// 2. Define architecture
+NetworkDesc desc;
+desc.name = "MyNetwork";
+desc.layers = {
+    {32, 64, ActivationType::ReLU},
+    {64, 64, ActivationType::ReLU},
+    {64, 3,  ActivationType::Sigmoid}
+};
+
+// 3. Create, upload weights, evaluate
+NetworkHandle handle = engine.CreateNetwork(desc);
+engine.UploadWeights(handle, trainedWeights);
+engine.Evaluate(handle, inputSRV, outputUAV, batchSize);
+
+// 4. Cleanup
+engine.DestroyNetwork(handle);
+```
+
+**Activation functions** supported by the shader:
+
+| Enum | Formula |
+|------|---------|
+| `ReLU` | `max(0, x)` |
+| `LeakyReLU` | `x > 0 ? x : 0.01 * x` |
+| `Sigmoid` | `1 / (1 + exp(-x))` |
+| `Tanh` | `tanh(x)` |
+| `None` | Identity (linear output) |
+
+---
+
+## Neural Radiance Cache
+
+`NeuralRadianceCache` implements a multi-resolution hash grid inspired by Instant NGP for caching indirect lighting. Instead of storing full irradiance probe grids, it learns a compact neural representation that maps (position, direction) to RGB radiance.
+
+### Hash Grid Encoding
+
+The cache uses **16 resolution levels** (`kHashGridLevels`), each with **64K entries** (`kDefaultHashTableSize`). Each entry stores a 2-float feature vector (`kFeaturesPerEntry`). A 3D position is hashed at each level, yielding a concatenated feature vector of 32 floats (16 levels x 2 features) that is fed through a small MLP decoder.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `hashTableSize` | 65536 | Entries per resolution level |
+| `mlpHiddenSize` | 64 | Neurons per hidden layer |
+| `mlpHiddenLayers` | 2 | Number of hidden layers |
+| `learningRate` | 0.01 | SGD learning rate |
+| `minResolution` | 1.0 | Finest grid cell size (world units) |
+| `maxResolution` | 1024.0 | Coarsest grid cell size |
+| `temporalBlend` | 0.9 | EMA blend factor with previous frame |
+
+### Training Loop
+
+Each frame, new radiance samples (from path tracing, screen-space GI, or other sources) are fed to `Update()`. The cache performs one round of stochastic gradient descent on the hash grid entries and MLP weights:
+
+```cpp
+NeuralRadianceCache cache;
+cache.Initialize({.hashTableSize = 65536, .learningRate = 0.01f});
+
+// Each frame: feed samples from your GI solution
+std::vector<RadianceSample> samples = GatherRadianceSamples();
+cache.Update(samples.data(), static_cast<uint32_t>(samples.size()), deltaTime);
+```
+
+A `RadianceSample` contains:
+
+```cpp
+struct RadianceSample
+{
+    float position[3];   // World-space position
+    float direction[3];  // View direction (normalized)
+    float radiance[3];   // RGB radiance value
+};
+```
+
+### Querying Radiance
+
+```cpp
+float position[3] = {10.0f, 2.0f, -5.0f};
+float direction[3] = {0.0f, 1.0f, 0.0f};
+float radiance[3];
+
+// Single query
+cache.QueryCPU(position, direction, radiance);
+
+// Batch query (more efficient)
+cache.QueryBatchCPU(positions, directions, outRadiance, batchSize);
+```
+
+---
+
+## Neural Texture Compression (NTC)
+
+`NeuralTextureCompressor` compresses RGBA textures by training a tiny MLP per block. Each block MLP learns the mapping `(u, v) -> (r, g, b, a)` using positional encoding, and the network weights become the compressed representation. Decompression evaluates the MLP to reconstruct pixels.
+
+### Compression Pipeline
+
+1. **Divide** the texture into blocks (default 16x16 pixels)
+2. **Encode** UV coordinates with positional encoding (sin/cos frequency bands)
+3. **Train** a per-block MLP via SGD to fit the block's pixels
+4. **Store** the trained weights as the compressed output
+
+```cpp
+NeuralTextureCompressor ntc;
+ntc.Initialize();
+
+NTCOptions opts;
+opts.qualityLevel = 2;          // 0=fast, 1=medium, 2=high, 3=best
+opts.blockSize = 16;            // 16x16 pixel blocks
+opts.positionalFrequencies = 4; // sin/cos frequency bands
+
+auto compressed = ntc.Compress(rgbaPixels, 512, 512, opts);
+
+// Save to disk
+ntc.SaveNTEX(compressed, "texture.ntex");
+
+// Load and decompress
+auto loaded = ntc.LoadNTEX("texture.ntex");
+auto decoded = ntc.DecompressCPU(loaded);
+```
+
+### Quality Levels
+
+| Level | Name | Description |
+|-------|------|-------------|
+| 0 | Fast | Fewest training iterations, smallest networks |
+| 1 | Medium | Balanced quality/speed |
+| 2 | High | Default -- good quality, moderate compression time |
+| 3 | Best | Maximum training iterations, highest fidelity |
+
+### .ntex File Format
+
+The `.ntex` binary format stores one complete neural-compressed texture:
+
+```
+┌─────────────────────────────────────────────────┐
+│ NTEXHeader (magic 'SNTX', version 1)           │
+│   - width, height, channels                     │
+│   - blockSize, blocksX, blocksY                 │
+│   - hiddenLayers, neuronsPerLayer               │
+│   - inputSize, outputSize                       │
+│   - positionalFrequencies                       │
+│   - weightsPerBlock, totalBlocks                │
+│   - qualityLevel                                │
+│   - reserved[3]                                 │
+├─────────────────────────────────────────────────┤
+│ Block 0 weights  [float32 x weightsPerBlock]    │
+│ Block 1 weights  [float32 x weightsPerBlock]    │
+│ ...                                             │
+│ Block N weights  [float32 x weightsPerBlock]    │
+└─────────────────────────────────────────────────┘
+```
+
+All fields are little-endian `uint32_t`. The magic number is `0x58544E53` (`"SNTX"`). All blocks share the same MLP architecture (described in the header), so only the weight data varies per block.
+
+Compression metrics are available via `NeuralCompressedTexture`:
+
+```cpp
+size_t compressed = tex.GetCompressedSize();  // Total weight bytes
+size_t original   = tex.GetOriginalSize();    // width * height * channels
+float ratio       = tex.GetCompressionRatio(); // compressed / original
+```
+
+---
+
+## Neural Post-Processing
+
+### Neural Denoiser
+
+`NeuralDenoiser` implements the `IDenoiser` interface with a learned MLP that processes **8x8 pixel patches** (`kDenoisePatchSize`). It accepts color input plus optional albedo and normal guide buffers.
+
+**MLP architecture:**
+- Input: noisy color (3 x 8 x 8 = 192 floats) + optional albedo (192) + normal (192)
+- Hidden: 3 layers of 128 neurons, ReLU activation
+- Output: denoised color (3 x 8 x 8 = 192 floats), Sigmoid activation
+
+```cpp
+NeuralDenoiser denoiser;
+denoiser.Initialize(settings);
+denoiser.LoadWeights(pretrainedWeights);
+
+denoiser.SetColorInput(colorBuffer);
+denoiser.SetAlbedoGuide(albedoBuffer);  // optional
+denoiser.SetNormalGuide(normalBuffer);  // optional
+denoiser.Execute();
+
+const float* result = denoiser.GetOutput();
+```
+
+Falls back to pass-through if no weights are loaded (`HasWeights()` returns false).
+
+### Neural Super-Resolution
+
+`NeuralSuperResolution` upscales **8x8 patches to 16x16** (`kSRScaleFactor = 2`). Designed as an optional refinement pass after SparkSR temporal accumulation.
+
+**MLP architecture:**
+- Input: low-res color (3 x 8 x 8 = 192 floats) + optional depth (8 x 8 = 64 floats)
+- Hidden: configurable (default 3 layers of 128 neurons)
+- Output: high-res color (3 x 16 x 16 = 768 floats)
+
+```cpp
+NeuralSuperResolution sr;
+sr.Initialize({.hiddenSize = 128, .hiddenLayers = 3, .useDepthInput = true});
+sr.LoadWeights(pretrainedWeights);
+
+auto upscaled = sr.UpscaleCPU(lowResInput, depthBuffer, width, height);
+// upscaled is (width * 2) x (height * 2) x 3 floats
+```
+
+---
+
+## Weight Serialization (.nnw)
+
+The `.nnw` (Neural Network Weights) format stores a `NetworkDesc` plus all float32 weights/biases in a single binary blob:
+
+```
+┌─────────────────────────────────────────┐
+│ NNWHeader                               │
+│   magic:  0x574E4E53 ('SNNW')          │
+│   version: 1                            │
+│   layerCount                            │
+│   totalParameters                       │
+├─────────────────────────────────────────┤
+│ LayerDesc[0] .. LayerDesc[layerCount-1] │
+│   (inputSize, outputSize, activation)   │
+├─────────────────────────────────────────┤
+│ float32[totalParameters]                │
+│   weights + biases, layer by layer      │
+└─────────────────────────────────────────┘
+```
+
+```cpp
+// Save
+TrainedNetwork network{desc, weights};
+SaveWeights(network, "model.nnw");
+
+// Load
+TrainedNetwork loaded = LoadWeights("model.nnw");
+engine.CreateNetwork(loaded.desc);
+engine.UploadWeights(handle, loaded.weights);
+```
+
+---
+
+## Console Commands
+
+Each neural rendering component exposes a `Console_GetStatus()` method that returns a diagnostic string. These are accessible through the engine's subsystem status commands:
+
+| Command | Description |
+|---------|-------------|
+| `r_neural_status` | Print NeuralInferenceEngine status (GPU availability, network count, dispatch count) |
+| `r_neural_cache_status` | Print NeuralRadianceCache status (hash table occupancy, sample count, training loss, memory) |
+| `r_neural_ntc_status` | Print NeuralTextureCompressor status (textures compressed, compression ratio) |
+| `r_neural_sr_status` | Print NeuralSuperResolution status (weights loaded, patches processed) |
+| `r_neural_denoise_status` | Print NeuralDenoiser status (backend type, execution time) |
+
+---
+
+## Source Files
+
+| File | Description |
+|------|-------------|
+| `Graphics/Neural/NeuralTypes.h` | Shared types: `ActivationType`, `LayerDesc`, `NetworkDesc`, `NetworkHandle`, `NeuralInferenceCB` |
+| `Graphics/Neural/NeuralInference.h/.cpp` | `NeuralInferenceEngine` -- GPU compute shader MLP evaluation singleton |
+| `Graphics/Neural/CpuNeuralInference.h/.cpp` | `CpuNeuralInference` -- SIMD-optimized CPU fallback with multi-threaded batching |
+| `Graphics/Neural/NeuralRadianceCache.h/.cpp` | `NeuralRadianceCache` -- multi-resolution hash grid + MLP for indirect lighting |
+| `Graphics/Neural/NeuralTextureCompressor.h/.cpp` | `NeuralTextureCompressor` -- per-block MLP texture compression |
+| `Graphics/Neural/NeuralTextureFormat.h` | `.ntex` binary format header (`NTEXHeader`, constants) |
+| `Graphics/Neural/NeuralPostProcessing.h/.cpp` | `NeuralDenoiser` (IDenoiser impl) and `NeuralSuperResolution` |
+| `Graphics/Neural/NeuralWeights.h/.cpp` | `.nnw` weight serialization (`SaveWeights`, `LoadWeights`) |
+
+All source paths are relative to `SparkEngine/Source/`.
+
+---
+
+## See Also
+
+- [Global Illumination](Global-Illumination) -- DDGI and Adaptive Probe Volumes (complementary to neural radiance cache)
+- [Virtual Texturing](Virtual-Texturing) -- Streaming virtual texture system (NTC is an alternative compression approach)
+- [Post-Processing](Post-Processing) -- Traditional post-processing pipeline (neural denoiser/SR integrate here)
+- [Upscaling (DLSS/FSR)](Upscaling-System) -- Temporal upscaling (neural SR is an optional enhancement pass)
+- [Rendering and Graphics](Rendering-and-Graphics) -- Top-level graphics overview
+- [RHI Abstraction Layer](RHI-Abstraction-Layer) -- Compute shader dispatch details

--- a/wiki/Particle-System.md
+++ b/wiki/Particle-System.md
@@ -1,0 +1,250 @@
+# Particle System
+
+SparkEngine includes a CPU-side particle system for visual effects such as explosions, trails, muzzle flashes, sparks, smoke, and environmental particles. Particles are simulated on the CPU and rendered via D3D11 billboard quads with configurable blend modes, color gradients, and size curves. For large-scale GPU-accelerated particles, see [GPU Particles](GPU-Particles).
+
+**Source:** `SparkEngine/Source/Graphics/ParticleSystem.h`
+**Namespace:** Global
+**Editor:** `SparkEditor/Source/Panels/ParticleEditorPanel.h`
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Emitter Shapes](#emitter-shapes)
+- [Blend Modes](#blend-modes)
+- [Emitter Configuration](#emitter-configuration)
+  - [Emission](#emission)
+  - [Particle Properties](#particle-properties)
+  - [Color and Size Over Lifetime](#color-and-size-over-lifetime)
+  - [Physics](#physics)
+  - [Sub-Emitters](#sub-emitters)
+- [Preset Effects](#preset-effects)
+- [Code Example](#code-example)
+- [Console Commands](#console-commands)
+- [Source Files](#source-files)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+The CPU particle system manages a pool of `ParticleEmitter` instances, each containing a fixed-size particle buffer. Every frame the `ParticleSystem` manager updates all active emitters (spawning, simulating, and culling particles) and then renders them as camera-facing billboard quads via a dynamic vertex buffer.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                      Game Loop                          │
+│         ParticleSystem::Update(dt)                      │
+│         ParticleSystem::Render(view, proj)              │
+└─────────────────────────┬───────────────────────────────┘
+                          │
+              ┌───────────▼───────────┐
+              │    ParticleSystem     │
+              │  CreateEmitter()      │
+              │  SpawnExplosion()     │
+              │  SpawnMuzzleFlash()   │
+              │  Console_* methods    │
+              └───────────┬───────────┘
+                          │  owns 0..N
+              ┌───────────▼───────────┐
+              │   ParticleEmitter     │
+              │  EmitParticle()       │
+              │  UpdateParticle()     │
+              │  Play / Stop / Burst  │
+              │  D3D11 vertex buffer  │
+              └───────────────────────┘
+```
+
+- **Simulation space:** World space (particles detach from emitter) or Local space (particles follow emitter)
+- **Rendering:** Point-sprite billboards uploaded to a dynamic `ID3D11Buffer` each frame
+- **Lifetime:** Each `Particle` tracks `age`, `lifetime`, and `maxLifetime`; dead particles are recycled
+
+---
+
+## Architecture
+
+The system is composed of three layers:
+
+| Layer | Class/Struct | Responsibility |
+|-------|-------------|----------------|
+| Manager | `ParticleSystem` | Owns all emitters, provides preset effects and console integration |
+| Emitter | `ParticleEmitter` | Simulates and renders a pool of particles from a `ParticleEmitterDesc` |
+| Data | `Particle`, `ParticleVertex`, `ParticleEmitterDesc` | Per-particle state and emitter configuration |
+
+`ParticleSystem::Initialize()` takes an `ID3D11Device*` and `ID3D11DeviceContext*`. Each `ParticleEmitter` creates its own vertex buffer via `ParticleEmitter::Initialize()`.
+
+---
+
+## Emitter Shapes
+
+The `EmitterShape` enum controls where particles spawn relative to the emitter origin:
+
+| Shape | Description | Relevant Parameters |
+|-------|-------------|-------------------|
+| `Point` | All particles spawn at a single point | None |
+| `Sphere` | Particles spawn on or within a sphere | `shapeRadius` |
+| `Cone` | Particles spawn within a cone | `shapeRadius`, `coneAngle` (degrees) |
+| `Box` | Particles spawn within an axis-aligned box | `shapeExtents` (half-extents) |
+| `Circle` | Particles spawn on or within a circle (2D, XZ plane) | `shapeRadius` |
+
+The spawn position is computed by `GetRandomSpawnPosition()` and the initial velocity direction by `GetRandomSpawnDirection()`, both respecting the chosen shape.
+
+---
+
+## Blend Modes
+
+The `ParticleBlendMode` enum selects the GPU blend state used when rendering particles:
+
+| Mode | Typical Use |
+|------|-------------|
+| `Additive` | Fire, sparks, glow, energy effects. Adds particle color to the framebuffer. |
+| `AlphaBlend` | Smoke, dust, clouds. Standard source-over-destination alpha blending. |
+| `Multiply` | Shadow overlays, darkening effects. Multiplies framebuffer by particle color. |
+| `Premultiplied` | UI particles, pre-multiplied alpha textures. Assumes RGB is pre-multiplied by alpha. |
+
+---
+
+## Emitter Configuration
+
+All emitter parameters are specified via the `ParticleEmitterDesc` struct.
+
+### Emission
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `emissionRate` | `float` | 10.0 | Particles spawned per second |
+| `maxParticles` | `int` | 1000 | Maximum live particles in the pool |
+| `burstCount` | `int` | 0 | Particles emitted in a single burst |
+| `burstInterval` | `float` | 0.0 | Seconds between bursts (0 = one-shot) |
+| `loop` | `bool` | true | Restart after duration expires |
+| `playOnAwake` | `bool` | true | Begin playing immediately on creation |
+| `prewarm` | `bool` | false | Simulate one full cycle on first frame |
+| `duration` | `float` | 0.0 | Total effect duration (0 = infinite when looping) |
+
+### Particle Properties
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `lifetime` | `FloatRange` | 1.0 -- 2.0 | Random lifetime per particle (seconds) |
+| `startSpeed` | `FloatRange` | 1.0 -- 5.0 | Random initial speed |
+| `startSize` | `FloatRange` | 0.1 -- 0.5 | Random initial billboard size |
+| `startRotation` | `FloatRange` | 0.0 -- 6.28 | Random initial rotation (radians) |
+| `rotationSpeed` | `FloatRange` | 0.0 -- 0.0 | Angular velocity (radians/sec) |
+| `texturePath` | `std::string` | (empty) | Optional billboard texture path |
+
+`FloatRange` stores a `min` and `max`; each particle samples a random value within the range at spawn time.
+
+### Color and Size Over Lifetime
+
+- **`colorOverLife`** -- A `std::vector<ColorKey>` defining an RGBA gradient. Each key has a normalized time `[0..1]` and an `XMFLOAT4` color. Default: white at t=0, transparent white at t=1 (fade out).
+- **`sizeOverLife`** -- A `std::vector<std::pair<float, float>>` mapping normalized time to a size multiplier. Default: 1.0 at t=0, 0.0 at t=1 (shrink to nothing).
+
+Both curves are evaluated per-particle each frame via `SampleColorGradient()` and `SampleSizeCurve()`.
+
+### Physics
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `gravity` | `XMFLOAT3` | (0, -9.81, 0) | Gravity vector |
+| `gravityMultiplier` | `float` | 0.0 | Scale factor for gravity (0 = no gravity) |
+| `drag` | `float` | 0.0 | Velocity damping per second |
+
+### Sub-Emitters
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `onDeathEmitter` | `std::string` | Emitter name to trigger when a particle dies |
+| `onCollisionEmitter` | `std::string` | Emitter name to trigger on particle collision |
+
+Sub-emitters reference other emitters by name within the same `ParticleSystem`.
+
+---
+
+## Preset Effects
+
+`ParticleSystem` provides convenience methods that create pre-configured emitters:
+
+| Method | Description |
+|--------|-------------|
+| `SpawnExplosion(position, radius)` | Short burst of additive particles expanding outward |
+| `SpawnMuzzleFlash(position, direction)` | Cone-shaped flash along a direction |
+| `SpawnSparks(position, normal, count)` | Directional sparks bouncing off a surface |
+| `SpawnSmoke(position, duration)` | Alpha-blended rising smoke |
+| `SpawnTrail(startPos)` | Continuous trail emitter attached to a moving object |
+
+All presets return a `ParticleEmitter*` that can be further customized.
+
+---
+
+## Code Example
+
+```cpp
+// Initialize the particle system
+ParticleSystem particles;
+particles.Initialize(device, context);
+
+// Create a custom fire emitter
+ParticleEmitterDesc desc;
+desc.name = "campfire";
+desc.emissionRate = 50.0f;
+desc.maxParticles = 500;
+desc.shape = EmitterShape::Cone;
+desc.coneAngle = 15.0f;
+desc.lifetime = {0.5f, 1.5f};
+desc.startSpeed = {2.0f, 4.0f};
+desc.startSize = {0.05f, 0.2f};
+desc.blendMode = ParticleBlendMode::Additive;
+desc.space = ParticleSpace::World;
+desc.gravityMultiplier = -0.5f; // Slight upward drift
+desc.colorOverLife = {
+    {0.0f, {1.0f, 0.8f, 0.2f, 1.0f}},  // Bright yellow
+    {0.5f, {1.0f, 0.3f, 0.0f, 0.8f}},   // Orange
+    {1.0f, {0.3f, 0.0f, 0.0f, 0.0f}}    // Fade to dark red
+};
+
+ParticleEmitter* fire = particles.CreateEmitter(desc);
+fire->SetPosition({10.0f, 0.0f, 5.0f});
+fire->Play();
+
+// Spawn a quick explosion preset
+particles.SpawnExplosion({20.0f, 1.0f, 0.0f}, 5.0f);
+
+// Per frame
+particles.Update(deltaTime);
+particles.Render(viewMatrix, projectionMatrix);
+```
+
+---
+
+## Console Commands
+
+`ParticleSystem` exposes three `Console_*` methods for runtime debugging:
+
+| Method | Description |
+|--------|-------------|
+| `Console_ListEmitters()` | Returns a string listing all active emitters with particle counts |
+| `Console_GetEmitterInfo(name)` | Returns detailed info for a named emitter |
+| `Console_SpawnEffect(type, x, y, z)` | Spawns a preset effect at world coordinates |
+
+Metrics are also available via `GetTotalActiveParticles()` and `GetEmitterCount()`.
+
+---
+
+## Source Files
+
+| File | Description |
+|------|-------------|
+| `SparkEngine/Source/Graphics/ParticleSystem.h` | `ParticleSystem`, `ParticleEmitter`, `ParticleEmitterDesc`, enums, and data structs |
+| `SparkEditor/Source/Panels/ParticleEditorPanel.h` | Editor panel for authoring and previewing particle emitters |
+| `SparkEditor/Source/Panels/ParticleEditorPanel.cpp` | Editor panel implementation |
+
+---
+
+## See Also
+
+- [GPU Particles](GPU-Particles) -- GPU-accelerated particle system using compute shaders (up to 1M particles)
+- [Rendering and Graphics](Rendering-and-Graphics) -- Graphics engine that hosts the particle system
+- [Day Night Cycle and Weather](Day-Night-Cycle-and-Weather) -- Weather effects that can drive environmental particles
+- [SparkEditor](SparkEditor) -- Editor panels including the Particle Editor
+- [Destruction System](Destruction-System) -- Debris effects that may spawn particle emitters

--- a/wiki/Post-Processing.md
+++ b/wiki/Post-Processing.md
@@ -1,0 +1,337 @@
+# Post-Processing
+
+SparkEngine provides a configurable post-processing pipeline that chains 14 screen-space effects in a fixed order. Each effect is a self-contained pass with its own settings struct, enable/disable state, and per-pass performance metrics. The pipeline manages render target ping-ponging between passes automatically using two `R16G16B16A16_FLOAT` textures, and integrates with the editor through the **PostProcessingPanel**.
+
+**Source Files:**
+- `SparkEngine/Source/Graphics/PostProcessingPipeline.h` -- Pipeline class (pass orchestration, render target management)
+- `SparkEngine/Source/Graphics/PostProcessingPipeline.cpp` -- Pipeline implementation
+- `SparkEngine/Source/Graphics/PostProcessingTypes.h` -- All settings structs, enums, and metric types
+- `SparkEngine/Source/Graphics/PostProcessingEffects.h` -- Backward-compatibility re-export of types
+- `SparkEditor/Source/Panels/PostProcessingPanel.h` -- Editor panel for post-processing settings
+
+## Pipeline Architecture
+
+All enabled passes execute in the fixed order defined by the `PostProcessPass` enum. Disabled passes are skipped with zero cost. Between each pass, the pipeline swaps source and destination render targets (ping-pong).
+
+```
+Scene Color (HDR input)
+       |
+       v
++------+------+------+------+------+------+------+------+------+------+------+------+------+------+
+| 1    | 2    | 3    | 4    | 5    | 6    | 7    | 8    | 9    |10    |11    |12    |13    |14    |
+|Bloom |Auto  |Tone  |Color |FXAA  |Depth |Motion|Vign- |Chrom.|Film  |Lens  |Light |Lens  |Sharp-|
+|      |Expos.|map   |Grade |      |OfFld |Blur  |ette  |Aberr.|Grain |Dist. |Shaft |Flare |en    |
++------+------+------+------+------+------+------+------+------+------+------+------+------+------+
+       |
+       v
+Final Output (LDR)
+```
+
+### Pass Order
+
+| # | Pass | Category | Description |
+|---|------|----------|-------------|
+| 1 | Bloom | HDR | Bright pixel extraction + multi-pass blur + composite |
+| 2 | AutoExposure | HDR | Luminance histogram eye adaptation |
+| 3 | Tonemapping | HDR | HDR-to-LDR conversion (ACES, Filmic, Neutral, Reinhard) |
+| 4 | ColorGrading | Color | Lift/Gamma/Gain, temperature, tint, hue shift |
+| 5 | FXAA | Anti-Aliasing | Fast Approximate Anti-Aliasing |
+| 6 | DepthOfField | Lens | Bokeh blur based on focal distance and aperture |
+| 7 | MotionBlur | Temporal | Per-pixel velocity-based blur |
+| 8 | Vignette | Lens | Screen-edge darkening |
+| 9 | ChromaticAberration | Lens | RGB channel separation at edges |
+| 10 | FilmGrain | Cinematic | Animated noise overlay |
+| 11 | LensDistortion | Lens | Barrel/pincushion distortion |
+| 12 | LightShafts | Volumetric | God rays from bright light sources |
+| 13 | LensFlare | Lens | Ghost images and halo from bright sources |
+| 14 | Sharpen | Output | Contrast-adaptive sharpening (CAS) |
+
+### Render Target Strategy
+
+The pipeline allocates two `R16G16B16A16_FLOAT` textures at the viewport resolution. Each pass reads from one texture and writes to the other. The `SwapTargets()` call alternates which texture is source and which is destination. On viewport resize, `Resize()` recreates both targets.
+
+## Effects Reference
+
+### Bloom (`BloomSettings`)
+
+Extracts bright pixels above a luminance threshold, applies multi-pass Gaussian blur, and composites the result back. Supports a soft knee around the threshold for smooth falloff.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `threshold` | float | 1.0 | Luminance cutoff for bright pixel extraction |
+| `softThreshold` | float | 0.5 | Soft knee width around threshold [0, 1] |
+| `intensity` | float | 0.8 | Final bloom composite strength |
+| `radius` | float | 4.0 | Blur radius in texels |
+| `iterations` | int | 5 | Downscale/blur passes [1, 8] |
+| `scatter` | float | 0.7 | Energy scatter between blur passes [0, 1] |
+| `highQuality` | bool | true | 13-tap dual filter (true) vs 5-tap (false) |
+
+### AutoExposure (`AutoExposureSettings`)
+
+Measures scene luminance via a histogram and smoothly adapts exposure over time, simulating human eye adaptation between bright and dark environments.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `minExposure` | float | 0.25 | Minimum EV (prevents over-darkening) |
+| `maxExposure` | float | 4.0 | Maximum EV (prevents over-brightening) |
+| `adaptSpeedUp` | float | 2.0 | Bright-to-dark adaptation speed (EV/s) |
+| `adaptSpeedDown` | float | 1.0 | Dark-to-bright adaptation speed (EV/s) |
+| `targetLuminance` | float | 0.18 | Middle-grey key value |
+| `histogramMin` | float | -8.0 | Log2 luminance histogram lower bound |
+| `histogramMax` | float | 4.0 | Log2 luminance histogram upper bound |
+| `compensationEV` | float | 0.0 | Manual EV compensation offset |
+
+### Tonemapping (`TonemappingSettings`)
+
+Converts the HDR scene to LDR display range. Four tonemapping operators are available via the `TonemapOperator` enum:
+
+| Operator | Description |
+|----------|-------------|
+| `ACES` | Academy Color Encoding System -- filmic, industry standard (default) |
+| `Filmic` | Uncharted 2 filmic curve (John Hable) |
+| `Neutral` | Minimal color shift, balanced contrast |
+| `Reinhard` | Simple luminance-based Reinhard |
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `op` | TonemapOperator | ACES | Active tonemapping operator |
+| `exposure` | float | 1.0 | Pre-tonemap exposure multiplier |
+| `whitePoint` | float | 11.2 | White point for Filmic/Reinhard |
+| `contrast` | float | 1.0 | Post-tonemap contrast [0.5, 2.0] |
+| `saturation` | float | 1.0 | Post-tonemap saturation [0, 2] |
+
+### ColorGrading (`ColorGradingSettings`)
+
+Professional color correction using Lift/Gamma/Gain (shadows/midtones/highlights) plus global adjustments for temperature, tint, hue, saturation, brightness, and contrast.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `lift` | XMFLOAT3 | (0, 0, 0) | Shadow color offset |
+| `gamma` | XMFLOAT3 | (1, 1, 1) | Midtone power curve |
+| `gain` | XMFLOAT3 | (1, 1, 1) | Highlight multiplier |
+| `temperature` | float | 0.0 | White balance [-1=cool, 1=warm] |
+| `tint` | float | 0.0 | Green-magenta shift [-1, 1] |
+| `hueShift` | float | 0.0 | Global hue rotation in degrees [-180, 180] |
+| `saturation` | float | 1.0 | Global saturation [0=mono, 2=oversaturated] |
+| `brightness` | float | 0.0 | Global brightness offset [-1, 1] |
+| `contrast` | float | 1.0 | Global contrast [0.5, 2.0] |
+
+### FXAA (`FXAASettings`)
+
+Fast Approximate Anti-Aliasing -- a single-pass post-process AA that smooths jagged edges based on luminance contrast. Lightweight alternative to MSAA with no geometry cost.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `edgeThreshold` | float | 0.166 | Minimum luminance edge detection [0.063, 0.333] |
+| `edgeThresholdMin` | float | 0.0833 | Darkest edge threshold |
+| `subpixelQuality` | float | 0.75 | Sub-pixel AA quality [0=off, 1=max] |
+| `qualityPreset` | int | 12 | Quality iterations [10=low, 29=ultra] |
+
+### DepthOfField (`DepthOfFieldSettings`)
+
+Physically-based depth of field with configurable focal plane, aperture, and bokeh shape. Uses the scene depth buffer to compute per-pixel circle of confusion.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `focalDistance` | float | 10.0 | Focus plane distance in meters |
+| `focalLength` | float | 50.0 | Lens focal length in mm |
+| `aperture` | float | 2.8 | F-stop (lower = more blur) |
+| `nearBlurStart` / `End` | float | 0.5 / 2.0 | Near blur distance range |
+| `farBlurStart` / `End` | float | 20.0 / 100.0 | Far blur distance range |
+| `maxBokehSize` | float | 8.0 | Maximum bokeh diameter in pixels |
+| `blurSamples` | int | 16 | Blur kernel samples |
+| `useCircularBokeh` | bool | true | Circular (true) vs hexagonal (false) |
+| `bokehBrightness` | float | 1.0 | Brightness threshold for bokeh highlights |
+
+### MotionBlur
+
+Per-pixel motion blur using temporal velocity data. This pass has no dedicated settings struct -- it uses velocity buffer data from the `TemporalEffects` system.
+
+### Vignette (`VignetteSettings`)
+
+Darkens screen edges to draw attention to the center. Supports configurable color, center position, and shape.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `intensity` | float | 0.3 | Darkening strength [0, 1] |
+| `smoothness` | float | 0.5 | Edge softness [0, 1] |
+| `roundness` | float | 1.0 | Shape (1=circular, 0=rectangular) |
+| `color` | XMFLOAT3 | (0, 0, 0) | Vignette color (default: black) |
+| `center` | XMFLOAT2 | (0.5, 0.5) | Center in UV space |
+
+### ChromaticAberration (`ChromaticAberrationSettings`)
+
+Simulates lens imperfection by separating RGB channels, with stronger effect at screen edges.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `intensity` | float | 0.5 | Separation amount [0, 3] |
+| `radialFalloff` | float | 1.0 | Edge emphasis [0=uniform, 2=strong edge] |
+| `channelOffsets` | XMFLOAT3 | (1, 0, -1) | R, G, B offset multipliers |
+
+### FilmGrain (`FilmGrainSettings`)
+
+Animated noise overlay that simulates cinematic film grain. Supports monochrome and colored modes.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `intensity` | float | 0.15 | Grain visibility [0, 1] |
+| `size` | float | 1.6 | Grain particle size |
+| `speed` | float | 1.0 | Animation speed |
+| `luminanceContribution` | float | 0.8 | Luminance influence on grain [0, 1] |
+| `colored` | bool | false | Color noise (true) vs monochrome (false) |
+
+### LensDistortion (`LensDistortionSettings`)
+
+Barrel or pincushion distortion simulating real lens imperfections.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `barrelDistortion` | float | 0.0 | [-1=pincushion, 1=barrel] |
+| `zoomCompensation` | float | 1.0 | Zoom to compensate for distortion |
+| `center` | XMFLOAT2 | (0.5, 0.5) | Distortion center in UV space |
+| `cubicDistortion` | float | 0.0 | Higher-order distortion term |
+
+### LightShafts (`LightShaftSettings`)
+
+Screen-space god rays via radial blur from a light source position. Uses ray marching with configurable density and decay.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `lightScreenPos` | XMFLOAT2 | (0.5, 0.3) | Light source screen position |
+| `density` | float | 1.0 | Ray density [0, 1] |
+| `weight` | float | 0.01 | Intensity per sample |
+| `decay` | float | 0.97 | Intensity decay per step [0, 1] |
+| `exposure` | float | 1.0 | Final exposure multiplier |
+| `sampleCount` | int | 64 | Ray marching samples |
+| `color` | XMFLOAT3 | (1.0, 0.95, 0.8) | Shaft color |
+
+### LensFlare (`LensFlareSettings`)
+
+Generates ghost images and halo rings from bright light sources in the scene.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `threshold` | float | 0.8 | Brightness threshold for flare trigger |
+| `intensity` | float | 0.5 | Flare overall intensity |
+| `ghostCount` | int | 5 | Number of ghost images |
+| `ghostSpacing` | float | 0.3 | Distance between ghosts |
+| `ghostThreshold` | float | 10.0 | Brightness for ghost generation |
+| `haloRadius` | float | 0.6 | Halo ring radius |
+| `haloThickness` | float | 0.1 | Halo ring width |
+| `chromaticDistortion` | float | 2.5 | Color separation in flare |
+
+### Sharpen (`SharpenSettings`)
+
+Contrast-adaptive sharpening inspired by AMD FidelityFX CAS. Applied last in the chain to counteract any softening from earlier passes.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `amount` | float | 0.5 | Sharpening strength [0, 1] |
+| `threshold` | float | 0.05 | Edge threshold (avoids noise amplification) |
+| `adaptiveSharpening` | bool | true | CAS mode (AMD FidelityFX style) |
+
+## Usage Example
+
+```cpp
+#include "Graphics/PostProcessingPipeline.h"
+
+using namespace Spark::Graphics;
+
+// Create and initialize the pipeline
+PostProcessingPipeline pipeline;
+pipeline.SetDevice(device, context);
+pipeline.Initialize(1920, 1080);
+
+// Enable and configure bloom
+pipeline.SetEffectEnabled(PostProcessPass::Bloom, true);
+pipeline.GetBloomSettings().threshold = 0.9f;
+pipeline.GetBloomSettings().intensity = 1.0f;
+
+// Enable tonemapping with ACES
+pipeline.SetEffectEnabled(PostProcessPass::Tonemapping, true);
+pipeline.GetTonemappingSettings().op = TonemapOperator::ACES;
+pipeline.GetTonemappingSettings().exposure = 1.2f;
+
+// Enable vignette
+pipeline.SetEffectEnabled(PostProcessPass::Vignette, true);
+pipeline.GetVignetteSettings().intensity = 0.4f;
+
+// Enable depth of field
+pipeline.SetEffectEnabled(PostProcessPass::DepthOfField, true);
+pipeline.GetDOFSettings().focalDistance = 15.0f;
+pipeline.GetDOFSettings().aperture = 2.8f;
+
+// Each frame, after scene rendering:
+pipeline.SetInputSRV(sceneColorSRV);
+pipeline.SetDepthSRV(sceneDepthSRV);
+pipeline.Process(deltaTime);
+pipeline.Render();
+
+// Handle viewport resize
+pipeline.Resize(newWidth, newHeight);
+
+// Query per-pass performance
+auto metrics = pipeline.GetPassMetrics();
+for (const auto& pm : metrics)
+{
+    if (pm.isEnabled)
+    {
+        Logger::Info("{}: {:.2f}ms", pm.name, pm.timeMs);
+    }
+}
+```
+
+## Console Commands
+
+Post-processing console commands are registered in `AdvancedConsoleCommands.cpp` (FPS game module):
+
+```
+pp_list              # List all post-processing effects and their on/off state
+exposure <value>     # Set light shaft exposure value
+hdr <on/off>         # Enable/disable HDR rendering
+```
+
+The `pp_list` command calls `PostProcessingPipeline::Console_ListEffects()`, which prints each pass name and its enabled/disabled state along with the total active pass count.
+
+## Performance Metrics
+
+Each pass records its GPU execution time in `m_passTimings[]`. Call `GetPassMetrics()` to retrieve a vector of `PassMetrics` structs:
+
+```cpp
+struct PassMetrics
+{
+    std::string name;    // Pass name (e.g., "Bloom", "FXAA")
+    float timeMs = 0.0f; // GPU time in milliseconds
+    bool isEnabled = false;
+};
+```
+
+The `GetActivePassCount()` method returns how many passes were active in the last frame.
+
+## Editor Integration
+
+The **PostProcessingPanel** (`SparkEditor::PostProcessingPanel`) exposes bloom, tonemapping, fog, sky, and wind parameters through ImGui controls. It reads from and writes to the scene's `EnvironmentSettings`, which are serialized to scene files. The `LightingTools` panel also provides post-processing controls for tonemapping, exposure, bloom, contrast, saturation, and brightness as part of the lighting preset system.
+
+## Source Files
+
+| File | Description |
+|------|-------------|
+| `SparkEngine/Source/Graphics/PostProcessingPipeline.h` | Pipeline class declaration |
+| `SparkEngine/Source/Graphics/PostProcessingPipeline.cpp` | Pipeline implementation (pass execution, GPU resources) |
+| `SparkEngine/Source/Graphics/PostProcessingTypes.h` | All enums, settings structs, and metric types |
+| `SparkEngine/Source/Graphics/PostProcessingEffects.h` | Backward-compatibility re-export header |
+| `SparkEditor/Source/Panels/PostProcessingPanel.h` | Editor panel declaration |
+| `SparkEditor/Source/Panels/PostProcessingPanel.cpp` | Editor panel ImGui implementation |
+| `SparkEditor/Source/Lighting/LightingTools.cpp` | Lighting preset post-processing integration |
+| `GameModules/SparkGameFPS/Source/Console/AdvancedConsoleCommands.cpp` | Console command registration |
+
+---
+
+## See Also
+
+- [Rendering and Graphics](Rendering-and-Graphics) -- GraphicsEngine and rendering pipeline overview
+- [Render Graph](Render-Graph) -- Render graph pass scheduling system
+- [Shader Pipeline](Shader-Pipeline) -- Shader compilation and management
+- [Camera System](Camera-System) -- Camera settings affecting depth of field
+- [Editor Panels](Editor-Panels) -- PostProcessingPanel and other editor UI

--- a/wiki/Shadow-System.md
+++ b/wiki/Shadow-System.md
@@ -1,0 +1,310 @@
+# Shadow System
+
+SparkEngine's shadow rendering pipeline combines a priority-based shadow atlas, temporal shadow caching, and Percentage-Closer Soft Shadows (PCSS) for realistic, distance-dependent soft shadows. The system supports directional, point, and spot light shadows with variable-resolution tiles allocated from a single atlas texture.
+
+**Source:** `SparkEngine/Source/Graphics/ShadowAtlas.h`, `CachedShadowAtlas.h`, `PCSSshadows.h`
+**Namespace:** `Spark::Graphics`
+**Tests:** `Tests/TestShadowAtlas.cpp` (7 test cases)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Shadow Atlas](#shadow-atlas)
+  - [Tile Allocation](#tile-allocation)
+  - [GPU Resources](#gpu-resources)
+  - [Atlas Metrics](#atlas-metrics)
+- [Cached Shadow Atlas](#cached-shadow-atlas)
+  - [Change Detection](#change-detection)
+  - [Dynamic vs Cached Regions](#dynamic-vs-cached-regions)
+- [PCSS Algorithm](#pcss-algorithm)
+  - [Three-Step Process](#three-step-process)
+  - [Sample Patterns](#sample-patterns)
+  - [HLSL Integration](#hlsl-integration)
+- [Settings](#settings)
+  - [PCSS Settings](#pcss-settings)
+- [Performance](#performance)
+- [Code Example](#code-example)
+- [Source Files](#source-files)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                       Shadow Pipeline                          │
+│                                                                │
+│  LightingSystem                                                │
+│       │                                                        │
+│       ▼                                                        │
+│  CachedShadowAtlas                                             │
+│  ┌──────────────────┐  ┌──────────────────┐                    │
+│  │  Dynamic Atlas    │  │  Cached Atlas     │                   │
+│  │  (ShadowAtlas)    │  │  (ShadowAtlas)    │                   │
+│  │  Re-render/frame  │  │  Render once,     │                   │
+│  │                   │  │  reuse until stale │                  │
+│  └────────┬──────────┘  └────────┬──────────┘                  │
+│           └──────────┬───────────┘                              │
+│                      ▼                                         │
+│            PCSSShadowEvaluator                                 │
+│            Blocker search → Penumbra → PCF                     │
+│                      │                                         │
+│                      ▼                                         │
+│              Final shadow factor [0..1]                        │
+└────────────────────────────────────────────────────────────────┘
+```
+
+The shadow system is composed of three cooperating classes:
+
+| Class | Responsibility |
+|-------|----------------|
+| `ShadowAtlas` | Subdivides a square depth texture into variable-size tiles, assigns tiles to lights by priority |
+| `CachedShadowAtlas` | Wraps two `ShadowAtlas` instances (dynamic + cached), skips re-rendering unchanged shadows |
+| `PCSSShadowEvaluator` | Evaluates shadow factor using the PCSS algorithm with variable penumbra |
+
+---
+
+## Shadow Atlas
+
+### Tile Allocation
+
+`ShadowAtlas` manages a single large depth texture (default 4096x4096) divided into a grid of cells. Lights request tiles via `RequestTile(lightId, priority, desiredSize)`:
+
+- **Priority-based sizing:** Higher-priority lights (closer, larger, more visible) receive larger tiles. The `GetDesiredTileSize()` heuristic maps priority > 0.8 to 1024px, > 0.4 to 512px, and below to 256px.
+- **Variable tile sizes:** Tiles are always square and power-of-two, from `minTileSize` (default 256) up to the atlas size.
+- **Grid occupancy:** An internal `std::vector<bool>` tracks which grid cells are occupied.
+- **Eviction:** `EndFrame()` evicts tiles that have not been used for several frames, freeing space for new lights.
+- **Persistence:** Tiles persist across frames for temporal stability -- a light keeps its tile as long as it remains active.
+
+The `ShadowTile` struct stores:
+
+| Field | Description |
+|-------|-------------|
+| `x`, `y` | Pixel offset within the atlas |
+| `size` | Tile width/height (always square) |
+| `lightId` | Owning light identifier |
+| `priority` | Assignment priority (higher = more important) |
+| `lastUsedFrame` | Frame index when last rendered |
+| `active` | Whether the tile is in use this frame |
+
+### GPU Resources
+
+`CreateGPUResources(device)` allocates the atlas as an R32_FLOAT depth texture through the [RHI](RHI-Abstraction-Layer). `BindForShadowPass(cmdList, lightId)` sets the viewport to the tile region for a given light's shadow rendering pass. The atlas texture is then bound for sampling in the lighting shader via `GetAtlasTexture()`.
+
+### Atlas Metrics
+
+`GetMetrics()` returns a `ShadowAtlasMetrics` snapshot:
+
+| Field | Description |
+|-------|-------------|
+| `atlasSize` | Total atlas resolution in pixels |
+| `totalTiles` | Number of allocated tiles |
+| `activeTiles` | Tiles active this frame |
+| `wastedPixels` | Unoccupied pixel area |
+| `utilization` | Fraction of atlas area in use (0.0 -- 1.0) |
+
+`Console_GetStatus()` returns a human-readable status string for the debug console.
+
+---
+
+## Cached Shadow Atlas
+
+`CachedShadowAtlas` wraps two separate `ShadowAtlas` instances to avoid re-rendering shadows for static or unchanged lights.
+
+### Dynamic vs Cached Regions
+
+| Region | Atlas Size (default) | Re-rendered | Use Case |
+|--------|---------------------|-------------|----------|
+| Dynamic | 2048x2048 | Every frame | Moving lights, animated shadow casters |
+| Cached | 4096x4096 | Only when stale | Static lights, fixed geometry |
+
+### Change Detection
+
+Each light tracked via a `ShadowCacheEntry` stores:
+
+| Field | Description |
+|-------|-------------|
+| `lightStateHash` | FNV-1a hash of light position, direction, range, and spot angle |
+| `casterSceneHash` | Hash of shadow casters in the light's frustum |
+| `isStatic` | Whether the light is flagged as static |
+| `needsUpdate` | Whether the shadow must be re-rendered this frame |
+
+The per-frame workflow:
+
+1. **`BeginFrame()`** -- Reset per-frame state, clear the render list.
+2. **`RequestShadow(request)`** -- For each light, compute the state hash and compare against the cache entry. If unchanged and static, reuse the cached tile (cache hit). Otherwise, allocate a tile and add the light to the render list.
+3. **Render** -- Iterate `GetShadowsToRender()` and render only the shadows that actually need updating.
+4. **`MarkRendered(lightId)`** -- After rendering, mark the cache entry as up-to-date.
+5. **`EndFrame()`** -- Evict stale tiles from both atlases.
+
+`InvalidateShadow(lightId)` forces a specific light's shadow to re-render next frame. `InvalidateAll()` invalidates every cached shadow (e.g., after a scene reload).
+
+`GetCachedRendersAvoided()` reports how many shadow renders were skipped this frame due to cache hits.
+
+---
+
+## PCSS Algorithm
+
+Percentage-Closer Soft Shadows produce realistic soft shadows with distance-dependent penumbra -- shadows are sharp near contact points and softer further from the occluding geometry.
+
+### Three-Step Process
+
+```
+Step 1: Blocker Search          Step 2: Penumbra Estimation      Step 3: PCF Filter
+┌─────────────────────┐        ┌─────────────────────────┐      ┌──────────────────┐
+│ Sample shadow map   │        │ penumbra = lightSize *  │      │ Sample shadow    │
+│ around the point    │ ────► │ (receiver - blocker)    │ ──► │ map with variable│
+│ to find average     │        │        / blocker        │      │ kernel size      │
+│ blocker depth       │        │                         │      │ = penumbra       │
+└─────────────────────┘        └─────────────────────────┘      └──────────────────┘
+```
+
+1. **Blocker search:** Sample the shadow map in a disk around the shading point using `blockerSearchSamples` Poisson samples. Collect depths that are closer than the receiver (i.e., occluders) and compute their average depth.
+
+2. **Penumbra estimation:** Using the similar triangles formula:
+   ```
+   penumbra = lightSize * (receiverDepth - avgBlockerDepth) / avgBlockerDepth
+   ```
+   The result is clamped to `[minPenumbraSize, maxPenumbraSize]`.
+
+3. **PCF filter:** Perform Percentage-Closer Filtering with `pcfSamples` Poisson samples at a radius determined by the estimated penumbra. The final shadow factor is the fraction of samples that pass the depth test.
+
+### Sample Patterns
+
+`PCSSSamplePattern` generates up to 64 sample points in two modes:
+
+| Pattern | Description |
+|---------|-------------|
+| `GeneratePoisson(numSamples, seed)` | Golden-angle spiral with optional per-pixel rotation via seed |
+| `GenerateGrid(gridSize)` | Regular NxN grid (fallback for debugging) |
+
+When `useRotatedPoisson` is enabled, each pixel rotates the Poisson disk by a noise value derived from the seed, which reduces visible banding artifacts.
+
+### HLSL Integration
+
+`PCSSShadowEvaluator::GetHLSLCode()` returns a self-contained HLSL function `PCSShadow()` that implements the full three-step algorithm. The function signature:
+
+```hlsl
+float PCSShadow(Texture2D shadowMap, SamplerComparisonState shadowSampler,
+                float2 uv, float depth, float lightSize, float2 texelSize);
+```
+
+This can be included directly in shadow sampling shaders. The HLSL version uses a 32-entry Poisson disk, 16 blocker search samples, and 32 PCF samples.
+
+---
+
+## Settings
+
+### PCSS Settings
+
+The `PCSSSettings` struct controls the shadow quality and behavior:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | true | Enable/disable PCSS |
+| `lightSize` | `float` | 1.0 | Light source size in world units. Larger values produce softer shadows. |
+| `blockerSearchSamples` | `int` | 16 | Number of samples for the blocker depth search |
+| `pcfSamples` | `int` | 32 | Number of samples for the final PCF filter |
+| `maxPenumbraSize` | `float` | 32.0 | Maximum penumbra width in shadow map texels |
+| `minPenumbraSize` | `float` | 1.0 | Minimum penumbra width (prevents fully hard edges) |
+| `nearPlane` | `float` | 0.1 | Shadow frustum near plane |
+| `shadowBias` | `float` | 0.002 | Depth bias to reduce self-shadowing (shadow acne) |
+| `normalBias` | `float` | 0.5 | Normal-based offset to reduce peter-panning artifacts |
+| `useRotatedPoisson` | `bool` | true | Rotate Poisson disk per pixel to reduce banding |
+
+---
+
+## Performance
+
+Shadow rendering is often the most expensive part of a lighting pipeline. The SparkEngine shadow system provides several mechanisms to manage cost:
+
+| Technique | Benefit |
+|-----------|---------|
+| **Priority-based atlas** | Low-priority lights get smaller (or no) shadow maps |
+| **Temporal caching** | Static shadows render once and reuse across frames |
+| **Variable penumbra** | PCSS uses fewer samples where shadows are sharp |
+| **Eviction** | Tiles for off-screen or distant lights are automatically freed |
+| **Tile persistence** | Avoids atlas fragmentation by keeping tiles stable across frames |
+
+**Tuning guidelines:**
+
+- Reduce `pcfSamples` for lower-end hardware (16 is a good minimum).
+- Lower `maxPenumbraSize` to limit the maximum filter radius.
+- Use the cached atlas for all static lights -- `GetCachedRendersAvoided()` should be high in a typical scene.
+- Monitor `ShadowAtlasMetrics::utilization` -- if consistently above 0.9, increase the atlas size.
+
+---
+
+## Code Example
+
+```cpp
+using namespace Spark::Graphics;
+
+// Initialize the cached shadow atlas
+CachedShadowAtlas shadows;
+shadows.Initialize(2048, 4096, 256); // dynamic: 2K, cached: 4K, min tile: 256
+
+// Per-frame shadow pass
+shadows.BeginFrame();
+
+for (auto& light : activeLights)
+{
+    ShadowUpdateRequest req;
+    req.lightId = light.id;
+    req.priority = ComputeLightPriority(light, camera);
+    req.isStatic = light.isStatic;
+    req.forceUpdate = false;
+    req.posX = light.position.x;
+    req.posY = light.position.y;
+    req.posZ = light.position.z;
+    req.dirX = light.direction.x;
+    req.dirY = light.direction.y;
+    req.dirZ = light.direction.z;
+    req.range = light.range;
+    req.spotAngle = light.spotAngle;
+
+    shadows.RequestShadow(req);
+}
+
+// Render only shadows that need updating
+for (uint32_t lightId : shadows.GetShadowsToRender())
+{
+    RenderShadowMap(lightId);
+    shadows.MarkRendered(lightId);
+}
+
+shadows.EndFrame();
+
+// Configure PCSS for soft shadows
+PCSSShadowEvaluator pcss;
+PCSSSettings settings;
+settings.lightSize = 2.0f;       // Larger area light
+settings.pcfSamples = 32;
+settings.blockerSearchSamples = 16;
+settings.shadowBias = 0.003f;
+pcss.SetSettings(settings);
+```
+
+---
+
+## Source Files
+
+| File | Description |
+|------|-------------|
+| `SparkEngine/Source/Graphics/ShadowAtlas.h` | `ShadowAtlas`, `ShadowTile`, `ShadowAtlasMetrics` |
+| `SparkEngine/Source/Graphics/CachedShadowAtlas.h` | `CachedShadowAtlas`, `ShadowCacheEntry`, `ShadowUpdateRequest` |
+| `SparkEngine/Source/Graphics/PCSSshadows.h` | `PCSSShadowEvaluator`, `PCSSSettings`, `PCSSSamplePattern` |
+| `Tests/TestShadowAtlas.cpp` | Unit tests for `ShadowAtlas` (7 test cases) |
+
+---
+
+## See Also
+
+- [Rendering and Graphics](Rendering-and-Graphics) -- Main rendering pipeline that integrates shadow passes
+- [Clustered Lighting](Clustered-Lighting) -- Lighting system that samples the shadow atlas per light
+- [RHI Abstraction Layer](RHI-Abstraction-Layer) -- Backend-agnostic texture and command list used by the atlas
+- [GPU-Driven Rendering](GPU-Driven-Rendering) -- Indirect draw calls that interact with shadow culling
+- [Performance Tips](Performance-Tips) -- General performance guidance including shadow budget

--- a/wiki/Sky-and-Atmosphere.md
+++ b/wiki/Sky-and-Atmosphere.md
@@ -1,0 +1,182 @@
+# Sky and Atmosphere
+
+SparkEngine provides an analytical sky rendering system based on the Preetham 1999 paper ("A Practical Analytic Model for Daylight"). The `SkyAtmosphereSystem` computes physically-plausible sky colors from any view direction using Perez distribution coefficients derived from atmospheric turbidity and sun position.
+
+**Source:** `SparkEngine/Source/Graphics/SkyAtmosphere.h`
+**Namespace:** `Spark::Graphics`
+**Tests:** `Tests/TestSkyAtmosphere.cpp` (5 test cases)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Sky Settings](#sky-settings)
+- [Preetham Sky Model](#preetham-sky-model)
+- [Integration with Day/Night Cycle](#integration-with-daynight-cycle)
+- [GPU Rendering](#gpu-rendering)
+- [Code Example](#code-example)
+- [Source Files](#source-files)
+- [See Also](#see-also)
+
+---
+
+## Overview
+
+The sky atmosphere system is a singleton (`SkyAtmosphereSystem::GetInstance()`) that evaluates sky luminance for any view direction given the current sun position and atmospheric turbidity. The system is primarily CPU-side -- computed colors can feed a skybox, be passed to shaders as uniform data, or be sampled for ambient lighting.
+
+```
+┌──────────────────────┐     sun direction      ┌──────────────────────┐
+│   TimeOfDaySystem    │ ─────────────────────► │  SkyAtmosphereSystem │
+│   (day/night cycle)  │     turbidity           │  Preetham/Perez      │
+└──────────────────────┘                         │  model evaluation    │
+                                                 └──────────┬───────────┘
+                                                            │
+                        ┌───────────────────────────────────┤
+                        │                                   │
+                ┌───────▼───────┐                   ┌───────▼───────┐
+                │ Skybox Render │                   │ Ambient Light │
+                │ (6 face       │                   │ Probe colors  │
+                │  colors)      │                   │               │
+                └───────────────┘                   └───────────────┘
+```
+
+Key capabilities:
+
+- **Analytical sky color** from any view direction via `ComputeSkyColor()`
+- **Sun disc color and intensity** via `ComputeSunColor()`
+- **Zenith and horizon colors** for ambient lighting or fog blending
+- **HDR exposure control** for tone mapping integration
+- **GPU constant buffer** for shader-side sky evaluation
+- **Cubemap face colors** rendered via `RenderGPU()` for skybox display
+
+---
+
+## Architecture
+
+| Class/Struct | Responsibility |
+|-------------|----------------|
+| `SkyAtmosphereSystem` | Singleton manager. Computes Perez coefficients, evaluates sky color, manages GPU resources. |
+| `SkySettings` | Configuration struct: turbidity, sun intensity, sun direction, exposure, ground albedo. |
+| `SkyColor` | Linear RGB color with `Lerp()` and scalar multiply. |
+| `PerezCoefficients` | Five coefficients (A-E) for one channel of the Perez distribution function. |
+
+---
+
+## Sky Settings
+
+The `SkySettings` struct controls all atmospheric parameters:
+
+| Field | Type | Default | Range | Description |
+|-------|------|---------|-------|-------------|
+| `turbidity` | `float` | 2.0 | 1 -- 10 | Atmospheric haze. 1 = perfectly clear, 10 = heavy haze/smog. |
+| `sunIntensity` | `float` | 20.0 | -- | Brightness multiplier for direct sunlight. |
+| `sunDirection` | `XMFLOAT3` | (0, -0.5, 0.5) | Normalized | Direction toward the sun. |
+| `exposure` | `float` | 1.0 | -- | HDR exposure control for tone mapping. |
+| `groundAlbedo` | `float` | 0.3 | 0 -- 1 | Ground reflectance for multi-scattering approximation. |
+| `enabled` | `bool` | true | -- | Master enable/disable switch. |
+
+Lower turbidity produces a deep blue sky with a sharp sun disc. Higher turbidity washes out the sky toward white/yellow and broadens the circumsolar glow.
+
+---
+
+## Preetham Sky Model
+
+The implementation follows the Preetham 1999 analytical model using the Perez luminance distribution function. For each color channel (Y luminance, x chrominance, y chrominance in CIE Yxy color space):
+
+1. **Perez coefficients (A-E)** are derived from the current turbidity value via `RecalculateCoefficients()`. These control:
+   - **A** -- Darkening or brightening of the horizon
+   - **B** -- Luminance gradient near the horizon
+   - **C** -- Relative intensity of the circumsolar region
+   - **D** -- Width of the circumsolar region
+   - **E** -- Relative backscattered light
+
+2. **Zenith values** are computed from sun elevation and turbidity via `ComputeZenithValues()`.
+
+3. **Sky evaluation** at a view direction uses:
+   - `theta` -- angle from zenith to the sample direction
+   - `gamma` -- angle between the sample direction and the sun direction
+   - The ratio `F(theta, gamma) / F(0, thetaSun)` normalizes the distribution relative to the zenith.
+
+The static method `EvaluatePerez()` computes the distribution value for a given (theta, gamma) pair and coefficient set.
+
+---
+
+## Integration with Day/Night Cycle
+
+The sky system integrates with the [Day/Night Cycle and Weather](Day-Night-Cycle-and-Weather) systems:
+
+- **Sun direction** is typically driven by `TimeOfDaySystem`, which updates the sun angle each frame based on the in-game clock.
+- **Turbidity** can be modulated by `WeatherSystem` -- clear weather uses low turbidity, overcast or polluted conditions use high turbidity.
+- **Exposure** can be linked to auto-exposure or post-processing tone mapping.
+- **`Update(deltaTime)`** optionally animates the sun position if linked to a time-of-day source.
+
+The `FogSystem` can sample `GetHorizonColor()` to match fog color to the sky at the horizon, creating seamless blending between distant geometry and the sky.
+
+---
+
+## GPU Rendering
+
+`RenderGPU(deltaTime)` creates a GPU constant buffer containing the Perez coefficients, zenith values, sun direction, and exposure. It then samples the Preetham model at six cardinal directions (+X, -X, +Y, -Y, +Z, -Z) to produce cubemap-ready colors stored internally.
+
+```cpp
+// Access the computed skybox face colors
+const SkyColor* faces = sky.GetSkyboxColors();
+// faces[0] = +X, faces[1] = -X, faces[2] = +Y, etc.
+```
+
+The constant buffer (`m_gpuConstantBuffer`) is created through the [RHI](RHI-Abstraction-Layer) abstraction, making the system backend-agnostic.
+
+---
+
+## Code Example
+
+```cpp
+// Get the singleton
+auto& sky = Spark::Graphics::SkyAtmosphereSystem::GetInstance();
+sky.Initialize();
+
+// Configure for a clear afternoon
+SkySettings settings;
+settings.turbidity = 3.0f;
+settings.sunIntensity = 22.0f;
+settings.sunDirection = {0.0f, -0.7f, 0.7f}; // Sun at ~45 degrees
+settings.exposure = 1.2f;
+settings.groundAlbedo = 0.3f;
+sky.SetSettings(settings);
+
+// Query sky color for a specific direction
+SkyColor overhead = sky.ComputeSkyColor({0.0f, 1.0f, 0.0f}); // Looking up
+SkyColor horizon  = sky.GetHorizonColor();
+SkyColor sunDisc  = sky.ComputeSunColor();
+
+// Use horizon color for fog blending
+fogSystem.SetColor(horizon.r, horizon.g, horizon.b);
+
+// Per-frame update
+sky.Update(deltaTime);
+sky.RenderGPU(deltaTime);
+
+// Cleanup
+sky.Shutdown();
+```
+
+---
+
+## Source Files
+
+| File | Description |
+|------|-------------|
+| `SparkEngine/Source/Graphics/SkyAtmosphere.h` | `SkyAtmosphereSystem`, `SkySettings`, `SkyColor`, `PerezCoefficients` |
+| `Tests/TestSkyAtmosphere.cpp` | Unit tests (5 test cases) |
+
+---
+
+## See Also
+
+- [Day Night Cycle and Weather](Day-Night-Cycle-and-Weather) -- Time-of-day and weather systems that drive sun direction and turbidity
+- [Volumetric Fog](Volumetric-Fog) -- Fog system that samples horizon color for seamless sky-fog blending
+- [Rendering and Graphics](Rendering-and-Graphics) -- Graphics engine and skybox rendering
+- [RHI Abstraction Layer](RHI-Abstraction-Layer) -- Backend-agnostic GPU resource creation
+- [Clustered Lighting](Clustered-Lighting) -- Lighting pipeline that uses sun intensity from the sky system

--- a/wiki/SparkEditor.md
+++ b/wiki/SparkEditor.md
@@ -1,6 +1,6 @@
 # SparkEditor
 
-The SparkEditor is an ImGui-based visual editor with 57 specialized dockable panels for creating and editing game content. It provides a full-featured workspace for [scene editing](Scene-Management), material authoring with [Shader Graph](Shader-Graph), [visual scripting](Visual-Scripting) (60 node types), [animation](Animation) timelines, [cinematic sequencing](Cinematic-Sequencer), AI/dialogue/ability/destruction editors, debugging, profiling, and [collaborative multi-user editing](Collaborative-Editing) (HeroEngine-inspired node locking and presence awareness). Features include a command palette (Ctrl+P), full undo/redo, play-mode editing, layout save/load, theming, and a plugin system (built-in + DLL).
+The SparkEditor is an ImGui-based visual editor with 59 specialized dockable panels for creating and editing game content. It provides a full-featured workspace for [scene editing](Scene-Management), material authoring with [Shader Graph](Shader-Graph), [visual scripting](Visual-Scripting) (60 node types), [animation](Animation) timelines, [cinematic sequencing](Cinematic-Sequencer), AI/dialogue/ability/destruction editors, debugging, profiling, and [collaborative multi-user editing](Collaborative-Editing) (HeroEngine-inspired node locking and presence awareness). Features include a command palette (Ctrl+P), full undo/redo, play-mode editing, layout save/load, theming, and a plugin system (built-in + DLL).
 
 ![SparkEditor default layout](../docs/screenshots/editor-overview.png)
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -6,6 +6,7 @@
 - [Getting Started](Getting-Started)
 - [Quick-Start Tutorial](Quick-Start-Tutorial)
 - [Making Your First Game](Making-Your-First-Game)
+- [Making Your First Multiplayer Game](Making-Your-First-Multiplayer-Game)
 - [Artist Workflow Guide](Artist-Workflow-Guide)
 - [Editor Walkthrough](Editor-Walkthrough)
 - [Migration Guide](Migration-Guide)
@@ -102,7 +103,15 @@
 - [Virtual Texturing](Virtual-Texturing)
 - [Water Rendering](Water-Rendering)
 - [Clustered Lighting](Clustered-Lighting)
+- [Material System](Material-System)
+- [Post-Processing](Post-Processing)
+- [Shadow System](Shadow-System)
+- [Particle System](Particle-System)
+- [Decal System](Decal-System)
+- [Sky and Atmosphere](Sky-and-Atmosphere)
+- [Foliage System](Foliage-System)
 - [Mesh Shaders](Mesh-Shaders)
+- [Neural Rendering](Neural-Rendering)
 
 ### Advanced
 - [Configuration Reference](Configuration-Reference)


### PR DESCRIPTION
New wiki pages: Post-Processing, Neural-Rendering, Material-System, Decal-System, Particle-System, Sky-and-Atmosphere, Shadow-System, Foliage-System. Total wiki pages: 125.

Fixed stale panel counts (57→59) across README, CHANGELOG, Home.md, SparkEditor.md, Codebase-Health.md, PROJECT_STATUS, docs/README, and engine-viability-evaluation. Updated test counts to 4290/338 in PROJECT_STATUS. Marked neural rendering as shipped in FEATURE_ROADMAP. Fixed stale AssetMigration.h path in Migration-Guide. Added Making-Your-First-Multiplayer-Game to sidebar. Regenerated stats, badges, flowchart, and context files.

https://claude.ai/code/session_015myt2Rsf1WkGHTZpwtedTy