### PR TITLE
Add componentized CPack packaging, install targets, CI packaging and package-consumption smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Publish Builds
 
 on:
   push:
+    branches: [ 'release/**' ]
     tags: [ 'v*' ]
   schedule:
     # Nightly at 04:00 UTC — after the day's merges settle
@@ -92,7 +93,7 @@ jobs:
       uses: microsoft/setup-msbuild@v3
 
     - name: Configure CMake
-      run: cmake -B build -G "Visual Studio 17 2022" -A x64 -DSPARK_MSVC_TOOLSET=v143 -DBUILD_TESTS=ON
+      run: cmake -B build -G "Visual Studio 17 2022" -A x64 -DSPARK_MSVC_TOOLSET=v143 -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/stage"
 
     - name: Build
       run: cmake --build build --config ${{ matrix.config }} --parallel
@@ -100,23 +101,17 @@ jobs:
     - name: Run Tests
       run: ctest --test-dir build -C ${{ matrix.config }} --output-on-failure
 
-    - name: Package artifacts
+    - name: Generate CPack packages
       shell: pwsh
       run: |
-        $outDir = "dist/SparkEngine-Windows-${{ matrix.config }}"
-        New-Item -ItemType Directory -Force -Path $outDir | Out-Null
-        if (Test-Path "build/bin/${{ matrix.config }}") {
-          Copy-Item "build/bin/${{ matrix.config }}/*" $outDir -Recurse -Force
-        } elseif (Test-Path "build/bin") {
-          Copy-Item "build/bin/*" $outDir -Recurse -Force
-        }
-        Compress-Archive -Path $outDir -DestinationPath "SparkEngine-Windows-${{ matrix.config }}.zip"
+        cmake --install build --config ${{ matrix.config }}
+        cpack --config build/CPackConfig.cmake -C ${{ matrix.config }} -B build/packages
 
     - name: Upload packaged artifact
       uses: actions/upload-artifact@v7
       with:
