### PR TITLE
Add separate 'Simulating' play mode with UI controls and manager support

### DIFF
--- a/SparkEditor/Source/Core/EditorMenuBar.cpp
+++ b/SparkEditor/Source/Core/EditorMenuBar.cpp
@@ -770,7 +770,7 @@ namespace SparkEditor
         if (cursorX > ImGui::GetCursorPosX())
             ImGui::SetCursorPosX(cursorX);
 
-        bool isPlaying = (m_playMode == PlayMode::Playing);
+        bool isPlaying = (m_playMode == PlayMode::Playing || m_playMode == PlayMode::Simulating);
         if (isPlaying)
         {
             ImGui::PushStyleColor(ImGuiCol_Button, playGreen);
@@ -785,11 +785,19 @@ namespace SparkEditor
         if (ImGui::Button(ICON_FA_PLAY, btnDim))
         {
             m_playModeManager.TogglePlayMode();
-            m_playMode = m_playModeManager.IsInPlayMode() ? PlayMode::Playing : PlayMode::Stopped;
+            m_playMode = m_playModeManager.IsPlaying()
+                             ? PlayMode::Playing
+                             : (m_playModeManager.IsSimulating()
+                                    ? PlayMode::Simulating
+                                    : (m_playModeManager.IsPaused() ? PlayMode::Paused : PlayMode::Stopped));
             SPARK_LOG_INFO(Spark::LogCategory::Editor, "Play mode toggled: %s",
-                           m_playModeManager.IsInPlayMode() ? "Playing" : "Stopped");
-            ShowNotification(m_playModeManager.IsInPlayMode() ? "Playing..." : "Stopped",
-                             m_playModeManager.IsInPlayMode() ? "success" : "info", 2.0f);
+                           m_playMode == PlayMode::Playing
+                               ? "Playing"
+                               : (m_playMode == PlayMode::Simulating
+                                      ? "Simulating"
+                                      : (m_playMode == PlayMode::Paused ? "Paused" : "Stopped")));
+            ShowNotification(m_playMode == PlayMode::Stopped ? "Stopped" : "Running...",
+                             m_playMode == PlayMode::Stopped ? "info" : "success", 2.0f);
         }
         ImGui::PopStyleColor(2);
         if (ImGui::IsItemHovered())
@@ -813,6 +821,8 @@ namespace SparkEditor
             m_playModeManager.TogglePause();
             if (m_playModeManager.IsPaused())
                 m_playMode = PlayMode::Paused;
+            else if (m_playModeManager.IsSimulating())
+                m_playMode = PlayMode::Simulating;
             else if (m_playModeManager.IsInPlayMode())
                 m_playMode = PlayMode::Playing;
         }

--- a/SparkEditor/Source/Core/EditorPanelFactory.cpp
+++ b/SparkEditor/Source/Core/EditorPanelFactory.cpp
@@ -306,6 +306,22 @@ namespace SparkEditor
             }
         }
 
+        // Wire play/sim manager into dependent panels after initialization.
+        if (auto it = m_panels.find("PlayModeToolbar"); it != m_panels.end())
+        {
+            if (auto* toolbar = dynamic_cast<PlayModeToolbarPanel*>(it->second.get()))
+            {
+                toolbar->SetPlayModeManager(&m_playModeManager);
+            }
+        }
+        if (auto it = m_panels.find("DedicatedServer"); it != m_panels.end())
+        {
+            if (auto* dedicatedServer = dynamic_cast<DedicatedServerPanel*>(it->second.get()))
+            {
+                dedicatedServer->SetPlayModeManager(&m_playModeManager);
+            }
+        }
+
         InitializePanelIcons();
         SetDefaultPanelVisibility();
 

--- a/SparkEditor/Source/Core/EditorUI.cpp
+++ b/SparkEditor/Source/Core/EditorUI.cpp
@@ -356,6 +356,9 @@ namespace SparkEditor
         // Tick notification lifetimes and remove expired ones
         UpdateNotifications(deltaTime);
 
+        // Tick play/simulate state machine (PIE and in-editor simulation stepping/stats)
+        m_playModeManager.Update(deltaTime);
+
         // Update stats
         UpdateStats(deltaTime);
 
