### PR TITLE
Thread-affinity assertions and thread-safe read/producer paths for GameplayTags and Telemetry

### DIFF
--- a/SparkEngine/Source/Engine/Gameplay/GameplayTags.h
+++ b/SparkEngine/Source/Engine/Gameplay/GameplayTags.h
@@ -31,11 +31,14 @@
 #pragma once
 
 #include "Spark/ServiceInterfaces.h"
+#include "Utils/Assert.h"
 
 #include <algorithm>
 #include <cstdint>
+#include <shared_mutex>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -158,10 +161,13 @@ namespace Spark::Gameplay
         }
 
         /**
-         * @brief Initialize the registry
+         * @brief Reset and initialize the registry state.
+         * @note Threading: game-thread-only.
          */
         void Initialize() override
         {
+            m_gameThreadId = std::this_thread::get_id();
+            std::unique_lock lock(m_registryMutex);
             m_nextId = 1;
             m_tags.clear();
             m_nameToId.clear();
@@ -169,26 +175,143 @@ namespace Spark::Gameplay
         }
 
         /**
-         * @brief Shut down and clear all registered tags
+         * @brief Clear all registered tags and mark the service uninitialized.
+         * @note Threading: game-thread-only.
          */
         void Shutdown() override
         {
+            AssertGameThread("Shutdown");
+            std::unique_lock lock(m_registryMutex);
             m_tags.clear();
             m_nameToId.clear();
             m_initialized = false;
         }
 
+        /**
+         * @brief Register a tag by string view.
+         * @note Threading: game-thread-only.
+         */
         uint32_t RegisterTag(std::string_view fullName) override { return RegisterTag(std::string(fullName)); }
 
         /**
-         * @brief Register a tag (and all parent tags implicitly)
-         * @param fullName Dot-separated tag name (e.g. "Damage.Fire.DoT")
-         * @return The tag ID for the registered tag
-         *
-         * If the tag already exists, returns its existing ID.
-         * Parent tags (e.g. "Damage", "Damage.Fire") are created automatically.
+         * @brief Register a tag (and all parent tags implicitly).
+         * @param fullName Dot-separated tag name (e.g. "Damage.Fire.DoT").
+         * @return The tag ID for the registered tag.
+         * @note Threading: game-thread-only.
          */
         GameplayTagId RegisterTag(const std::string& fullName)
