### PR TITLE
Add Tier-3 Polish & Maturity milestone (M1) with 7 scoped epics

### DIFF
--- a/.claude/index.md
+++ b/.claude/index.md
@@ -42,7 +42,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 
 - **Physics**: Jolt Physics (migrated from Bullet3). Use `EngineContext::Get()->GetPhysics()`
 - **Networking**: Enabled by default (`ENABLE_NETWORKING=ON`), UDP sockets, no external deps
-- **Tests**: 341 test files, 4416 tests (all pass on native Linux except 1 pre-existing MMO test)
+- **Tests**: 345 test files, 4434 tests (all pass on native Linux except 1 pre-existing MMO test)
 - **Editor**: 59 panels, all wired including GizmoSystem, CollaborativeEditSession, CinematicSequencer, TimeOfDay, AbilityEditor, TriggerEditor, ConditionEditor, DecalEditor
 - **Rendering**: All 12 former stubs now have .cpp implementations. 6 RHI backends (D3D11, D3D12, Vulkan, OpenGL, Metal, NullRHI)
 - **Post-processing**: 14 passes (Bloom, AutoExposure, Tonemapping, ColorGrading, FXAA, DOF, MotionBlur, Vignette, ChromaticAberration, FilmGrain, LensDistortion, LightShafts, LensFlare, Sharpen)
@@ -50,7 +50,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 - **Game modules**: 10 (SparkGame, FPS, MMO, RPG, ARPG, RTS, Racing, Platformer, OpenWorld, VisualScript)
 - **Infrastructure**: JobSystem wired, DeferredDeletionQueue in RHI, collision layer filtering, EntityEventBus cleanup, archetype spawn overrides
 - **Gameplay**: TimeOfDaySystem, AI enemies in SparkGame, WeatherSystem integration
-- **Codebase**: ~515K lines of C++ across 1581 source files, 125 wiki pages
+- **Codebase**: ~519K lines of C++ across 1604 source files, 125 wiki pages
 
 ### Before Writing Code
 

--- a/.github/badges/files.json
+++ b/.github/badges/files.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": 1,
-  "label": "source files",
-  "message": "1604",
-  "color": "green"
+    "schemaVersion": 1,
+    "label": "source files",
+    "message": "1604",
+    "color": "green"
 }

--- a/.github/badges/loc-breakdown.json
+++ b/.github/badges/loc-breakdown.json
@@ -1,11 +1,11 @@
 {
-  "schemaVersion": 1,
-  "total": 519811,
-  "files": 1604,
-  "engine": 264419,
-  "editor": 86744,
-  "game": 58451,
-  "tests": 107806,
-  "tools": 2391,
-  "updated": "2026-04-09T19:18:33Z"
+    "schemaVersion": 1,
+    "total": 519811,
+    "files": 1604,
+    "engine": 264419,
+    "editor": 86744,
+    "game": 58451,
+    "tests": 107806,
+    "tools": 2391,
+    "updated": "2026-04-09T19:59:07Z"
 }

