### PR TITLE
Avoid dlclose-related teardown crashes on Linux headless and add agent bootstrap doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Session Bootstrap
+
+Scope: entire repository (`/workspace/SparkEngine`).
+
+For every new session/chat in this repo:
+
+1. Read `CLAUDE.md` first.
+2. Then read `.claude/index.md`.
+3. Use those two files as persistent project context for workflow, conventions, and task execution.
+
+If either file is missing, report that clearly and continue with available context.

--- a/SparkEngine/Source/Core/SparkEngine.cpp
+++ b/SparkEngine/Source/Core/SparkEngine.cpp
@@ -216,8 +216,25 @@ static void ShutdownEngine()
         if (g_eventBus)
             g_eventBus->ClearAll();
 
-        g_moduleManager->UnloadAll();
-        g_moduleManager.reset();
+        const bool shouldSkipModuleUnload =
+#ifndef _WIN32
+            (EngineContext::Get() != nullptr && EngineContext::Get()->IsHeadless());
+#else
+            false;
+#endif
+
+        if (shouldSkipModuleUnload)
+        {
+            // Linux/headless teardown currently hits a late-shutdown crash path
+            // when module-owned callbacks/channels are destroyed after dlclose().
+            // Keep modules mapped until process exit in this mode.
+            g_moduleManager.release();
+        }
+        else
+        {
+            g_moduleManager->UnloadAll();
+            g_moduleManager.reset();
+        }
     }
     else
     {
@@ -1852,6 +1869,31 @@ int main(int argc, char* argv[])
 #endif
 
         Spark::SimpleConsole::GetInstance().LogInfo("Spark Engine shut down cleanly.");
+
+#ifndef _WIN32
+        // Defensive finalization for Linux:
+        // Dynamic module code can still be referenced by late static destructors
+        // (e.g., event channels/handlers captured in global singletons), which can
+        // trigger a use-after-dlclose segfault during process teardown.
+        // We intentionally clear/release these pointers and terminate without
+        // running additional static destruction code.
+        if (g_eventBus)
+        {
+            try
+            {
+                g_eventBus->ClearAll();
+            }
+            catch (...)
+            {
+                // Best-effort only during final process teardown.
+            }
+        }
+        g_moduleHotReload.release();
+        g_moduleManager.release();
+        g_eventBus.release();
+        std::_Exit(result);
+#endif
+
         return result;
     }
     catch (const std::system_error& e)


### PR DESCRIPTION
### Motivation

- Prevent late-shutdown segfaults on Linux caused by static destructors or global singletons referencing code in dynamically loaded modules after `dlclose()` during headless teardown.  
- Make the engine shutdown path more robust by retaining module mappings in problematic modes and performing a defensive finalization before process exit.  
- Provide a short repository-level agent bootstrap guide for new sessions.

### Description

- In `ShutdownEngine()` skip unloading modules on non-Windows headless runs by checking `EngineContext::Get()->IsHeadless()` and calling `g_moduleManager.release()` to keep modules mapped instead of `UnloadAll()`/`reset()`.  
- Preserve the original unload-and-reset behavior for other modes and platforms.  
- In `main()` add a Linux-only finalization step that best-effort clears `g_eventBus`, releases `g_moduleHotReload`, `g_moduleManager`, and `g_eventBus`, and calls `std::_Exit(result)` to avoid running additional static destructors that could reference module code.  
- Add `AGENTS.md` containing agent session bootstrap instructions to read `CLAUDE.md` and `.claude/index.md` as persistent project context.

### Testing

- Project compiled successfully on Linux and Windows toolchains after changes.  
- Verified a local Linux headless repro no longer triggers the late-shutdown segfault when the headless flag is used.  
- Ran the project's unit/integration smoke tests and common runtime paths which completed without new failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6dac2a6f08326a090a610bd3fbab5)