+        {
+            AssertGameThread("RegisterTag");
+            std::unique_lock lock(m_registryMutex);
+            return RegisterTagUnlocked(fullName);
+        }
+
+        /**
+         * @brief Get the ID for a tag name
+         * @param fullName Dot-separated tag name
+         * @return Tag ID, or INVALID_TAG_ID if not registered
+         */
+        uint32_t GetTagId(std::string_view fullName) const override { return GetTagId(std::string(fullName)); }
+
+        /**
+         * @brief Get the ID for a tag name.
+         * @param fullName Dot-separated tag name.
+         * @return Tag ID, or INVALID_TAG_ID if not registered.
+         * @note Threading: thread-safe.
+         */
+        GameplayTagId GetTagId(const std::string& fullName) const
+        {
+            std::shared_lock lock(m_registryMutex);
+            return GetTagIdUnlocked(fullName);
+        }
+
+        /**
+         * @brief Get tag info by ID.
+         * @param id Tag ID.
+         * @return Pointer to immutable tag info, or nullptr if not found.
+         * @note Threading: thread-safe.
+         */
+        const GameplayTagInfo* GetTagInfo(GameplayTagId id) const
+        {
+            std::shared_lock lock(m_registryMutex);
+            auto it = m_tags.find(id);
+            return it != m_tags.end() ? &it->second : nullptr;
+        }
+
+        /**
+         * @brief Check if @p tagId equals @p parentTagId or is its descendant.
+         * @note Threading: thread-safe.
+         */
+        bool IsTagChildOf(GameplayTagId tagId, GameplayTagId parentTagId) const
+        {
+            std::shared_lock lock(m_registryMutex);
+            return IsTagChildOfUnlocked(tagId, parentTagId);
+        }
+
+        /**
+         * @brief Check if any tag in @p container matches @p parentTagName or its descendants.
+         * @note Threading: thread-safe.
+         */
+        bool ContainerMatchesTag(const GameplayTagContainer& container, const std::string& parentTagName) const
+        {
+            std::shared_lock lock(m_registryMutex);
+            GameplayTagId parentId = GetTagIdUnlocked(parentTagName);
+            if (parentId == INVALID_TAG_ID)
+                return false;
+
+            for (auto tagId : container.GetTags())
+            {
+                if (IsTagChildOfUnlocked(tagId, parentId))
+                    return true;
+            }
+            return false;
+        }
+
+        /**
+         * @brief Get the total number of registered tags.
+         * @note Threading: thread-safe.
+         */
+        size_t GetTagCount() const
+        {
+            std::shared_lock lock(m_registryMutex);
+            return m_tags.size();
+        }
+
+        /**
+         * @brief Get all registered tag names, sorted alphabetically.
+         * @note Threading: thread-safe.
+         */
+        std::vector<std::string> GetAllTagNames() const
+        {
+            std::shared_lock lock(m_registryMutex);
+            std::vector<std::string> names;
+            names.reserve(m_nameToId.size());
+            for (const auto& [name, id] : m_nameToId)
+                names.push_back(name);
+            std::sort(names.begin(), names.end());
+            return names;
+        }
+
+        /**
+         * @brief Get debug/console status text.
+         * @note Threading: thread-safe.
+         */
+        std::string Console_GetStatus() const
+        {
+            std::shared_lock lock(m_registryMutex);
+            return "GameplayTagRegistry: " + std::to_string(m_tags.size()) + " tags registered";
+        }
+
+      private:
+        GameplayTagRegistry() = default;
+
+        void AssertGameThread(const char* methodName) const
+        {
+            ASSERT_MSG(std::this_thread::get_id() == m_gameThreadId, "GameplayTagRegistry::%s must run on game thread",
+                       methodName);
+        }
+
+        GameplayTagId RegisterTagUnlocked(const std::string& fullName)
         {
             if (fullName.empty())
                 return INVALID_TAG_ID;
@@ -197,13 +320,12 @@ namespace Spark::Gameplay
             if (existing != m_nameToId.end())
                 return existing->second;
 
-            // Register parent tags first
             GameplayTagId parentId = INVALID_TAG_ID;
             auto lastDot = fullName.rfind('.');
             if (lastDot != std::string::npos)
             {
                 std::string parentName = fullName.substr(0, lastDot);
-                parentId = RegisterTag(parentName);
+                parentId = RegisterTagUnlocked(parentName);
             }
 
             GameplayTagId id = m_nextId++;
@@ -214,44 +336,19 @@ namespace Spark::Gameplay
             m_tags[id] = info;
             m_nameToId[fullName] = id;
 
-            // Add as child of parent
             if (parentId != INVALID_TAG_ID)
                 m_tags[parentId].children.push_back(id);
 
             return id;
         }
 
-        /**
-         * @brief Get the ID for a tag name
-         * @param fullName Dot-separated tag name
-         * @return Tag ID, or INVALID_TAG_ID if not registered
-         */
-        uint32_t GetTagId(std::string_view fullName) const override { return GetTagId(std::string(fullName)); }
-
-        GameplayTagId GetTagId(const std::string& fullName) const
+        GameplayTagId GetTagIdUnlocked(const std::string& fullName) const
         {
             auto it = m_nameToId.find(fullName);
             return it != m_nameToId.end() ? it->second : INVALID_TAG_ID;
         }
 
-        /**
-         * @brief Get tag info by ID
-         * @param id Tag ID
-         * @return Pointer to tag info, or nullptr if not found
-         */
-        const GameplayTagInfo* GetTagInfo(GameplayTagId id) const
-        {
-            auto it = m_tags.find(id);
-            return it != m_tags.end() ? &it->second : nullptr;
-        }
-
-        /**
-         * @brief Check if a tag matches another tag or is a child of it
-         * @param tagId The tag to check
-         * @param parentTagId The potential parent tag
-         * @return true if tagId equals parentTagId or is a descendant
-         */
-        bool IsTagChildOf(GameplayTagId tagId, GameplayTagId parentTagId) const
+        bool IsTagChildOfUnlocked(GameplayTagId tagId, GameplayTagId parentTagId) const
         {
             GameplayTagId current = tagId;
             while (current != INVALID_TAG_ID)
@@ -266,59 +363,9 @@ namespace Spark::Gameplay
             return false;
         }
 
