### PR TITLE
Inject INetworkRuntime into DedicatedServer with NetworkManager adapter and runtime tests

### DIFF
--- a/SparkEngine/Source/Engine/Networking/DedicatedServer.cpp
+++ b/SparkEngine/Source/Engine/Networking/DedicatedServer.cpp
@@ -32,12 +32,22 @@
 
 namespace Spark::Net
 {
+    namespace
+    {
+        INetworkRuntime& GetDefaultNetworkRuntime()
+        {
+            static NetworkManagerRuntimeAdapter runtimeAdapter(NetworkManager::GetInstance());
+            return runtimeAdapter;
+        }
+    } // namespace
 
     // ============================================================================
     // Constructor / Destructor
     // ============================================================================
 
-    DedicatedServer::DedicatedServer() = default;
+    DedicatedServer::DedicatedServer() : DedicatedServer(GetDefaultNetworkRuntime()) {}
+
+    DedicatedServer::DedicatedServer(INetworkRuntime& networkRuntime) : m_networkRuntime(&networkRuntime) {}
 
     DedicatedServer::~DedicatedServer()
     {
@@ -62,108 +72,23 @@ namespace Spark::Net
         m_currentRound = 1;
         m_matchInProgress = false;
 
-        auto& netMgr = NetworkManager::GetInstance();
-        if (!netMgr.Initialize())
+        if (!m_networkRuntime->Initialize())
         {
             SPARK_LOG_ERROR(Spark::LogCategory::Network, "Failed to initialize NetworkManager");
             Log("ERROR: Failed to initialize NetworkManager");
             return false;
         }
 
-        if (!netMgr.StartServer(m_config.port, m_config.maxClients))
+        if (!m_networkRuntime->StartServer(m_config.port, m_config.maxClients))
         {
             SPARK_LOG_ERROR(Spark::LogCategory::Network, "Failed to start server on port %d", m_config.port);
             Log("ERROR: Failed to start server on port " + std::to_string(m_config.port));
-            netMgr.Shutdown();
+            m_networkRuntime->Shutdown();
             return false;
         }
 
         RegisterBuiltInRconCommands();
-
-        // Register handlers for dedicated-server-specific messages
-        netMgr.RegisterHandler(
-            MessageType::Connect,
-            [this](const NetworkMessage& msg)
-            {
-                // Check bans
-                {
-                    std::lock_guard<std::mutex> lock(m_banMutex);
-                    if (Spark::ContainerUtils::Contains(m_bannedClients, msg.senderID))
-                    {
-                        SPARK_LOG_WARN(Spark::LogCategory::Network, "Rejected banned client %u", msg.senderID);
-                        NetworkManager::GetInstance().KickClient(msg.senderID, "You are banned from this server");
-                        return;
-                    }
-                }
-                m_stats.totalConnectionsServed++;
-                SPARK_LOG_INFO(Spark::LogCategory::Network, "Client %u connected", msg.senderID);
-                uint32_t playerCount = GetPlayerCount();
-                if (playerCount > m_stats.peakPlayers)
-                    m_stats.peakPlayers = playerCount;
-                m_stats.currentPlayers = playerCount;
-
-                if (m_callbacks.onClientConnected)
-                {
-                    auto clients = NetworkManager::GetInstance().GetClients();
-                    auto it = clients.find(msg.senderID);
-                    std::string name = (it != clients.end()) ? it->second.name : "Unknown";
-                    m_callbacks.onClientConnected(msg.senderID, name);
-                }
-                Log("Client " + std::to_string(msg.senderID) + " connected");
-            });
-
-        netMgr.RegisterHandler(MessageType::Disconnect,
-                               [this](const NetworkMessage& msg)
-                               {
-                                   m_stats.currentPlayers = GetPlayerCount();
-                                   SPARK_LOG_INFO(Spark::LogCategory::Network, "Client %u disconnected", msg.senderID);
-                                   if (m_callbacks.onClientDisconnected)
-                                   {
-                                       m_callbacks.onClientDisconnected(msg.senderID, "Disconnected");
-                                   }
-                                   Log("Client " + std::to_string(msg.senderID) + " disconnected");
-                               });
-
-        netMgr.RegisterHandler(MessageType::ChatMessage,
-                               [this](const NetworkMessage& msg)
-                               {
-                                   if (msg.payload.empty())
-                                       return;
-                                   NetBuffer buf;
-                                   buf.WriteBytes(msg.payload.data(), msg.payload.size());
-                                   std::string chatText = buf.ReadString();
-
-                                   // Check for RCON prefix — bypassing this gate allows
-                                   // any client to execute server admin commands (kick, ban,
-                                   // map change, shutdown). Critical security boundary.
-                                   SPARK_BRANCH_GUARD_BEGIN("rcon_command_gate")
-                                   if (chatText.size() > 1 && chatText[0] == '/')
-                                   {
-                                       std::string rconCmd = chatText.substr(1);
-                                       std::string response = ExecuteRcon(rconCmd);
-                                       // Send response back to the issuing client
-                                       NetworkMessage reply;
-                                       reply.type = MessageType::ChatMessage;
-                                       reply.channel = ChannelType::Reliable;
-                                       NetBuffer replyBuf;
-                                       replyBuf.WriteString("[RCON] " + response);
-                                       reply.payload = replyBuf.GetData();
-                                       NetworkManager::GetInstance().SendToClient(msg.senderID, reply);
-                                       return;
-                                   }
-                                   SPARK_BRANCH_GUARD_END("rcon_command_gate")
-
-                                   // Broadcast chat to all clients
-                                   NetworkMessage broadcast;
-                                   broadcast.type = MessageType::ChatMessage;
-                                   broadcast.channel = ChannelType::Reliable;
-                                   broadcast.payload = msg.payload;
-                                   NetworkManager::GetInstance().SendToAllExcept(msg.senderID, broadcast);
-
-                                   if (m_callbacks.onChatMessage)
-                                       m_callbacks.onChatMessage(chatText);
-                                   Log("Chat: " + chatText);
-                               });
+        RegisterNetworkHandlers();
 
         // Set initial map
         if (!m_config.mapRotation.empty())
@@ -224,17 +149,16 @@ namespace Spark::Net
         Log("Server shutting down...");
 
         // Signal all clients
-        auto& netMgr = NetworkManager::GetInstance();
         NetworkMessage shutdownMsg;
         shutdownMsg.type = MessageType::Disconnect;
         shutdownMsg.channel = ChannelType::Reliable;
         NetBuffer buf;
         buf.WriteString("Server shutting down");
         shutdownMsg.payload = buf.GetData();
-        netMgr.SendToAll(shutdownMsg);
+        m_networkRuntime->SendToAll(shutdownMsg);
 
         // Give the message a chance to be flushed
-        netMgr.Update(0.0f);
+        m_networkRuntime->Update(0.0f);
 
         m_running.store(false, std::memory_order_release);
 
@@ -249,8 +173,9 @@ namespace Spark::Net
         if (m_lanBroadcastThread.joinable())
             m_lanBroadcastThread.join();
 
-        netMgr.StopServer();
-        netMgr.Shutdown();
+        ClearNetworkHandlers();
+        m_networkRuntime->StopServer();
+        m_networkRuntime->Shutdown();
 
         if (m_callbacks.onServerStopped)
             m_callbacks.onServerStopped();
@@ -265,8 +190,7 @@ namespace Spark::Net
 
         auto tickStart = std::chrono::steady_clock::now();
 
-        auto& netMgr = NetworkManager::GetInstance();
-        SPARK_GUARDED_UPDATE("Server:Network", "Network", { netMgr.Update(deltaTime); });
+        SPARK_GUARDED_UPDATE("Server:Network", "Network", { m_networkRuntime->Update(deltaTime); });
 
         SPARK_GUARDED_UPDATE("Server:Messages", "Network", { ProcessServerMessages(deltaTime); });
         SPARK_GUARDED_UPDATE("Server:MatchState", "Network", { UpdateMatchState(deltaTime); });
@@ -286,7 +210,7 @@ namespace Spark::Net
         m_stats.currentTickRate = (tickMs > 0.0f) ? (1000.0f / tickMs) : m_config.tickRate;
 
         // Update network byte counters
-        const auto& netStats = netMgr.GetStats();
+        const auto& netStats = m_networkRuntime->GetStats();
         m_stats.totalBytesIn = netStats.bytesReceived;
         m_stats.totalBytesOut = netStats.bytesSent;
         m_stats.currentPlayers = GetPlayerCount();
@@ -330,6 +254,98 @@ namespace Spark::Net
         // such as anti-cheat validation or rate-limit enforcement.
     }
 
+    void DedicatedServer::RegisterNetworkHandlers()
+    {
+        m_networkRuntime->RegisterHandler(
+            MessageType::Connect,
+            [this](const NetworkMessage& msg)
+            {
+                {
+                    std::lock_guard<std::mutex> lock(m_banMutex);
+                    if (Spark::ContainerUtils::Contains(m_bannedClients, msg.senderID))
+                    {
+                        SPARK_LOG_WARN(Spark::LogCategory::Network, "Rejected banned client %u", msg.senderID);
+                        m_networkRuntime->KickClient(msg.senderID, "You are banned from this server");
+                        return;
+                    }
+                }
+
+                m_stats.totalConnectionsServed++;
+                SPARK_LOG_INFO(Spark::LogCategory::Network, "Client %u connected", msg.senderID);
+
+                uint32_t playerCount = GetPlayerCount();
+                if (playerCount > m_stats.peakPlayers)
+                    m_stats.peakPlayers = playerCount;
+                m_stats.currentPlayers = playerCount;
+
+                if (m_callbacks.onClientConnected)
+                {
+                    const auto& clients = m_networkRuntime->GetClients();
+                    auto it = clients.find(msg.senderID);
+                    std::string name = (it != clients.end()) ? it->second.name : "Unknown";
+                    m_callbacks.onClientConnected(msg.senderID, name);
+                }
+
+                Log("Client " + std::to_string(msg.senderID) + " connected");
+            });
+
+        m_networkRuntime->RegisterHandler(MessageType::Disconnect,
+                                          [this](const NetworkMessage& msg)
+                                          {
+                                              m_stats.currentPlayers = GetPlayerCount();
+                                              SPARK_LOG_INFO(Spark::LogCategory::Network, "Client %u disconnected",
+                                                             msg.senderID);
+                                              if (m_callbacks.onClientDisconnected)
+                                              {
+                                                  m_callbacks.onClientDisconnected(msg.senderID, "Disconnected");
+                                              }
+                                              Log("Client " + std::to_string(msg.senderID) + " disconnected");
+                                          });
+
+        m_networkRuntime->RegisterHandler(MessageType::ChatMessage,
+                                          [this](const NetworkMessage& msg)
+                                          {
+                                              if (msg.payload.empty())
+                                                  return;
+
+                                              NetBuffer buf;
+                                              buf.WriteBytes(msg.payload.data(), msg.payload.size());
+                                              std::string chatText = buf.ReadString();
+
+                                              SPARK_BRANCH_GUARD_BEGIN("rcon_command_gate")
+                                              if (chatText.size() > 1 && chatText[0] == '/')
+                                              {
+                                                  std::string rconCmd = chatText.substr(1);
+                                                  std::string response = ExecuteRcon(rconCmd);
+
+                                                  NetworkMessage reply;
+                                                  reply.type = MessageType::ChatMessage;
+                                                  reply.channel = ChannelType::Reliable;
+                                                  NetBuffer replyBuf;
+                                                  replyBuf.WriteString("[RCON] " + response);
+                                                  reply.payload = replyBuf.GetData();
+                                                  m_networkRuntime->SendToClient(msg.senderID, reply);
+                                                  return;
+                                              }
+                                              SPARK_BRANCH_GUARD_END("rcon_command_gate")
+
+                                              NetworkMessage broadcast;
+                                              broadcast.type = MessageType::ChatMessage;
+                                              broadcast.channel = ChannelType::Reliable;
+                                              broadcast.payload = msg.payload;
+                                              m_networkRuntime->SendToAllExcept(msg.senderID, broadcast);
+
+                                              if (m_callbacks.onChatMessage)
+                                                  m_callbacks.onChatMessage(chatText);
+                                              Log("Chat: " + chatText);
+                                          });
+    }
+
+    void DedicatedServer::ClearNetworkHandlers()
+    {
+        m_networkRuntime->ClearHandlers();
+    }
+
     // ============================================================================
     // Match State
     // ============================================================================
@@ -352,7 +368,7 @@ namespace Spark::Net
         buf.WriteFloat(m_matchTimeRemaining);
         buf.WriteUint32(static_cast<uint32_t>(m_config.scoreLimit));
         msg.payload = buf.GetData();
-        NetworkManager::GetInstance().SendToAll(msg);
+        m_networkRuntime->SendToAll(msg);
 
         SPARK_LOG_INFO(Spark::LogCategory::Network, "Match started on map '%s' (mode: %d, time limit: %.0fs)",
                        m_currentMap.c_str(), static_cast<int>(m_config.gameMode), m_matchTimeRemaining);
@@ -374,7 +390,7 @@ namespace Spark::Net
         buf.WriteString(m_currentMap);
         buf.WriteUint32(static_cast<uint32_t>(m_currentRound));
         msg.payload = buf.GetData();
-        NetworkManager::GetInstance().SendToAll(msg);
+        m_networkRuntime->SendToAll(msg);
 
         Log("Match ended on map '" + m_currentMap + "'");
 
@@ -423,7 +439,7 @@ namespace Spark::Net
             buf.WriteUint32(static_cast<uint32_t>(m_currentRound));
             buf.WriteUint32(m_stats.currentPlayers);
             msg.payload = buf.GetData();
-            NetworkManager::GetInstance().SendToAll(msg);
+            m_networkRuntime->SendToAll(msg);
         }
     }
 
