### PR TITLE
Add per-pass GPU timeline, D3D11 pipeline stats, and capture UX to profiler

### DIFF
--- a/SparkEditor/Source/Profiler/PerformanceProfiler.cpp
+++ b/SparkEditor/Source/Profiler/PerformanceProfiler.cpp
@@ -15,6 +15,15 @@
 #include <sstream>
 #include <fstream>
 
+#ifdef SPARK_PLATFORM_WINDOWS
+#if __has_include(<DXProgrammableCapture.h>)
+#include <DXProgrammableCapture.h>
+#define SPARK_EDITOR_HAS_DX_PROGRAMMABLE_CAPTURE 1
+#else
+#define SPARK_EDITOR_HAS_DX_PROGRAMMABLE_CAPTURE 0
+#endif
+#endif
+
 using namespace DirectX;
 namespace SparkEditor
 {
@@ -923,6 +932,7 @@ namespace SparkEditor
 
         if (m_pixCaptureAvailable)
         {
+#if SPARK_EDITOR_HAS_DX_PROGRAMMABLE_CAPTURE
             HMODULE dxgiDebug = LoadLibraryA("dxgidebug.dll");
             if (dxgiDebug)
             {
@@ -944,6 +954,7 @@ namespace SparkEditor
                 }
                 FreeLibrary(dxgiDebug);
             }
+#endif
         }
 
         m_captureStatus = "No capture API available (RenderDoc/PIX not attached).";
@@ -966,6 +977,7 @@ namespace SparkEditor
                                       GetProcAddress(GetModuleHandleA("renderdoc.dll"), "RENDERDOC_TriggerCapture");
 
         m_pixCaptureAvailable = false;
+#if SPARK_EDITOR_HAS_DX_PROGRAMMABLE_CAPTURE
         HMODULE dxgiDebug = LoadLibraryA("dxgidebug.dll");
         if (dxgiDebug)
         {
@@ -980,6 +992,7 @@ namespace SparkEditor
             }
             FreeLibrary(dxgiDebug);
         }
+#endif
 
         if (m_renderDocCaptureAvailable || m_pixCaptureAvailable)
         {

--- a/SparkEditor/Source/Profiler/PerformanceProfiler.cpp
+++ b/SparkEditor/Source/Profiler/PerformanceProfiler.cpp
@@ -122,6 +122,14 @@ namespace SparkEditor
         SPARK_TRACE_ENTER(Spark::LogCategory::Editor);
         SPARK_LOG_INFO(Spark::LogCategory::Editor, "Initializing Performance Profiler panel");
         m_isProfiling = true;
+        m_pendingGPUQueries.clear();
+        m_gpuScopeStack.clear();
+        m_currentGPUScopeDepth = 0;
+        m_timestampSupported = false;
+        m_pipelineStatsSupported = false;
+        m_gpuBackendName = "Unsupported";
+        m_gpuSupportStatus = "GPU backend not configured.";
+        RefreshCaptureAvailability();
         return true;
     }
 
@@ -274,6 +282,46 @@ namespace SparkEditor
     {
         m_device = device;
         m_context = context;
+
+#ifdef SPARK_PLATFORM_WINDOWS
+        m_timestampSupported = false;
+        m_pipelineStatsSupported = false;
+        m_gpuBackendName = "Unsupported";
+        m_gpuSupportStatus = "GPU profiling unavailable (D3D11 device/context missing).";
+
+        if (!m_device || !m_context)
+        {
+            return;
+        }
+
+        m_gpuBackendName = "D3D11";
+        m_gpuSupportStatus = "D3D11 GPU profiling ready.";
+
+        D3D11_QUERY_DESC timestampDesc = {};
+        timestampDesc.Query = D3D11_QUERY_TIMESTAMP;
+        Microsoft::WRL::ComPtr<ID3D11Query> testTimestampQuery;
+        if (SUCCEEDED(m_device->CreateQuery(&timestampDesc, testTimestampQuery.ReleaseAndGetAddressOf())))
+        {
+            m_timestampSupported = true;
+        }
+        else
+        {
+            m_gpuSupportStatus = "D3D11 backend active, but timestamp queries are unsupported.";
+        }
+
+        D3D11_QUERY_DESC pipelineDesc = {};
+        pipelineDesc.Query = D3D11_QUERY_PIPELINE_STATISTICS;
+        Microsoft::WRL::ComPtr<ID3D11Query> testPipelineQuery;
+        if (SUCCEEDED(m_device->CreateQuery(&pipelineDesc, testPipelineQuery.ReleaseAndGetAddressOf())))
+        {
+            m_pipelineStatsSupported = true;
+        }
+
+        if (m_timestampSupported && !m_pipelineStatsSupported)
+        {
+            m_gpuSupportStatus = "D3D11 timestamps enabled; pipeline statistics unavailable.";
+        }
+#endif // SPARK_PLATFORM_WINDOWS
     }
 
     void PerformanceProfiler::BeginGPUSample(const std::string& name, const std::string& shaderName)
@@ -284,11 +332,14 @@ namespace SparkEditor
         GPUProfileSample sample;
         sample.name = name;
         sample.shaderName = shaderName;
+        sample.depth = m_currentGPUScopeDepth;
         m_activeGPUSamples[name] = sample;
+        m_gpuScopeStack.push_back(name);
+        m_currentGPUScopeDepth++;
 
 #ifdef SPARK_PLATFORM_WINDOWS
         // Issue a D3D11 timestamp query if device is available