--- a/.github/badges/loc.json
+++ b/.github/badges/loc.json
@@ -1,8 +1,8 @@
 {
-  "schemaVersion": 1,
-  "label": "C++ lines of code",
-  "message": "519811",
-  "color": "blue",
-  "namedLogo": "cplusplus",
-  "logoColor": "white"
+    "schemaVersion": 1,
+    "label": "C++ lines of code",
+    "message": "519811",
+    "color": "blue",
+    "namedLogo": "cplusplus",
+    "logoColor": "white"
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,7 @@ SparkConsole/        ← External debug console app (named pipe communication)
 
 Shaders/HLSL/        ← DirectX shaders (PBR, post-processing, compute)
 Shaders/GLSL/        ← OpenGL shaders (experimental)
-Tests/               ← 4416 unit tests across 341 files, CTest integration
+Tests/               ← 4434 unit tests across 345 files, CTest integration
 Templates/           ← Game module templates
 Assets/              ← Demo scenes, models, scripts
 ```

--- a/.github/prompts/build-test.prompt.md
+++ b/.github/prompts/build-test.prompt.md
@@ -65,7 +65,7 @@ Builds on every push/PR: Windows MSVC + Linux GCC + Linux Clang (Debug + Release
 
 ## Testing
 
-4416 unit tests across 341 files in `Tests/` with internal framework + CTest.
+4434 unit tests across 345 files in `Tests/` with internal framework + CTest.
 
 ```bash
 cd build && ctest --output-on-failure          # all tests

--- a/.github/prompts/copilot-instructions.md
+++ b/.github/prompts/copilot-instructions.md
@@ -40,7 +40,7 @@ SparkConsole/        ← External debug console app (named pipe communication)
 
 Shaders/HLSL/        ← DirectX shaders (PBR, post-processing, compute)
 Shaders/GLSL/        ← OpenGL shaders (experimental)
-Tests/               ← 4416 unit tests across 341 files, CTest integration
+Tests/               ← 4434 unit tests across 345 files, CTest integration
 Templates/           ← Game module templates
 Assets/              ← Demo scenes, models, scripts
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ GameModules/SparkGameVisualScript/Source/ — Visual script game module (DLL)
 SparkConsole/src/                        — Standalone console application
 SparkShaderCompiler/src/                 — Shader compilation tool
 SparkSDK/                                — Public SDK/interface headers
-Tests/                                   — 4416 unit tests across 341 files, CTest
+Tests/                                   — 4434 unit tests across 345 files, CTest
 ```
 
 NullRHIDevice automatically activates when no GPU backend is available — engine continues in headless mode. GLAD (OpenGL loader) and SDL2 are bundled in `ThirdParty/`. SDL2 requires `libgl-dev` before CMake configure on Linux.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 **Quality & Testing:**
 
-[![Tests](https://img.shields.io/badge/tests-4416_cases-brightgreen)](https://github.com/Krilliac/SparkEngine/tree/Working/Tests)
+[![Tests](https://img.shields.io/badge/tests-4434_cases-brightgreen)](https://github.com/Krilliac/SparkEngine/tree/Working/Tests)
 [![clang--format](https://img.shields.io/badge/style-clang--format-blue)](https://github.com/Krilliac/SparkEngine/blob/Working/.clang-format)
 [![clang--tidy](https://img.shields.io/badge/analysis-clang--tidy-blue)](https://github.com/Krilliac/SparkEngine/blob/Working/.clang-tidy)
 
@@ -427,7 +427,7 @@ SparkEngine/
 |   |-- Scenes/             # Level/scene JSON files
 |   |-- Scripts/            # AngelScript game scripts
 |-- Templates/               # Game module project templates
-|-- Tests/                   # 4416 unit tests across 341 files (CTest + 5 sanitizers)
+|-- Tests/                   # 4434 unit tests across 345 files (CTest + 5 sanitizers)
 |-- tools/
 |   |-- SparkBuild.exe       # Pre-built SparkBuild binary
 |   |-- update-sparkbuild.*  # Manual update scripts (ps1/sh)
@@ -472,7 +472,7 @@ The following libraries are included directly in the source tree:
 
 ## Tests
 
-4416 unit tests across 341 test files covering all major engine systems, built with a lightweight internal test framework (no external test dependencies). Integrated with CMake's CTest.
+4434 unit tests across 345 test files covering all major engine systems, built with a lightweight internal test framework (no external test dependencies). Integrated with CMake's CTest.
 
 ```bash
 # Build and run tests

--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -37,6 +37,9 @@ Features being evaluated but not yet committed to.
 | **Machine Learning Integration** | **Shipped** (v1.0.0) — Neural texture compression, radiance cache, denoiser, super-resolution. See `ENABLE_NEURAL_RENDERING`. |
 | **Deterministic Lockstep Networking** | Alternative to current snapshot-based replication. |
 
+
+Tier 3 execution is tracked in detail by **Milestone M1**: `docs/plans/tier3-polish-maturity-milestone.md` (7 scoped epics, acceptance tests, perf budgets, owner/estimate, docs gates).
+
 ## Completed (v1.0.0)
 
 Major features shipped in the initial release:

--- a/docs/plans/tier3-polish-maturity-milestone.md
+++ b/docs/plans/tier3-polish-maturity-milestone.md
@@ -1,0 +1,202 @@
+# Milestone: Tier 3 Polish & Maturity (M1)
+
+**Created:** 2026-04-09  
+**Status:** Proposed  
+**Gate:** Milestone is complete only when (1) required CI jobs pass and (2) wiki pages are updated for every subsystem touched by each epic.
+
+## Scope Source
+
+This milestone scopes the seven Tier-3 items from `.claude/knowledge/engine-recommendations-2026-04-04.md` (items 9-15), each represented as one epic.
+
+## Global Completion Gates
+
+1. **CI gate (mandatory):**
+   - `check-format`
+   - `validate-prompts`
+   - `build-linux-gcc`
+   - `build-linux-clang`
+   - `build-linux-asan`
+   - `build-linux-tsan`
+   - `build-windows-vs2022`
+   - `coverage`
+2. **Docs gate (mandatory):**
+   - Every changed subsystem must have its corresponding `wiki/` page updated in the same PR.
+   - `docs/sync-wiki.sh sync` and `docs/update-all-docs.sh check` must pass before merge.
+
+---
+
+## Epic T3-1: CPack Packaging / SDK Distribution
+
+- **Owner:** Build & Release (primary), SDK Maintainer (support)
+- **Estimate:** 8 engineer-days
+- **Subsystems:** CMake/install, packaging, SparkSDK
+- **Perf budget impact:** None at runtime. Build pipeline time budget: **+5 minutes max** for packaging jobs.
+
+### Acceptance Tests
+
+- CPack generates `.zip` and platform-native package artifacts from CI.
+- `find_package(SparkEngine CONFIG REQUIRED)` works in a clean external sample project.
+- Packaged SDK includes headers, import libs, runtime binaries, and license files.
+- Installation paths validate on Windows + Linux.
+
+### Required Docs Updates
+
+- `docs/packaging.md` — add CPack invocation, artifact matrix, troubleshooting.
+- `wiki/Build-System.md` — document packaging targets and install layout.
+- `wiki/Getting-Started.md` — add SDK consumer quickstart.
+
+---
+
+## Epic T3-2: Game Module Code Deduplication
+
+- **Owner:** Gameplay Architecture
+- **Estimate:** 10 engineer-days
+- **Subsystems:** Engine gameplay systems, SparkGameRPG, SparkGameARPG
+- **Perf budget impact:** Neutral to positive. CPU frame budget target: **no regression >0.10 ms** in gameplay-system update slices.
+
+### Acceptance Tests
+
+- RPG/ARPG modules compile and run using shared engine Quest/Dialogue extension points.
+- Existing quest/dialogue save/load compatibility tests pass.
+- New tests verify module-specific behavior through extension hooks (not duplicated systems).
+- Static analysis confirms duplicate class removal from module scope.
+
+### Required Docs Updates
+
+- `wiki/Gameplay-Systems.md` — extension/override model and ownership boundaries.
+- `wiki/Game-Modules.md` — module integration contract for engine-provided gameplay systems.
+- `docs/architecture/gameplay-extension-policy.md` — update policy and examples.
+
+---
+
+## Epic T3-3: Undo/Redo Wiring Completeness
+
+- **Owner:** Editor Team
+- **Estimate:** 7 engineer-days
+- **Subsystems:** SparkEditor command stack, panel editing flows, hierarchy/gizmo operations
+- **Perf budget impact:** Editor interaction budget: **<0.25 ms median** command push/pop overhead; no frame hitch >2 ms on history operations.
+
+### Acceptance Tests
+
+- Transform gizmo move/rotate/scale produce reversible command entries.
+- Component add/remove/edit operations are fully undoable/redone across supported panels.
+- Hierarchy reparent, create, delete are undoable with entity integrity preserved.
+- Serialized undo stack survives editor save/load session boundaries (if persistence is enabled).
+
+### Required Docs Updates
+
+- `wiki/Editor.md` — undo/redo coverage matrix by operation type.
+- `wiki/Editor-Panels.md` — panel compliance table for command wiring.
+- `wiki/Collaborative-Editing.md` — note interaction model between collaboration and local undo.
+
+---
+
+## Epic T3-4: LOD Auto-Generation
+
+- **Owner:** Rendering Geometry Pipeline
+- **Estimate:** 9 engineer-days
+- **Subsystems:** MeshLOD, asset import/cook pipeline, meshoptimizer integration
+- **Perf budget impact:**
+  - Build/cook time budget: **+15% max** per mesh asset.
+  - Runtime render budget target: **-0.50 ms or better** in geometry-heavy scenes at 1080p baseline.
+
+### Acceptance Tests
+
+- Given a high-poly mesh, pipeline emits deterministic LOD chain (L0..Ln) from configured reduction targets.
+- Visual/metric validation: geometric error thresholds stay within configured limits.
+- Runtime LOD selection transitions correctly by distance with no missing index/vertex buffers.
+- Cooked content hash changes only when source mesh/settings change.
+
+### Required Docs Updates
+
+- `wiki/Rendering-System.md` — auto-LOD generation pipeline + quality settings.
+- `wiki/Asset-Pipeline.md` — import/cook options and LOD metadata schema.
+- `docs/specs/asset-format.md` — extend format spec for generated LOD descriptors.
+
+---
+
+## Epic T3-5: Multi-Monitor / Floating Editor Windows
+
+- **Owner:** Editor UX/Platform
+- **Estimate:** 11 engineer-days
+- **Subsystems:** Docking/layout persistence, window lifecycle, platform windowing abstraction
+- **Perf budget impact:** Editor UI frame budget: **no regression >0.30 ms** in ImGui update/render path with two active monitors.
+
+### Acceptance Tests
+
+- Panels can detach to native secondary windows and re-dock reliably.
+- Layout persistence restores multi-monitor placements across editor restarts.
+- Fallback behavior when secondary monitor disappears (hot unplug) is safe and deterministic.
+- DPI scaling and input focus operate correctly across mixed-DPI displays.
+
+### Required Docs Updates
+
+- `wiki/Editor.md` — multi-window workflow and known constraints.
+- `wiki/Editor-Panels.md` — detachable panel support matrix.
+- `wiki/Threading-Model.md` — any thread-affinity constraints for window operations.
+
+---
+
+## Epic T3-6: Multiplayer Tutorial Documentation
+
+- **Owner:** DevRel + Networking
+- **Estimate:** 4 engineer-days
+- **Subsystems:** Documentation/tutorial content; references Networking, ECS, and game module setup
+- **Perf budget impact:** None.
+
+### Acceptance Tests
+
+- A new user can follow the tutorial end-to-end and run a two-client local session.
+- Tutorial code/config snippets compile and run against current default branch.
+- Tutorial includes one authoritative-server example and one client prediction/reconciliation example.
+- Link-check and docs lint pass for all added/updated pages.
+
+### Required Docs Updates
+
+- `wiki/Making-Your-First-Multiplayer-Game.md` — expand to full guided flow.
+- `wiki/Networking.md` — tutorial cross-links and prerequisites.
+- `docs/specs/networking-wire-format.md` — reference tutorial packet examples where applicable.
+
+---
+
+## Epic T3-7: AI/NavMesh Visual Debugger
+
+- **Owner:** AI/Gameplay Systems
+- **Estimate:** 8 engineer-days
+- **Subsystems:** AI runtime debug rendering, navmesh introspection, behavior tree state overlay
+- **Perf budget impact:**
+  - Debug-off: **zero measurable overhead** in shipping/profile builds.
+  - Debug-on: **<=1.00 ms** frame overhead budget on reference AI test scene.
+
+### Acceptance Tests
+
+- Toggleable navmesh polygon overlay with area type coloring.
+- Toggleable perception cones/radii for selected AI entities.
+- Behavior tree node-state visualization (running/success/failure) updates live.
+- Debug renderer remains thread-safe with async AI updates and does not crash on scene reload.
+
+### Required Docs Updates
+
+- `wiki/AI-and-Navigation.md` — debugger usage, overlays, and troubleshooting.
+- `wiki/Editor.md` — where the debugger is exposed in editor UI.
+- `wiki/Debug-Rendering.md` (or equivalent) — draw-call/debug pass integration details.
+
+---
+
+## Tracking Template (per Epic)
+
+- [ ] Scope approved
+- [ ] Implementation merged
+- [ ] Acceptance tests passing
+- [ ] Perf budget validated
+- [ ] Required docs updated (`wiki/` + any `docs/specs/` changes)
+- [ ] CI gate passing
+
+## Exit Criteria (Milestone M1)
+
+Milestone M1 closes only when all seven epics are complete and every epic satisfies:
+
+1. Acceptance tests pass on CI.
+2. Performance impact is within the declared budget.
+3. Required documentation updates are merged, including subsystem wiki pages.
+4. Mandatory CI jobs are green on the integrating branch.

--- a/wiki/Codebase-Statistics.md
+++ b/wiki/Codebase-Statistics.md
@@ -8,33 +8,33 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 
 | Section | Lines |
 |---------|------:|
-| **SparkEngine/Source** | 263169 |
-| **SparkEditor/Source** | 85762 |
-| **GameModules** | 57801 |
-| **Tests** | 106315 |
+| **SparkEngine/Source** | 264419 |
+| **SparkEditor/Source** | 86744 |
+| **GameModules** | 58451 |
+| **Tests** | 107806 |
 | **SparkConsole/src** | 1858 |
 | **SparkShaderCompiler/src** | 533 |
-| **Total C++ (excl. ThirdParty)** | **~515438** |
+| **Total C++ (excl. ThirdParty)** | **~519811** |
 
 ### File Counts
 
 | Category | Count |
 |----------|------:|
-| Header files (.h/.hpp) | 741 |
-| Implementation files (.cpp) | 850 |
+| Header files (.h/.hpp) | 748 |
+| Implementation files (.cpp) | 867 |
 | HLSL shader files | 38 |
 | GLSL shader files | 14 |
 | AngelScript files (.as) | 1 |
-| Test files (.cpp) | 341 |
+| Test files (.cpp) | 345 |
 | Wiki pages (.md) | 125 |
 
 ### Code Density
 
 | Metric | Value |
 |--------|-------|
-| Average lines per .cpp file | ~878 |
-| Average lines per .h file | ~570 |
-| Largest codebase section | Graphics (101158 lines — 38% of SparkEngine/Source) |
+| Average lines per .cpp file | ~860 |
+| Average lines per .h file | ~569 |
+| Largest codebase section | Graphics (101631 lines — 38% of SparkEngine/Source) |
 
 ## SparkEngine/Source Breakdown
 
@@ -42,12 +42,12 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 
 | Subsystem | Lines | % of Source |
 |-----------|------:|:----------:|
-| Graphics | 101158 | 38.4% |
-| Engine (all subsystems) | 79805 | 30.3% |
-| Utils | 36886 | 14.0% |
-| Core | 20266 | 7.7% |
+| Graphics | 101631 | 38.4% |
+| Engine (all subsystems) | 80172 | 30.3% |
+| Utils | 36969 | 13.9% |
+| Core | 20593 | 7.7% |
 | Physics | 10101 | 3.8% |
-| Audio | 5548 | 2.1% |
+| Audio | 5548 | 2.0% |
 | Input | 3888 | 1.4% |
 | SceneManager | 1886 | 0.7% |
 | Enums | 1423 | 0.5% |
@@ -59,18 +59,18 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 | Subsystem | Lines |
 |-----------|------:|
 | AI | 13133 |
-| Networking | 11635 |
-| ECS | 8545 |
-| Gameplay | 7386 |
+| Networking | 11853 |
+| ECS | 8546 |
+| Gameplay | 7511 |
 | Animation | 6534 |
 | Scripting | 4539 |
-| UI | 2524 |
+| UI | 2521 |
 | SaveSystem | 2491 |
 | Streaming | 1763 |
 | World | 1588 |
 | Cinematic | 1526 |
 | Editor | 1495 |
-| Dialogue | 1359 |
+| Dialogue | 1384 |
 | Modding | 1263 |
 | 2D | 979 |
 | Persistence | 955 |
@@ -99,14 +99,14 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 | Metric | Count |
 |--------|------:|
 | Editor panel classes | 59 |
-| Total editor lines | 85762 |
+| Total editor lines | 86744 |
 
 ## Testing Metrics
 
 | Metric | Count |
 |--------|------:|
-| Test files | 341 |
-| TEST() definitions | 4416 |
+| Test files | 345 |
+| TEST() definitions | 4434 |
 | Subsystems covered | All major |
 | Sanitizer coverage | ASan + UBSan + LSan + TSan + MSan |
 
@@ -117,7 +117,7 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 | CMake option() declarations | 23 |
 | ENABLE_* feature toggles | 15 |
 | Game modules | 10 |
-| SDK public headers | 10 |
+| SDK public headers | 11 |
 | Supported compilers | MSVC v143/v144, GCC 13+, Clang 17+, Apple Clang, MinGW-w64 |
 | Platforms | Windows, Linux, macOS (experimental) |
 
@@ -154,13 +154,13 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 
 | File | Lines |
 |------|------:|
-| `OpenGLDevice.cpp` | 1945 |
+| `OpenGLDevice.cpp` | 1959 |
 | `SparkEngine.cpp` | 1936 |
-| `VulkanDevice.cpp` | 1728 |
+| `VulkanDevice.cpp` | 1835 |
 | `GraphicsEngine.cpp` | 1695 |
-| `D3D12Device.cpp` | 1564 |
+| `D3D12Device.cpp` | 1565 |
 | `EngineSettings.cpp` | 1554 |
-| `D3D11Device.cpp` | 1470 |
+| `D3D11Device.cpp` | 1471 |
 | `GraphicsDeviceResources.cpp` | 1335 |
 | `CrashHandler.cpp` | 1322 |
 | `LightingSystem.cpp` | 1283 |
@@ -173,23 +173,23 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 | `EngineSettings.h` | 1079 |
 | `JsonUtils.h` | 963 |
 | `BasisTranscoder.h` | 912 |
-| `UILayoutExtensions.h` | 857 |
 | `ECSystems.h` | 849 |
 | `MeshClusterSystem.h` | 819 |
 | `SVGRenderer.h` | 803 |
 | `DataTableSystem.h` | 800 |
 | `PhysicsTypes.h` | 779 |
+| `FastNoise2SIMD.h` | 749 |
 
 ### SparkEditor .cpp Files (by line count)
 
 | File | Lines |
 |------|------:|
-| `VisualScriptPanel.cpp` | 1850 |
-| `EditorUI.cpp` | 1673 |
+| `VisualScriptPanel.cpp` | 1851 |
+| `EditorUI.cpp` | 1674 |
+| `PerformanceProfiler.cpp` | 1609 |
 | `ProjectSettingsPanel.cpp` | 1501 |
-| `CollaborativeEditSession.cpp` | 1382 |
-| `EditorTheme.cpp` | 1341 |
-| `PerformanceProfiler.cpp` | 1332 |
+| `EditorTheme.cpp` | 1456 |
+| `CollaborativeEditSession.cpp` | 1384 |
 | `LevelStreamingSystem.cpp` | 1272 |
 | `MaterialEditor.cpp` | 1269 |
 | `InspectorPanel.cpp` | 1262 |

--- a/wiki/Engine-Architecture-Flowchart.md
+++ b/wiki/Engine-Architecture-Flowchart.md
@@ -3,7 +3,7 @@
 > Complete visual guide to how SparkEngine works, from boot to shutdown.
 
 <!-- AUTO:flowchart_stats -->
-_Generated 2026-04-07 from 612 headers, 401 source files, 79 ECS components, 11 ECS systems, 59 editor panels, 6 RHI backends._
+_Generated 2026-04-09 from 617 headers, 412 source files, 79 ECS components, 11 ECS systems, 59 editor panels, 6 RHI backends._
 <!-- /AUTO:flowchart_stats -->
 
 ---

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -178,12 +178,12 @@ SparkEngine is licensed under the [Spark Open License](https://github.com/Krilli
 <!-- AUTO:stats -->
 | Metric | Count |
 |--------|-------|
-| Header files | 633 |
+| Header files | 638 |
 | ECS Components | 79 |
 | ECS Systems | 75 |
 | Editor Panels | 59 |
-| Test files | 340 |
-| Test cases | 4416+ |
+| Test files | 344 |
+| Test cases | 4438+ |
 | Wiki pages | 125 |
-| *Last synced* | *2026-04-09 04:51* |
+| *Last synced* | *2026-04-09 20:02* |
 <!-- /AUTO:stats -->

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -517,10 +517,11 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 ## Test File Inventory
 
 <!-- AUTO:test_inventory -->
-*340 test files, 4416+ test cases*
+*344 test files, 4438+ test cases*
 
 | Test File | Test Cases |
 |-----------|------------|
+| `TestSubsystemIntegrationScenarios` | 4 |
 | `TestAIBehaviorTree` | 16 |
 | `TestAIBudgetLimiter` | 6 |
 | `TestAIDebugRenderer` | 7 |
@@ -552,6 +553,7 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 | `TestAtomicSharedPtr` | 3 |
 | `TestAudioEngine` | 18 |
 | `TestAudioMixerBus` | 17 |
+| `TestAutoLODPerformance` | 2 |
 | `TestBehaviorTreeNodes` | 22 |
 | `TestBenchmarkFramework` | 15 |
 | `TestBitFlags` | 14 |
@@ -597,6 +599,7 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 | `TestDebugUtilities` | 28 |
 | `TestDecalSystem` | 7 |
 | `TestDedicatedServer` | 27 |
+| `TestDedicatedServerRuntime` | 3 |
 | `TestDeferredDeletion` | 6 |
 | `TestDeferredQueue` | 6 |
 | `TestDelegate` | 9 |
@@ -669,7 +672,7 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 | `TestGameplayDebugger` | 11 |
 | `TestGameplayExtensionRegistry` | 7 |
 | `TestGameplayStress` | 15 |
-| `TestGameplayTags` | 13 |
+| `TestGameplayTags` | 14 |
 | `TestGizmoMath` | 3 |
 | `TestGoldenImageTest` | 14 |
 | `TestGraphicsEngine` | 14 |
@@ -730,7 +733,7 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 | `TestNetworkMMOIntegration` | 11 |
 | `TestNetworkManagerEdgeCases` | 23 |
 | `TestNetworkManagerOrchestration` | 27 |
-| `TestNetworkReplicationIntegration` | 10 |
+| `TestNetworkReplicationIntegration` | 11 |
 | `TestNetworkSecurity` | 12 |
 | `TestNetworkStress` | 21 |
 | `TestNeuralInference` | 17 |
@@ -765,6 +768,7 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 | `TestProfiler` | 19 |
 | `TestProximityTriggerSystem` | 4 |
 | `TestQuestSystem` | 10 |
+| `TestRHICapabilityParity` | 4 |
 | `TestRHIHandlePool` | 10 |
 | `TestRandomEngine` | 11 |
 | `TestRecastIntegration` | 6 |
@@ -806,7 +810,7 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 | `TestShaderDiskCache` | 6 |
 | `TestShaderGraphCompiler` | 8 |
 | `TestShaderHotReload` | 8 |
-| `TestShaderHotReloadCompilation` | 7 |
+| `TestShaderHotReloadCompilation` | 9 |
 | `TestShadowAtlas` | 7 |
 | `TestSkyAtmosphere` | 5 |
 | `TestSoftwareRendering` | 5 |
@@ -828,7 +832,7 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 | `TestSubTickInput` | 5 |
 | `TestSubsystemConsoleCommands` | 14 |
 | `TestTacticalPointSystem` | 4 |
-| `TestTelemetry` | 14 |
+| `TestTelemetry` | 15 |
 | `TestTemporalEffects` | 11 |
 | `TestTerrainRenderer` | 5 |
 | `TestTextureCompressor` | 9 |
@@ -845,14 +849,14 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 | `TestUILayoutExtensions` | 29 |
 | `TestUISystem` | 6 |
 | `TestUUID` | 12 |
-| `TestUndoRedoManager` | 6 |
+| `TestUndoRedoManager` | 7 |
 | `TestUpscalingSystem` | 10 |
 | `TestUtilsStress` | 13 |
 | `TestVRSystem` | 12 |
 | `TestVersionedHandle` | 9 |
 | `TestVideoPlayer` | 12 |
 | `TestVisualScriptCompiler` | 12 |
-| `TestVulkanLavapipe` | 5 |
+| `TestVulkanLavapipe` | 8 |
 | `TestWARPRendering` | 4 |
 | `TestWaterRenderer` | 6 |
 | `TestWeaponMechanics` | 29 |


### PR DESCRIPTION
### Motivation

- Consolidate Tier‑3 polish/maturity work into a single, gated milestone so each item has clear acceptance tests, perf budgets, owners, estimates, and required docs updates.
- Ensure milestone completion is quality‑gated by CI and by updating wiki pages for every subsystem touched.
- Make Tier‑3 execution discoverable from the main roadmap and enforce the repo’s generated‑docs policy for planning artifacts.

### Description

- Add `docs/plans/tier3-polish-maturity-milestone.md`, a milestone (M1) that defines 7 epics (T3-1..T3-7) each with acceptance tests, perf budget impact, owner + estimate, and required documentation updates.
- Link the new milestone from `docs/FEATURE_ROADMAP.md` and update contextual AI/docs files (`.claude/index.md`, `CLAUDE.md`, `README.md`, and related prompt files) to reflect refreshed statistics and test counts.
- Run the repository docs automation to regenerate generated artifacts; this updated `wiki/Engine-Architecture-Flowchart.md`, `wiki/Codebase-Statistics.md`, `wiki/Home.md`, `wiki/Testing.md`, and the badges/loc JSON files.
- No runtime engine code was changed; this is a planning/documentation change that also refreshes generated doc artifacts required by project policy.

### Testing

- Ran `docs/sync-wiki.sh sync` to refresh wiki AUTO sections, which updated the necessary pages and completed successfully.
- Ran `docs/update-all-docs.sh` to regenerate flowchart, codebase stats, badges, and AI context, and it completed successfully producing updated `wiki/` and badge files.
- Ran `docs/update-all-docs.sh check` and `docs/sync-wiki.sh check` which initially reported out‑of‑date generated sources (auto stats/Home.md) but after running the sync + full update all doc checks passed.
- All automated documentation generation and wiki sync steps required by the milestone policy completed successfully in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d801e6ea1483269fb7d8ba30ab6904)