@@ -491,7 +507,7 @@ namespace Spark::Net
     void DedicatedServer::KickPlayer(ClientID id, const std::string& reason)
     {
         SPARK_WARN_IF(Spark::LogCategory::Network, reason.empty(), "KickPlayer called with empty reason");
-        NetworkManager::GetInstance().KickClient(id, reason);
+        m_networkRuntime->KickClient(id, reason);
         m_stats.currentPlayers = GetPlayerCount();
         Log("Kicked client " + std::to_string(id) + ": " + reason);
     }
@@ -509,7 +525,7 @@ namespace Spark::Net
     std::vector<ClientInfo> DedicatedServer::GetConnectedClients() const
     {
         std::vector<ClientInfo> result;
-        const auto& clients = NetworkManager::GetInstance().GetClients();
+        const auto& clients = m_networkRuntime->GetClients();
         result.reserve(clients.size());
         for (const auto& [id, info] : clients)
         {
@@ -520,7 +536,7 @@ namespace Spark::Net
 
     uint32_t DedicatedServer::GetPlayerCount() const
     {
-        return static_cast<uint32_t>(NetworkManager::GetInstance().GetClients().size());
+        return static_cast<uint32_t>(m_networkRuntime->GetClients().size());
     }
 
     // ============================================================================
@@ -623,7 +639,7 @@ namespace Spark::Net
                             });
 
         RegisterRconCommand("say", "Broadcast server message: say <text>",
-                            [](const std::vector<std::string>& args)
+                            [this](const std::vector<std::string>& args)
                             {
                                 if (args.empty())
                                     return std::string("Usage: say <message>");
@@ -640,7 +656,7 @@ namespace Spark::Net
                                 NetBuffer buf;
                                 buf.WriteString("[SERVER] " + text);
                                 msg.payload = buf.GetData();
-                                NetworkManager::GetInstance().SendToAll(msg);
+                                m_networkRuntime->SendToAll(msg);
                                 return std::format("Broadcast: {}", text);
                             });
 