-        name: SparkEngine-Windows-${{ matrix.config }}
-        path: SparkEngine-Windows-${{ matrix.config }}.zip
+        name: SparkEngine-Windows-${{ matrix.config }}-packages
+        path: build/packages/*
         retention-days: 7
 
   # ===========================================================================
@@ -145,6 +140,7 @@ jobs:
         cmake -B build \
           -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
           -DBUILD_TESTS=ON \
+          -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/stage" \
           -DCMAKE_C_COMPILER=gcc-14 \
           -DCMAKE_CXX_COMPILER=g++-14
 
@@ -157,18 +153,23 @@ jobs:
         ctest --output-on-failure
         if [ -f bin/SparkTests ]; then ./bin/SparkTests; fi
 
-    - name: Package artifacts
+    - name: Validate external package consumption
       run: |
-        mkdir -p dist/SparkEngine-Linux-${{ matrix.config }}
-        cp -r build/bin/* dist/SparkEngine-Linux-${{ matrix.config }}/
-        tar -czf SparkEngine-Linux-${{ matrix.config }}.tar.gz \
-          -C dist SparkEngine-Linux-${{ matrix.config }}
+        cmake --install build
+        cmake -S Tests/PackageSmoke -B smoke-build \
+          -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
+          -DSparkEngine_DIR="${{ github.workspace }}/stage/lib/cmake/SparkEngine"
+        cmake --build smoke-build --parallel $(nproc)
+
+    - name: Generate CPack packages
+      run: |
+        cpack --config build/CPackConfig.cmake -B build/packages
 
     - name: Upload packaged artifact
       uses: actions/upload-artifact@v7
       with:
-        name: SparkEngine-Linux-${{ matrix.config }}
-        path: SparkEngine-Linux-${{ matrix.config }}.tar.gz
+        name: SparkEngine-Linux-${{ matrix.config }}-packages
+        path: build/packages/*
         retention-days: 7
 
   # ===========================================================================
@@ -272,26 +273,27 @@ jobs:
     - name: Collect release assets
       id: assets
       run: |
-        # Flatten all artifacts to current directory
-        find release-assets -type f \( -name "*.zip" -o -name "*.tar.gz" \) \
+        # Flatten all package artifacts to current directory
+        find release-assets -type f \
+          \( -name "*.zip" -o -name "*.tar.gz" -o -name "*.exe" -o -name "*.msi" \) \
           -exec cp {} . \;
 
-        # Build the file list and downloads table dynamically
         FILES=""
-        TABLE="| Asset | Platform | Config |"$'\n'"|---|---|---|"
-
-        for config in Debug Release; do
-          WIN="SparkEngine-Windows-${config}.zip"
-          LIN="SparkEngine-Linux-${config}.tar.gz"
-
-          if [ -f "$WIN" ]; then
-            FILES="${FILES}${WIN}"$'\n'
-            TABLE="${TABLE}"$'\n'"| \`${WIN}\` | Windows (VS 2022 x64) | ${config} |"
+        TABLE="| Asset | Notes |"$'\n'"|---|---|"
+        for artifact in *.zip *.tar.gz *.exe *.msi; do
+          if [ ! -f "$artifact" ]; then
+            continue
           fi
-          if [ -f "$LIN" ]; then
-            FILES="${FILES}${LIN}"$'\n'
-            TABLE="${TABLE}"$'\n'"| \`${LIN}\` | Linux (GCC, ubuntu-24.04) | ${config} |"
+
+          note="CPack package"
+          if [[ "$artifact" == *"-Windows-"* ]]; then
+            note="Windows package"
+          elif [[ "$artifact" == *"-Linux-"* ]]; then
+            note="Linux package"
           fi
+
+          FILES="${FILES}${artifact}"$'\n'
+          TABLE="${TABLE}"$'\n'"| \`${artifact}\` | ${note} |"
         done
 
         # Write multiline outputs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,8 @@ if(WIN32 AND NOT CMAKE_GENERATOR_PLATFORM)
     set(CMAKE_GENERATOR_PLATFORM "x64")
 endif()
 
-project(SparkEngine LANGUAGES CXX C)
+set(SPARK_ENGINE_VERSION "1.0.0" CACHE STRING "SparkEngine semantic version used for package metadata")
+project(SparkEngine VERSION ${SPARK_ENGINE_VERSION} LANGUAGES CXX C)
 
 # Set consistent runtime library for all targets using modern CMake (CMP0091)
 # Must be after project() so that the MSVC variable is defined.
@@ -974,7 +975,7 @@ endif()
 
 # zstd — Zstandard compression (faster than miniz, used alongside it)
 if(TARGET zstd)
-    target_link_libraries(SparkEngineLib PRIVATE zstd)
+    target_link_libraries(SparkEngineLib PRIVATE $<BUILD_INTERFACE:zstd>)
     target_compile_definitions(SparkEngineLib PUBLIC SPARK_ZSTD_AVAILABLE=1)
     target_compile_definitions(SparkEngine PRIVATE SPARK_ZSTD_AVAILABLE=1)
     message(STATUS "Linking SparkEngineLib with zstd")
@@ -992,14 +993,14 @@ if(CURL_FOUND)
 endif()
 
 if(TINYOBJ_FOUND)
-    target_link_libraries(SparkEngineLib PRIVATE tinyobjloader)
+    target_link_libraries(SparkEngineLib PRIVATE $<BUILD_INTERFACE:tinyobjloader>)
     message(STATUS "Linking SparkEngineLib with TinyObjLoader")
 endif()
 
 # Link stb_image (cross-platform texture loading)
 # PUBLIC because TextureSystem.h consumers may transitively need it
 if(TARGET stb_image)
-    target_link_libraries(SparkEngineLib PUBLIC stb_image)
+    target_link_libraries(SparkEngineLib PUBLIC $<BUILD_INTERFACE:stb_image>)
     target_compile_definitions(SparkEngineLib PUBLIC SPARK_HAS_STB_IMAGE=1)
     message(STATUS "Linking SparkEngineLib with stb_image")
 endif()
@@ -1007,7 +1008,7 @@ endif()
 # Link cgltf (glTF 2.0 model loading)
 # PUBLIC because AssetPipeline.h consumers may transitively need it
 if(TARGET cgltf)
-    target_link_libraries(SparkEngineLib PUBLIC cgltf)
+    target_link_libraries(SparkEngineLib PUBLIC $<BUILD_INTERFACE:cgltf>)
     target_compile_definitions(SparkEngineLib PUBLIC SPARK_HAS_CGLTF=1)
     message(STATUS "Linking SparkEngineLib with cgltf")
 endif()
@@ -1015,7 +1016,7 @@ endif()
 # Link miniaudio (cross-platform audio backend)
 # PUBLIC because PlatformAudioStubs.h includes miniaudio.h transitively
 if(TARGET miniaudio)
-    target_link_libraries(SparkEngineLib PUBLIC miniaudio)
+    target_link_libraries(SparkEngineLib PUBLIC $<BUILD_INTERFACE:miniaudio>)
     target_compile_definitions(SparkEngineLib PUBLIC SPARK_HAS_MINIAUDIO=1)
     message(STATUS "Linking SparkEngineLib with miniaudio")
 endif()
@@ -1023,7 +1024,7 @@ endif()
 # Link nlohmann/json (JSON parsing library)
 # PUBLIC because JsonUtils.h includes nlohmann_json.h when available
 if(TARGET nlohmann_json)
-    target_link_libraries(SparkEngineLib PUBLIC nlohmann_json)
+    target_link_libraries(SparkEngineLib PUBLIC $<BUILD_INTERFACE:nlohmann_json>)
     target_compile_definitions(SparkEngineLib PUBLIC SPARK_HAS_NLOHMANN_JSON=1)
     message(STATUS "Linking SparkEngineLib with nlohmann/json")
 endif()
@@ -1031,7 +1032,7 @@ endif()
 # Link tinyexr (OpenEXR image loading)
 # PUBLIC because TextureSystem consumers may transitively need it
 if(TARGET tinyexr)
-    target_link_libraries(SparkEngineLib PUBLIC tinyexr)
+    target_link_libraries(SparkEngineLib PUBLIC $<BUILD_INTERFACE:tinyexr>)
     target_compile_definitions(SparkEngineLib PUBLIC SPARK_HAS_TINYEXR=1)
     message(STATUS "Linking SparkEngineLib with tinyexr")
 endif()
@@ -1132,7 +1133,7 @@ if(JOLT_FOUND)
         endif()
     endif()
 
-    target_link_libraries(SparkEngineLib PRIVATE Jolt)
+    target_link_libraries(SparkEngineLib PRIVATE $<BUILD_INTERFACE:Jolt>)
     target_compile_definitions(SparkEngineLib PUBLIC SPARK_JOLT_PHYSICS_AVAILABLE=1)
     target_compile_definitions(SparkEngine PRIVATE SPARK_JOLT_PHYSICS_AVAILABLE=1)
     message(STATUS "Linking SparkEngineLib with Jolt Physics")
@@ -1170,7 +1171,7 @@ else()
 endif()
 
 if(RECAST_FOUND)
-    target_link_libraries(SparkEngineLib PRIVATE Recast Detour)
+    target_link_libraries(SparkEngineLib PRIVATE $<BUILD_INTERFACE:Recast> $<BUILD_INTERFACE:Detour>)
     target_compile_definitions(SparkEngineLib PUBLIC SPARK_RECAST_AVAILABLE=1)
     message(STATUS "Linking SparkEngineLib with Recast/Detour")
 endif()
@@ -1438,7 +1439,7 @@ if(SPARK_OPENGL_AVAILABLE)
         if(MSVC)
             set_property(TARGET glad PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
         endif()
-        target_link_libraries(SparkEngineLib PUBLIC glad)
+        target_link_libraries(SparkEngineLib PUBLIC $<BUILD_INTERFACE:glad>)
     endif()
 
     # EGL for headless software rendering on Linux
@@ -1690,24 +1691,29 @@ endif()
 # Install with: cmake --install build --prefix /path/to/install
 # ---------------------------------------------------------------------
 
+set(SPARK_INSTALL_COMPONENT_RUNTIME "runtime")
+set(SPARK_INSTALL_COMPONENT_SDK "sdk")
+set(SPARK_INSTALL_COMPONENT_TOOLS "tools")
+set(SPARK_INSTALL_COMPONENT_TEMPLATES "templates")
+set(SPARK_INSTALL_COMPONENT_SAMPLES "samples")
+
 set(_SPARK_INSTALL_TARGETS SparkEngineLib)
-if(TARGET tinyobjloader)
-    list(APPEND _SPARK_INSTALL_TARGETS tinyobjloader)
-endif()
 install(TARGETS ${_SPARK_INSTALL_TARGETS}
     EXPORT SparkEngineTargets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib COMPONENT ${SPARK_INSTALL_COMPONENT_SDK}
+    LIBRARY DESTINATION lib COMPONENT ${SPARK_INSTALL_COMPONENT_SDK}
 )
 
 # Install SparkSDK public headers
 install(DIRECTORY SparkSDK/Include/Spark
     DESTINATION include
+    COMPONENT ${SPARK_INSTALL_COMPONENT_SDK}
 )
 
 # Install the engine's public headers (needed by modules that use engine types directly)
 install(DIRECTORY "SparkEngine/Source/"
     DESTINATION include/SparkEngine
+    COMPONENT ${SPARK_INSTALL_COMPONENT_SDK}
     FILES_MATCHING
         PATTERN "*.h"
         PATTERN "*.hpp"
@@ -1718,6 +1724,7 @@ foreach(dir ${THIRDPARTY_INCLUDE_DIRS})
     if(EXISTS "${dir}")
         install(DIRECTORY "${dir}/"
             DESTINATION include/SparkEngine/ThirdParty
+            COMPONENT ${SPARK_INSTALL_COMPONENT_SDK}
             FILES_MATCHING
                 PATTERN "*.h"
                 PATTERN "*.hpp"
@@ -1725,14 +1732,12 @@ foreach(dir ${THIRDPARTY_INCLUDE_DIRS})
     endif()
 endforeach()
 
-# Export targets (only when all dependencies are in export sets)
-if(FALSE) # Disabled: third-party targets (Jolt, miniz) lack EXPORT sets
 install(EXPORT SparkEngineTargets
     FILE SparkEngineTargets.cmake
     NAMESPACE Spark::
     DESTINATION lib/cmake/SparkEngine
+    COMPONENT ${SPARK_INSTALL_COMPONENT_SDK}
 )
-endif()
 
 # Package config
 include(CMakePackageConfigHelpers)
@@ -1741,21 +1746,28 @@ configure_package_config_file(
     "${CMAKE_BINARY_DIR}/SparkEngineConfig.cmake"
     INSTALL_DESTINATION lib/cmake/SparkEngine
 )
+write_basic_package_version_file(
+    "${CMAKE_BINARY_DIR}/SparkEngineConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
 
 install(FILES
     "${CMAKE_BINARY_DIR}/SparkEngineConfig.cmake"
+    "${CMAKE_BINARY_DIR}/SparkEngineConfigVersion.cmake"
     "${CMAKE_SOURCE_DIR}/cmake/SparkGameModule.cmake"
     DESTINATION lib/cmake/SparkEngine
+    COMPONENT ${SPARK_INSTALL_COMPONENT_SDK}
 )
 
 # Install engine executable and game DLL
 install(TARGETS SparkEngine
-    RUNTIME DESTINATION bin
+    RUNTIME DESTINATION bin COMPONENT ${SPARK_INSTALL_COMPONENT_RUNTIME}
 )
 if(TARGET SparkGameFPS)
     install(TARGETS SparkGameFPS
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION bin
+        RUNTIME DESTINATION bin COMPONENT ${SPARK_INSTALL_COMPONENT_SAMPLES}
+        LIBRARY DESTINATION bin COMPONENT ${SPARK_INSTALL_COMPONENT_SAMPLES}
     )
 endif()
 
@@ -1763,6 +1775,46 @@ endif()
 if(EXISTS "${CMAKE_SOURCE_DIR}/SparkEngine/Shaders")
     install(DIRECTORY "SparkEngine/Shaders/"
         DESTINATION bin/Shaders
+        COMPONENT ${SPARK_INSTALL_COMPONENT_RUNTIME}
+    )
+endif()
+
+# Install tools
+if(TARGET SparkShaderCompiler)
+    install(TARGETS SparkShaderCompiler
+        RUNTIME DESTINATION bin COMPONENT ${SPARK_INSTALL_COMPONENT_TOOLS}
+    )
+endif()
+if(EXISTS "${CMAKE_SOURCE_DIR}/Tools")
+    install(DIRECTORY "Tools/"
+        DESTINATION tools
+        COMPONENT ${SPARK_INSTALL_COMPONENT_TOOLS}
+    )
+endif()
+
+# Install project templates and samples
+if(EXISTS "${CMAKE_SOURCE_DIR}/Templates")
+    install(DIRECTORY "Templates/"
+        DESTINATION share/SparkEngine/templates
+        COMPONENT ${SPARK_INSTALL_COMPONENT_TEMPLATES}
+    )
+endif()
+if(EXISTS "${CMAKE_SOURCE_DIR}/Samples")
+    install(DIRECTORY "Samples/"
+        DESTINATION share/SparkEngine/samples
+        COMPONENT ${SPARK_INSTALL_COMPONENT_SAMPLES}
+    )
+endif()
+if(EXISTS "${CMAKE_SOURCE_DIR}/GameModules/SparkGame")
+    install(DIRECTORY "GameModules/SparkGame/"
+        DESTINATION share/SparkEngine/samples/SparkGame
+        COMPONENT ${SPARK_INSTALL_COMPONENT_SAMPLES}
+        FILES_MATCHING
+            PATTERN "*.h"
+            PATTERN "*.hpp"
+            PATTERN "*.cpp"
+            PATTERN "*.json"
+            PATTERN "CMakeLists.txt"
     )
 endif()
 
@@ -2126,6 +2178,72 @@ message(STATUS "")
 # ---------------------------------------------------------------------
 # CPack packaging configuration
 # ---------------------------------------------------------------------
-if(EXISTS "${CMAKE_SOURCE_DIR}/cmake/SparkCPack.cmake")
-    include("${CMAKE_SOURCE_DIR}/cmake/SparkCPack.cmake")
+set(CPACK_PACKAGE_NAME "SparkEngine")
+set(CPACK_PACKAGE_VENDOR "Spark Engine Team")
+set(CPACK_PACKAGE_CONTACT "https://github.com/Krilliac/SparkEngine")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/Krilliac/SparkEngine")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SparkEngine C++23 game engine SDK/runtime distribution")
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_PACKAGE_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}")
+set(CPACK_PACKAGE_VERSION_MINOR "${PROJECT_VERSION_MINOR}")
+set(CPACK_PACKAGE_VERSION_PATCH "${PROJECT_VERSION_PATCH}")
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "SparkEngine")
+
+set(CPACK_GENERATOR "ZIP")
+if(WIN32)
+    list(APPEND CPACK_GENERATOR "NSIS" "WIX")
+else()
+    list(APPEND CPACK_GENERATOR "TGZ")
 endif()
+
+set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)
+set(CPACK_COMPONENTS_ALL
+    ${SPARK_INSTALL_COMPONENT_RUNTIME}
+    ${SPARK_INSTALL_COMPONENT_SDK}
+    ${SPARK_INSTALL_COMPONENT_TOOLS}
+    ${SPARK_INSTALL_COMPONENT_TEMPLATES}
+    ${SPARK_INSTALL_COMPONENT_SAMPLES}
+)
+
+set(CPACK_COMPONENT_RUNTIME_DISPLAY_NAME "Runtime Binaries")
+set(CPACK_COMPONENT_RUNTIME_DESCRIPTION "SparkEngine runtime executable, runtime shaders, and required binaries")
+set(CPACK_COMPONENT_RUNTIME_REQUIRED ON)
+
+set(CPACK_COMPONENT_SDK_DISPLAY_NAME "Headers and SDK")
+set(CPACK_COMPONENT_SDK_DESCRIPTION "SparkEngine static library, CMake package files, and public headers")
+set(CPACK_COMPONENT_SDK_DEPENDS runtime)
+
+set(CPACK_COMPONENT_TOOLS_DISPLAY_NAME "Developer Tools")
+set(CPACK_COMPONENT_TOOLS_DESCRIPTION "Command-line tools such as spark-cli and SparkShaderCompiler")
+set(CPACK_COMPONENT_TOOLS_DEPENDS runtime)
+
+set(CPACK_COMPONENT_TEMPLATES_DISPLAY_NAME "Project Templates")
+set(CPACK_COMPONENT_TEMPLATES_DESCRIPTION "Starter templates for new SparkEngine projects")
+set(CPACK_COMPONENT_TEMPLATES_DEPENDS sdk)
+
+set(CPACK_COMPONENT_SAMPLES_DISPLAY_NAME "Sample Content")
+set(CPACK_COMPONENT_SAMPLES_DESCRIPTION "Reference sample modules and sample project content")
+set(CPACK_COMPONENT_SAMPLES_DEPENDS runtime)
+
+if(EXISTS "${CMAKE_SOURCE_DIR}/LICENSE")
+    set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE")
+endif()
+if(EXISTS "${CMAKE_SOURCE_DIR}/README.md")
+    set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")
+endif()
+
+set(CPACK_SOURCE_GENERATOR "ZIP;TGZ")
+set(CPACK_SOURCE_IGNORE_FILES
+    "/build/"
+    "/[.]git/"
+    "/[.]claude/"
+    "/[.]vs/"
+    "/[.]vscode/"
+    "/out/"
+)
+set(CPACK_PACKAGE_FILE_NAME
+    "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}"
+)
+
+include(CPack)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ Stable releases are published manually and thoroughly tested. Recommended for mo
 
 > Download the latest stable release (v1.0.0). For bleeding-edge features, use the nightly build above.
 
+### Release Package Types (CPack)
+
+- **Linux/macOS:** ZIP and TGZ archives
+- **Windows:** ZIP archive plus NSIS and WiX installers
+
+Package components:
+
+- `runtime` (engine runtime binaries/content)
+- `sdk` (headers, libraries, CMake config)
+- `tools` (spark-cli and build tools)
+- `templates` (starter project templates)
+- `samples` (sample content)
+
+Install layout and versioning policy are documented in [`docs/packaging.md`](docs/packaging.md).
+
 ### CI Artifacts
 
 Per-commit build artifacts from CI on the `Working` branch via [nightly.link](https://nightly.link) (no GitHub login required).
@@ -561,10 +576,11 @@ Two GitHub Actions workflows run automatically:
 
 > ^1 **VS 2026 (v144 toolset):** The VS 2026 CI job is included for forward compatibility but will be skipped until GitHub Actions runners ship with the v144 platform toolset. It is marked `continue-on-error` and does not gate merges.
 
-**`release.yml`** — runs on every push to `master` / `main`:
+**`release.yml`** — runs on release branches (`release/**`) and tags (`v*`):
 - Builds Windows (VS 2022) and Linux (GCC) in Debug + Release
-- Packages each configuration into a zip / tar.gz archive
-- Creates or updates the rolling [`latest` GitHub Release](https://github.com/Krilliac/SparkEngine/releases/tag/latest) with all four binaries and the exact commit hash
+- Runs install + CPack package generation and uploads package artifacts (ZIP/TGZ on Linux, ZIP/NSIS/WiX on Windows)
+- Validates package consumption from a clean external sample using `SparkEngineConfig.cmake`
+- Creates or updates GitHub Release assets with generated package files
 
 **`update-sparkbuild.yml`** — runs weekly (Monday 06:00 UTC) or on manual dispatch:
 - Downloads the latest [SparkBuild](https://github.com/Krilliac/SparkBuild) release binary
@@ -576,6 +592,7 @@ Two GitHub Actions workflows run automatically:
 - **[Feature Roadmap](docs/FEATURE_ROADMAP.md)** — Planned features across 3 priority tiers
 - **[Project Status](docs/PROJECT_STATUS.md)** — Current system status and recent changes
 - **[API Documentation](docs/README.md)** — Doxygen-based auto-generated API docs
+- **[Packaging Guide](docs/packaging.md)** — Package formats, install layout, components, and versioning policy
 - **[AI Prompt Library](.github/AI_README.md)** — Prompts for Copilot, GPT, Claude, and others
 
 ### Generating API Docs

--- a/Tests/PackageSmoke/CMakeLists.txt
+++ b/Tests/PackageSmoke/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.25)
+project(SparkPackageSmoke LANGUAGES CXX)
+
+find_package(SparkEngine REQUIRED)
+
+add_executable(spark_package_smoke main.cpp)
+
+target_compile_features(spark_package_smoke PRIVATE cxx_std_23)
+target_link_libraries(spark_package_smoke PRIVATE Spark::SparkEngineLib)
+
+target_include_directories(spark_package_smoke PRIVATE
+    ${SPARK_ENGINE_INCLUDE_DIR}
+    ${SPARK_ENGINE_SDK_DIR}
+)

--- a/Tests/PackageSmoke/main.cpp
+++ b/Tests/PackageSmoke/main.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << "Spark package smoke test" << '\n';
+    return 0;
+}

--- a/cmake/SparkCPack.cmake
+++ b/cmake/SparkCPack.cmake
@@ -1,81 +1,14 @@
 # =============================================================================
-# SparkCPack.cmake — CPack packaging configuration for SparkEngine
+# SparkCPack.cmake (compatibility shim)
 # =============================================================================
 #
-# Generates distributable packages (ZIP, TGZ, NSIS on Windows).
-# Include this file from the root CMakeLists.txt to enable `cpack` commands.
+# CPack metadata now lives in the top-level CMakeLists.txt so package
+# configuration is visible next to install/component definitions.
+# This file is intentionally kept as a lightweight include target for
+# downstream scripts that still include(cmake/SparkCPack.cmake).
 
-# Package metadata
-set(CPACK_PACKAGE_NAME "SparkEngine")
-set(CPACK_PACKAGE_VENDOR "Spark Engine Team")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "C++23 3D Game Engine")
-set(CPACK_PACKAGE_VERSION_MAJOR 1)
-set(CPACK_PACKAGE_VERSION_MINOR 0)
-set(CPACK_PACKAGE_VERSION_PATCH 0)
-set(CPACK_PACKAGE_CONTACT "https://github.com/SparkEngine")
-set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/SparkEngine")
-
-if(EXISTS "${CMAKE_SOURCE_DIR}/LICENSE")
-    set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE")
+if(NOT DEFINED CPACK_PACKAGE_NAME)
+    message(FATAL_ERROR
+        "SparkCPack.cmake is a compatibility shim. Include the project root "
+        "CMakeLists.txt (which calls include(CPack)) to configure packaging.")
 endif()
-
-if(EXISTS "${CMAKE_SOURCE_DIR}/README.md")
-    set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")
-endif()
-
-# Generator configuration — ZIP and TGZ everywhere, NSIS on Windows
-set(CPACK_GENERATOR "ZIP;TGZ")
-if(WIN32)
-    list(APPEND CPACK_GENERATOR "NSIS")
-    set(CPACK_NSIS_DISPLAY_NAME "SparkEngine SDK")
-    set(CPACK_NSIS_INSTALL_ROOT "$PROGRAMFILES64")
-    set(CPACK_NSIS_PACKAGE_NAME "SparkEngine ${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
-    set(CPACK_NSIS_HELP_LINK "https://github.com/SparkEngine")
-    set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
-endif()
-
-# Component-based install
-set(CPACK_COMPONENTS_ALL Runtime Development Headers Shaders Templates)
-
-set(CPACK_COMPONENT_RUNTIME_DISPLAY_NAME "Engine Runtime")
-set(CPACK_COMPONENT_RUNTIME_DESCRIPTION "Core engine binaries and shared libraries")
-set(CPACK_COMPONENT_RUNTIME_REQUIRED ON)
-
-set(CPACK_COMPONENT_DEVELOPMENT_DISPLAY_NAME "Development Libraries")
-set(CPACK_COMPONENT_DEVELOPMENT_DESCRIPTION "Static libraries and import libraries for linking")
-set(CPACK_COMPONENT_DEVELOPMENT_DEPENDS Runtime)
-
-set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "SDK Headers")
-set(CPACK_COMPONENT_HEADERS_DESCRIPTION "Public header files for engine development")
-set(CPACK_COMPONENT_HEADERS_DEPENDS Development)
-
-set(CPACK_COMPONENT_SHADERS_DISPLAY_NAME "Shader Files")
-set(CPACK_COMPONENT_SHADERS_DESCRIPTION "Built-in shader source files")
-
-set(CPACK_COMPONENT_TEMPLATES_DISPLAY_NAME "Project Templates")
-set(CPACK_COMPONENT_TEMPLATES_DESCRIPTION "Starter project templates for new game modules")
-
-# Component grouping
-set(CPACK_COMPONENT_RUNTIME_GROUP "Core")
-set(CPACK_COMPONENT_DEVELOPMENT_GROUP "SDK")
-set(CPACK_COMPONENT_HEADERS_GROUP "SDK")
-set(CPACK_COMPONENT_SHADERS_GROUP "Content")
-set(CPACK_COMPONENT_TEMPLATES_GROUP "Content")
-
-# Source package configuration
-set(CPACK_SOURCE_GENERATOR "TGZ;ZIP")
-set(CPACK_SOURCE_IGNORE_PATTERN
-    "/build/"
-    "/.git/"
-    "/.claude/"
-    "/.vs/"
-    "/.vscode/"
-    "/out/"
-    "\\\\.user$"
-    "\\\\.suo$"
-)
-
-# Package naming
-set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}-${CMAKE_SYSTEM_NAME}")
-
-include(CPack)

--- a/cmake/SparkEngineConfig.cmake.in
+++ b/cmake/SparkEngineConfig.cmake.in
@@ -1,5 +1,24 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
+if(NOT WIN32)
+    find_dependency(Threads REQUIRED)
+endif()
+
+if(NOT TARGET OpenGL::GL)
+    find_package(OpenGL QUIET)
+endif()
+if(NOT TARGET Vulkan::Vulkan)
+    find_package(Vulkan QUIET)
+endif()
+if(NOT TARGET X11::X11)
+    find_package(X11 QUIET)
+endif()
+if(NOT TARGET SDL2::SDL2 AND NOT TARGET SDL2)
+    find_package(SDL2 QUIET)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/SparkEngineTargets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/SparkGameModule.cmake")
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,63 @@
+# SparkEngine Packaging and Distribution
+
+This document defines SparkEngine binary package formats, install layout, components, and versioning policy.
+
+## Package Generators
+
+SparkEngine uses CPack from the top-level `CMakeLists.txt`.
+
+- **Linux/macOS:** `ZIP`, `TGZ`
+- **Windows:** `ZIP`, `NSIS`, `WIX`
+
+Create packages after configure/build:
+
+```bash
+cmake --build build --config Release
+cpack --config build/CPackConfig.cmake
+```
+
+## Package Components
+
+CPack component install is enabled. Components are:
+
+- `runtime` — engine runtime binaries and runtime shader content
+- `sdk` — public headers, static libraries, and CMake package files (`SparkEngineConfig.cmake`)
+- `tools` — helper tooling (`spark-cli`, `SparkShaderCompiler` when built)
+- `templates` — starter project templates under `Templates/`
+- `samples` — sample project content (`Samples/` when present, plus `GameModules/SparkGame` source snapshot)
+
+## Install Layout
+
+Default install prefix layout:
+
+- `bin/` — runtime executables and runtime content
+- `lib/` — static/shared libraries
+- `include/` — `SparkSDK` and engine public headers
+- `lib/cmake/SparkEngine/` — `SparkEngineConfig.cmake`, `SparkEngineConfigVersion.cmake`, target exports, helpers
+- `tools/` — Spark command-line tooling
+- `share/SparkEngine/templates/` — installable templates
+- `share/SparkEngine/samples/` — installable sample content
+
+## External Consumption (`find_package`)
+
+After installation:
+
+```bash
+cmake -S MyGame -B build -DSparkEngine_DIR=/path/to/install/lib/cmake/SparkEngine
+```
+
+Then in the external CMake project:
+
+```cmake
+find_package(SparkEngine REQUIRED)
+target_link_libraries(MyTarget PRIVATE Spark::SparkEngineLib)
+```
+
+A CI smoke project exists at `Tests/PackageSmoke/` and is used to validate package consumption on release pipelines.
+
+## Versioning Policy
+
+- Engine package version is driven by `SPARK_ENGINE_VERSION` (cache var) and mapped to `project(... VERSION ...)`.
+- `SparkEngineConfigVersion.cmake` uses `SameMajorVersion` compatibility.
+- Release tags are expected as `vMAJOR.MINOR.PATCH` and should align with `SPARK_ENGINE_VERSION` before final release publishing.
+- Nightly/release branch package artifacts are CI-generated snapshots and may include pre-release behavior.


### PR DESCRIPTION
### Motivation
- Provide reproducible distributable packages (ZIP/TGZ on Linux/macOS; ZIP/NSIS/WiX on Windows) and a clear SDK/install layout for external game projects. 
- Separate runtime, SDK, tools, templates and samples into installable components so downstream users can consume just what they need. 
- Wire packaging into CI release jobs and validate `find_package(SparkEngine)` consumption from a clean external project. 

### Description
- Exposed `SPARK_ENGINE_VERSION` and made `project(... VERSION ...)` drive CPack package versioning via `SparkEngineConfigVersion.cmake`. 
- Added CPack metadata & generator configuration to the top-level `CMakeLists.txt` and enabled componentized packaging (`runtime`, `sdk`, `tools`, `templates`, `samples`) with component descriptions, grouping and source-package settings. 
- Implemented component-aware install rules and file layout (`bin/`, `lib/`, `include/`, `lib/cmake/SparkEngine/`, `tools/`, `share/SparkEngine/...`) and exported `SparkEngineTargets` for `find_package` consumption. 
- Hardened `cmake/SparkEngineConfig.cmake.in` to locate required `Threads` but probe optional platform deps (`OpenGL`, `Vulkan`, `X11`, `SDL2`) without failing package discovery. 
- Adjusted target link expressions to `$<BUILD_INTERFACE:...>` for third-party build-only targets so exported targets remain consistent. 
- Kept `cmake/SparkCPack.cmake` as a lightweight compatibility shim for downstream includes. 
- CI: updated `.github/workflows/release.yml` to trigger on `release/**` branches and `v*` tags, run `cmake --install` into a staging prefix, generate CPack packages (`cpack`), upload all package artifacts, and run an external package-consumption validation step. 
- Added a minimal smoke consumer at `Tests/PackageSmoke/` and `docs/packaging.md` plus README release/packaging notes. 

### Testing
- Ran CMake configure for packaging smoke: `cmake -S . -B build-packaging-smoke -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF -DENABLE_EDITOR=OFF -DBUILD_GAME_MODULES=OFF` which completed successfully. 
- Built the engine static library: `cmake --build build-packaging-smoke --target SparkEngineLib --parallel 4` and the build succeeded. 
- Installed the SDK component: `cmake --install build-packaging-smoke --prefix /tmp/spark-package-stage --component sdk` and the SDK files and CMake config files were installed successfully. 
- Validated external consumption by configuring and building the smoke consumer: `cmake -S Tests/PackageSmoke -B build-package-consumer3 -DSparkEngine_DIR=/tmp/spark-package-stage/lib/cmake/SparkEngine` and `cmake --build build-package-consumer3` which succeeded. 
- Attempted local `cpack` runs: forcing only `sdk` via `-D CPACK_COMPONENTS_ALL=sdk` failed because the component dependency graph requires `runtime`; a direct local `cpack` invocation produced an error when packaging a component set that left `runtime` absent (expected with partial-component attempts). 
- Note: CI path performs a full `cmake --install` into a staging prefix followed by `cpack` (no forced single-component override) and is configured to upload resulting packages and validate the installed package with the smoke consumer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d76c0c6fac83269abe3e514e0356a2)