-        /**
-         * @brief Check if a container has a tag matching the given tag or any child of it
-         * @param container The tag container to search
-         * @param parentTagName Tag name to match (also matches children)
-         * @return true if any tag in the container matches
-         */
-        bool ContainerMatchesTag(const GameplayTagContainer& container, const std::string& parentTagName) const
-        {
-            GameplayTagId parentId = GetTagId(parentTagName);
-            if (parentId == INVALID_TAG_ID)
-                return false;
-
-            for (auto tagId : container.GetTags())
-            {
-                if (IsTagChildOf(tagId, parentId))
-                    return true;
-            }
-            return false;
-        }
-
-        /**
-         * @brief Get the total number of registered tags
-         * @return Number of tags
-         */
-        size_t GetTagCount() const { return m_tags.size(); }
-
-        /**
-         * @brief Get all registered tag names
-         * @return Vector of tag names sorted alphabetically
-         */
-        std::vector<std::string> GetAllTagNames() const
-        {
-            std::vector<std::string> names;
-            names.reserve(m_nameToId.size());
-            for (const auto& [name, id] : m_nameToId)
-                names.push_back(name);
-            std::sort(names.begin(), names.end());
-            return names;
-        }
-
-        /**
-         * @brief Get status string for console/debug display
-         * @return Formatted status string
-         */
-        std::string Console_GetStatus() const
-        {
-            return "GameplayTagRegistry: " + std::to_string(m_tags.size()) + " tags registered";
-        }
-
-      private:
-        GameplayTagRegistry() = default;
-
         bool m_initialized = false;
+        std::thread::id m_gameThreadId = std::this_thread::get_id();
+        mutable std::shared_mutex m_registryMutex;
         GameplayTagId m_nextId = 1;
         std::unordered_map<GameplayTagId, GameplayTagInfo> m_tags;
         std::unordered_map<std::string, GameplayTagId> m_nameToId;

--- a/SparkEngine/Source/Utils/Telemetry.h
+++ b/SparkEngine/Source/Utils/Telemetry.h
@@ -29,12 +29,17 @@
 #pragma once
 
 #include "Spark/ServiceInterfaces.h"
+#include "Utils/Assert.h"
 
+#include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <fstream>
+#include <mutex>
 #include <memory>
 #include <optional>
+#include <thread>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -56,6 +61,7 @@ namespace Spark
         uint64_t timestamp = 0;                                  ///< Epoch milliseconds
         std::unordered_map<std::string, std::string> properties; ///< Key-value metadata
         std::string sessionId;                                   ///< Session identifier
+        uint64_t sequence = 0;                                   ///< Monotonic enqueue order for deterministic flush
     };
 
     // ============================================================================
@@ -231,13 +237,23 @@ namespace Spark
         /**
          * @brief Initialize the telemetry system.
          * @param config Configuration (enable, consent, paths, batching).
+         * @note Threading: game-thread-only.
          */
         void Initialize(const TelemetryConfig& config)
         {
+            m_gameThreadId = std::this_thread::get_id();
             m_config = config;
-            m_eventQueue.clear();
+            {
+                std::lock_guard<std::mutex> queueLock(m_eventQueueMutex);
+                m_eventQueue.clear();
+            }
             m_timeSinceFlush = 0.0f;
-            m_totalEventsRecorded = 0;
+            m_queuedEventCount.store(0, std::memory_order_relaxed);
+            m_totalEventsRecorded.store(0, std::memory_order_relaxed);
+            m_nextEventSequence.store(1, std::memory_order_relaxed);
+            m_enabled.store(m_config.enabled, std::memory_order_relaxed);
+            m_consentGiven.store(m_config.consentGiven, std::memory_order_relaxed);
+            m_maxQueueSize.store(m_config.maxQueueSize, std::memory_order_relaxed);
 
             // Generate a simple session ID from the current time
             auto now = std::chrono::system_clock::now().time_since_epoch();
@@ -250,19 +266,27 @@ namespace Spark
                 m_backend = std::make_unique<LocalFileTelemetryBackend>(m_config.localExportPath);
             }
 
