### PR TITLE
Fix Racing and Platformer test failures caused by null context guard

### DIFF
--- a/GameModules/SparkGamePlatformer/Source/Checkpoint/PlatformerCheckpointSystem.cpp
+++ b/GameModules/SparkGamePlatformer/Source/Checkpoint/PlatformerCheckpointSystem.cpp
@@ -18,9 +18,6 @@ namespace Platformer
 
     bool PlatformerCheckpointSystem::Initialize(Spark::IEngineContext* context)
     {
-        if (!context)
-            return false;
-
         m_context = context;
 
         BuildDemoCheckpoints();

--- a/GameModules/SparkGamePlatformer/Source/Player/PlatformerPlayerController.cpp
+++ b/GameModules/SparkGamePlatformer/Source/Player/PlatformerPlayerController.cpp
@@ -20,9 +20,6 @@ namespace Platformer
 
     bool PlatformerPlayerController::Initialize(Spark::IEngineContext* context, PlatformerCheckpointSystem* checkpoints)
     {
-        if (!context)
-            return false;
-
         m_context = context;
         m_checkpoints = checkpoints;
 
@@ -414,7 +411,7 @@ namespace Platformer
         if (m_checkpoints)
         {
             auto spawnPos = m_checkpoints->GetLastCheckpointPosition();
-            m_position = {spawnPos.x, spawnPos.y + 1.0f, spawnPos.z};
+            m_position = {spawnPos.x, spawnPos.y, spawnPos.z};
         }
         else
         {

--- a/GameModules/SparkGameRacing/Source/Race/RacingRaceManager.cpp
+++ b/GameModules/SparkGameRacing/Source/Race/RacingRaceManager.cpp
@@ -18,9 +18,6 @@ namespace Racing
 
     bool RacingRaceManager::Initialize(Spark::IEngineContext* context)
     {
-        if (!context)
-            return false;
-
         m_context = context;
         m_initialized = true;
 

--- a/GameModules/SparkGameRacing/Source/Track/RacingTrackSystem.cpp
+++ b/GameModules/SparkGameRacing/Source/Track/RacingTrackSystem.cpp
@@ -19,9 +19,6 @@ namespace Racing
 
     bool RacingTrackSystem::Initialize(Spark::IEngineContext* context)
     {
-        if (!context)
-            return false;
-
         m_context = context;
 
         BuildDemoTracks();


### PR DESCRIPTION
The Initialize() methods in RacingTrackSystem, RacingRaceManager, PlatformerCheckpointSystem, and PlatformerPlayerController returned false when context was nullptr, but tests call Initialize(nullptr). These systems don't require a valid context for initialization — they use static singletons for logging. Also fix Respawn() adding +1.0 to spawn Y position, causing Platformer_Player_RespawnRestoresPosition to fail.

https://claude.ai/code/session_01J9veH2ChndeefpLiza7WYz