--- a/SparkEngine/Source/Engine/Networking/DedicatedServer.h
+++ b/SparkEngine/Source/Engine/Networking/DedicatedServer.h
@@ -20,7 +20,8 @@
 #pragma once
 
 #include "../../Core/Platform.h"
-#include "NetworkManager.h"
+#include "INetworkRuntime.h"
+#include "NetworkManagerRuntimeAdapter.h"
 
 #include <atomic>
 #include <chrono>
@@ -194,6 +195,7 @@ namespace Spark::Net
     {
       public:
         DedicatedServer();
+        explicit DedicatedServer(INetworkRuntime& networkRuntime);
         ~DedicatedServer();
 
         // Non-copyable
@@ -316,6 +318,8 @@ namespace Spark::Net
 
         /// @brief Register built-in RCON commands (help, status, kick, ban, map, say).
         void RegisterBuiltInRconCommands();
+        void RegisterNetworkHandlers();
+        void ClearNetworkHandlers();
 
         /// @brief Log a message to file and callback.
         void Log(const std::string& message);
@@ -354,6 +358,7 @@ namespace Spark::Net
 
         // Logging
         mutable std::mutex m_logMutex;
+        INetworkRuntime* m_networkRuntime = nullptr;
     };
 
 } // namespace Spark::Net