-            m_initialized = true;
+            m_initialized.store(true, std::memory_order_release);
         }
 
-        /** @brief Flush remaining events and shut down. */
+        /**
+         * @brief Flush remaining events and shut down.
+         * @note Threading: game-thread-only.
+         */
         void Shutdown() override
         {
-            if (m_initialized)
+            AssertGameThread("Shutdown");
+            if (m_initialized.load(std::memory_order_acquire))
             {
                 FlushEvents();
             }
-            m_eventQueue.clear();
+            {
+                std::lock_guard<std::mutex> queueLock(m_eventQueueMutex);
+                m_eventQueue.clear();
+            }
+            m_queuedEventCount.store(0, std::memory_order_relaxed);
             m_backend.reset();
-            m_initialized = false;
+            m_initialized.store(false, std::memory_order_release);
         }
 
         // --- Recording ---
@@ -273,6 +297,7 @@ namespace Spark
          * @param properties Optional key-value metadata.
          *
          * Silently drops the event if consent is not given or the queue is full.
+         * @note Threading: thread-safe (multi-producer).
          */
         void RecordEvent(std::string_view name,
                          const std::optional<std::unordered_map<std::string, std::string>>& properties = std::nullopt)
@@ -280,18 +305,15 @@ namespace Spark
             if (!CanRecord())
                 return;
 
-            if (m_eventQueue.size() >= m_config.maxQueueSize)
-                return;
-
             TelemetryEvent evt;
             evt.name = std::string(name);
             evt.timestamp = GetCurrentTimestampMs();
             evt.sessionId = m_sessionId;
+            evt.sequence = m_nextEventSequence.fetch_add(1, std::memory_order_relaxed);
             if (properties.has_value())
                 evt.properties = properties.value();
 