-        if (m_device && m_context)
+        if (m_device && m_context && m_timestampSupported)
         {
             // Start the per-frame disjoint query if not already active
             if (!m_disjointActive)
@@ -303,9 +354,23 @@ namespace SparkEditor
                 }
             }
 
+            if (m_pipelineStatsSupported && !m_pipelineStatsActive)
+            {
+                D3D11_QUERY_DESC pipelineDesc = {};
+                pipelineDesc.Query = D3D11_QUERY_PIPELINE_STATISTICS;
+                HRESULT pipelineHr =
+                    m_device->CreateQuery(&pipelineDesc, m_pipelineStatsQuery.ReleaseAndGetAddressOf());
+                if (SUCCEEDED(pipelineHr))
+                {
+                    m_context->Begin(m_pipelineStatsQuery.Get());
+                    m_pipelineStatsActive = true;
+                }
+            }
+
             GPUQueryPair queryPair;
             queryPair.name = name;
             queryPair.shaderName = shaderName;
+            queryPair.depth = sample.depth;
 
             D3D11_QUERY_DESC tsDesc = {};
             tsDesc.Query = D3D11_QUERY_TIMESTAMP;
@@ -320,7 +385,7 @@ namespace SparkEditor
             {
                 m_context->End(queryPair.beginQuery.Get()); // Timestamp queries use End(), not Begin()
                 queryPair.begun = true;
-                m_pendingGPUQueries[name] = std::move(queryPair);
+                m_pendingGPUQueries.push_back(std::move(queryPair));
             }
         }
 #endif // SPARK_PLATFORM_WINDOWS
@@ -335,16 +400,28 @@ namespace SparkEditor
         // Issue the end timestamp query
         if (m_context)
         {
-            auto it = m_pendingGPUQueries.find(name);
-            if (it != m_pendingGPUQueries.end() && it->second.begun)
+            for (auto it = m_pendingGPUQueries.rbegin(); it != m_pendingGPUQueries.rend(); ++it)
             {
-                m_context->End(it->second.endQuery.Get());
-                it->second.ended = true;
+                if (it->name == name && it->begun && !it->ended)
+                {
+                    m_context->End(it->endQuery.Get());
+                    it->ended = true;
+                    break;
+                }
             }
         }
 #endif // SPARK_PLATFORM_WINDOWS
 
         m_activeGPUSamples.erase(name);
+
+        if (!m_gpuScopeStack.empty())
+        {
+            m_gpuScopeStack.pop_back();
+        }
+        if (m_currentGPUScopeDepth > 0)
+        {
+            m_currentGPUScopeDepth--;
+        }
     }
 
     void PerformanceProfiler::RecordMemoryAllocation(const std::string& category, size_t bytes, void* pointer)