--- a/SparkEngine/Source/Engine/Networking/INetworkRuntime.h
+++ b/SparkEngine/Source/Engine/Networking/INetworkRuntime.h
@@ -1,0 +1,46 @@
+/**
+ * @file INetworkRuntime.h
+ * @brief Minimal networking runtime interface used by DedicatedServer.
+ */
+
+#pragma once
+
+#include "NetworkManager.h"
+
+#ifdef ENABLE_NETWORKING
+
+#include <functional>
+#include <unordered_map>
+
+namespace Spark::Net
+{
+
+    /// @brief DedicatedServer-facing networking runtime abstraction.
+    class INetworkRuntime
+    {
+      public:
+        using MessageHandler = std::function<void(const NetworkMessage&)>;
+
+        virtual ~INetworkRuntime() = default;
+
+        virtual bool Initialize() = 0;
+        virtual bool StartServer(uint16_t port, int maxClients) = 0;
+        virtual void StopServer() = 0;
+        virtual void Shutdown() = 0;
+        virtual void Update(float deltaTime) = 0;
+
+        virtual void SendToClient(ClientID client, const NetworkMessage& msg) = 0;
+        virtual void SendToAll(const NetworkMessage& msg) = 0;
+        virtual void SendToAllExcept(ClientID excludeClient, const NetworkMessage& msg) = 0;
+
+        virtual void RegisterHandler(MessageType type, MessageHandler handler) = 0;
+        virtual void ClearHandlers() = 0;
+
+        virtual const std::unordered_map<ClientID, ClientInfo>& GetClients() const = 0;
+        virtual const NetworkStats& GetStats() const = 0;
+        virtual void KickClient(ClientID client, const std::string& reason) = 0;
+    };
+
+} // namespace Spark::Net
+
+#endif // ENABLE_NETWORKING