-            m_eventQueue.push_back(std::move(evt));
-            m_totalEventsRecorded++;
+            EnqueueEventThreadSafe(std::move(evt));
         }
 
         /**
@@ -299,6 +321,7 @@ namespace Spark
          * @param name       Event name.
          * @param durationMs Duration of the measured operation in milliseconds.
          * @param properties Optional additional metadata.
+         * @note Threading: thread-safe (multi-producer).
          */
         void RecordTimedEvent(
             std::string_view name, float durationMs,
@@ -319,42 +342,54 @@ namespace Spark
          * @brief Flush all queued events to the registered backend.
          *
          * Sends events in batches of config.batchSize.
+         * @note Threading: game-thread-only.
          */
         void FlushEvents()
         {
-            if (!m_backend || m_eventQueue.empty())
+            AssertGameThread("FlushEvents");
+            if (!m_backend)
                 return;
+
+            std::vector<TelemetryEvent> pendingEvents;
+            ExtractQueuedEventsForFlush_GameThread(pendingEvents);
+            if (pendingEvents.empty())
+                return;
+
+            std::sort(pendingEvents.begin(), pendingEvents.end(),
+                      [](const TelemetryEvent& lhs, const TelemetryEvent& rhs) { return lhs.sequence < rhs.sequence; });
 
             // Send in batches
             size_t offset = 0;
-            while (offset < m_eventQueue.size())
+            while (offset < pendingEvents.size())
             {
                 size_t batchEnd = offset + m_config.batchSize;
-                if (batchEnd > m_eventQueue.size())
-                    batchEnd = m_eventQueue.size();
+                if (batchEnd > pendingEvents.size())
+                    batchEnd = pendingEvents.size();
 
-                std::vector<TelemetryEvent> batch(m_eventQueue.begin() + static_cast<ptrdiff_t>(offset),
-                                                  m_eventQueue.begin() + static_cast<ptrdiff_t>(batchEnd));
+                std::vector<TelemetryEvent> batch(pendingEvents.begin() + static_cast<ptrdiff_t>(offset),
+                                                  pendingEvents.begin() + static_cast<ptrdiff_t>(batchEnd));
 
                 m_backend->Send(batch);
                 offset = batchEnd;
             }
 
-            m_eventQueue.clear();
             m_timeSinceFlush = 0.0f;
         }
 
         /**
          * @brief Per-frame update. Auto-flushes when the interval elapses.
          * @param dt Delta time in seconds.
+         * @note Threading: game-thread-only.
          */
         void Update(float dt) override
         {
-            if (!m_initialized || !m_config.enabled)
+            AssertGameThread("Update");
+            if (!m_initialized.load(std::memory_order_acquire) || !m_enabled.load(std::memory_order_relaxed))
                 return;
 
             m_timeSinceFlush += dt;
-            if (m_timeSinceFlush >= m_config.flushIntervalSeconds && !m_eventQueue.empty())
+            if (m_timeSinceFlush >= m_config.flushIntervalSeconds &&
+                m_queuedEventCount.load(std::memory_order_relaxed) > 0)
             {
                 FlushEvents();
             }
@@ -367,52 +402,81 @@ namespace Spark
          * @param consent true to allow recording, false to revoke.
          *
          * Revoking consent immediately clears all queued events.
+         * @note Threading: game-thread-only.
          */
         void SetConsent(bool consent)
         {
+            AssertGameThread("SetConsent");
             m_config.consentGiven = consent;
+            m_consentGiven.store(consent, std::memory_order_relaxed);
             if (!consent)
             {
+                std::lock_guard<std::mutex> queueLock(m_eventQueueMutex);
                 m_eventQueue.clear();
+                m_queuedEventCount.store(0, std::memory_order_relaxed);
             }
         }
 
-        /** @brief Check if the user has given consent. */
-        bool HasConsent() const { return m_config.consentGiven; }
+        /**
+         * @brief Check if the user has given consent.
+         * @note Threading: thread-safe.
+         */
+        bool HasConsent() const { return m_consentGiven.load(std::memory_order_relaxed); }
 
-        /** @brief Check if telemetry service has been initialized. */
-        bool IsInitialized() const override { return m_initialized; }
+        /**
+         * @brief Check if telemetry service has been initialized.
+         * @note Threading: thread-safe.
+         */
+        bool IsInitialized() const override { return m_initialized.load(std::memory_order_acquire); }
 
         // --- Queries ---
 
-        /** @brief Get the current configuration (read-only). */
-        const TelemetryConfig& GetConfig() const { return m_config; }
+        /**
+         * @brief Get the current configuration (read-only snapshot).
+         * @note Threading: game-thread-only.
+         */
+        const TelemetryConfig& GetConfig() const
+        {
+            AssertGameThread("GetConfig");
+            return m_config;
+        }
 
-        /** @brief Number of events currently queued. */
-        uint32_t GetQueueSize() const { return static_cast<uint32_t>(m_eventQueue.size()); }
+        /**
+         * @brief Number of events currently queued.
+         * @note Threading: thread-safe.
+         */
+        uint32_t GetQueueSize() const { return m_queuedEventCount.load(std::memory_order_relaxed); }
 
         // --- Backend ---
 
         /**
          * @brief Register a custom telemetry backend.
          * @param backend The backend to use (replaces any existing backend).
+         * @note Threading: game-thread-only.
          */
-        void RegisterBackend(std::unique_ptr<ITelemetryBackend> backend) { m_backend = std::move(backend); }
+        void RegisterBackend(std::unique_ptr<ITelemetryBackend> backend)
+        {
+            AssertGameThread("RegisterBackend");
+            m_backend = std::move(backend);
+        }
 
         // --- Console ---
 
-        /** @brief Get telemetry system status (console integration). */
+        /**
+         * @brief Get telemetry system status (console integration).
+         * @note Threading: thread-safe.
+         */
         std::string Console_GetStatus() const
         {
             std::string status = "TelemetrySystem: ";
-            status += m_initialized ? "initialized" : "not initialized";
+            status += m_initialized.load(std::memory_order_acquire) ? "initialized" : "not initialized";
             status += " | Enabled: ";
-            status += m_config.enabled ? "yes" : "no";
+            status += m_enabled.load(std::memory_order_relaxed) ? "yes" : "no";
             status += " | Consent: ";
-            status += m_config.consentGiven ? "yes" : "no";
-            status += " | Queued: " + std::to_string(m_eventQueue.size());
+            status += m_consentGiven.load(std::memory_order_relaxed) ? "yes" : "no";
+            status += " | Queued: " + std::to_string(m_queuedEventCount.load(std::memory_order_relaxed));
             status += "/" + std::to_string(m_config.maxQueueSize);
-            status += " | Total recorded: " + std::to_string(m_totalEventsRecorded);
+            status += " | Total recorded: " + std::to_string(m_totalEventsRecorded.load(std::memory_order_relaxed));
             status += " | Backend: ";
             status += m_backend ? std::string(m_backend->GetBackendName()) : "none";
             status += " | Session: " + m_sessionId;
@@ -423,8 +487,40 @@ namespace Spark
         TelemetrySystem() = default;
         ~TelemetrySystem() = default;
 
+        void AssertGameThread(const char* methodName) const
+        {
+            ASSERT_MSG(std::this_thread::get_id() == m_gameThreadId, "TelemetrySystem::%s must run on game thread",
+                       methodName);
+        }
+
         /** @brief Check if recording is permitted. */
-        bool CanRecord() const { return m_initialized && m_config.enabled && m_config.consentGiven; }
+        bool CanRecord() const
+        {
+            return m_initialized.load(std::memory_order_acquire) && m_enabled.load(std::memory_order_relaxed) &&
+                   m_consentGiven.load(std::memory_order_relaxed);
+        }
+
+        /** @brief Thread-safe writer path for producers calling RecordEvent. */
+        void EnqueueEventThreadSafe(TelemetryEvent&& evt)
+        {
+            std::lock_guard<std::mutex> queueLock(m_eventQueueMutex);
+            if (m_eventQueue.size() >= static_cast<size_t>(m_maxQueueSize.load(std::memory_order_relaxed)))
+                return;
+
+            m_eventQueue.push_back(std::move(evt));
+            m_queuedEventCount.store(static_cast<uint32_t>(m_eventQueue.size()), std::memory_order_relaxed);
+            m_totalEventsRecorded.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        /** @brief Game-thread read/flush path; swaps queued events into @p outEvents. */
+        void ExtractQueuedEventsForFlush_GameThread(std::vector<TelemetryEvent>& outEvents)
+        {
+            AssertGameThread("ExtractQueuedEventsForFlush_GameThread");
+            std::lock_guard<std::mutex> queueLock(m_eventQueueMutex);
+            outEvents.clear();
+            outEvents.swap(m_eventQueue);
+            m_queuedEventCount.store(0, std::memory_order_relaxed);
+        }
 
         /** @brief Get current time in epoch milliseconds. */
         static uint64_t GetCurrentTimestampMs()
@@ -433,13 +529,20 @@ namespace Spark
             return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(now).count());
         }
 
-        bool m_initialized = false;
+        std::thread::id m_gameThreadId = std::this_thread::get_id();
+        std::atomic<bool> m_initialized{false};
+        std::atomic<bool> m_enabled{false};
+        std::atomic<bool> m_consentGiven{false};
+        std::atomic<uint32_t> m_maxQueueSize{0};
         TelemetryConfig m_config;
+        mutable std::mutex m_eventQueueMutex;
         std::vector<TelemetryEvent> m_eventQueue;
         std::unique_ptr<ITelemetryBackend> m_backend;
         std::string m_sessionId;
+        std::atomic<uint32_t> m_queuedEventCount{0};
+        std::atomic<uint64_t> m_nextEventSequence{1};
         float m_timeSinceFlush = 0.0f;
-        uint64_t m_totalEventsRecorded = 0;
+        std::atomic<uint64_t> m_totalEventsRecorded{0};
     };
 
 } // namespace Spark

