### PR TITLE
Introduce DI service interfaces and migrate networking lifecycle to EngineContext

### DIFF
--- a/SparkEngine/Source/Core/EngineContext.h
+++ b/SparkEngine/Source/Core/EngineContext.h
@@ -166,6 +166,18 @@ class EngineContext : public Spark::IEngineContext
     const Spark::AI::AISystem* GetAI() const override { return GetSystem<Spark::AI::AISystem>(); }
     Spark::NetworkManager* GetNetwork() override { return GetSystem<Spark::NetworkManager>(); }
     const Spark::NetworkManager* GetNetwork() const override { return GetSystem<Spark::NetworkManager>(); }
+    Spark::INetworkService* GetNetworkService() override { return GetSystem<Spark::INetworkService>(); }
+    const Spark::INetworkService* GetNetworkService() const override { return GetSystem<Spark::INetworkService>(); }
+    Spark::ITelemetryService* GetTelemetryService() override { return GetSystem<Spark::ITelemetryService>(); }
+    const Spark::ITelemetryService* GetTelemetryService() const override
+    {
+        return GetSystem<Spark::ITelemetryService>();
+    }
+    Spark::IGameplayTagService* GetGameplayTagService() override { return GetSystem<Spark::IGameplayTagService>(); }
+    const Spark::IGameplayTagService* GetGameplayTagService() const override
+    {
+        return GetSystem<Spark::IGameplayTagService>();
+    }
     World* GetWorld() override { return GetSystem<World>(); }
     const World* GetWorld() const override { return GetSystem<World>(); }
     SceneManager* GetSceneManager() override { return GetSystem<SceneManager>(); }
@@ -266,6 +278,9 @@ class EngineContext : public Spark::IEngineContext
     void SetAnimation(Spark::Animation::AnimationSystem* a) { RegisterSystem<Spark::Animation::AnimationSystem>(a); }
     void SetAI(Spark::AI::AISystem* a) { RegisterSystem<Spark::AI::AISystem>(a); }
     void SetNetwork(Spark::NetworkManager* n) { RegisterSystem<Spark::NetworkManager>(n); }
+    void SetNetworkService(Spark::INetworkService* s) { RegisterSystem<Spark::INetworkService>(s); }
+    void SetTelemetryService(Spark::ITelemetryService* s) { RegisterSystem<Spark::ITelemetryService>(s); }
+    void SetGameplayTagService(Spark::IGameplayTagService* s) { RegisterSystem<Spark::IGameplayTagService>(s); }
     void SetWorld(World* w) { RegisterSystem<World>(w); }
     void SetSceneManager(SceneManager* s) { RegisterSystem<SceneManager>(s); }
     void SetScriptEngine(AngelScriptEngine* s) { RegisterSystem<AngelScriptEngine>(s); }

--- a/SparkEngine/Source/Core/EngineSetup.h
+++ b/SparkEngine/Source/Core/EngineSetup.h
@@ -128,7 +128,11 @@ namespace Spark::EngineSetup
             ctx.RegisterSubsystem<AngelScriptEngine>(script, DependsOn<Timer, Spark::EventBus>{});
         }
 
-        // Networking depends on Timer (only registered when ENABLE_NETWORKING=ON)
+        // Networking depends on Timer (DI service + concrete compatibility path)
+        if (auto* networkService = ctx.GetNetworkService())
+        {
+            ctx.RegisterSubsystem<Spark::INetworkService>(networkService, DependsOn<Timer>{});
+        }
         if (auto* network = ctx.GetNetwork())
         {
             ctx.RegisterSubsystem<Spark::NetworkManager>(network, DependsOn<Timer>{});

--- a/SparkEngine/Source/Core/GameplaySystemLifecycle.cpp
+++ b/SparkEngine/Source/Core/GameplaySystemLifecycle.cpp
@@ -90,6 +90,7 @@
 #include "Graphics/LightmapBaker.h"
 #include "Engine/Procedural/ProceduralGenerator.h"
 #include "Engine/Networking/DeltaSnapshotManager.h"
+#include "Engine/Networking/NetworkManager.h"
 #include "Engine/Networking/InstabilitySimulator.h"
 #include "Engine/Security/MemoryIntegrity.h"
 #include "Utils/InvalidStateDetector.h"
@@ -328,6 +329,29 @@ void InitDebugSystems()
 // Gameplay system lifecycle
 // ============================================================================
 
+static void InitNetworkingLifecycle(EngineContext* ctx)
+{
+    SPARK_DEBUG_HOOK_SYSTEM(SystemPreInit, "NetworkingLifecycle", 0.0);
+
+    if (!ctx->GetNetworkService())
+    {
+        auto& networkSingleton = Spark::NetworkManager::GetInstance(); // DI_SHIM_OK: one-time compatibility bridge
+        ctx->SetNetwork(&networkSingleton);
+        ctx->SetNetworkService(&networkSingleton);
+    }
+
+    auto* network = ctx->GetNetworkService();
+    if (network)
+    {
+        if (!network->IsInitialized() && !network->Initialize())
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "Network service failed to initialize");
+        }
+    }
+
+    SPARK_DEBUG_HOOK_SYSTEM(SystemPostInit, "NetworkingLifecycle", 0.0);
+}
+
 static void InitCoreGameplaySystems(EngineContext* ctx)
 {
     SPARK_DEBUG_HOOK_SYSTEM(SystemPreInit, "CoreGameplaySystems", 0.0);
@@ -376,7 +400,7 @@ static void InitAIAndWorldSystems(Spark::EventBus* eventBus)
     SPARK_DEBUG_HOOK_SYSTEM(SystemPostInit, "AIAndWorldSystems", 0.0);
 }
 
