### PR TITLE
Harden serialization and replication boundary checks

### DIFF
--- a/SparkEngine/Source/Engine/Networking/EntityReplicator.cpp
+++ b/SparkEngine/Source/Engine/Networking/EntityReplicator.cpp
@@ -7,6 +7,7 @@
 #include "../../Utils/Validate.h"
 
 #include <cstring>
+#include <limits>
 
 namespace Spark::Net
 {
@@ -66,10 +67,25 @@ namespace Spark::Net
 
         const auto& entry = it->second;
         const uint8_t fieldCount = entry.fieldSet.GetFieldCount();
+        if (fieldCount > MAX_REPLICATED_FIELDS)
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network,
+                           "WriteCreatePacket: entity %u has invalid field count %u (max %u)", entityID, fieldCount,
+                           MAX_REPLICATED_FIELDS);
+            return false;
+        }
+
+        constexpr size_t kHeaderSize = sizeof(uint32_t) + sizeof(uint8_t);
+        if (buffer.size() > (std::numeric_limits<size_t>::max() - kHeaderSize))
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network,
+                           "WriteCreatePacket: buffer size overflow while writing header for entity %u", entityID);
+            return false;
+        }
 
         // Header: entityID + fieldCount
         const auto headerOffset = buffer.size();
-        buffer.resize(headerOffset + sizeof(uint32_t) + sizeof(uint8_t));
+        buffer.resize(headerOffset + kHeaderSize);
         std::memcpy(buffer.data() + headerOffset, &entityID, sizeof(uint32_t));
         buffer[headerOffset + sizeof(uint32_t)] = fieldCount;
 
@@ -94,6 +110,14 @@ namespace Spark::Net
         }
 
         const auto& entry = it->second;
+        const uint8_t fieldCount = entry.fieldSet.GetFieldCount();
+        if (fieldCount > MAX_REPLICATED_FIELDS)
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network,
+                           "WriteUpdatePacket: entity %u has invalid field count %u (max %u)", entityID, fieldCount,
+                           MAX_REPLICATED_FIELDS);
+            return false;
+        }
 
         // Build a combined visibility mask
         uint64_t visibleMask = entry.fieldSet.GetVisibilityMask(FieldVisibility::Public);
@@ -102,20 +126,31 @@ namespace Spark::Net
             visibleMask |= entry.fieldSet.GetVisibilityMask(observerVisibility);
         }
 
-        const uint64_t dirtyMask = entry.fieldSet.GetDirtyMask() & visibleMask;
+        uint64_t dirtyMask = entry.fieldSet.GetDirtyMask() & visibleMask;
+        if (fieldCount < MAX_REPLICATED_FIELDS)
+        {
+            dirtyMask &= ((1ULL << fieldCount) - 1ULL);
+        }
         if (dirtyMask == 0)
         {
             return false; // Nothing to send for this observer
         }
 
+        constexpr size_t kHeaderSize = sizeof(uint32_t) + sizeof(uint64_t);
+        if (buffer.size() > (std::numeric_limits<size_t>::max() - kHeaderSize))
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network,
+                           "WriteUpdatePacket: buffer size overflow while writing header for entity %u", entityID);
+            return false;
+        }
+
         // Header: entityID + filtered dirty mask
         const auto headerOffset = buffer.size();
-        buffer.resize(headerOffset + sizeof(uint32_t) + sizeof(uint64_t));
+        buffer.resize(headerOffset + kHeaderSize);
         std::memcpy(buffer.data() + headerOffset, &entityID, sizeof(uint32_t));
         std::memcpy(buffer.data() + headerOffset + sizeof(uint32_t), &dirtyMask, sizeof(uint64_t));
 
         // Serialize only dirty+visible fields
-        const uint8_t fieldCount = entry.fieldSet.GetFieldCount();
         for (uint8_t i = 0; i < fieldCount; ++i)
         {
             if ((dirtyMask >> i) & 1ULL)

--- a/SparkEngine/Source/Engine/Networking/ReplicationFields.cpp
+++ b/SparkEngine/Source/Engine/Networking/ReplicationFields.cpp
@@ -24,8 +24,16 @@ namespace Spark::Net
             return;
         }
 
+        const auto visibilityIndex = static_cast<size_t>(visibility);
+        if (visibilityIndex >= static_cast<size_t>(FieldVisibility::Count))
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Network, "RegisterField: visibility value %zu is out of range [0, %zu)",
+                           visibilityIndex, static_cast<size_t>(FieldVisibility::Count));
+            return;
+        }
+
         const uint64_t bit = 1ULL << index;
-        m_visibilityMasks[static_cast<size_t>(visibility)] |= bit;
+        m_visibilityMasks[visibilityIndex] |= bit;
 
         if (index >= m_fieldCount)
         {

--- a/SparkEngine/Source/Utils/Serializer.h
+++ b/SparkEngine/Source/Utils/Serializer.h
@@ -280,6 +280,11 @@ namespace Spark
         {
             if (size == 0)
                 return true;
+            if (dest == nullptr)
+            {
+                m_error = true;
+                return false;
+            }
             if (!Consume(size))
                 return false;
             std::memcpy(dest, m_data + m_cursor - size, size);
@@ -326,7 +331,7 @@ namespace Spark
       private:
         bool Consume(size_t count) noexcept
         {
-            if (m_error || m_cursor + count > m_size)
+            if (m_error || m_cursor > m_size || count > (m_size - m_cursor))
             {
                 m_error = true;
                 return false;


### PR DESCRIPTION
### Motivation

- Close multiple stability gaps at serialization and network-replication boundaries to prevent crashes or undefined behavior from malformed or out-of-range inputs.

### Description

- Added a null-pointer guard to `BinaryReader::ReadBytes()` so `size > 0` with `dest == nullptr` sets the reader error and fails safely.
- Strengthened `BinaryReader::Consume()` bounds checking to avoid overflow/underflow in cursor arithmetic and detect invalid internal cursor state.
- Validated `FieldVisibility` values in `ReplicatedFieldSet::RegisterField()` before indexing the visibility masks to prevent out-of-bounds writes for invalid enum values.
- Hardened `EntityReplicator::WriteCreatePacket()` and `WriteUpdatePacket()` with field-count sanity checks against `MAX_REPLICATED_FIELDS`, header growth overflow checks before `std::vector::resize`, and masking of dirty bits to the registered field count; also added the required `<limits>` include.

### Testing

- Ran `clang-format -i` on modified files; formatting step succeeded.
- Configured the Linux GCC release preset with `cmake --preset linux-gcc-release` and the configure step completed successfully.
- Built the engine library with `cmake --build build/linux-gcc-release --target SparkEngineLib -j4` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d84bbe38bc8326a73ab8de92b507aa)