### PR TITLE
Route editor mutations through UndoRedoManager, add checklist and undo/redo coverage

### DIFF
--- a/SparkEditor/Source/CommandHistory.h
+++ b/SparkEditor/Source/CommandHistory.h
@@ -41,6 +41,7 @@
 #include <vector>
 #include <memory>
 #include <functional>
+#include "UndoRedo/UndoRedoManager.h"
 
 namespace Spark::Editor
 {
@@ -115,30 +116,8 @@ namespace Spark::Editor
      */
         void Execute(std::unique_ptr<ICommand> command)
         {
-            command->Execute();
-
-            // Try to merge with the last command
-            if (!m_undoStack.empty() && command->GetTypeId() != 0 &&
-                m_undoStack.back()->GetTypeId() == command->GetTypeId())
-            {
-                if (m_undoStack.back()->MergeWith(*command))
-                {
-                    // Merged — discard the new command
-                    m_redoStack.clear();
-                    NotifyChange();
-                    return;
-                }
-            }
-
-            m_undoStack.push_back(std::move(command));
-            m_redoStack.clear();
-
-            // Enforce max history size
-            while (m_undoStack.size() > m_maxHistory)
-            {
-                m_undoStack.erase(m_undoStack.begin());
-            }
-
+            auto wrapped = std::make_unique<CommandHistoryAdapterCommand>(std::move(command));
+            m_manager.ExecuteCommand(std::move(wrapped));
             NotifyChange();
         }
 
@@ -148,15 +127,12 @@ namespace Spark::Editor
      */
         bool Undo()
         {
-            if (m_undoStack.empty())
-                return false;
-
-            auto cmd = std::move(m_undoStack.back());
-            m_undoStack.pop_back();
-            cmd->Undo();
-            m_redoStack.push_back(std::move(cmd));
-            NotifyChange();
-            return true;
+            const bool changed = m_manager.Undo();
+            if (changed)
+            {
+                NotifyChange();
+            }
+            return changed;
         }
 
         /**
@@ -165,48 +141,38 @@ namespace Spark::Editor
      */
         bool Redo()
         {
-            if (m_redoStack.empty())
-                return false;
-
-            auto cmd = std::move(m_redoStack.back());
-            m_redoStack.pop_back();
-            cmd->Execute();
-            m_undoStack.push_back(std::move(cmd));
-            NotifyChange();
-            return true;
+            const bool changed = m_manager.Redo();
+            if (changed)
+            {
+                NotifyChange();
+            }
+            return changed;
         }
 
-        bool CanUndo() const { return !m_undoStack.empty(); }
-        bool CanRedo() const { return !m_redoStack.empty(); }
+        bool CanUndo() const { return m_manager.CanUndo(); }
+        bool CanRedo() const { return m_manager.CanRedo(); }
 
         /** @brief Get the description of the command that would be undone. */
-        std::string GetUndoDescription() const
-        {
-            return m_undoStack.empty() ? "" : m_undoStack.back()->GetDescription();
-        }
+        std::string GetUndoDescription() const { return m_manager.GetUndoDescription(); }
 
         /** @brief Get the description of the command that would be redone. */
-        std::string GetRedoDescription() const
-        {
-            return m_redoStack.empty() ? "" : m_redoStack.back()->GetDescription();
-        }
+        std::string GetRedoDescription() const { return m_manager.GetRedoDescription(); }
 
         /** @brief Clear all history (e.g., when opening a new scene). */
         void Clear()
         {
-            m_undoStack.clear();
-            m_redoStack.clear();
+            m_manager.Clear();
             NotifyChange();
         }
 
         /** @brief Set the maximum number of undo steps to retain. */
-        void SetMaxHistory(size_t max) { m_maxHistory = max; }
+        void SetMaxHistory(size_t max) { m_manager.SetMaxStackDepth(max); }
 
         /** @brief Number of undo steps available. */
-        size_t UndoCount() const { return m_undoStack.size(); }
+        size_t UndoCount() const { return m_manager.GetUndoStack().size(); }
 
         /** @brief Number of redo steps available. */
-        size_t RedoCount() const { return m_redoStack.size(); }
+        size_t RedoCount() const { return m_manager.GetRedoStack().size(); }
 
         /** @brief Register a callback invoked whenever the history changes. */
         void OnChange(std::function<void()> callback) { m_changeCallbacks.push_back(std::move(callback)); }
@@ -216,13 +182,65 @@ namespace Spark::Editor
      *
      * `IsModified()` returns false until further commands are executed.
      */
-        void MarkSaved() { m_savedIndex = m_undoStack.size(); }
+        void MarkSaved() { m_manager.MarkSaved(); }
 
         /** @brief True if the scene has been modified since the last save. */
-        bool IsModified() const { return m_undoStack.size() != m_savedIndex; }
+        bool IsModified() const { return m_manager.HasUnsavedChanges(); }
+
+        /**
+         * @brief Runtime guard for mutation paths that bypass command dispatch.
+         */
+        static void WarnIfBypassingDispatch(const char* operation)
+        {
+            SparkEditor::UndoRedoManager::WarnIfMutationBypassesDispatch(operation);
+        }
 
       private:
-        CommandHistory() = default;
+        class CommandHistoryAdapterCommand final : public SparkEditor::EditorCommand
+        {
+          public:
+            explicit CommandHistoryAdapterCommand(std::unique_ptr<ICommand> command) : m_command(std::move(command)) {}
+
+            void Execute() override
+            {
+                if (m_command)
+                {
+                    m_command->Execute();
+                }
+            }
+
+            void Undo() override
+            {
+                if (m_command)
+                {
+                    m_command->Undo();
+                }
+            }
+
+            std::string GetDescription() const override
+            {
+                return m_command ? m_command->GetDescription() : "CommandHistoryAdapter";
+            }
+
+            bool MergeWith(const SparkEditor::EditorCommand* other) override
+            {
+                const auto* rhs = dynamic_cast<const CommandHistoryAdapterCommand*>(other);
+                if (!rhs || !m_command || !rhs->m_command)
+                {
+                    return false;
+                }
+                if (m_command->GetTypeId() == 0 || m_command->GetTypeId() != rhs->m_command->GetTypeId())
+                {
+                    return false;
+                }
+                return m_command->MergeWith(*rhs->m_command);
+            }
+
+          private:
+            std::unique_ptr<ICommand> m_command;
+        };
+
+        CommandHistory() : m_manager(SparkEditor::UndoRedoManager::GetInstance()) {}
 
         void NotifyChange()
         {
@@ -233,11 +251,8 @@ namespace Spark::Editor
             }
         }
 
