### PR TITLE
Add AGENTS.md to define agent session bootstrap steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Session Bootstrap
+
+Scope: entire repository (`/workspace/SparkEngine`).
+
+For every new session/chat in this repo:
+
+1. Read `CLAUDE.md` first.
+2. Then read `.claude/index.md`.
+3. Use those two files as persistent project context for workflow, conventions, and task execution.
+
+If either file is missing, report that clearly and continue with available context.


### PR DESCRIPTION
### Motivation

- Provide repository-wide agent session bootstrap instructions so every new session reads `CLAUDE.md` and `.claude/index.md` first and continues with available context if either file is missing.

### Description

- Add `AGENTS.md` at the repository root that defines the scope and a three-step bootstrap: read `CLAUDE.md`, then `.claude/index.md`, use those files as persistent project context, and report missing files while continuing with available context.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6dac2a6f08326a090a610bd3fbab5)