@@ -450,8 +453,37 @@ namespace SparkEditor
             else
             {
                 m_playModeManager.TogglePlayMode();
-                m_playMode = m_playModeManager.IsInPlayMode() ? PlayMode::Playing : PlayMode::Stopped;
-                ShowNotification(m_playMode == PlayMode::Playing ? "Playing..." : "Stopped", "info", 2.0f);
+                m_playMode = m_playModeManager.IsPlaying()
+                                 ? PlayMode::Playing
+                                 : (m_playModeManager.IsSimulating()
+                                        ? PlayMode::Simulating
+                                        : (m_playModeManager.IsPaused() ? PlayMode::Paused : PlayMode::Stopped));
+                ShowNotification(m_playMode == PlayMode::Playing
+                                     ? "Playing..."
+                                     : (m_playMode == PlayMode::Simulating ? "Simulating..." : "Stopped"),
+                                 "info", 2.0f);
+            }
+        }
+
+        // F6: Toggle simulation mode (physics/AI/etc. while retaining editor camera workflow)
+        if (ImGui::IsKeyPressed(ImGuiKey_F6) && !io.WantTextInput)
+        {
+            if (io.KeyShift)
+            {
+                m_playModeManager.ExitPlayMode();
+                m_playMode = PlayMode::Stopped;
+                ShowNotification("Stopped simulation", "info", 2.0f);
+            }
+            else
+            {
+                m_playModeManager.ToggleSimulationMode();
+                m_playMode = m_playModeManager.IsPlaying()
+                                 ? PlayMode::Playing
+                                 : (m_playModeManager.IsSimulating()
+                                        ? PlayMode::Simulating
+                                        : (m_playModeManager.IsPaused() ? PlayMode::Paused : PlayMode::Stopped));
+                ShowNotification(m_playMode == PlayMode::Simulating ? "Simulation running..." : "Simulation stopped",
+                                 "info", 2.0f);
             }
         }
 

--- a/SparkEditor/Source/Core/EditorUI.h
+++ b/SparkEditor/Source/Core/EditorUI.h
@@ -230,6 +230,7 @@ namespace SparkEditor
         {
             Stopped,
             Playing,
+            Simulating,
             Paused
         };
         PlayMode m_playMode = PlayMode::Stopped;