--- a/SparkEngine/Source/Engine/Networking/NetworkConnection.cpp
+++ b/SparkEngine/Source/Engine/Networking/NetworkConnection.cpp
@@ -520,6 +520,12 @@ namespace Spark::Net
         m_handlers[static_cast<uint16_t>(type)] = std::move(handler);
     }
 
+    void NetworkManager::ClearHandlers()
+    {
+        std::lock_guard<std::mutex> lock(m_handlerMutex);
+        m_handlers.clear();
+    }
+
     // --------------------------------------------------------------------------
     // KickClient
     // --------------------------------------------------------------------------

--- a/SparkEngine/Source/Engine/Networking/NetworkManager.h
+++ b/SparkEngine/Source/Engine/Networking/NetworkManager.h
@@ -365,6 +365,7 @@ namespace Spark::Net
         /// Register message handler
         using MessageHandler = std::function<void(const NetworkMessage&)>;
         void RegisterHandler(MessageType type, MessageHandler handler);
+        void ClearHandlers();
 
         // Entity replication
         uint32_t RegisterReplicatedEntity(const ReplicatedEntity& entity);

--- a/SparkEngine/Source/Engine/Networking/NetworkManagerRuntimeAdapter.cpp
+++ b/SparkEngine/Source/Engine/Networking/NetworkManagerRuntimeAdapter.cpp
@@ -1,0 +1,85 @@
+/**
+ * @file NetworkManagerRuntimeAdapter.cpp
+ * @brief INetworkRuntime adapter backed by NetworkManager.
+ */
+
+#include "NetworkManagerRuntimeAdapter.h"
+
+#ifdef ENABLE_NETWORKING
+
+namespace Spark::Net
+{
+
+    NetworkManagerRuntimeAdapter::NetworkManagerRuntimeAdapter(NetworkManager& networkManager)
+        : m_networkManager(networkManager)
+    {
+    }
+
+    bool NetworkManagerRuntimeAdapter::Initialize()
+    {
+        return m_networkManager.Initialize();
+    }
+
+    bool NetworkManagerRuntimeAdapter::StartServer(uint16_t port, int maxClients)
+    {
+        return m_networkManager.StartServer(port, maxClients);
+    }
+
+    void NetworkManagerRuntimeAdapter::StopServer()
+    {
+        m_networkManager.StopServer();
+    }
+
+    void NetworkManagerRuntimeAdapter::Shutdown()
+    {
+        m_networkManager.Shutdown();
+    }
+
+    void NetworkManagerRuntimeAdapter::Update(float deltaTime)
+    {
+        m_networkManager.Update(deltaTime);
+    }
+
+    void NetworkManagerRuntimeAdapter::SendToClient(ClientID client, const NetworkMessage& msg)
+    {
+        m_networkManager.SendToClient(client, msg);
+    }
+
+    void NetworkManagerRuntimeAdapter::SendToAll(const NetworkMessage& msg)
+    {
+        m_networkManager.SendToAll(msg);
+    }
+
+    void NetworkManagerRuntimeAdapter::SendToAllExcept(ClientID excludeClient, const NetworkMessage& msg)
+    {
+        m_networkManager.SendToAllExcept(excludeClient, msg);
+    }
+
+    void NetworkManagerRuntimeAdapter::RegisterHandler(MessageType type, MessageHandler handler)
+    {
+        m_networkManager.RegisterHandler(type, std::move(handler));
+    }
+
+    void NetworkManagerRuntimeAdapter::ClearHandlers()
+    {
+        m_networkManager.ClearHandlers();
+    }
+
+    const std::unordered_map<ClientID, ClientInfo>& NetworkManagerRuntimeAdapter::GetClients() const
+    {
+        return m_networkManager.GetClients();
+    }
+
+    const NetworkStats& NetworkManagerRuntimeAdapter::GetStats() const
+    {
+        return m_networkManager.GetStats();
+    }
+
+    void NetworkManagerRuntimeAdapter::KickClient(ClientID client, const std::string& reason)
+    {
+        m_networkManager.KickClient(client, reason);
+    }
+
+} // namespace Spark::Net
+
+#endif // ENABLE_NETWORKING

