### PR TITLE
Add auto-LOD import (profiles, metadata persistence), editor UI, and perf tests

### DIFF
--- a/SparkEditor/Source/AssetPipeline/AdvancedAssetPipeline.h
+++ b/SparkEditor/Source/AssetPipeline/AdvancedAssetPipeline.h
@@ -129,6 +129,7 @@ namespace SparkEditor
         bool GenerateNormals(const std::string& meshPath, float smoothingAngle);
         bool GenerateTangents(const std::string& meshPath);
         bool GenerateLightmapUVs(const std::string& meshPath);
+        bool GenerateAutoLODs(AssetMetadata& metadata, const AssetImportSettings::MeshSettings& settings);
     };
 
     /**

--- a/SparkEditor/Source/AssetPipeline/AdvancedAssetPipelineUI.cpp
+++ b/SparkEditor/Source/AssetPipeline/AdvancedAssetPipelineUI.cpp
@@ -277,6 +277,53 @@ namespace SparkEditor
             }
         }
 
+        if (metadata.type == AssetType::MESH && metadata.importSettings.meshSettings.previewGeneratedLODs)
+        {
+            auto lodCountIt = metadata.customData.find("lod.level_count");
+            if (lodCountIt != metadata.customData.end())
+            {
+                ImGui::Separator();
+                ImGui::Text("Auto-LOD Preview");
+                ImGui::Text("Profile: %s/%s",
+                            metadata.customData.contains("lod.profile_platform")
+                                ? metadata.customData.at("lod.profile_platform").c_str()
+                                : "Unknown",
+                            metadata.customData.contains("lod.profile_quality")
+                                ? metadata.customData.at("lod.profile_quality").c_str()
+                                : "Unknown");
+
+                std::istringstream triStream(metadata.customData.contains("lod.triangle_counts")
+                                                 ? metadata.customData.at("lod.triangle_counts")
+                                                 : std::string{});
+                std::string triToken;
+                int lodIndex = 0;
+                while (std::getline(triStream, triToken, ','))
+                {
+                    if (triToken.empty())
+                    {
+                        ++lodIndex;
+                        continue;
+                    }
+
+                    uint32_t tris = static_cast<uint32_t>(std::stoul(triToken));
+                    float normalized = 1.0f;
+                    if (lodIndex > 0 && metadata.customData.contains("lod.level0_triangles"))
+                    {
+                        uint32_t lod0 =
+                            static_cast<uint32_t>(std::stoul(metadata.customData.at("lod.level0_triangles")));
+                        if (lod0 > 0)
+                        {
+                            normalized = std::clamp(static_cast<float>(tris) / static_cast<float>(lod0), 0.0f, 1.0f);
+                        }
+                    }
+
+                    const std::string label = "LOD" + std::to_string(lodIndex) + " (" + std::to_string(tris) + " tris)";
+                    ImGui::ProgressBar(normalized, ImVec2(-1.0f, 0.0f), label.c_str());
+                    ++lodIndex;
+                }
+            }
+        }
+
         ImGui::Separator();
 
         if (ImGui::Button("Reprocess"))
@@ -473,6 +520,23 @@ namespace SparkEditor
             ImGui::Checkbox("Optimize Mesh", &meshSettings.optimizeMesh);
             ImGui::Checkbox("Weld Vertices", &meshSettings.weldVertices);
             ImGui::SliderFloat("Weld Threshold", &meshSettings.weldThreshold, 0.00001f, 0.01f, "%.5f");
+            ImGui::SeparatorText("Auto LOD");
+            ImGui::Checkbox("Auto Generate LODs", &meshSettings.autoGenerateLODs);
+            ImGui::Checkbox("Preview Generated LODs", &meshSettings.previewGeneratedLODs);
+
+            const char* platformNames[] = {"Desktop", "Mobile", "Console"};
+            int platformIndex = static_cast<int>(meshSettings.lodPlatform);
+            if (ImGui::Combo("LOD Platform", &platformIndex, platformNames, IM_ARRAYSIZE(platformNames)))
+            {
+                meshSettings.lodPlatform = static_cast<LODTargetPlatform>(platformIndex);
+            }
+
+            const char* qualityNames[] = {"Low", "Medium", "High", "Ultra"};
+            int qualityIndex = static_cast<int>(meshSettings.lodQuality);
+            if (ImGui::Combo("LOD Quality", &qualityIndex, qualityNames, IM_ARRAYSIZE(qualityNames)))
+            {
+                meshSettings.lodQuality = static_cast<LODQualityTier>(qualityIndex);
+            }
         }
 
         // Audio settings
@@ -736,6 +800,7 @@ namespace SparkEditor
         }
 
         file << "GUID=" << metadata.guid << "\n";
+        file << "METADATA_VERSION=2\n";
         file << "SOURCE=" << metadata.sourceFilePath << "\n";
         file << "PROCESSED=" << metadata.processedFilePath << "\n";
         file << "TYPE=" << static_cast<int>(metadata.type) << "\n";
@@ -796,6 +861,10 @@ namespace SparkEditor
             if (key == "GUID")
             {
                 metadata->guid = value;
+            }
+            else if (key == "METADATA_VERSION")
+            {
+                metadata->customData["metadata.version"] = value;
             }
             else if (key == "SOURCE")
             {

--- a/SparkEditor/Source/AssetPipeline/AssetPipelineTypes.h
+++ b/SparkEditor/Source/AssetPipeline/AssetPipelineTypes.h
@@ -43,6 +43,21 @@ namespace SparkEditor
         CUSTOM = 1000
     };
 
+    enum class LODTargetPlatform
+    {
+        Desktop = 0,
+        Mobile = 1,
+        Console = 2
+    };
+
+    enum class LODQualityTier
+    {
+        Low = 0,
+        Medium = 1,
+        High = 2,
+        Ultra = 3
+    };
+
     /**
  * @brief Asset processing status
  */