-        std::vector<std::unique_ptr<ICommand>> m_undoStack;
-        std::vector<std::unique_ptr<ICommand>> m_redoStack;
+        SparkEditor::UndoRedoManager& m_manager;
         std::vector<std::function<void()>> m_changeCallbacks;
-        size_t m_maxHistory = 100;
-        size_t m_savedIndex = 0;
     };
 
     // ============================================================================

--- a/SparkEditor/Source/Gizmos/GizmoSystem.cpp
+++ b/SparkEditor/Source/Gizmos/GizmoSystem.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "GizmoSystem.h"
+#include "../CommandHistory.h"
 #include "Utils/LogMacros.h"
 #include "Utils/MathUtils.h"
 #include "Utils/Validate.h"
@@ -241,7 +242,44 @@ namespace SparkEditor
             if (m_isDragging)
             {
                 // Mouse released -- end drag
+                if (!m_dragStartSnapshots.empty())
+                {
+                    std::vector<TransformSnapshot> startSnapshots = m_dragStartSnapshots;
+                    std::vector<TransformSnapshot> endSnapshots;
+                    endSnapshots.reserve(m_dragStartSnapshots.size());
+                    for (const auto& snap : m_dragStartSnapshots)
+                    {
+                        if (snap.target)
+                        {
+                            endSnapshots.push_back({snap.target, *snap.target});
+                        }
+                    }
+
+                    Spark::Editor::CommandHistory::GetInstance().Execute(std::make_unique<Spark::Editor::LambdaCommand>(
+                        [endSnapshots]()
+                        {
+                            for (const auto& snap : endSnapshots)
+                            {
+                                if (snap.target)
+                                {
+                                    *snap.target = snap.value;
+                                }
+                            }
+                        },
+                        [startSnapshots]()
+                        {
+                            for (const auto& snap : startSnapshots)
+                            {
+                                if (snap.target)
+                                {
+                                    *snap.target = snap.value;
+                                }
+                            }
+                        },
+                        "Gizmo Transform Apply"));
+                }
                 m_isDragging = false;
+                m_dragStartSnapshots.clear();
                 m_interaction.isActive = false;
                 m_interaction.isDragging = false;
             }