-static void InitRenderingAndUtilitySystems()
+static void InitRenderingAndUtilitySystems(EngineContext* ctx)
 {
     SPARK_DEBUG_HOOK_SYSTEM(SystemPreInit, "RenderingAndUtility", 0.0);
     Spark::FreezeSystem::GetInstance().Initialize();
@@ -400,7 +424,16 @@ static void InitRenderingAndUtilitySystems()
     Spark::PluginRegistry::InitializeAll();
 
     Spark::Animation::AnimNotifyManager::GetInstance().Initialize();
-    Spark::Gameplay::GameplayTagRegistry::GetInstance().Initialize();
+    if (ctx->GetGameplayTagService())
+    {
+        ctx->GetGameplayTagService()->Initialize();
+    }
+    else
+    {
+        auto& gameplayTagRegistry = Spark::Gameplay::GameplayTagRegistry::GetInstance();
+        ctx->SetGameplayTagService(&gameplayTagRegistry);
+        gameplayTagRegistry.Initialize();
+    }
     Spark::Utils::GameplayDebugger::GetInstance().Initialize();
     Spark::Graphics::ScreenCapture::GetInstance().Initialize();
     Spark::Cinematic::VideoPlayer::GetInstance().Initialize();
@@ -510,6 +543,7 @@ void InitGameplaySystems()
         return;
     }
 
+    InitNetworkingLifecycle(ctx);
     InitCoreGameplaySystems(ctx);
 
     // Register snapshot serializers for play-in-editor mode
@@ -523,7 +557,7 @@ void InitGameplaySystems()
     {
         SPARK_LOG_WARN(Spark::LogCategory::Core, "EventBus is null — AI/World systems skipped");
     }
-    InitRenderingAndUtilitySystems();
+    InitRenderingAndUtilitySystems(ctx);
     InitScriptingAndPlatformSystems(ctx);
 }
 