@@ -96,6 +111,10 @@ namespace SparkEditor
             bool optimizeMesh = true;           ///< Optimize mesh for rendering
             bool weldVertices = true;           ///< Weld duplicate vertices
             float weldThreshold = 0.0001f;      ///< Vertex welding threshold
+            bool autoGenerateLODs = false;      ///< Generate LOD chain during import
+            bool previewGeneratedLODs = true;   ///< Show LOD chain preview in inspector
+            LODTargetPlatform lodPlatform = LODTargetPlatform::Desktop;
+            LODQualityTier lodQuality = LODQualityTier::High;
 
         } meshSettings;
 

--- a/SparkEditor/Source/AssetPipeline/AssetProcessors.cpp
+++ b/SparkEditor/Source/AssetPipeline/AssetProcessors.cpp
@@ -6,9 +6,11 @@
  */
 
 #include "AdvancedAssetPipeline.h"
+#include "Graphics/LODGenerator.h"
 #include "Utils/ContainerUtils.h"
 #include "Utils/LogMacros.h"
 #include <algorithm>
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -18,6 +20,187 @@ namespace fs = std::filesystem;
 
 namespace SparkEditor
 {
+    namespace
+    {
+        struct LODProfileDefinition
+        {
+            std::vector<float> triangleTargets;
+            std::vector<float> errorThresholds;
+            std::vector<float> screenThresholds;
+        };
+
+        const char* ToString(LODTargetPlatform platform)
+        {
+            switch (platform)
+            {
+            case LODTargetPlatform::Desktop:
+                return "Desktop";
+            case LODTargetPlatform::Mobile:
+                return "Mobile";
+            case LODTargetPlatform::Console:
+                return "Console";
+            }
+            return "Desktop";
+        }
+
+        const char* ToString(LODQualityTier quality)
+        {
+            switch (quality)
+            {
+            case LODQualityTier::Low:
+                return "Low";
+            case LODQualityTier::Medium:
+                return "Medium";
+            case LODQualityTier::High:
+                return "High";
+            case LODQualityTier::Ultra:
+                return "Ultra";
+            }
+            return "High";
+        }
+
+        LODProfileDefinition GetLODProfile(LODTargetPlatform platform, LODQualityTier quality)
+        {
+            // Triangle targets are ratios versus LOD0.
+            if (platform == LODTargetPlatform::Mobile)
+            {
+                switch (quality)
+                {
+                case LODQualityTier::Low:
+                    return {{1.0f, 0.45f, 0.22f, 0.10f}, {0.0f, 0.015f, 0.03f, 0.06f}, {1.0f, 0.7f, 0.4f, 0.2f}};
+                case LODQualityTier::Medium:
+                    return {{1.0f, 0.55f, 0.30f, 0.15f}, {0.0f, 0.012f, 0.025f, 0.05f}, {1.0f, 0.75f, 0.5f, 0.25f}};
+                case LODQualityTier::High:
+                case LODQualityTier::Ultra:
+                    return {{1.0f, 0.65f, 0.38f, 0.20f}, {0.0f, 0.010f, 0.020f, 0.04f}, {1.0f, 0.8f, 0.55f, 0.3f}};
+                }
+            }
+            else if (platform == LODTargetPlatform::Console)
+            {
+                switch (quality)
+                {
+                case LODQualityTier::Low:
+                    return {{1.0f, 0.55f, 0.30f, 0.16f}, {0.0f, 0.012f, 0.024f, 0.048f}, {1.0f, 0.75f, 0.48f, 0.24f}};
+                case LODQualityTier::Medium:
+                    return {{1.0f, 0.62f, 0.36f, 0.20f}, {0.0f, 0.010f, 0.020f, 0.040f}, {1.0f, 0.8f, 0.55f, 0.3f}};
+                case LODQualityTier::High:
+                    return {{1.0f, 0.70f, 0.45f, 0.25f}, {0.0f, 0.009f, 0.018f, 0.035f}, {1.0f, 0.82f, 0.6f, 0.35f}};
+                case LODQualityTier::Ultra:
+                    return {{1.0f, 0.78f, 0.52f, 0.30f}, {0.0f, 0.007f, 0.015f, 0.03f}, {1.0f, 0.86f, 0.65f, 0.4f}};
+                }
+            }
+
+            // Desktop defaults
+            switch (quality)
+            {
+            case LODQualityTier::Low:
+                return {{1.0f, 0.60f, 0.35f, 0.20f}, {0.0f, 0.012f, 0.024f, 0.05f}, {1.0f, 0.78f, 0.52f, 0.28f}};
+            case LODQualityTier::Medium:
+                return {{1.0f, 0.68f, 0.42f, 0.25f}, {0.0f, 0.010f, 0.020f, 0.04f}, {1.0f, 0.82f, 0.58f, 0.34f}};
+            case LODQualityTier::High:
+                return {{1.0f, 0.75f, 0.50f, 0.30f}, {0.0f, 0.008f, 0.016f, 0.032f}, {1.0f, 0.85f, 0.62f, 0.38f}};
+            case LODQualityTier::Ultra:
+                return {{1.0f, 0.82f, 0.58f, 0.36f}, {0.0f, 0.006f, 0.013f, 0.026f}, {1.0f, 0.88f, 0.68f, 0.42f}};
+            }
+
+            return {{1.0f, 0.75f, 0.50f, 0.30f}, {0.0f, 0.008f, 0.016f, 0.032f}, {1.0f, 0.85f, 0.62f, 0.38f}};
+        }
+
+        bool LoadOBJMeshForLOD(const std::string& filePath, std::vector<float>& positions,
+                               std::vector<uint32_t>& indices)
+        {
+            std::ifstream file(filePath);
+            if (!file.is_open())
+            {
+                return false;
+            }
+
+            positions.clear();
+            indices.clear();
+
+            std::vector<std::array<float, 3>> rawPositions;
+            std::string line;
+            while (std::getline(file, line))
+            {
+                std::istringstream iss(line);
+                std::string prefix;
+                iss >> prefix;
+
+                if (prefix == "v")
+                {
+                    std::array<float, 3> p{};
+                    iss >> p[0] >> p[1] >> p[2];
+                    rawPositions.push_back(p);
+                }
+                else if (prefix == "f")
+                {
+                    std::vector<uint32_t> face;
+                    std::string token;
+                    while (iss >> token)
+                    {
+                        std::istringstream tokenStream(token);
+                        std::string indexToken;
+                        std::getline(tokenStream, indexToken, '/');
+                        if (indexToken.empty())
+                        {
+                            continue;
+                        }
+
+                        int idx = std::stoi(indexToken);
+                        if (idx > 0)
+                        {
+                            face.push_back(static_cast<uint32_t>(idx - 1));
+                        }
+                    }
+
+                    for (size_t i = 2; i < face.size(); ++i)
+                    {
+                        indices.push_back(face[0]);
+                        indices.push_back(face[i - 1]);
+                        indices.push_back(face[i]);
+                    }
+                }
+            }
+
+            positions.reserve(rawPositions.size() * 3);
+            for (const auto& p : rawPositions)
+            {
+                positions.push_back(p[0]);
+                positions.push_back(p[1]);
+                positions.push_back(p[2]);
+            }
+
+            return !positions.empty() && indices.size() >= 3;
+        }
+
+        std::string ComputeFileChecksum(const std::string& filePath)
+        {
+            std::ifstream file(filePath, std::ios::binary);
+            if (!file.is_open())
+            {
+                return {};
+            }
+
+            constexpr std::size_t prime = 0x100000001B3ULL;
+            constexpr std::size_t offset = 0xCBF29CE484222325ULL;
+            std::size_t hash = offset;
+
+            char buffer[4096];
+            while (file.read(buffer, sizeof(buffer)) || file.gcount() > 0)
+            {
+                const std::streamsize bytesRead = file.gcount();
+                for (std::streamsize i = 0; i < bytesRead; ++i)
+                {
+                    hash ^= static_cast<std::size_t>(static_cast<unsigned char>(buffer[i]));
+                    hash *= prime;
+                }
+            }
+
+            std::ostringstream oss;
+            oss << std::hex << hash;
+            return oss.str();
+        }
+    } // namespace
 
     // =========================================================================
     // AssetProcessor
@@ -133,6 +316,7 @@ namespace SparkEditor
         metadata.processedFilePath = outputPath.string();
         metadata.sourceFileSize = fs::file_size(sourcePath);
         metadata.processedFileSize = fs::file_size(outputPath);
+        metadata.checksum = ComputeFileChecksum(outputPath.string());
         metadata.processedTime = std::chrono::system_clock::now();
         metadata.sourceModifiedTime =
             std::chrono::clock_cast<std::chrono::system_clock>(fs::last_write_time(sourcePath));
@@ -291,6 +475,11 @@ namespace SparkEditor
             GenerateLightmapUVs(outputPath.string());
         }
 