@@ -734,8 +811,11 @@ namespace SparkEditor
         {
             ImGui::Text("Frame: %d", m_currentFrame->frameNumber);
             ImGui::Text("Frame Time: %.2f ms", m_currentFrame->frameTime);
+            ImGui::Text("CPU/GPU: %.2f ms / %.2f ms", m_currentFrame->cpuTime, m_currentFrame->gpuTime);
             ImGui::Text("FPS: %.1f", m_currentFrame->fps);
             ImGui::Text("Draw Calls: %d", m_currentFrame->drawCalls);
+            ImGui::Text("GPU Backend: %s", m_currentFrame->gpuProfilerBackend.c_str());
+            ImGui::TextWrapped("%s", m_currentFrame->gpuProfilerStatus.c_str());
         }
         else
         {
@@ -765,18 +845,157 @@ namespace SparkEditor
     {
         ImGui::Text("GPU Profiler");
         ImGui::Separator();
+        ImGui::Text("Backend: %s", m_gpuBackendName.c_str());
+        ImGui::TextWrapped("%s", m_gpuSupportStatus.c_str());
+        if (ImGui::Button("Trigger GPU Capture"))
+        {
+            TriggerExternalGPUCapture();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Refresh Capture Support"))
+        {
+            RefreshCaptureAvailability();
+        }
+        ImGui::TextWrapped("%s", m_captureStatus.c_str());
+        ImGui::Separator();
 
         if (m_currentFrame && !m_currentFrame->gpuSamples.empty())
         {
+            ImGui::Text("GPU Time: %.2f ms", m_currentFrame->gpuTime);
+            ImGui::Text("CPU Time: %.2f ms", m_currentFrame->cpuTime);
+            ImGui::Text("Frame Time: %.2f ms", m_currentFrame->frameTime);
+            ImGui::Separator();
+
+            if (m_currentFrame->gpuPipelineStatsSupported)
+            {
+                ImGui::Text("Pipeline Statistics");
+                ImGui::BulletText("IA Vertices: %llu",
+                                  static_cast<unsigned long long>(m_currentFrame->pipelineIAVertices));
+                ImGui::BulletText("IA Primitives: %llu",
+                                  static_cast<unsigned long long>(m_currentFrame->pipelineIAPrimitives));
+                ImGui::BulletText("VS Invocations: %llu",
+                                  static_cast<unsigned long long>(m_currentFrame->pipelineVSInvocations));
+                ImGui::BulletText("PS Invocations: %llu",
+                                  static_cast<unsigned long long>(m_currentFrame->pipelinePSInvocations));
+                ImGui::BulletText("CS Invocations: %llu",
+                                  static_cast<unsigned long long>(m_currentFrame->pipelineCSInvocations));
+                ImGui::Separator();
+            }
+
+            ImGui::Text("GPU Timeline (per pass)");
             for (const auto& sample : m_currentFrame->gpuSamples)
             {
-                ImGui::Text("%s: %.2f ms (%d draw calls)", sample.name.c_str(), sample.duration, sample.drawCalls);
+                std::string indent(sample.depth * 2, ' ');
+                ImGui::Text("%s%s: %.2f ms (%d draw calls)", indent.c_str(), sample.name.c_str(), sample.duration,
+                            sample.drawCalls);
             }
         }
         else
         {
-            ImGui::Text("No GPU samples available");
+            if (m_timestampSupported)
+            {
+                ImGui::Text("No GPU samples available");
+            }
+            else
+            {
+                ImGui::TextWrapped("GPU timestamp timeline is unavailable on this backend/build.");
+            }
         }
+    }
+
+    bool PerformanceProfiler::TriggerExternalGPUCapture()
+    {
+#ifndef NDEBUG
+#ifdef SPARK_PLATFORM_WINDOWS
+        if (m_renderDocCaptureAvailable)
+        {
+            HMODULE renderDocModule = GetModuleHandleA("renderdoc.dll");
+            using TriggerCaptureFn = void (*)();
+            auto triggerCapture =
+                reinterpret_cast<TriggerCaptureFn>(GetProcAddress(renderDocModule, "RENDERDOC_TriggerCapture"));
+            if (triggerCapture)
+            {
+                triggerCapture();
+                m_captureStatus = "Triggered RenderDoc capture.";
+                return true;
+            }
+        }
+
+        if (m_pixCaptureAvailable)
+        {
+            HMODULE dxgiDebug = LoadLibraryA("dxgidebug.dll");
+            if (dxgiDebug)
+            {
+                auto getDebugInterface = reinterpret_cast<HRESULT(WINAPI*)(UINT, REFIID, void**)>(
+                    GetProcAddress(dxgiDebug, "DXGIGetDebugInterface1"));
+                if (getDebugInterface)
+                {
+                    ComPtr<IDXGraphicsAnalysis> graphicsAnalysis;
+                    HRESULT hr = getDebugInterface(0, __uuidof(IDXGraphicsAnalysis),
+                                                   reinterpret_cast<void**>(graphicsAnalysis.GetAddressOf()));
+                    if (SUCCEEDED(hr) && graphicsAnalysis)
+                    {
+                        graphicsAnalysis->BeginCapture();
+                        graphicsAnalysis->EndCapture();
+                        FreeLibrary(dxgiDebug);
+                        m_captureStatus = "Triggered PIX capture.";
+                        return true;
+                    }
+                }
+                FreeLibrary(dxgiDebug);
+            }
+        }
+
+        m_captureStatus = "No capture API available (RenderDoc/PIX not attached).";
+        return false;
+#else
+        m_captureStatus = "Capture trigger currently implemented for Windows D3D11 only.";
+        return false;
+#endif
+#else
+        m_captureStatus = "Capture trigger disabled in non-dev builds.";
+        return false;
+#endif
+    }
+
+    void PerformanceProfiler::RefreshCaptureAvailability()
+    {
+#ifndef NDEBUG
+#ifdef SPARK_PLATFORM_WINDOWS
+        m_renderDocCaptureAvailable = GetModuleHandleA("renderdoc.dll") &&
+                                      GetProcAddress(GetModuleHandleA("renderdoc.dll"), "RENDERDOC_TriggerCapture");
+
+        m_pixCaptureAvailable = false;
+        HMODULE dxgiDebug = LoadLibraryA("dxgidebug.dll");
+        if (dxgiDebug)
+        {
+            auto getDebugInterface = reinterpret_cast<HRESULT(WINAPI*)(UINT, REFIID, void**)>(
+                GetProcAddress(dxgiDebug, "DXGIGetDebugInterface1"));
+            if (getDebugInterface)
+            {
+                ComPtr<IDXGraphicsAnalysis> graphicsAnalysis;
+                HRESULT hr = getDebugInterface(0, __uuidof(IDXGraphicsAnalysis),
+                                               reinterpret_cast<void**>(graphicsAnalysis.GetAddressOf()));
+                m_pixCaptureAvailable = SUCCEEDED(hr) && graphicsAnalysis;
+            }
+            FreeLibrary(dxgiDebug);
+        }
+
+        if (m_renderDocCaptureAvailable || m_pixCaptureAvailable)
+        {
+            m_captureStatus = "Capture tools: " + std::string(m_renderDocCaptureAvailable ? "RenderDoc " : "") +
+                              std::string(m_pixCaptureAvailable ? "PIX" : "");
+        }
+        else
+        {
+            m_captureStatus = "No GPU capture tool API found in this process.";
+        }
+#else
+        m_captureStatus = "Capture availability check is Windows-only.";
+#endif
+#else
+        m_captureStatus = "Capture support hidden in non-dev builds.";
+#endif
     }
 
     void PerformanceProfiler::RenderMemoryProfilerPanel()
@@ -875,11 +1094,18 @@ namespace SparkEditor
 
     void PerformanceProfiler::UpdateFrameData()
     {
-        auto frame = std::make_unique<FrameProfileData>();
-        frame->frameNumber = m_currentFrameNumber;
-        frame->timestamp = std::chrono::steady_clock::now();
+        m_currentFrame = std::make_unique<FrameProfileData>();
+        m_currentFrame->frameNumber = m_currentFrameNumber;
+        m_currentFrame->timestamp = std::chrono::steady_clock::now();
+        m_currentFrame->gpuTimestampQueriesSupported = m_timestampSupported;
+        m_currentFrame->gpuPipelineStatsSupported = m_pipelineStatsSupported;
+        m_currentFrame->gpuProfilerBackend = m_gpuBackendName;
+        m_currentFrame->gpuProfilerStatus = m_gpuSupportStatus;
 
-        m_currentFrame = std::move(frame);
+        ProcessGPUQueries();
+        UpdateMemoryTracking();
+        CalculateStatistics();
+        AnalyzePerformance();
 
         // Keep history within limits
         if (static_cast<int>(m_frameHistory.size()) >= m_config.maxFrameHistory)
@@ -1126,7 +1352,14 @@ namespace SparkEditor
     void PerformanceProfiler::ProcessGPUQueries()
     {
         if (!m_currentFrame)
-            return;
+        {
+            m_currentFrame = std::make_unique<FrameProfileData>();
+            m_currentFrame->gpuTimestampQueriesSupported = m_timestampSupported;
+            m_currentFrame->gpuPipelineStatsSupported = m_pipelineStatsSupported;
+            m_currentFrame->gpuProfilerBackend = m_gpuBackendName;
+            m_currentFrame->gpuProfilerStatus = m_gpuSupportStatus;
+        }
+        m_currentFrame->gpuSamples.clear();
 
 #ifdef SPARK_PLATFORM_WINDOWS
         // Collect results from D3D11 timestamp queries
@@ -1138,14 +1371,15 @@ namespace SparkEditor
 
             // Retrieve the disjoint query data (contains GPU frequency)
             D3D11_QUERY_DATA_TIMESTAMP_DISJOINT disjointData = {};
-            HRESULT hr = m_context->GetData(m_disjointQuery.Get(), &disjointData, sizeof(disjointData), 0);
+            HRESULT hr = m_context->GetData(m_disjointQuery.Get(), &disjointData, sizeof(disjointData),
+                                            D3D11_ASYNC_GETDATA_DONOTFLUSH);
 
             if (SUCCEEDED(hr) && !disjointData.Disjoint && disjointData.Frequency > 0)
             {
                 // Collect timestamp results for all completed query pairs
                 for (auto it = m_pendingGPUQueries.begin(); it != m_pendingGPUQueries.end();)
                 {
-                    auto& [name, queryPair] = *it;
+                    auto& queryPair = *it;
                     if (!queryPair.begun || !queryPair.ended)
                     {
                         ++it;
@@ -1155,9 +1389,10 @@ namespace SparkEditor
                     UINT64 beginTimestamp = 0;
                     UINT64 endTimestamp = 0;
 
-                    HRESULT hrBegin =
-                        m_context->GetData(queryPair.beginQuery.Get(), &beginTimestamp, sizeof(UINT64), 0);
-                    HRESULT hrEnd = m_context->GetData(queryPair.endQuery.Get(), &endTimestamp, sizeof(UINT64), 0);
+                    HRESULT hrBegin = m_context->GetData(queryPair.beginQuery.Get(), &beginTimestamp, sizeof(UINT64),
+                                                         D3D11_ASYNC_GETDATA_DONOTFLUSH);
+                    HRESULT hrEnd = m_context->GetData(queryPair.endQuery.Get(), &endTimestamp, sizeof(UINT64),
+                                                       D3D11_ASYNC_GETDATA_DONOTFLUSH);
 
                     if (SUCCEEDED(hrBegin) && SUCCEEDED(hrEnd) && endTimestamp > beginTimestamp)
                     {
@@ -1170,17 +1405,46 @@ namespace SparkEditor
                         sample.startTimestamp = beginTimestamp;
                         sample.endTimestamp = endTimestamp;
                         sample.duration = durationMs;
+                        sample.depth = queryPair.depth;
+
+                        auto sampleIt = m_activeGPUSamples.find(queryPair.name);
+                        if (sampleIt != m_activeGPUSamples.end())
+                        {
+                            sample.drawCalls = sampleIt->second.drawCalls;
+                        }
 
                         m_currentFrame->gpuSamples.push_back(sample);
+                        it = m_pendingGPUQueries.erase(it);
+                        continue;
                     }
 
-                    it = m_pendingGPUQueries.erase(it);
+                    ++it;
                 }
             }
             else
             {
                 // Disjoint or failed — discard all pending queries
                 m_pendingGPUQueries.clear();
+            }
+        }
+
+        if (m_context && m_pipelineStatsActive && m_pipelineStatsQuery)
+        {
+            m_context->End(m_pipelineStatsQuery.Get());
+            m_pipelineStatsActive = false;
+
+            D3D11_QUERY_DATA_PIPELINE_STATISTICS stats = {};
+            HRESULT statsHr =
+                m_context->GetData(m_pipelineStatsQuery.Get(), &stats, sizeof(stats), D3D11_ASYNC_GETDATA_DONOTFLUSH);
+            if (SUCCEEDED(statsHr))
+            {
+                m_currentFrame->pipelineIAVertices = stats.IAVertices;
+                m_currentFrame->pipelineIAPrimitives = stats.IAPrimitives;
+                m_currentFrame->pipelineVSInvocations = stats.VSInvocations;
+                m_currentFrame->pipelinePSInvocations = stats.PSInvocations;
+                m_currentFrame->pipelineCSInvocations = stats.CSInvocations;
+                m_currentFrame->pipelineCInvocations = stats.CInvocations;
+                m_currentFrame->pipelineCPrimitives = stats.CPrimitives;
             }
         }
 #endif // SPARK_PLATFORM_WINDOWS

--- a/SparkEditor/Source/Profiler/PerformanceProfiler.h
+++ b/SparkEditor/Source/Profiler/PerformanceProfiler.h
@@ -362,6 +362,9 @@ namespace SparkEditor
      */
         void RenderPerformanceGraph(const PerformanceCounter& counter, const XMFLOAT2& size);
 
+        bool TriggerExternalGPUCapture();
+        void RefreshCaptureAvailability();
+
       private:
         // Profiling state
         bool m_isProfiling = false; ///< Whether profiling is active
@@ -391,13 +394,25 @@ namespace SparkEditor
             Microsoft::WRL::ComPtr<ID3D11Query> endQuery;   ///< Timestamp at sample end
             std::string name;                               ///< Sample name
             std::string shaderName;                         ///< Associated shader
+            uint32_t depth = 0;                             ///< Scope depth at BeginGPUSample()
             bool begun = false;                             ///< Whether begin was issued
             bool ended = false;                             ///< Whether end was issued
         };
 
-        std::unordered_map<std::string, GPUQueryPair> m_pendingGPUQueries; ///< In-flight GPU queries
-        Microsoft::WRL::ComPtr<ID3D11Query> m_disjointQuery;               ///< Per-frame disjoint query
-        bool m_disjointActive = false;                                     ///< Whether disjoint query is active
+        std::vector<GPUQueryPair> m_pendingGPUQueries;                      ///< In-flight GPU queries (ordered)
+        std::vector<std::string> m_gpuScopeStack;                           ///< Active GPU sample scope stack
+        uint32_t m_currentGPUScopeDepth = 0;                                ///< Current GPU scope depth
+        Microsoft::WRL::ComPtr<ID3D11Query> m_disjointQuery;                ///< Per-frame disjoint query
+        bool m_disjointActive = false;                                      ///< Whether disjoint query is active
+        Microsoft::WRL::ComPtr<ID3D11Query> m_pipelineStatsQuery;           ///< Per-frame pipeline statistics
+        bool m_pipelineStatsActive = false;                                 ///< Whether pipeline stats query is active
+        bool m_timestampSupported = false;                                  ///< Whether timestamp queries are supported
+        bool m_pipelineStatsSupported = false;                              ///< Whether pipeline stats are supported
+        std::string m_gpuBackendName = "Unsupported";                       ///< Current GPU profiler backend label
+        std::string m_gpuSupportStatus = "No GPU backend configured.";      ///< User-facing status message
+        bool m_renderDocCaptureAvailable = false;                           ///< RenderDoc capture API availability
+        bool m_pixCaptureAvailable = false;                                 ///< PIX capture API availability
+        std::string m_captureStatus = "Capture unavailable in this build."; ///< Last capture action/status text
 
         // Memory profiling
         std::unordered_map<void*, std::pair<std::string, size_t>> m_memoryAllocations; ///< Active allocations

--- a/SparkEditor/Source/Profiler/ProfilerTypes.h
+++ b/SparkEditor/Source/Profiler/ProfilerTypes.h
@@ -125,6 +125,7 @@ namespace SparkEditor
         uint64_t startTimestamp = 0; ///< GPU start timestamp
         uint64_t endTimestamp = 0;   ///< GPU end timestamp
         float duration = 0.0f;       ///< Duration in milliseconds
+        uint32_t depth = 0;          ///< Scope nesting depth (render pass hierarchy)
         int drawCalls = 0;           ///< Number of draw calls
         int vertices = 0;            ///< Number of vertices processed
         int pixels = 0;              ///< Number of pixels processed
@@ -178,6 +179,19 @@ namespace SparkEditor
         float fps = 0.0f;                ///< Frames per second
         float targetFrameTime = 16.67f;  ///< Target frame time (60 FPS)
         bool isPerformanceTarget = true; ///< Whether frame met performance target
+
+        // GPU profiling capability/telemetry
+        bool gpuTimestampQueriesSupported = false;  ///< Whether GPU timestamps are supported on this backend
+        bool gpuPipelineStatsSupported = false;     ///< Whether pipeline stats are supported on this backend
+        std::string gpuProfilerBackend = "Unknown"; ///< Backend label (e.g. D3D11)
+        std::string gpuProfilerStatus;              ///< Human-readable status for UI fallback messaging
+        uint64_t pipelineIAVertices = 0;            ///< IA vertex count (pipeline statistics)
+        uint64_t pipelineIAPrimitives = 0;          ///< IA primitive count
+        uint64_t pipelineVSInvocations = 0;         ///< VS invocation count
+        uint64_t pipelinePSInvocations = 0;         ///< PS invocation count
+        uint64_t pipelineCSInvocations = 0;         ///< CS invocation count
+        uint64_t pipelineCInvocations = 0;          ///< Clipper invocation count
+        uint64_t pipelineCPrimitives = 0;           ///< Clipper output primitive count
 
         std::vector<std::unique_ptr<CPUProfileSample>> cpuSamples; ///< CPU profiling samples
         std::vector<GPUProfileSample> gpuSamples;                  ///< GPU profiling samples

--- a/SparkEngine/Source/Graphics/GPUDebugMarkers.h
+++ b/SparkEngine/Source/Graphics/GPUDebugMarkers.h
@@ -30,6 +30,9 @@
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <d3d11_1.h>
 #include <d3d11.h>
+#include <dxgi1_3.h>
+#include <dxgidebug.h>
+#include <windows.h>
 #include <wrl/client.h>
 #include <cstdint>
 #include <string>
@@ -38,6 +41,20 @@ using Microsoft::WRL::ComPtr;
 
 namespace Spark::Graphics
 {
+    enum class GPUCaptureTool : uint8_t
+    {
+        None,
+        RenderDoc,
+        PIX
+    };
+
+    struct GPUCaptureAvailability
+    {
+        bool devBuild = false;
+        bool renderDocAvailable = false;
+        bool pixAvailable = false;
+        std::wstring status = L"Capture unavailable";
+    };
 
     /**
  * @brief GPU debug annotation system
@@ -144,6 +161,69 @@ namespace Spark::Graphics
         /** @brief Get current event nesting depth (for validation) */
         uint32_t GetEventDepth() const { return m_eventDepth; }
 
+        /** @brief Query capture API support (RenderDoc/PIX) for current process. */
+        GPUCaptureAvailability QueryCaptureAvailability()
+        {
+            GPUCaptureAvailability state{};
+#ifndef NDEBUG
+            state.devBuild = true;
+            state.renderDocAvailable = (GetModuleHandleA("renderdoc.dll") != nullptr);
+            state.pixAvailable = IsPIXAvailable();
+            if (state.renderDocAvailable || state.pixAvailable)
+            {
+                state.status = L"External GPU capture available.";
+            }
+            else
+            {
+                state.status = L"No RenderDoc/PIX capture API found in this process.";
+            }
+#else
+            state.status = L"External capture is disabled in non-dev builds.";
+#endif
+            return state;
+        }
+
+        /**
+     * @brief Trigger a one-click external GPU capture when tool API is available.
+     * @param preferredTool Preferred capture tool (RenderDoc or PIX). Falls back automatically.
+     * @return True if a capture was triggered.
+     */
+        bool TriggerExternalCapture(GPUCaptureTool preferredTool = GPUCaptureTool::RenderDoc)
+        {
+#ifndef NDEBUG
+            if (preferredTool == GPUCaptureTool::RenderDoc && TriggerRenderDocCapture())
+            {
+                m_lastCaptureStatus = L"Triggered RenderDoc capture.";
+                return true;
+            }
+
+            if (preferredTool == GPUCaptureTool::PIX && TriggerPIXCapture())
+            {
+                m_lastCaptureStatus = L"Triggered PIX capture.";
+                return true;
+            }
+
+            // Fallback order
+            if (TriggerRenderDocCapture())
+            {
+                m_lastCaptureStatus = L"Triggered RenderDoc capture.";
+                return true;
+            }
+            if (TriggerPIXCapture())
+            {
+                m_lastCaptureStatus = L"Triggered PIX capture.";
+                return true;
+            }
+
+            m_lastCaptureStatus = L"Capture API unavailable (RenderDoc/PIX not attached).";
+#else
+            m_lastCaptureStatus = L"Capture is disabled in non-dev builds.";
+#endif
+            return false;
+        }
+
+        const std::wstring& GetLastCaptureStatus() const { return m_lastCaptureStatus; }
+
         /**
      * @brief Get a console-friendly status string
      */
@@ -169,6 +249,81 @@ namespace Spark::Graphics
         ComPtr<ID3DUserDefinedAnnotation> m_annotation;
         uint32_t m_eventDepth = 0;
         bool m_initialized = false;
+        std::wstring m_lastCaptureStatus = L"Capture unavailable";
+
+        bool TriggerRenderDocCapture()
+        {
+            HMODULE renderDocModule = GetModuleHandleA("renderdoc.dll");
+            if (!renderDocModule)
+            {
+                return false;
+            }
+
+            using TriggerCaptureFn = void (*)();
+            auto triggerCapture =
+                reinterpret_cast<TriggerCaptureFn>(GetProcAddress(renderDocModule, "RENDERDOC_TriggerCapture"));
+            if (!triggerCapture)
+            {
+                return false;
+            }
+
+            triggerCapture();
+            return true;
+        }
+
+        bool IsPIXAvailable() const
+        {
+            HMODULE dxgiDebug = LoadLibraryA("dxgidebug.dll");
+            if (!dxgiDebug)
+            {
+                return false;
+            }
+
+            auto getDebugInterface = reinterpret_cast<HRESULT(WINAPI*)(UINT, REFIID, void**)>(
+                GetProcAddress(dxgiDebug, "DXGIGetDebugInterface1"));
+            if (!getDebugInterface)
+            {
+                FreeLibrary(dxgiDebug);
+                return false;
+            }
+
+            ComPtr<IDXGraphicsAnalysis> graphicsAnalysis;
+            HRESULT hr = getDebugInterface(0, __uuidof(IDXGraphicsAnalysis),
+                                           reinterpret_cast<void**>(graphicsAnalysis.GetAddressOf()));
+            FreeLibrary(dxgiDebug);
+            return SUCCEEDED(hr) && graphicsAnalysis;
+        }
+
+        bool TriggerPIXCapture()
+        {
+            HMODULE dxgiDebug = LoadLibraryA("dxgidebug.dll");
+            if (!dxgiDebug)
+            {
+                return false;
+            }
+
+            auto getDebugInterface = reinterpret_cast<HRESULT(WINAPI*)(UINT, REFIID, void**)>(
+                GetProcAddress(dxgiDebug, "DXGIGetDebugInterface1"));
+            if (!getDebugInterface)
+            {
+                FreeLibrary(dxgiDebug);
+                return false;
+            }
+
+            ComPtr<IDXGraphicsAnalysis> graphicsAnalysis;
+            HRESULT hr = getDebugInterface(0, __uuidof(IDXGraphicsAnalysis),
+                                           reinterpret_cast<void**>(graphicsAnalysis.GetAddressOf()));
+            if (FAILED(hr) || !graphicsAnalysis)
+            {
+                FreeLibrary(dxgiDebug);
+                return false;
+            }
+
+            graphicsAnalysis->BeginCapture();
+            graphicsAnalysis->EndCapture();
+            FreeLibrary(dxgiDebug);
+            return true;
+        }
     };
 
     /**

--- a/SparkEngine/Source/Graphics/GPUDebugMarkers.h
+++ b/SparkEngine/Source/Graphics/GPUDebugMarkers.h
@@ -30,12 +30,17 @@
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <d3d11_1.h>
 #include <d3d11.h>
-#include <dxgi1_3.h>
 #include <dxgidebug.h>
 #include <windows.h>
 #include <wrl/client.h>
 #include <cstdint>
 #include <string>
+#if __has_include(<DXProgrammableCapture.h>)
+#include <DXProgrammableCapture.h>
+#define SPARK_HAS_DX_PROGRAMMABLE_CAPTURE 1
+#else
+#define SPARK_HAS_DX_PROGRAMMABLE_CAPTURE 0
+#endif
 
 using Microsoft::WRL::ComPtr;
 
@@ -273,6 +278,7 @@ namespace Spark::Graphics
 
         bool IsPIXAvailable() const
         {
+#if SPARK_HAS_DX_PROGRAMMABLE_CAPTURE
             HMODULE dxgiDebug = LoadLibraryA("dxgidebug.dll");
             if (!dxgiDebug)
             {
@@ -292,10 +298,14 @@ namespace Spark::Graphics
                                            reinterpret_cast<void**>(graphicsAnalysis.GetAddressOf()));
             FreeLibrary(dxgiDebug);
             return SUCCEEDED(hr) && graphicsAnalysis;
+#else
+            return false;
+#endif
         }
 
         bool TriggerPIXCapture()
         {
+#if SPARK_HAS_DX_PROGRAMMABLE_CAPTURE
             HMODULE dxgiDebug = LoadLibraryA("dxgidebug.dll");
             if (!dxgiDebug)
             {
@@ -323,6 +333,9 @@ namespace Spark::Graphics
             graphicsAnalysis->EndCapture();
             FreeLibrary(dxgiDebug);
             return true;
+#else
+            return false;
+#endif
         }
     };
 

--- a/SparkEngine/Source/Utils/GPUPerfCounters.h
+++ b/SparkEngine/Source/Utils/GPUPerfCounters.h
@@ -12,6 +12,8 @@
 #include <array>
 #include <cstdint>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace Spark
 {
@@ -58,6 +60,33 @@ namespace Spark
         };
 
         /**
+         * @brief Timestamped GPU render pass sample for the current frame.
+         */
+        struct GPUPassTimestamp
+        {
+            std::string passName;
+            uint64_t beginTicks = 0;
+            uint64_t endTicks = 0;
+            uint64_t frequencyHz = 0;
+            float durationMs = 0.0f;
+            uint32_t depth = 0;
+        };
+
+        /**
+         * @brief Snapshot of hardware pipeline statistics for a frame.
+         */
+        struct GPUPipelineStatsCounters
+        {
+            uint64_t iaVertices = 0;
+            uint64_t iaPrimitives = 0;
+            uint64_t vsInvocations = 0;
+            uint64_t psInvocations = 0;
+            uint64_t csInvocations = 0;
+            uint64_t clipInvocations = 0;
+            uint64_t clipPrimitives = 0;
+        };
+
+        /**
          * @brief Tracks and aggregates GPU performance counters per frame.
          */
         class GPUPerfCounters
@@ -77,12 +106,33 @@ namespace Spark
              */
             void Increment(GPUCounterCategory category, uint64_t amount = 1) { m_current[category] += amount; }
 
+            void RecordPassTimestamp(const std::string& passName, uint64_t beginTicks, uint64_t endTicks,
+                                     uint64_t frequencyHz, uint32_t depth = 0)
+            {
+                GPUPassTimestamp ts;
+                ts.passName = passName;
+                ts.beginTicks = beginTicks;
+                ts.endTicks = endTicks;
+                ts.frequencyHz = frequencyHz;
+                ts.depth = depth;
+                if (endTicks > beginTicks && frequencyHz > 0)
+                {
+                    ts.durationMs =
+                        static_cast<float>(endTicks - beginTicks) / static_cast<float>(frequencyHz) * 1000.0f;
+                }
+                m_currentPassTimestamps.push_back(std::move(ts));
+            }
+
+            void SetPipelineStats(const GPUPipelineStatsCounters& stats) { m_currentPipelineStats = stats; }
+
             /**
              * @brief Call at the end of each frame to snapshot counters.
              */
             void EndFrame()
             {
                 m_lastFrame = m_current;
+                m_lastPassTimestamps = m_currentPassTimestamps;
+                m_lastPipelineStats = m_currentPipelineStats;
 
                 // Update rolling averages
                 for (size_t i = 0; i < m_rollingSum.size(); ++i)
@@ -94,6 +144,8 @@ namespace Spark
                 m_historyIndex = (m_historyIndex + 1) % HISTORY_SIZE;
 
                 m_current.Reset();
+                m_currentPassTimestamps.clear();
+                m_currentPipelineStats = {};
                 m_frameCount++;
             }
 
@@ -101,6 +153,10 @@ namespace Spark
             {
                 m_current.Reset();
                 m_lastFrame.Reset();
+                m_currentPassTimestamps.clear();
+                m_lastPassTimestamps.clear();
+                m_currentPipelineStats = {};
+                m_lastPipelineStats = {};
                 for (auto& h : m_history)
                     h.Reset();
                 m_rollingSum.fill(0);
@@ -110,6 +166,8 @@ namespace Spark
 
             const GPUFrameCounters& GetLastFrame() const { return m_lastFrame; }
             const GPUFrameCounters& GetCurrentFrame() const { return m_current; }
+            const std::vector<GPUPassTimestamp>& GetLastPassTimestamps() const { return m_lastPassTimestamps; }
+            const GPUPipelineStatsCounters& GetLastPipelineStats() const { return m_lastPipelineStats; }
 
             uint64_t GetAverage(GPUCounterCategory category) const
             {
@@ -155,6 +213,19 @@ namespace Spark
                     report += "  " + std::string(GetCategoryName(cat)) + ": " + std::to_string(m_lastFrame[cat]) +
                               " (avg: " + std::to_string(GetAverage(cat)) + ")\n";
                 }
+                report += "Pipeline Stats: IA Vtx=" + std::to_string(m_lastPipelineStats.iaVertices) +
+                          ", IA Prim=" + std::to_string(m_lastPipelineStats.iaPrimitives) +
+                          ", VS=" + std::to_string(m_lastPipelineStats.vsInvocations) +
+                          ", PS=" + std::to_string(m_lastPipelineStats.psInvocations) + "\n";
+                if (!m_lastPassTimestamps.empty())
+                {
+                    report += "Pass Timeline:\n";
+                    for (const auto& pass : m_lastPassTimestamps)
+                    {
+                        report += "  [" + std::to_string(pass.depth) + "] " + pass.passName + ": " +
+                                  std::to_string(pass.durationMs) + " ms\n";
+                    }
+                }
                 return report;
             }
 
@@ -165,6 +236,10 @@ namespace Spark
 
             GPUFrameCounters m_current;
             GPUFrameCounters m_lastFrame;
+            std::vector<GPUPassTimestamp> m_currentPassTimestamps;
+            std::vector<GPUPassTimestamp> m_lastPassTimestamps;
+            GPUPipelineStatsCounters m_currentPipelineStats;
+            GPUPipelineStatsCounters m_lastPipelineStats;
             std::array<GPUFrameCounters, HISTORY_SIZE> m_history;
             std::array<uint64_t, static_cast<size_t>(GPUCounterCategory::Count)> m_rollingSum = {};
             uint32_t m_historyIndex = 0;


### PR DESCRIPTION
### Motivation

- Provide per-pass GPU timing and pipeline-stat visibility so the editor can present a GPU timeline alongside CPU timings and surface hardware counters where available.
- Prefer a D3D11-first implementation (timestamp + pipeline-stat queries) while keeping graceful fallbacks for unsupported backends.
- Allow one-click external GPU captures (RenderDoc/PIX) from the profiler in development builds to speed up capture workflows.

### Description

- Extended profiling data model by adding `depth` to `GPUProfileSample` and backend/capability fields plus pipeline-stat counters to `FrameProfileData` so frames carry GPU capability and stats metadata.
- Implemented ordered timestamp query plumbing in `PerformanceProfiler`: probe capability in `SetDevice()`, create per-sample `GPUQueryPair` in `BeginGPUSample()`, close queries in `EndGPUSample()`, and collect results non-blocking in `ProcessGPUQueries()` (D3D11 timestamp + disjoint + pipeline-stat support); added scope stack and depth tracking so timeline entries are nested correctly.
- Updated editor UI in `PerformanceProfiler` (Overview and GPU tabs) to show CPU/GPU timing side-by-side, indented per-pass GPU timeline, pipeline statistics when available, backend/support status text, and buttons to `Trigger GPU Capture` / `Refresh Capture Support`.
- Added one-click capture helpers: `GPUDebugMarkers` gained capture-query and trigger helpers for RenderDoc/PIX (dev-build gated), and profiler exposes a `TriggerExternalGPUCapture()` / `RefreshCaptureAvailability()` surface that prefers RenderDoc then PIX and reports user-facing status messages.
- Augmented `GPUPerfCounters` to record per-pass timestamps and a frame-level pipeline-stats snapshot and include these in the console report output.

### Testing

- Ran `clang-format` and `clang-format --dry-run --Werror` on modified files, both succeeded.
- Ran `cmake --preset linux-gcc-release` (configuration completed); environment shows optional deps missing (Dear ImGui/SDL2) so full editor UI build/runtime is not available in this container.
- Initiated `cmake --build --target SparkEngineLib`; build started and progressed (no formatting/compile failures reported for modified files in the run), but full editor/runtime validation and D3D11 runtime behavior are deferred to Windows/dev builds where D3D11, RenderDoc and PIX can be exercised.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d71e6d8050832690583d6c30c5ce0d)