@@ -903,7 +937,8 @@ static void ShutdownRenderingAndUtilitySystems()
 
 void ShutdownGameplaySystems()
 {
-    if (auto* ctx = EngineContext::Get())
+    auto* ctx = EngineContext::Get();
+    if (ctx)
     {
         if (auto* vr = ctx->GetVR())
             vr->Shutdown();
@@ -927,7 +962,14 @@ void ShutdownGameplaySystems()
     Spark::Accessibility::AccessibilitySystem::GetInstance().Shutdown();
 
     Spark::Animation::AnimNotifyManager::GetInstance().Shutdown();
-    Spark::Gameplay::GameplayTagRegistry::GetInstance().Shutdown();
+    if (ctx && ctx->GetGameplayTagService())
+    {
+        ctx->GetGameplayTagService()->Shutdown();
+    }
+    else
+    {
+        Spark::Gameplay::GameplayTagRegistry::GetInstance().Shutdown();
+    }
     Spark::Utils::GameplayDebugger::GetInstance().Shutdown();
     Spark::Graphics::ScreenCapture::GetInstance().Shutdown();
     Spark::Cinematic::VideoPlayer::GetInstance().Shutdown();
@@ -949,6 +991,14 @@ void ShutdownGameplaySystems()
     Spark::Rendering::MovieRenderPipeline::GetInstance().Shutdown();
     Spark::Data::DataTableRegistry::GetInstance().Shutdown();
     Spark::OnlineServices::OnlineServiceManager::GetInstance().Shutdown();
+
+    if (ctx)
+    {
+        if (auto* network = ctx->GetNetworkService())
+        {
+            network->Shutdown();
+        }
+    }
 
     if (auto* as = AngelScriptEngine::GetInstance())
     {

--- a/SparkEngine/Source/Engine/Gameplay/GameplayTags.h
+++ b/SparkEngine/Source/Engine/Gameplay/GameplayTags.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "Spark/ServiceInterfaces.h"
+
 #include <algorithm>
 #include <cstdint>
 #include <sstream>
@@ -142,7 +144,7 @@ namespace Spark::Gameplay
      * Singleton that manages tag registration, hierarchy resolution, and ID lookup.
      * Tags are registered once at startup and referenced by ID at runtime for O(1) lookups.
      */
-    class GameplayTagRegistry
+    class GameplayTagRegistry : public Spark::IGameplayTagService
     {
       public:
         /**
@@ -158,7 +160,7 @@ namespace Spark::Gameplay
         /**
          * @brief Initialize the registry
          */
-        void Initialize()
+        void Initialize() override
         {
             m_nextId = 1;
             m_tags.clear();
@@ -169,12 +171,14 @@ namespace Spark::Gameplay
         /**
          * @brief Shut down and clear all registered tags
          */
-        void Shutdown()
+        void Shutdown() override
         {
             m_tags.clear();
             m_nameToId.clear();
             m_initialized = false;
         }
+
+        uint32_t RegisterTag(std::string_view fullName) override { return RegisterTag(std::string(fullName)); }
 
         /**
          * @brief Register a tag (and all parent tags implicitly)
@@ -222,6 +226,8 @@ namespace Spark::Gameplay
          * @param fullName Dot-separated tag name
          * @return Tag ID, or INVALID_TAG_ID if not registered
          */
+        uint32_t GetTagId(std::string_view fullName) const override { return GetTagId(std::string(fullName)); }
+
         GameplayTagId GetTagId(const std::string& fullName) const
         {
             auto it = m_nameToId.find(fullName);

--- a/SparkEngine/Source/Engine/Networking/NetworkManager.cpp
+++ b/SparkEngine/Source/Engine/Networking/NetworkManager.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "NetworkManager.h"
+#include "../../Core/EngineContext.h"
 #include "../../Utils/Assert.h"
 #include "../../Utils/DebugHookManager.h"
 #include "../../Utils/Validate.h"
@@ -128,6 +129,17 @@ namespace Spark::Net
 
     NetworkManager& NetworkManager::GetInstance()
     {
+        if (auto* ctx = EngineContext::Get())
+        {
+            if (auto* service = ctx->GetNetworkService())
+            {
+                if (auto* network = dynamic_cast<NetworkManager*>(service))
+                {
+                    return *network;
+                }
+            }
+        }
+
         static NetworkManager instance;
         return instance;
     }

--- a/SparkEngine/Source/Engine/Networking/NetworkManager.h
+++ b/SparkEngine/Source/Engine/Networking/NetworkManager.h
@@ -18,6 +18,7 @@
 
 #pragma once
 #include "../../Core/Platform.h"
+#include "Spark/ServiceInterfaces.h"
 
 #ifdef SPARK_PLATFORM_WINDOWS
 #include <DirectXMath.h>
@@ -324,17 +325,17 @@ namespace Spark::Net
 
     // Thread safety: Queue mutex protects message I/O and handler registration.
     // Socket operations run on a dedicated network thread when connected.
-    class NetworkManager
+    class NetworkManager : public Spark::INetworkService
     {
       public:
         static NetworkManager& GetInstance();
 
         /// Initialize the networking subsystem (platform sockets).
         /// Must be called before StartServer() or Connect().
-        bool Initialize();
+        bool Initialize() override;
 
         /// Shut down the networking subsystem and release all resources.
-        void Shutdown();
+        void Shutdown() override;
 
         /// Initialize as server
         bool StartServer(uint16_t port = DEFAULT_PORT, int maxClients = 32);
@@ -350,7 +351,7 @@ namespace Spark::Net
         void Disconnect();
 
         /// Process incoming messages and send outgoing
-        void Update(float deltaTime);
+        void Update(float deltaTime) override;
 
         /// Send a message to the connected server (client) or broadcast (server)
         void SendMessage(const NetworkMessage& msg);
@@ -402,7 +403,7 @@ namespace Spark::Net
         float GetServerTime() const { return m_serverTime; }
         const NetworkStats& GetStats() const { return m_stats; }
         void SetPredictionCorrectionCount(uint32_t correctionCount) { m_stats.correctionCount = correctionCount; }
-        bool IsInitialized() const { return m_initialized; }
+        bool IsInitialized() const override { return m_initialized; }
 
         // Client management (server only)
         const std::unordered_map<ClientID, ClientInfo>& GetClients() const { return m_clients; }

--- a/SparkEngine/Source/Utils/Telemetry.h
+++ b/SparkEngine/Source/Utils/Telemetry.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include "Spark/ServiceInterfaces.h"
+
 #include <chrono>
 #include <cstdint>
 #include <fstream>
@@ -211,7 +213,7 @@ namespace Spark
      * @class TelemetrySystem
      * @brief Singleton managing event recording, batching, and backend dispatch.
      */
-    class TelemetrySystem
+    class TelemetrySystem : public ITelemetryService
     {
       public:
         /** @brief Get the singleton instance. */
@@ -252,7 +254,7 @@ namespace Spark
         }
 
         /** @brief Flush remaining events and shut down. */
-        void Shutdown()
+        void Shutdown() override
         {
             if (m_initialized)
             {
@@ -346,7 +348,7 @@ namespace Spark
          * @brief Per-frame update. Auto-flushes when the interval elapses.
          * @param dt Delta time in seconds.
          */
-        void Update(float dt)
+        void Update(float dt) override
         {
             if (!m_initialized || !m_config.enabled)
                 return;
@@ -377,6 +379,9 @@ namespace Spark
 
         /** @brief Check if the user has given consent. */
         bool HasConsent() const { return m_config.consentGiven; }
+
+        /** @brief Check if telemetry service has been initialized. */
+        bool IsInitialized() const override { return m_initialized; }
 
         // --- Queries ---
 

--- a/SparkSDK/Include/Spark/IEngineContext.h
+++ b/SparkSDK/Include/Spark/IEngineContext.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <cstdint>
+#include "Spark/ServiceInterfaces.h"
 
 // Forward declarations — engine types accessible through the context.
 // Modules include the specific engine headers they need for full definitions.
@@ -159,6 +160,18 @@ namespace Spark
         /** @brief Get the network manager (requires ENABLE_NETWORKING) */
         virtual NetworkManager* GetNetwork() { return nullptr; }
         virtual const NetworkManager* GetNetwork() const { return nullptr; }
+
+        /** @brief Get the network lifecycle interface (DI-friendly). */
+        virtual INetworkService* GetNetworkService() { return nullptr; }
+        virtual const INetworkService* GetNetworkService() const { return nullptr; }
+
+        /** @brief Get the telemetry lifecycle interface (DI-friendly). */
+        virtual ITelemetryService* GetTelemetryService() { return nullptr; }
+        virtual const ITelemetryService* GetTelemetryService() const { return nullptr; }
+
+        /** @brief Get the gameplay tag lifecycle interface (DI-friendly). */
+        virtual IGameplayTagService* GetGameplayTagService() { return nullptr; }
+        virtual const IGameplayTagService* GetGameplayTagService() const { return nullptr; }
 
         /** @brief Get the ECS world for entity/component access */
         virtual World* GetWorld() { return nullptr; }

--- a/SparkSDK/Include/Spark/ServiceInterfaces.h
+++ b/SparkSDK/Include/Spark/ServiceInterfaces.h
@@ -1,0 +1,46 @@
+/**
+ * @file ServiceInterfaces.h
+ * @brief Thin service interfaces for context-driven dependency injection.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace Spark
+{
+
+    /** @brief Thin runtime interface for networking lifecycle orchestration. */
+    class INetworkService
+    {
+      public:
+        virtual ~INetworkService() = default;
+        virtual bool Initialize() = 0;
+        virtual void Shutdown() = 0;
+        virtual void Update(float deltaTime) = 0;
+        virtual bool IsInitialized() const = 0;
+    };
+
+    /** @brief Thin runtime interface for telemetry lifecycle orchestration. */
+    class ITelemetryService
+    {
+      public:
+        virtual ~ITelemetryService() = default;
+        virtual void Update(float deltaTime) = 0;
+        virtual void Shutdown() = 0;
+        virtual bool IsInitialized() const = 0;
+    };
+
+    /** @brief Thin runtime interface for gameplay tag registry orchestration. */
+    class IGameplayTagService
+    {
+      public:
+        virtual ~IGameplayTagService() = default;
+        virtual void Initialize() = 0;
+        virtual void Shutdown() = 0;
+        virtual uint32_t RegisterTag(std::string_view fullName) = 0;
+        virtual uint32_t GetTagId(std::string_view fullName) const = 0;
+    };
+
+} // namespace Spark

--- a/tools/check-di-singletons.sh
+++ b/tools/check-di-singletons.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Enforce DI boundaries for migrated modules.
+# Fails if forbidden singleton lookups appear in files that must use EngineContext services.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+TARGET_FILE="$PROJECT_ROOT/SparkEngine/Source/Core/GameplaySystemLifecycle.cpp"
+
+if [ ! -f "$TARGET_FILE" ]; then
+    echo "ERROR: Missing target file: $TARGET_FILE"
+    exit 1
+fi
+
+violations="$(rg -n "Spark::NetworkManager::GetInstance\s*\(" "$TARGET_FILE" | rg -v "DI_SHIM_OK" || true)"
+if [ -n "$violations" ]; then
+    echo "ERROR: Forbidden singleton usage found in DI-required module:"
+    echo "$violations"
+    echo "Use EngineContext::GetNetworkService() instead."
+    exit 1
+fi
+
+echo "DI singleton guard passed: networking in GameplaySystemLifecycle uses EngineContext services."

--- a/tools/validate-all.sh
+++ b/tools/validate-all.sh
@@ -48,6 +48,7 @@ case "${1:-check}" in
         echo "  tools/check-bloat.sh             File size threshold checker (baseline-aware)"
         echo "  tools/check-doxygen-coverage.sh  Doxygen comment coverage"
         echo "  tools/check-cross-utilization.sh Architectural dependency boundaries"
+        echo "  tools/check-di-singletons.sh      DI singleton guardrails"
         exit 0
         ;;
 esac
@@ -91,6 +92,7 @@ run_check "System Wiring"                "check-wiring.sh"
 run_check "Bloat Thresholds (New Only)"  "check-bloat.sh" "new-only"
 run_check "Doxygen Coverage"             "check-doxygen-coverage.sh" "check"
 run_check "Cross-Utilization Boundaries" "check-cross-utilization.sh"
+run_check "DI Singleton Guardrails"     "check-di-singletons.sh"
 
 # Summary
 echo ""


### PR DESCRIPTION
### Motivation
- Provide thin, stable service interfaces for high-traffic singletons (networking, telemetry, gameplay tags) so subsystems can be consumed via dependency injection instead of global singletons.
- Expose those services through the existing `EngineContext` service registry to centralize lookup and enable staged migration away from `GetInstance()` global calls.
- Migrate the first vertical slice (networking lifecycle) to validate the pattern and keep a compatibility shim while call sites are ported.
- Add an architecture guard to prevent new direct singleton lookups in modules where DI is required.

### Description
- Added `SparkSDK/Include/Spark/ServiceInterfaces.h` containing `Spark::INetworkService`, `Spark::ITelemetryService`, and `Spark::IGameplayTagService` thin interfaces.
- Extended `IEngineContext` and `EngineContext` to expose `Get*/Set*Service()` accessors for the new interfaces and wire them into the generic registry via `RegisterSystem<T>()`.
- Made `NetworkManager` implement `INetworkService`, updated its header/source to include the interface, and changed `NetworkManager::GetInstance()` to prefer a context-backed service (compatibility shim) before falling back to the static singleton.
- Updated `TelemetrySystem` and `GameplayTagRegistry` to implement `ITelemetryService` / `IGameplayTagService` respectively and added `string_view`-based overloads for DI compatibility.
- Migrated the networking lifecycle in `GameplaySystemLifecycle.cpp` by adding `InitNetworkingLifecycle(ctx)` which resolves/initializes the network service via `EngineContext::GetNetworkService()`, seeded by a one-time compatibility bridge if needed, and adjusted rendering/gameplay tag init/shutdown paths to prefer context services when available.
- Registered the DI-capable `INetworkService` in `EngineSetup` alongside the concrete `NetworkManager` to preserve compatibility during rollout.
- Added `tools/check-di-singletons.sh` to enforce that `GameplaySystemLifecycle.cpp` uses `EngineContext` services instead of `NetworkManager::GetInstance()` (with a scoped `DI_SHIM_OK` exception), and wired this guard into `tools/validate-all.sh`.
- Ran `clang-format` on modified files for style conformity.

### Testing
- Ran formatting via `clang-format -i` on modified headers and sources, and the command completed successfully.
- Ran CMake configuration with `cmake --preset linux-gcc-release`, which completed successfully and generated build files.
- Executed the DI guard script with `bash tools/check-di-singletons.sh`, which passed (the one allowed compatibility occurrence is explicitly marked `DI_SHIM_OK`).
- Started a full build with `cmake --build build/linux-gcc-release --config Release -j4`; compilation progressed across many translation units without immediate configuration or compile-time failures observed in the session, though the entire long-running build was not observed to completion within the interaction window.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74e6dc7248326b00e94a75bc941a2)