@@ -265,6 +303,15 @@ namespace SparkEditor
                 m_interaction.totalDelta = 0.0f;
                 m_lastMouseWorldPos = ray.origin;
                 m_interactionStartPos = center;
+                m_dragStartSnapshots.clear();
+                m_dragStartSnapshots.reserve(selectedObjects.size());
+                for (Transform* transform : selectedObjects)
+                {
+                    if (transform)
+                    {
+                        m_dragStartSnapshots.push_back({transform, *transform});
+                    }
+                }
             }
         }
 
@@ -685,6 +732,7 @@ namespace SparkEditor
 
     void GizmoSystem::ApplyTranslation(const XMFLOAT3& delta, std::vector<Transform*>& transforms)
     {
+        Spark::Editor::CommandHistory::WarnIfBypassingDispatch("GizmoSystem::ApplyTranslation");
         SPARK_LOG_DEBUG(Spark::LogCategory::Editor, "Applying translation delta (%.3f, %.3f, %.3f) to %zu objects",
                         delta.x, delta.y, delta.z, transforms.size());
         for (auto* t : transforms)
@@ -700,6 +748,7 @@ namespace SparkEditor
 
     void GizmoSystem::ApplyRotation(GizmoAxis axis, float angleDelta, std::vector<Transform*>& transforms)
     {
+        Spark::Editor::CommandHistory::WarnIfBypassingDispatch("GizmoSystem::ApplyRotation");
         SPARK_LOG_DEBUG(Spark::LogCategory::Editor, "Applying rotation delta %.3f rad on axis %d to %zu objects",
                         angleDelta, static_cast<int>(axis), transforms.size());
         XMVECTOR rotAxis = XMVectorSet(0.0f, 0.0f, 0.0f, 0.0f);
@@ -734,6 +783,7 @@ namespace SparkEditor
 
     void GizmoSystem::ApplyScale(const XMFLOAT3& scale, GizmoAxis axis, std::vector<Transform*>& transforms)
     {
+        Spark::Editor::CommandHistory::WarnIfBypassingDispatch("GizmoSystem::ApplyScale");
         SPARK_LOG_DEBUG(Spark::LogCategory::Editor, "Applying scale (%.3f, %.3f, %.3f) on axis %d to %zu objects",
                         scale.x, scale.y, scale.z, static_cast<int>(axis), transforms.size());
         for (auto* t : transforms)

--- a/SparkEditor/Source/Gizmos/GizmoSystem.h
+++ b/SparkEditor/Source/Gizmos/GizmoSystem.h
@@ -411,6 +411,12 @@ namespace SparkEditor
         XMFLOAT3 m_interactionStartPos = {0, 0, 0}; ///< Interaction start position
         bool m_isDragging = false;                  ///< Currently dragging
         GizmoAxis m_hoveredAxis = GizmoAxis::NONE;  ///< Currently hovered axis
+        struct TransformSnapshot
+        {
+            Transform* target = nullptr;
+            Transform value = {};
+        };
+        std::vector<TransformSnapshot> m_dragStartSnapshots; ///< Snapshot at gizmo drag begin for undo command
 
         // Rendering resources
         struct GizmoGeometry

--- a/SparkEditor/Source/Panels/InspectorComponentRenderers_Core3D.cpp
+++ b/SparkEditor/Source/Panels/InspectorComponentRenderers_Core3D.cpp
@@ -151,7 +151,33 @@ namespace SparkEditor
                 if (ImGui::InputText("Mesh", meshBuf, sizeof(meshBuf), ImGuiInputTextFlags_EnterReturnsTrue))
                 {
                     SPARK_LOG_DEBUG(Spark::LogCategory::Editor, "Inspector: mesh asset changed to '%s'", meshBuf);
-                    mr->meshAssetPath = meshBuf;
+                    const std::string oldPath = mr->meshAssetPath;
+                    const std::string newPath = meshBuf;
+                    SceneFile* capturedScene = m_scene;
+                    ObjectID capturedID = m_inspectedObjectID;
+                    auto& history = Spark::Editor::CommandHistory::GetInstance();
+                    history.Execute(std::make_unique<Spark::Editor::LambdaCommand>(
+                        [capturedScene, capturedID, newPath]()
+                        {
+                            if (Component* c = FindComponent(capturedScene, capturedID, ComponentType::MESH_RENDERER))
+                            {
+                                if (MeshRenderer* data = c->GetData<MeshRenderer>())
+                                {
+                                    data->meshAssetPath = newPath;
+                                }
+                            }
+                        },
+                        [capturedScene, capturedID, oldPath]()
+                        {
+                            if (Component* c = FindComponent(capturedScene, capturedID, ComponentType::MESH_RENDERER))
+                            {
+                                if (MeshRenderer* data = c->GetData<MeshRenderer>())
+                                {
+                                    data->meshAssetPath = oldPath;
+                                }
+                            }
+                        },
+                        "Assign Mesh Asset"));
                 }
 
                 // Material path
@@ -162,7 +188,33 @@ namespace SparkEditor
                 if (ImGui::InputText("Material", matBuf, sizeof(matBuf), ImGuiInputTextFlags_EnterReturnsTrue))
                 {
                     SPARK_LOG_DEBUG(Spark::LogCategory::Editor, "Inspector: material asset changed to '%s'", matBuf);
-                    mr->materialAssetPath = matBuf;
+                    const std::string oldPath = mr->materialAssetPath;
+                    const std::string newPath = matBuf;
+                    SceneFile* capturedScene = m_scene;
+                    ObjectID capturedID = m_inspectedObjectID;
+                    auto& history = Spark::Editor::CommandHistory::GetInstance();
+                    history.Execute(std::make_unique<Spark::Editor::LambdaCommand>(
+                        [capturedScene, capturedID, newPath]()
+                        {
+                            if (Component* c = FindComponent(capturedScene, capturedID, ComponentType::MESH_RENDERER))
+                            {
+                                if (MeshRenderer* data = c->GetData<MeshRenderer>())
+                                {
+                                    data->materialAssetPath = newPath;
+                                }
+                            }
+                        },
+                        [capturedScene, capturedID, oldPath]()
+                        {
+                            if (Component* c = FindComponent(capturedScene, capturedID, ComponentType::MESH_RENDERER))
+                            {
+                                if (MeshRenderer* data = c->GetData<MeshRenderer>())
+                                {
+                                    data->materialAssetPath = oldPath;
+                                }
+                            }
+                        },
+                        "Assign Material Asset"));
                 }
 
                 ImGui::Checkbox("Cast Shadows", &mr->castShadows);

--- a/SparkEditor/Source/UndoRedo/EditorCommand.h
+++ b/SparkEditor/Source/UndoRedo/EditorCommand.h
@@ -17,6 +17,7 @@
 #include <functional>
 #include <variant>
 #include <unordered_map>
+#include <utility>
 
 #ifdef _WIN32
 #include <DirectXMath.h>
@@ -469,6 +470,44 @@ namespace SparkEditor
       private:
         std::string m_description;
         std::vector<std::unique_ptr<EditorCommand>> m_commands;
+    };
+
+    /**
+     * @brief Generic command backed by execute/undo lambdas.
+     *
+     * Used to bridge legacy command callsites onto UndoRedoManager while
+     * preserving undo/redo behavior.
+     */
+    class LambdaEditorCommand : public EditorCommand
+    {
+      public:
+        LambdaEditorCommand(std::function<void()> execute, std::function<void()> undo, std::string description)
+            : m_execute(std::move(execute)), m_undo(std::move(undo)), m_description(std::move(description))
+        {
+        }
+
+        void Execute() override
+        {
+            if (m_execute)
+            {
+                m_execute();
+            }
+        }
+
+        void Undo() override
+        {
+            if (m_undo)
+            {
+                m_undo();
+            }
+        }
+
+        std::string GetDescription() const override { return m_description; }
+
+      private:
+        std::function<void()> m_execute;
+        std::function<void()> m_undo;
+        std::string m_description;
     };
 
 } // namespace SparkEditor

--- a/SparkEditor/Source/UndoRedo/UndoRedoManager.cpp
+++ b/SparkEditor/Source/UndoRedo/UndoRedoManager.cpp
@@ -12,6 +12,16 @@
 
 namespace SparkEditor
 {
+    namespace
+    {
+        thread_local int g_dispatchDepth = 0;
+    }
+
+    UndoRedoManager& UndoRedoManager::GetInstance()
+    {
+        static UndoRedoManager instance;
+        return instance;
+    }
 
     UndoRedoManager::UndoRedoManager() = default;
 
@@ -32,7 +42,9 @@ namespace SparkEditor
 
         SPARK_LOG_DEBUG(Spark::LogCategory::Editor, "Executing command: '%s'", command->GetDescription().c_str());
         // Execute the command
+        ++g_dispatchDepth;
         command->Execute();
+        --g_dispatchDepth;
 
         // Push onto undo stack
         m_undoStack.push_back(std::move(command));
@@ -59,7 +71,9 @@ namespace SparkEditor
         m_undoStack.pop_back();
         SPARK_LOG_DEBUG(Spark::LogCategory::Editor, "Undoing command: '%s' (stack depth: %zu)",
                         command->GetDescription().c_str(), m_undoStack.size());
+        ++g_dispatchDepth;
         command->Undo();
+        --g_dispatchDepth;
 
         m_redoStack.push_back(std::move(command));
 
@@ -79,7 +93,9 @@ namespace SparkEditor
         auto command = std::move(m_redoStack.back());
         m_redoStack.pop_back();
 
+        ++g_dispatchDepth;
         command->Execute();
+        --g_dispatchDepth;
 
         m_undoStack.push_back(std::move(command));
 
@@ -188,6 +204,21 @@ namespace SparkEditor
             {
                 --m_savedIndex;
             }
+        }
+    }
+
+    bool UndoRedoManager::IsDispatchingCommand()
+    {
+        return g_dispatchDepth > 0;
+    }
+
+    void UndoRedoManager::WarnIfMutationBypassesDispatch(const char* operation)
+    {
+        if (!IsDispatchingCommand())
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Editor,
+                           "Editor mutation bypassed UndoRedoManager dispatch at '%s'. Wrap this in an EditorCommand.",
+                           operation ? operation : "unknown");
         }
     }
 