--- a/Tests/TestGameplayTags.cpp
+++ b/Tests/TestGameplayTags.cpp
@@ -2,6 +2,10 @@
 #include "TestFramework.h"
 #include "Engine/Gameplay/GameplayTags.h"
 
+#include <atomic>
+#include <thread>
+#include <vector>
+
 // ============================================================================
 // Registration
 // ============================================================================
@@ -206,5 +210,47 @@ TEST(GameplayTags_GetAllTagNames)
     EXPECT_EQ(names.size(), static_cast<size_t>(4)); // A, A.Child, B, B.Child
     // Should be sorted alphabetically
     EXPECT_TRUE(names[0] <= names[1]);
+    reg.Shutdown();
+}
+
+TEST(GameplayTags_ConcurrentReadPath_IsThreadSafe)
+{
+    auto& reg = Spark::Gameplay::GameplayTagRegistry::GetInstance();
+    reg.Initialize();
+    reg.RegisterTag("Damage.Fire.DoT");
+    reg.RegisterTag("Damage.Ice");
+    reg.RegisterTag("Status.Immune.Fire");
+
+    const auto dotId = reg.GetTagId("Damage.Fire.DoT");
+    const auto damageId = reg.GetTagId("Damage");
+    const auto immuneFireId = reg.GetTagId("Status.Immune.Fire");
+
+    constexpr int kThreadCount = 8;
+    constexpr int kIterationsPerThread = 2000;
+    std::atomic<int> successfulChecks = 0;
+    std::vector<std::thread> workers;
+    workers.reserve(kThreadCount);
+
+    for (int i = 0; i < kThreadCount; ++i)
+    {
+        workers.emplace_back(
+            [&]()
+            {
+                for (int j = 0; j < kIterationsPerThread; ++j)
+                {
+                    if (reg.IsTagChildOf(dotId, damageId))
+                        successfulChecks.fetch_add(1, std::memory_order_relaxed);
+
+                    const auto resolved = reg.GetTagId("Status.Immune.Fire");
+                    if (resolved == immuneFireId)
+                        successfulChecks.fetch_add(1, std::memory_order_relaxed);
+                }
+            });
+    }
+
+    for (auto& worker : workers)
+        worker.join();
+
+    EXPECT_EQ(successfulChecks.load(std::memory_order_relaxed), kThreadCount * kIterationsPerThread * 2);
     reg.Shutdown();
 }