--- a/SparkEditor/Source/Panels/PlayModeToolbarPanel.cpp
+++ b/SparkEditor/Source/Panels/PlayModeToolbarPanel.cpp
@@ -43,8 +43,8 @@ namespace SparkEditor
 
     void PlayModeToolbarPanel::Update(float deltaTime)
     {
-        // Animate the play-button pulse when playing
-        if (m_playModeManager && m_playModeManager->IsPlaying())
+        // Animate the play-button pulse when playing or simulating
+        if (m_playModeManager && (m_playModeManager->IsPlaying() || m_playModeManager->IsSimulating()))
         {
             m_playButtonPulse += deltaTime * 3.0f;
             if (m_playButtonPulse > 6.2831853f) // 2 * PI
@@ -167,12 +167,13 @@ namespace SparkEditor
         using namespace Spark::Editor;
 
         bool isPlaying = m_playModeManager->IsPlaying();
+        bool isSimulating = m_playModeManager->IsSimulating();
         bool isPaused = m_playModeManager->IsPaused();
         bool isStopped = m_playModeManager->IsStopped();
         bool isInPlayMode = m_playModeManager->IsInPlayMode();
 
         // --- Play Button ---
-        if (isPlaying)
+        if (isPlaying || isSimulating)
         {
             // Pulsing green when playing
             float pulse = 0.5f + 0.5f * std::sin(m_playButtonPulse);
@@ -224,7 +225,7 @@ namespace SparkEditor
             ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImGui::GetStyle().Colors[ImGuiCol_ButtonActive]);
         }
 
-        bool pauseDisabled = !isPlaying && !isPaused;
+        bool pauseDisabled = (!isPlaying && !isSimulating) && !isPaused;
         if (pauseDisabled)
         {
             ImGui::BeginDisabled();
@@ -588,6 +589,10 @@ namespace SparkEditor
 
         case PlayModeState::Playing:
             ImGui::TextColored(ImVec4(0.3f, 0.9f, 0.3f, 1.0f), ICON_FA_PLAY " Playing");
+            break;
+
+        case PlayModeState::Simulating:
+            ImGui::TextColored(ImVec4(0.2f, 0.8f, 1.0f, 1.0f), ICON_FA_CUBE " Simulating");
             break;
 
         case PlayModeState::Paused:

--- a/SparkEngine/Source/Engine/Editor/PlayModeManager.h
+++ b/SparkEngine/Source/Engine/Editor/PlayModeManager.h
@@ -60,6 +60,7 @@ namespace Spark::Editor
             m_playStartTime = Clock::now();
             m_stepRequested = false;
             m_multiStepRemaining = 0;
+            m_wasSimulatingBeforePause = false;
             m_stats.Reset();
             m_liveEdits.clear();
             m_cameraMode = m_config.cameraMode;
@@ -72,11 +73,47 @@ namespace Spark::Editor
             return true;
         }
 
+        /// @brief Enter simulation mode without switching to game camera behavior.
+        bool EnterSimulationMode()
+        {
+            if (m_state != PlayModeState::Stopped)
+                return false;
+
+            m_state = PlayModeState::Starting;
+
+            if (!SaveSnapshot())
+            {
+                m_state = PlayModeState::Stopped;
+                if (m_callbacks.onError)
+                    m_callbacks.onError("Failed to save scene snapshot before entering simulation mode");
+                return false;
+            }
+
+            m_playTimeSeconds = 0.0f;
+            m_frameCount = 0;
+            m_playStartTime = Clock::now();
+            m_stepRequested = false;
+            m_multiStepRemaining = 0;
+            m_wasSimulatingBeforePause = true;
+            m_stats.Reset();
+            m_liveEdits.clear();
+            m_cameraMode = EditorCameraMode::EditorFree;
+
+            m_state = m_config.startPaused ? PlayModeState::Paused : PlayModeState::Simulating;
+
+            if (m_callbacks.onEnterSimulate)
+                m_callbacks.onEnterSimulate();
+
+            return true;
+        }
+
         bool ExitPlayMode()
         {
             if (m_state == PlayModeState::Stopped)
                 return false;
 
+            const bool wasSimulating = (m_state == PlayModeState::Simulating) ||
+                                       (m_state == PlayModeState::Paused && m_wasSimulatingBeforePause);
             m_state = PlayModeState::Stopping;
 
             if (!m_config.keepChangesOnStop)
@@ -96,9 +133,12 @@ namespace Spark::Editor
 
             m_cameraMode = EditorCameraMode::EditorFree;
             m_state = PlayModeState::Stopped;
+            m_wasSimulatingBeforePause = false;
 
             if (m_callbacks.onExitPlay)
                 m_callbacks.onExitPlay();
+            if (wasSimulating && m_callbacks.onExitSimulate)
+                m_callbacks.onExitSimulate();
 
             return true;
         }
@@ -111,12 +151,21 @@ namespace Spark::Editor
                 EnterPlayMode();
         }
 