--- a/SparkEditor/Source/UndoRedo/UndoRedoManager.h
+++ b/SparkEditor/Source/UndoRedo/UndoRedoManager.h
@@ -6,6 +6,13 @@
  *
  * The UndoRedoManager maintains two stacks (undo and redo) of EditorCommand
  * objects, allowing the user to undo and redo operations in the editor.
+ *
+ * Required undoable action categories (central checklist):
+ * 1) Transform gizmo apply (translate/rotate/scale commits)
+ * 2) Component add/remove/edit (including property and asset reference edits)
+ * 3) Hierarchy mutations (create/delete/reparent/duplicate/rename)
+ * 4) Asset assignment and reassignment (mesh/material/texture/script references)
+ * 5) Multi-object/batch edits that mutate scene/editor state
  */
 
 #pragma once
@@ -29,6 +36,11 @@ namespace SparkEditor
     class UndoRedoManager
     {
       public:
+        /**
+         * @brief Global undo/redo manager instance for editor command dispatch.
+         */
+        static UndoRedoManager& GetInstance();
+
         UndoRedoManager();
         ~UndoRedoManager() = default;
 
@@ -137,6 +149,17 @@ namespace SparkEditor
          * @param depth Max stack depth
          */
         void SetMaxStackDepth(size_t depth) { m_maxStackDepth = depth; }
+
+        /**
+         * @brief Returns true while a command is being executed via UndoRedoManager.
+         */
+        static bool IsDispatchingCommand();
+
+        /**
+         * @brief Logs a warning when editor state mutation bypasses command dispatch.
+         * @param operation Context string for the mutation path.
+         */
+        static void WarnIfMutationBypassesDispatch(const char* operation);
 
       private:
         std::vector<std::unique_ptr<EditorCommand>> m_undoStack;

--- a/Tests/TestUndoRedoManager.cpp
+++ b/Tests/TestUndoRedoManager.cpp
@@ -148,6 +148,60 @@ namespace UndoRedoTest
         std::string m_oldValue;
     };
 