--- a/SparkEngine/Source/Engine/Networking/NetworkManagerRuntimeAdapter.h
+++ b/SparkEngine/Source/Engine/Networking/NetworkManagerRuntimeAdapter.h
@@ -1,0 +1,43 @@
+/**
+ * @file NetworkManagerRuntimeAdapter.h
+ * @brief INetworkRuntime adapter backed by NetworkManager.
+ */
+
+#pragma once
+
+#include "INetworkRuntime.h"
+
+#ifdef ENABLE_NETWORKING
+
+namespace Spark::Net
+{
+
+    class NetworkManagerRuntimeAdapter final : public INetworkRuntime
+    {
+      public:
+        explicit NetworkManagerRuntimeAdapter(NetworkManager& networkManager);
+
+        bool Initialize() override;
+        bool StartServer(uint16_t port, int maxClients) override;
+        void StopServer() override;
+        void Shutdown() override;
+        void Update(float deltaTime) override;
+
+        void SendToClient(ClientID client, const NetworkMessage& msg) override;
+        void SendToAll(const NetworkMessage& msg) override;
+        void SendToAllExcept(ClientID excludeClient, const NetworkMessage& msg) override;
+
+        void RegisterHandler(MessageType type, MessageHandler handler) override;
+        void ClearHandlers() override;
+
+        const std::unordered_map<ClientID, ClientInfo>& GetClients() const override;
+        const NetworkStats& GetStats() const override;
+        void KickClient(ClientID client, const std::string& reason) override;
+
+      private:
+        NetworkManager& m_networkManager;
+    };
+
+} // namespace Spark::Net
+
+#endif // ENABLE_NETWORKING

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(SparkTests
     TestEnvironmentQuery.cpp
     TestAnimationRetargeting.cpp
     TestDedicatedServer.cpp
+    TestDedicatedServerRuntime.cpp
     TestServerMockClient.cpp
     TestServerLiveMockClient.cpp
     TestSplineMath.cpp

--- a/Tests/TestDedicatedServerRuntime.cpp
+++ b/Tests/TestDedicatedServerRuntime.cpp
@@ -1,0 +1,226 @@
+#include "TestFramework.h"
+
+#include "../SparkEngine/Source/Engine/Networking/DedicatedServer.h"
+
+#ifdef ENABLE_NETWORKING
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace Spark::Net;
+
+namespace
+{
+    class MockNetworkRuntime final : public INetworkRuntime
+    {
+      public:
+        bool Initialize() override
+        {
+            initializeCalled = true;
+            return initializeResult;
+        }
+
+        bool StartServer(uint16_t port, int maxClients) override
+        {
+            startServerCalled = true;
+            startedPort = port;
+            startedMaxClients = maxClients;
+            return startServerResult;
+        }
+
+        void StopServer() override { stopServerCalled = true; }
+
+        void Shutdown() override { shutdownCalled = true; }
+
+        void Update(float deltaTime) override
+        {
+            updateCalled = true;
+            lastUpdateDelta = deltaTime;
+        }
+
+        void SendToClient(ClientID client, const NetworkMessage& msg) override
+        {
+            sendToClientCalls.emplace_back(client, msg);
+        }
+
+        void SendToAll(const NetworkMessage& msg) override { sendToAllCalls.push_back(msg); }
+
+        void SendToAllExcept(ClientID excludeClient, const NetworkMessage& msg) override
+        {
+            sendToAllExceptCalls.emplace_back(excludeClient, msg);
+        }
+
+        void RegisterHandler(MessageType type, MessageHandler handler) override
+        {
+            handlers[static_cast<uint16_t>(type)] = std::move(handler);
+        }
+
+        void ClearHandlers() override
+        {
+            clearHandlersCalled = true;
+            handlers.clear();
+        }
+
+        const std::unordered_map<ClientID, ClientInfo>& GetClients() const override { return clients; }
+
+        const NetworkStats& GetStats() const override { return stats; }
+
+        void KickClient(ClientID client, const std::string& reason) override
+        {
+            kickedClients.emplace_back(client, reason);
+            clients.erase(client);
+        }
+
+        void Dispatch(const NetworkMessage& msg)
+        {
+            auto it = handlers.find(static_cast<uint16_t>(msg.type));
+            if (it != handlers.end())
+                it->second(msg);
+        }
+
+        bool initializeResult = true;
+        bool startServerResult = true;
+
+        bool initializeCalled = false;
+        bool startServerCalled = false;
+        bool stopServerCalled = false;
+        bool shutdownCalled = false;
+        bool updateCalled = false;
+        bool clearHandlersCalled = false;
+        float lastUpdateDelta = 0.0f;
+        uint16_t startedPort = 0;
+        int startedMaxClients = 0;
+
+        NetworkStats stats{};
+        std::unordered_map<ClientID, ClientInfo> clients;
+        std::unordered_map<uint16_t, MessageHandler> handlers;
+        std::vector<std::pair<ClientID, NetworkMessage>> sendToClientCalls;
+        std::vector<NetworkMessage> sendToAllCalls;
+        std::vector<std::pair<ClientID, NetworkMessage>> sendToAllExceptCalls;
+        std::vector<std::pair<ClientID, std::string>> kickedClients;
+    };
+
+    static NetworkMessage BuildStringMessage(MessageType type, ClientID sender, const std::string& text)
+    {
+        NetworkMessage msg;
+        msg.type = type;
+        msg.senderID = sender;
+        msg.channel = ChannelType::Reliable;
+        NetBuffer buf;
+        buf.WriteString(text);
+        msg.payload = buf.GetData();
+        return msg;
+    }
+} // namespace
+
+TEST(DedicatedServerRuntime_ConnectDisconnectCallbacks)
+{
+    MockNetworkRuntime runtime;
+    DedicatedServer server(runtime);
+
+    ServerConfig config;
+    config.enableLanBroadcast = false;
+    config.mapRotation = {"arena"};
+    config.maxClients = 8;
+
+    ClientInfo client;
+    client.id = 7;
+    client.name = "Alice";
+    runtime.clients[7] = client;
+
+    bool connectedCalled = false;
+    bool disconnectedCalled = false;
+    std::string connectedName;
+    ClientID disconnectedClient = INVALID_CLIENT;
+    ServerCallbacks callbacks;
+    callbacks.onClientConnected = [&](ClientID id, const std::string& name)
+    {
+        connectedCalled = true;
+        EXPECT_EQ(id, static_cast<ClientID>(7));
+        connectedName = name;
+    };
+    callbacks.onClientDisconnected = [&](ClientID id, const std::string&)
+    {
+        disconnectedCalled = true;
+        disconnectedClient = id;
+    };
+    server.SetCallbacks(callbacks);
+
+    EXPECT_TRUE(server.InitializeOnly(config));
+    EXPECT_TRUE(runtime.initializeCalled);
+    EXPECT_TRUE(runtime.startServerCalled);
+    EXPECT_EQ(runtime.startedPort, config.port);
+    EXPECT_EQ(runtime.startedMaxClients, config.maxClients);
+
+    runtime.Dispatch({.type = MessageType::Connect, .senderID = 7});
+    EXPECT_TRUE(connectedCalled);
+    EXPECT_EQ(connectedName, std::string("Alice"));
+    EXPECT_EQ(server.GetStats().totalConnectionsServed, static_cast<uint32_t>(1));
+    EXPECT_EQ(server.GetStats().currentPlayers, static_cast<uint32_t>(1));
+
+    runtime.Dispatch({.type = MessageType::Disconnect, .senderID = 7});
+    EXPECT_TRUE(disconnectedCalled);
+    EXPECT_EQ(disconnectedClient, static_cast<ClientID>(7));
+
+    server.Stop();
+    EXPECT_TRUE(runtime.clearHandlersCalled);
+}
+
+TEST(DedicatedServerRuntime_ChatAndRconFlow)
+{
+    MockNetworkRuntime runtime;
+    DedicatedServer server(runtime);
+
+    ServerConfig config;
+    config.enableLanBroadcast = false;
+    config.mapRotation = {"arena"};
+
+    std::string seenChat;
+    ServerCallbacks callbacks;
+    callbacks.onChatMessage = [&](const std::string& chat) { seenChat = chat; };
+    server.SetCallbacks(callbacks);
+
+    EXPECT_TRUE(server.InitializeOnly(config));
+
+    const NetworkMessage chat = BuildStringMessage(MessageType::ChatMessage, 12, "hello squad");
+    runtime.Dispatch(chat);
+    EXPECT_EQ(runtime.sendToAllExceptCalls.size(), static_cast<size_t>(1));
+    EXPECT_EQ(runtime.sendToAllExceptCalls[0].first, static_cast<ClientID>(12));
+    EXPECT_EQ(seenChat, std::string("hello squad"));
+
+    const NetworkMessage rcon = BuildStringMessage(MessageType::ChatMessage, 12, "/status");
+    runtime.Dispatch(rcon);
+    EXPECT_EQ(runtime.sendToClientCalls.size(), static_cast<size_t>(1));
+    EXPECT_EQ(runtime.sendToClientCalls[0].first, static_cast<ClientID>(12));
+
+    NetBuffer responseBuf;
+    const auto& payload = runtime.sendToClientCalls[0].second.payload;
+    responseBuf.WriteBytes(payload.data(), payload.size());
+    const std::string response = responseBuf.ReadString();
+    EXPECT_TRUE(response.find("[RCON] Server:") == 0);
+
+    server.Stop();
+}
+
+TEST(DedicatedServerRuntime_StopClearsHandlersAndShutsDownRuntime)
+{
+    MockNetworkRuntime runtime;
+    DedicatedServer server(runtime);
+
+    ServerConfig config;
+    config.enableLanBroadcast = false;
+    config.mapRotation = {"arena"};
+
+    EXPECT_TRUE(server.InitializeOnly(config));
+    EXPECT_FALSE(runtime.handlers.empty());
+
+    server.Stop();
+    EXPECT_TRUE(runtime.stopServerCalled);
+    EXPECT_TRUE(runtime.shutdownCalled);
+    EXPECT_TRUE(runtime.clearHandlersCalled);
+    EXPECT_TRUE(runtime.handlers.empty());
+}
+
+#endif // ENABLE_NETWORKING


### PR DESCRIPTION
### Motivation
- Reduce tight coupling between `DedicatedServer` and the `NetworkManager` singleton by introducing a minimal runtime abstraction covering only the operations the server needs. 
- Make handler lifecycle ownership explicit so server-start/stop boundaries clear and safe by allowing handlers to be unbound on stop. 
- Enable focused server unit tests by allowing a mock runtime to drive connect/disconnect/chat/RCON flows without real sockets. 

### Description
- Added `INetworkRuntime` as a narrow interface used by `DedicatedServer` with methods: `Initialize`, `StartServer`, `StopServer`, `Shutdown`, `Update`, send APIs, `RegisterHandler`, `ClearHandlers`, `GetClients`, `GetStats`, and `KickClient` (`SparkEngine/Source/Engine/Networking/INetworkRuntime.h`).
- Implemented `NetworkManagerRuntimeAdapter` that forwards `INetworkRuntime` calls to the existing `NetworkManager` (header + implementation added under `SparkEngine/Source/Engine/Networking/`).
- Injected `INetworkRuntime&` into `DedicatedServer` via a new constructor overload and made the default constructor wire a static adapter around `NetworkManager::GetInstance()` for production bootstrap (`DedicatedServer.h/.cpp`).
- Replaced direct `NetworkManager::GetInstance()` usages inside `DedicatedServer.cpp` with calls to the injected `m_networkRuntime` for lifecycle, update, send, query, and kick paths. 
- Moved registration of server-specific message handlers into `RegisterNetworkHandlers()` and added `ClearNetworkHandlers()` which calls `INetworkRuntime::ClearHandlers()`; `Stop()` now explicitly clears handlers before shutting down the runtime. 
- Added `NetworkManager::ClearHandlers()` and hooked it so the adapter can clear handler registrations when the server stops (`NetworkConnection.cpp` + `NetworkManager.h`).
- Added unit tests `Tests/TestDedicatedServerRuntime.cpp` implementing a `MockNetworkRuntime` to validate connect/disconnect callbacks, chat and RCON flows, handler teardown, and lifecycle interactions, and registered the test in `Tests/CMakeLists.txt`.

### Testing
- Ran configuration with `cmake --preset linux-gcc-release` and the configure step completed successfully. (Succeeded.)
- Built the engine library with `cmake --build build/linux-gcc-release --target SparkEngineLib -j4` and the library build completed successfully. (Succeeded.)
- Built the full test target with `cmake --build build/linux-gcc-release --target SparkTests -j4`; the build failed during tests compilation due to pre-existing unrelated ambiguous overload errors in `Tests/TestGameplayTags.cpp` against `GameplayTags.h`, not caused by the networking changes, preventing test-run completion. (Failed — unrelated pre-existing test ambiguity.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d75abcd01083269e46304a076adc6c)