+        void ToggleSimulationMode()
+        {
+            if (IsInPlayMode())
+                ExitPlayMode();
+            else
+                EnterSimulationMode();
+        }
+
         // -- Pause / Step --
 
         void PausePlayMode()
         {
-            if (m_state == PlayModeState::Playing)
+            if (m_state == PlayModeState::Playing || m_state == PlayModeState::Simulating)
             {
+                m_wasSimulatingBeforePause = (m_state == PlayModeState::Simulating);
                 m_state = PlayModeState::Paused;
                 if (m_callbacks.onPause)
                     m_callbacks.onPause();
@@ -127,7 +176,7 @@ namespace Spark::Editor
         {
             if (m_state == PlayModeState::Paused)
             {
-                m_state = PlayModeState::Playing;
+                m_state = m_wasSimulatingBeforePause ? PlayModeState::Simulating : PlayModeState::Playing;
                 if (m_callbacks.onResume)
                     m_callbacks.onResume();
             }
@@ -237,9 +286,14 @@ namespace Spark::Editor
 
         PlayModeState GetState() const { return m_state; }
         bool IsPlaying() const { return m_state == PlayModeState::Playing; }
+        bool IsSimulating() const { return m_state == PlayModeState::Simulating; }
         bool IsPaused() const { return m_state == PlayModeState::Paused; }
         bool IsStopped() const { return m_state == PlayModeState::Stopped; }
-        bool IsInPlayMode() const { return m_state == PlayModeState::Playing || m_state == PlayModeState::Paused; }
+        bool IsInPlayMode() const
+        {
+            return m_state == PlayModeState::Playing || m_state == PlayModeState::Simulating ||
+                   m_state == PlayModeState::Paused;
+        }
 
         // -- Config --
 
@@ -379,6 +433,9 @@ namespace Spark::Editor
             case PlayModeState::Playing:
                 oss << "Playing";
                 break;
+            case PlayModeState::Simulating:
+                oss << "Simulating";
+                break;
             case PlayModeState::Paused:
                 oss << "Paused";
                 break;
@@ -483,6 +540,7 @@ namespace Spark::Editor
         uint64_t m_frameCount = 0;
         bool m_stepRequested = false;
         uint32_t m_multiStepRemaining = 0;
+        bool m_wasSimulatingBeforePause = false;
 
         EditorCameraMode m_cameraMode = EditorCameraMode::EditorFree;
         std::vector<LiveEditRecord> m_liveEdits;

--- a/SparkEngine/Source/Engine/Editor/PlayModeTypes.h
+++ b/SparkEngine/Source/Engine/Editor/PlayModeTypes.h
@@ -24,11 +24,12 @@ namespace Spark::Editor
 
     enum class PlayModeState
     {
-        Stopped,  ///< Editor mode — scene is editable
-        Starting, ///< Transitioning to play: saving snapshot
-        Playing,  ///< Game loop running in viewport
-        Paused,   ///< Game loop paused — can inspect/step
-        Stopping  ///< Transitioning back: restoring snapshot
+        Stopped,    ///< Editor mode — scene is editable
+        Starting,   ///< Transitioning to play: saving snapshot
+        Playing,    ///< Game loop running in viewport
+        Simulating, ///< Simulation running while retaining editor camera/workflow
+        Paused,     ///< Game loop paused — can inspect/step
+        Stopping    ///< Transitioning back: restoring snapshot
     };
 
     // ============================================================================
@@ -184,6 +185,8 @@ namespace Spark::Editor
     {
         PlayModeCallback onEnterPlay;
         PlayModeCallback onExitPlay;
+        PlayModeCallback onEnterSimulate;
+        PlayModeCallback onExitSimulate;
         PlayModeCallback onPause;
         PlayModeCallback onResume;
         PlayModeCallback onFrameStep;


### PR DESCRIPTION
### Motivation

- Introduce a simulation mode that runs selected subsystems (physics/AI/etc.) while retaining the editor camera/workflow, so users can validate runtime behavior without fully entering game-camera play mode.
- Provide keyboard and toolbar controls to enter/exit/toggle simulation independently of normal play, and reflect simulation state consistently in UI and logs.

### Description

- Add `Simulating` to `PlayModeState` and introduce `onEnterSimulate` / `onExitSimulate` callbacks in `PlayModeCallbacks` in `PlayModeTypes.h`.
- Extend `PlayModeManager` with `EnterSimulationMode`, `ToggleSimulationMode`, `IsSimulating`, and `m_wasSimulatingBeforePause` to preserve simulation-vs-play semantics across pauses and exits, and update console/status reporting.
- Update pause/resume/exit logic in `PlayModeManager` to correctly handle the `Simulating` state and invoke simulation callbacks where appropriate.
- Wire `PlayModeManager` into panels after initialization in `EditorPanelFactory.cpp` so dependent panels (e.g. `PlayModeToolbar`, `DedicatedServer`) receive the manager instance.
- Update editor UI and toolbar code (`EditorUI.*`, `PlayModeToolbarPanel.*`, `EditorMenuBar.cpp`) to visualize and handle the `Simulating` state, add an F6 hotkey for toggling simulation, call `m_playModeManager.Update(deltaTime)` during the editor update loop, and adjust notifications and button styling accordingly.

### Testing

- Built the project and ran the automated unit test suite via `ctest`, which completed successfully.
- Ran the editor integration smoke tests (`tests/editor_integration`) to verify play/simulate toggle behavior and UI updates, which all passed.
- Verified logs and notifications show the new `Simulating` state transitions and callbacks during automated runs, with no failures observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d830beec2c8326a54e8663242e49a5)