+    struct EditorState
+    {
+        int transformX = 0;
+        bool hasLightComponent = false;
+        int parentId = 0;
+        bool entityDeleted = false;
+        std::string materialAssetPath;
+    };
+
+    class IntFieldCommand : public IUndoCommand
+    {
+      public:
+        IntFieldCommand(int& target, int value) : m_target(target), m_oldValue(target), m_newValue(value) {}
+        void Execute() override { m_target = m_newValue; }
+        void Undo() override { m_target = m_oldValue; }
+        std::string GetName() const override { return "IntField"; }
+
+      private:
+        int& m_target;
+        int m_oldValue;
+        int m_newValue;
+    };
+
+    class BoolFieldCommand : public IUndoCommand
+    {
+      public:
+        BoolFieldCommand(bool& target, bool value) : m_target(target), m_oldValue(target), m_newValue(value) {}
+        void Execute() override { m_target = m_newValue; }
+        void Undo() override { m_target = m_oldValue; }
+        std::string GetName() const override { return "BoolField"; }
+
+      private:
+        bool& m_target;
+        bool m_oldValue;
+        bool m_newValue;
+    };
+
+    class StringFieldCommand : public IUndoCommand
+    {
+      public:
+        StringFieldCommand(std::string& target, std::string value)
+            : m_target(target), m_oldValue(target), m_newValue(std::move(value))
+        {
+        }
+        void Execute() override { m_target = m_newValue; }
+        void Undo() override { m_target = m_oldValue; }
+        std::string GetName() const override { return "StringField"; }
+
+      private:
+        std::string& m_target;
+        std::string m_oldValue;
+        std::string m_newValue;
+    };
+
 } // namespace UndoRedoTest
 
 // ============================================================================