--- a/Tests/TestTelemetry.cpp
+++ b/Tests/TestTelemetry.cpp
@@ -2,6 +2,47 @@
 #include "TestFramework.h"
 #include "Utils/Telemetry.h"
 
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace
+{
+    class CountingTelemetryBackend final : public Spark::ITelemetryBackend
+    {
+      public:
+        bool Send(const std::vector<Spark::TelemetryEvent>& events) override
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_batches++;
+            m_totalEvents += events.size();
+
+            uint64_t previous = 0;
+            for (const auto& event : events)
+            {
+                if (previous != 0)
+                    m_nonDecreasingOrder = m_nonDecreasingOrder && event.sequence >= previous;
+                previous = event.sequence;
+            }
+
+            return true;
+        }
+
+        std::string_view GetBackendName() const override { return "Counting"; }
+
+        size_t GetTotalEvents() const { return m_totalEvents; }
+        size_t GetBatchCount() const { return m_batches; }
+        bool IsOrderNonDecreasing() const { return m_nonDecreasingOrder; }
+
+      private:
+        mutable std::mutex m_mutex;
+        size_t m_totalEvents = 0;
+        size_t m_batches = 0;
+        bool m_nonDecreasingOrder = true;
+    };
+} // namespace
+
 // ============================================================================
 // Initialize with default config
 // ============================================================================
@@ -249,4 +290,52 @@ TEST(Telemetry_Console_GetStatus_NotInitialized)
     auto status = telemetry.Console_GetStatus();
     EXPECT_FALSE(status.empty());
     EXPECT_STR_CONTAINS(status, "not initialized");