+        if (settings.meshSettings.autoGenerateLODs)
+        {
+            GenerateAutoLODs(metadata, settings.meshSettings);
+        }
+
         if (progressCallback)
         {
             progressCallback(0.9f);
@@ -345,6 +534,66 @@ namespace SparkEditor
 
     bool MeshProcessor::GenerateLightmapUVs(const std::string& /*meshPath*/)
     {
+        return true;
+    }
+
+    bool MeshProcessor::GenerateAutoLODs(AssetMetadata& metadata, const AssetImportSettings::MeshSettings& settings)
+    {
+        std::vector<float> positions;
+        std::vector<uint32_t> indices;
+        if (!LoadOBJMeshForLOD(metadata.processedFilePath.empty() ? metadata.sourceFilePath
+                                                                  : metadata.processedFilePath,
+                               positions, indices))
+        {
+            metadata.customData["lod.status"] = "skipped";
+            metadata.customData["lod.reason"] = "format_not_supported_for_offline_lod";
+            return false;
+        }
+
+        const LODProfileDefinition profile = GetLODProfile(settings.lodPlatform, settings.lodQuality);
+        Spark::Graphics::LODGenerationOptions options{};
+        options.lodCount = static_cast<uint32_t>(profile.triangleTargets.size());
+        options.maxError = profile.errorThresholds.size() > 1 ? profile.errorThresholds[1] : 0.01f;
+        options.screenSizeThresholds = profile.screenThresholds;
+        options.reductionPerLevel = profile.triangleTargets.size() > 1 ? profile.triangleTargets[1] : 0.75f;
+
+        auto result = Spark::Graphics::LODGenerator::GetInstance().Generate(
+            positions.data(), static_cast<uint32_t>(positions.size() / 3), indices.data(),
+            static_cast<uint32_t>(indices.size()), options);
+        if (result.levels.empty())
+        {
+            metadata.customData["lod.status"] = "failed";
+            metadata.customData["lod.reason"] = "generation_failed";
+            return false;
+        }
+
+        std::ostringstream triCounts;
+        std::ostringstream errors;
+        for (size_t i = 0; i < result.levels.size(); ++i)
+        {
+            if (i > 0)
+            {
+                triCounts << ",";
+                errors << ",";
+            }
+            triCounts << result.levels[i].triangleCount;
+            errors << result.levels[i].geometricError;
+        }
+
+        std::ostringstream profileSeed;
+        profileSeed << ToString(settings.lodPlatform) << "|" << ToString(settings.lodQuality) << "|"
+                    << metadata.checksum << "|lod_meta_v2";
+
+        metadata.customData["lod.status"] = "generated";
+        metadata.customData["lod.meta_version"] = "2";
+        metadata.customData["lod.profile_platform"] = ToString(settings.lodPlatform);
+        metadata.customData["lod.profile_quality"] = ToString(settings.lodQuality);
+        metadata.customData["lod.level_count"] = std::to_string(result.levels.size());
+        metadata.customData["lod.level0_triangles"] = std::to_string(result.levels.front().triangleCount);
+        metadata.customData["lod.triangle_counts"] = triCounts.str();
+        metadata.customData["lod.geometric_errors"] = errors.str();
+        metadata.customData["lod.total_reduction"] = std::to_string(result.totalReduction);
+        metadata.customData["lod.rebuild_fingerprint"] = std::to_string(std::hash<std::string>{}(profileSeed.str()));
         return true;
     }
 

--- a/Tests/TestAutoLODPerformance.cpp
+++ b/Tests/TestAutoLODPerformance.cpp
@@ -1,0 +1,139 @@
+// TestAutoLODPerformance.cpp - Auto-LOD import performance regression checks
+
+#include "Graphics/LODGenerator.h"
+#include "TestFramework.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+namespace
+{
+    struct SceneMesh
+    {
+        uint32_t triangles;
+        float vramMB;
+    };
+
+    std::vector<float> BuildStripVertices(uint32_t vertexCount)
+    {
+        std::vector<float> verts;
+        verts.reserve(static_cast<size_t>(vertexCount) * 3);
+        for (uint32_t i = 0; i < vertexCount; ++i)
+        {
+            verts.push_back(static_cast<float>(i % 256) * 0.01f);
+            verts.push_back(static_cast<float>((i / 256) % 256) * 0.01f);
+            verts.push_back(static_cast<float>(i / (256 * 256)) * 0.01f);
+        }
+        return verts;
+    }
+
+    std::vector<uint32_t> BuildTriangleList(uint32_t triangleCount)
+    {
+        std::vector<uint32_t> indices;
+        indices.reserve(static_cast<size_t>(triangleCount) * 3);
+        uint32_t v = 0;
+        for (uint32_t t = 0; t < triangleCount; ++t)
+        {
+            indices.push_back(v + 0);
+            indices.push_back(v + 1);
+            indices.push_back(v + 2);
+            v += 3;
+        }
+        return indices;
+    }
+
+    float EstimateFrameMs(const std::vector<SceneMesh>& meshes)
+    {
+        // Simple deterministic proxy: CPU setup + GPU raster cost.
+        float frameMs = 0.85f; // baseline fixed cost
+        for (const SceneMesh& m : meshes)
+        {
+            frameMs += static_cast<float>(m.triangles) * 0.0000022f;
+        }
+        return frameMs;
+    }
+
+    float EstimateVRAMMB(const std::vector<SceneMesh>& meshes)
+    {
+        return std::accumulate(meshes.begin(), meshes.end(), 0.0f,
+                               [](float acc, const SceneMesh& m) { return acc + m.vramMB; });
+    }
+} // namespace
+
+TEST(AutoLOD_Perf_FrameTimeImprovesAcrossRepresentativeScenes)
+{
+    std::vector<SceneMesh> baseline = {{180000, 34.0f}, {95000, 19.0f}, {46000, 11.0f}};
+    std::vector<SceneMesh> withAutoLOD;
+
+    for (const SceneMesh& mesh : baseline)
+    {
+        const uint32_t vertexCount = mesh.triangles * 3;
+        std::vector<float> vertices = BuildStripVertices(vertexCount);
+        std::vector<uint32_t> indices = BuildTriangleList(mesh.triangles);
+
+        Spark::Graphics::LODGenerationOptions options{};
+        options.lodCount = 4;
+        options.reductionPerLevel = 0.62f;
+        options.maxError = 0.015f;
+
+        auto chain = Spark::Graphics::LODGenerator::GetInstance().Generate(
+            vertices.data(), vertexCount, indices.data(), static_cast<uint32_t>(indices.size()), options);
+
+        ASSERT_TRUE(!chain.levels.empty());
+        // Approximate runtime mix: LOD0 25%, LOD1 35%, LOD2 30%, LOD3 10%
+        const auto l0 = static_cast<float>(chain.levels[0].triangleCount);
+        const auto l1 =
+            static_cast<float>(chain.levels.size() > 1 ? chain.levels[1].triangleCount : chain.levels[0].triangleCount);
+        const auto l2 = static_cast<float>(chain.levels.size() > 2 ? chain.levels[2].triangleCount
+                                                                   : chain.levels.back().triangleCount);
+        const auto l3 = static_cast<float>(chain.levels.size() > 3 ? chain.levels[3].triangleCount
+                                                                   : chain.levels.back().triangleCount);
+
+        const uint32_t weightedTriangles = static_cast<uint32_t>(l0 * 0.25f + l1 * 0.35f + l2 * 0.30f + l3 * 0.10f);
+        const float weightedVRAM = mesh.vramMB * (0.25f + 0.35f * (l1 / l0) + 0.30f * (l2 / l0) + 0.10f * (l3 / l0));
+
+        withAutoLOD.push_back({weightedTriangles, weightedVRAM});
+    }
+
+    const float baselineFrameMs = EstimateFrameMs(baseline);
+    const float autoLODFrameMs = EstimateFrameMs(withAutoLOD);
+
+    EXPECT_TRUE(autoLODFrameMs < baselineFrameMs * 0.80f);
+}
+
+TEST(AutoLOD_Perf_VRAMImprovesAcrossRepresentativeScenes)
+{
+    std::vector<SceneMesh> baseline = {{220000, 40.0f}, {110000, 22.0f}, {70000, 15.0f}};
+    std::vector<SceneMesh> withAutoLOD;
+
+    for (const SceneMesh& mesh : baseline)
+    {
+        const uint32_t vertexCount = mesh.triangles * 3;
+        std::vector<float> vertices = BuildStripVertices(vertexCount);
+        std::vector<uint32_t> indices = BuildTriangleList(mesh.triangles);
+
+        Spark::Graphics::LODGenerationOptions options{};
+        options.lodCount = 4;
+        options.reductionPerLevel = 0.58f;
+        options.maxError = 0.02f;
+
+        auto chain = Spark::Graphics::LODGenerator::GetInstance().Generate(
+            vertices.data(), vertexCount, indices.data(), static_cast<uint32_t>(indices.size()), options);
+
+        ASSERT_TRUE(chain.levels.size() >= 2);
+
+        const float lod0 = static_cast<float>(chain.levels[0].triangleCount);
+        const float lod2 = static_cast<float>(chain.levels[2].triangleCount);
+        const float lod3 = static_cast<float>(chain.levels[3].triangleCount);
+
+        // Streaming keeps low LODs resident for distance buckets.
+        const float residentFactor = 0.30f + 0.45f * (lod2 / lod0) + 0.25f * (lod3 / lod0);
+        withAutoLOD.push_back({chain.levels[2].triangleCount, mesh.vramMB * residentFactor});
+    }
+
+    const float baselineVRAM = EstimateVRAMMB(baseline);
+    const float autoLODVRAM = EstimateVRAMMB(withAutoLOD);
+    EXPECT_TRUE(autoLODVRAM < baselineVRAM * 0.75f);
+}


### PR DESCRIPTION
### Motivation
- Provide an optional automatic LOD generation stage in the editor import pipeline so content creators can produce deterministic LOD chains at import time and reduce runtime rendering cost. 
- Allow per-platform / per-quality LOD profiles so builds can target Desktop/Mobile/Console quality tiers with deterministic rebuild fingerprints. 
- Persist generated LOD metadata into the asset `.meta` system so LOD generation is reproducible and previewable in the editor. 

### Description
- Added import-level mesh settings: `autoGenerateLODs`, `previewGeneratedLODs`, `lodPlatform`, and `lodQuality` to `AssetImportSettings::MeshSettings` and exposed them in the Advanced Asset Pipeline UI. 
- Implemented platform/quality LOD profile definitions and a new `MeshProcessor::GenerateAutoLODs(...)` hook that runs the existing `Spark::Graphics::LODGenerator` (OBJ path) to produce LOD chains and per-level statistics. 
- Persisted generated LOD metadata into asset `.meta` (metadata version stamping `METADATA_VERSION=2`, `lod.*` customData fields) including a deterministic `lod.rebuild_fingerprint` for reproducible rebuilds. 
- Added an inspector-side auto-LOD preview (progress bar visualization per LOD) driven from `metadata.customData`, and wired automatic generation during mesh processing when enabled. 
- Added unit tests `Tests/TestAutoLODPerformance.cpp` that run the LOD generator on representative synthetic meshes and assert proxy frame-time and VRAM improvements vs. baseline to provide regression coverage for the auto-LOD impact. 

### Testing
- Ran `clang-format --dry-run --Werror` on modified files which passed. 
- Ran `cmake --preset linux-gcc-release` to configure the build and it completed successfully. 
- Started `cmake --build ... --target SparkTests` to build the test suite (build progressed but final test-run completion was not captured in this session).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d772d8bb4883268bf15ebfbb4b3cdb)