@@ -276,4 +330,53 @@ TEST(UndoRedo_ClearHistory)
 
     EXPECT_FALSE(mgr.CanUndo());
     EXPECT_FALSE(mgr.CanRedo());
+}
+
+TEST(UndoRedo_EditorMutationCategoriesRoundtrip)
+{
+    using namespace UndoRedoTest;
+
+    UndoRedoManager mgr;
+    EditorState s{};
+
+    // 1) Transform gizmo apply
+    mgr.Push(std::make_unique<IntFieldCommand>(s.transformX, 42));
+    // 2) Component add/remove/edit
+    mgr.Push(std::make_unique<BoolFieldCommand>(s.hasLightComponent, true));
+    // 3) Hierarchy reparent
+    mgr.Push(std::make_unique<IntFieldCommand>(s.parentId, 17));
+    // 4) Hierarchy delete
+    mgr.Push(std::make_unique<BoolFieldCommand>(s.entityDeleted, true));
+    // 5) Asset assignment
+    mgr.Push(std::make_unique<StringFieldCommand>(s.materialAssetPath, "Materials/Metal.mat"));
+
+    EXPECT_EQ(s.transformX, 42);
+    EXPECT_TRUE(s.hasLightComponent);
+    EXPECT_EQ(s.parentId, 17);
+    EXPECT_TRUE(s.entityDeleted);
+    EXPECT_EQ(s.materialAssetPath, std::string("Materials/Metal.mat"));
+
+    // Undo full stack
+    for (int i = 0; i < 5; ++i)
+    {
+        EXPECT_TRUE(mgr.Undo());
+    }
+
+    EXPECT_EQ(s.transformX, 0);
+    EXPECT_FALSE(s.hasLightComponent);
+    EXPECT_EQ(s.parentId, 0);
+    EXPECT_FALSE(s.entityDeleted);
+    EXPECT_TRUE(s.materialAssetPath.empty());
+
+    // Redo full stack
+    for (int i = 0; i < 5; ++i)
+    {
+        EXPECT_TRUE(mgr.Redo());
+    }
+
+    EXPECT_EQ(s.transformX, 42);
+    EXPECT_TRUE(s.hasLightComponent);
+    EXPECT_EQ(s.parentId, 17);
+    EXPECT_TRUE(s.entityDeleted);
+    EXPECT_EQ(s.materialAssetPath, std::string("Materials/Metal.mat"));
 }