+}
+
+TEST(Telemetry_ConcurrentRecordAndFlush_DeterministicCountAndOrder)
+{
+    auto& telemetry = Spark::TelemetrySystem::GetInstance();
+    Spark::TelemetryConfig cfg;
+    cfg.enabled = true;
+    cfg.consentGiven = true;
+    cfg.batchSize = 64;
+    cfg.maxQueueSize = 5000;
+    telemetry.Initialize(cfg);
+
+    auto backend = std::make_unique<CountingTelemetryBackend>();
+    auto* backendPtr = backend.get();
+    telemetry.RegisterBackend(std::move(backend));
+
+    constexpr int kThreadCount = 6;
+    constexpr int kEventsPerThread = 300;
+    std::vector<std::thread> workers;
+    workers.reserve(kThreadCount);
+
+    for (int i = 0; i < kThreadCount; ++i)
+    {
+        workers.emplace_back(
+            [&, threadIndex = i]()
+            {
+                for (int j = 0; j < kEventsPerThread; ++j)
+                {
+                    std::unordered_map<std::string, std::string> props{{"producer", std::to_string(threadIndex)},
+                                                                       {"index", std::to_string(j)}};
+                    telemetry.RecordEvent("concurrent_event", props);
+                }
+            });
+    }
+
+    for (auto& worker : workers)
+        worker.join();
+
+    EXPECT_EQ(telemetry.GetQueueSize(), static_cast<uint32_t>(kThreadCount * kEventsPerThread));
+
+    telemetry.FlushEvents();
+
+    EXPECT_EQ(telemetry.GetQueueSize(), 0u);
+    EXPECT_EQ(backendPtr->GetTotalEvents(), static_cast<size_t>(kThreadCount * kEventsPerThread));
+    EXPECT_TRUE(backendPtr->GetBatchCount() > 0);
+    EXPECT_TRUE(backendPtr->IsOrderNonDecreasing());
+
+    telemetry.Shutdown();
 }


### PR DESCRIPTION
### Motivation
- Prevent accidental cross-thread use of mutable singletons by making thread contracts explicit and enforced at the API level.
- Minimize locking on hot paths by separating write-path (game-thread) and read/producer paths (thread-safe) for registries and event queues.
- Ensure deterministic behavior under concurrent telemetry producers by providing monotonic sequencing and a clear game-thread flush path.

### Description
- GameplayTagRegistry: documented method-level threading contracts, record game-thread id, add `AssertGameThread` on mutating APIs (`Initialize`, `Shutdown`, `RegisterTag`), make read-paths (`GetTagId`, `GetTagInfo`, `IsTagChildOf`, `GetAllTagNames`, `Console_GetStatus`, `GetTagCount`, `ContainerMatchesTag`) thread-safe using `std::shared_mutex`, and factor write logic into `RegisterTagUnlocked`/unlocked helpers.
- TelemetrySystem: documented method-level threading contracts, added `AssertGameThread` for lifecycle/flush/update/backend/consent APIs, implemented a lock-protected multi-producer `EnqueueEventThreadSafe` writer path, a game-thread `ExtractQueuedEventsForFlush_GameThread` read/flush path that swaps queues to minimize lock hold time, introduced `sequence` on events for deterministic ordering, and converted counters/state to atomics.
- Tests: added `GameplayTags_ConcurrentReadPath_IsThreadSafe` to exercise concurrent reads of the tag registry, and `Telemetry_ConcurrentRecordAndFlush_DeterministicCountAndOrder` plus an in-test `CountingTelemetryBackend` to validate concurrent `RecordEvent` producers, deterministic flush ordering, and total counts.
- Misc: added necessary includes (`Utils/Assert.h`, threading/locking headers) and updated Doxygen comments at method level describing threading contracts.

### Testing
- Ran `clang-format --dry-run --Werror` on the modified headers/tests and it succeeded for the changed files.
- Ran `cmake --preset linux-gcc-release` which configured the project successfully in this environment (build files generated).
- Attempted to run tests via CTest; `ctest -N` shows tests are registered, but the test executable (`SparkTests`) was not present / not built in this environment so unit tests were not executed here.
- All added files were formatted with `clang-format -i` before committing and the changes were committed as "Enforce thread-affinity contracts for gameplay tags and telemetry".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d760c1d36c8326b6e08b13eac56f90)