### PR DESCRIPTION
### Motivation

- Ensure all editor mutation paths (gizmo transforms, component add/remove/edit, hierarchy operations, asset assignments, batch edits) are routed through the undo/redo pipeline so state changes are undoable and auditable.
- Provide a single, discoverable checklist of required undoable action categories for editor contributors to reduce accidental direct state mutations.
- Detect and warn at runtime when editor-mode code mutates state without dispatching a command so maintainers can fix bypasses early.

### Description

- Route legacy `CommandHistory` execution through the central `UndoRedoManager` by wrapping `CommandHistory` `ICommand` instances inside an `EditorCommand` adapter (`CommandHistoryAdapterCommand`) so existing callsites now dispatch via `UndoRedoManager` and use its merge/stack semantics (`SparkEditor::CommandHistory` → adapter → `UndoRedoManager`).
- Add a centralized checklist comment to `UndoRedoManager` listing required undoable action categories (transform gizmo apply, component add/remove/edit, hierarchy mutations, asset assignment, batch edits) to guide future code changes.
- Add a global dispatch tracking guard to `UndoRedoManager` (`GetInstance()`, thread-local dispatch depth, `IsDispatchingCommand()`), plus `WarnIfMutationBypassesDispatch()` to log warnings when mutation operations run outside command dispatch.
- Add `LambdaEditorCommand` (lambda-backed `EditorCommand`) to `EditorCommand.h` to make it easy to wrap inline execute/undo lambdas and bridge UI code into the `UndoRedoManager` pipeline.
- Update `GizmoSystem` to snapshot transforms at drag start and, on drag release, commit a single undoable command (`"Gizmo Transform Apply"`) that captures end and start snapshots for correct undo/redo roundtrip, and add runtime warnings in `ApplyTranslation`, `ApplyRotation`, and `ApplyScale` when dispatch is bypassed.
- Update `InspectorComponentRenderers_Core3D` mesh/material assignment UI to execute changes via `CommandHistory::Execute(std::make_unique<LambdaCommand>(...))` so asset assignments are undoable.
- Add/extend tests in `Tests/TestUndoRedoManager.cpp` to exercise a roundtrip covering the required categories (transform, component add/remove/edit, hierarchy reparent/delete, asset assignment) as a synthetic verification of stack behavior.

### Testing

- Ran `clang-format` on changed files (format applied) and verified no formatting errors were produced.
- Configured the project with `cmake --preset linux-gcc-release` successfully (project configured and build files generated).
- Performed a syntax-only verification of the extended test binary with `g++ -std=c++23 -I Tests -fsyntax-only Tests/TestUndoRedoManager.cpp`, which completed successfully.
- Attempted the larger test build with `cmake --build ... --target SparkTests` but the full build is large and long-running and did not complete within this session; partial build workfiles were produced before the session timed out.

If you want, I can (1) run the full test target (long build) in CI or locally, (2) add more UI callsites converted to use `LambdaEditorCommand`, or (3) run the new unit tests end-to-end in a CI job and post the results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d76432cfbc8326a70d1db472c3705b)