### PR TITLE
docs(claude): catalog Tier 1–4 stub and abandoned features

### DIFF
--- a/.claude/index.md
+++ b/.claude/index.md
@@ -35,6 +35,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 | Memory integrity system (branch guards, code scanning) | [knowledge/memory-integrity-system.md](knowledge/memory-integrity-system.md) | Observation | Active | 2026-04-05 |
 | Memory safety evaluation & C++26 bridge (Contracts, NonNull, SafeCast) | [knowledge/memory-safety-evaluation.md](knowledge/memory-safety-evaluation.md) | Decision | Active | 2026-04-06 |
 | ConnectionScopeFilter wired into replication path | [knowledge/connection-scope-wiring-2026-04-10.md](knowledge/connection-scope-wiring-2026-04-10.md) | Observation | Resolved | 2026-04-10 |
+| Stub & abandoned features catalog (Tier 1–4, ~30 Graphics orphans, VR/Steam stubs) | [knowledge/stub-and-abandoned-features-2026-04-10.md](knowledge/stub-and-abandoned-features-2026-04-10.md) | Observation | Active | 2026-04-10 |
 ## Quick Reference
 
 ### Current Engine State (2026-04-10)

--- a/.claude/knowledge/stub-and-abandoned-features-2026-04-10.md
+++ b/.claude/knowledge/stub-and-abandoned-features-2026-04-10.md
@@ -1,0 +1,233 @@
+# Stub & Abandoned Features Audit — April 10, 2026
+
+**Type:** Observation
+**Status:** Active (catalog for follow-up sessions)
+**Severity:** Medium
+**Related:** [codebase-bloat-audit-2026-03-15.md](codebase-bloat-audit-2026-03-15.md)
+
+---
+
+## Context
+
+Prompted by a user question about whether SparkEngine needs a SpeedTree-equivalent
+vegetation library. Investigation uncovered `FoliageSystem.h` as a header-only
+stub never wired into the render path. Three parallel audits (Graphics, Engine,
+Editor/GameModules) were then run to catalog other "started but abandoned" or
+stubbed features across the codebase so they can be addressed in follow-up
+sessions.
+
+**Important:** the Explore agents returned several false positives — systems
+they claimed were "never referenced" are actually wired in. This entry lists
+only findings that have been spot-verified with grep against
+`GameplayLifecycleShared.cpp` and test files. Untrusted claims are excluded.
+
+The existing [codebase-bloat-audit-2026-03-15.md](codebase-bloat-audit-2026-03-15.md)
+already covers oversized files, orphaned singletons, and public-method-count
+violations from March. This entry is complementary: it focuses specifically on
+**stubs and unfinished features** discovered on April 10, and includes new
+findings not in the March audit.
+
+---
+
+## Tier 1 — Stub implementations (class exists, body is a no-op or returns false)
+
+These are actively called somewhere but deliberately do nothing. They are the
+highest-impact items because their presence implies a capability the engine
+does not actually have.
+
+| Feature | File | Evidence |
+|---|---|---|
+| **VRSystem** | `SparkEngine/Source/Engine/VR/VRSystem.cpp:23-40` | `Initialize()` sets `m_initialized = false` with comment `// Set to true when OpenXR is linked`; `UpdateTracking()` is a no-op past the initialized check. Instantiated in `GameplayLifecycleShared.cpp:509` but produces a warning log and disables itself. `index.md:46` incorrectly implies full rendering support. |
+| **SteamTransport** | `SparkEngine/Source/Engine/Networking/SteamTransport.h` | Header-only stub. `Initialize()` returns `false`, `Send()` returns `false`, `Receive()` returns `-1`. Marked "not yet implemented" in comments. Gated behind `#ifdef ENABLE_NETWORKING` but not called anywhere. |
+| **OnlineServices — Steam/Epic/Console platforms** | `SparkEngine/Source/Engine/OnlineServices/OnlineServices.h:333-506` | `NullOnlinePlatform` works and is wired via `OnlineServiceManager` (verified at `GameplayLifecycleShared.cpp:451,863,1003`). `SteamPlatform`, `EpicPlatform`, `ConsolePlatform` are declared as stubs awaiting their respective SDKs — header comments state this explicitly. |
+| **FoliageSystem / FoliageManager** | `SparkEngine/Source/Graphics/FoliageSystem.h` | 126 lines, header-only, no `.cpp`. `FoliageVolumeComponent` (`Engine/ECS/Components/AdvancedPlacementComponents.h:435-458`) bridges editor → manager, but manager singleton is never instantiated in any lifecycle path. Editor references in `InspectorPanel.cpp` and `ObjectPlacementPanel.cpp` only configure the component data. Full analysis in `~/.claude/plans/delightful-crunching-waffle.md`. |
+
+**Recommended action:** For VR and Steam/Epic/Console platforms — document in
+`CLAUDE.md` that these are stubs awaiting optional SDKs; do not claim them
+as features. For SteamTransport — delete if no plan, or wire properly. For
+FoliageSystem — see the in-house implementation plan already written.
+
+---
+
+## Tier 2 — Header-only systems with zero engine references (truly orphaned)
+
+These are fully designed-and-implemented-in-header classes that no `.cpp`
+anywhere in the engine calls. Most have no tests either. They are candidates
+for deletion if no follow-up owner claims them.
+
+### Engine subsystems (verified orphaned — no refs outside their own headers)
+
+| File | Lines | Purpose |
+|---|---|---|
+| `SparkEngine/Source/Engine/DataTable/DataTableSystem.h` | ~? | `DataTableManager` singleton, CSV/JSON row tables. Never instantiated. |
+| `SparkEngine/Source/Engine/AI/NavMeshLink.h` | ~100+ | `NavMeshLinkSystem` singleton for off-mesh connections. Never called. |
+| `SparkEngine/Source/Engine/Gameplay/GameplayTags.h` | ~? | `GameplayTagManager` singleton (Unreal-style tag system). Never referenced. |
+| `SparkEngine/Source/Engine/Gameplay/GameplaySystemExtension.h` | ~? | Extension framework with `GetInstance()`. Never referenced. |
+| `SparkEngine/Source/Engine/ECS/RuntimePrefab.h` | ~? | Runtime prefab instantiation with serialization. Only referenced in its own test file `Tests/TestRuntimePrefab.cpp`. |
+| `SparkEngine/Source/Engine/SaveSystem/SaveSystemTypes.h` | ~? | Type file containing a `GetInstance()` declaration. Never used. |
+
+### Graphics subsystems (reported by audit, require re-verification before action)
+
+The Graphics audit listed ~30 header-only files with zero engine-code references.
+Spot-checks against `GameplayLifecycleShared.cpp` confirmed none of the sampled
+items are wired into the engine lifecycle. Several have test files but no
+engine-side integration. **Before deleting, re-verify each file individually
+with grep across all `.cpp` directories including `Tests/`, `SparkEditor/`, and
+`GameModules/`.**
+
+High-value orphans (substantial implementations, would be useful if wired):
+
+| File | Lines | What it would provide |
+|---|---|---|
+| `SparkEngine/Source/Graphics/BVHAccelerator.h` | 441 | SAH-based hierarchical frustum culling |
+| `SparkEngine/Source/Graphics/VolumeSystem.h` | 461 | Unity-style post-process volume blending |
+| `SparkEngine/Source/Graphics/VoxelConeTracing.h` | 463 | Voxel cone traced global illumination |
+| `SparkEngine/Source/Graphics/GTAOEffect.h` | 444 | Ground-truth AO implementation |
+| `SparkEngine/Source/Graphics/SSAOTemporal.h` | 231 | Temporal SSAO variant |
+| `SparkEngine/Source/Graphics/MeshOptimizer.h` | 471 | Mesh/index buffer optimization |
+| `SparkEngine/Source/Graphics/RenderTargetPool.h` | 398 | RT pooling with acquire/release |
+| `SparkEngine/Source/Graphics/PipelineStateCache.h` | 398 | PSO caching. **Note:** a file at `Graphics/RHI/PipelineStateCache.cpp` exists — verify whether it implements this header or a different class before action. |
+| `SparkEngine/Source/Graphics/ReflectionProbeCache.h` | 317 | Reflection probe cache |
+| `SparkEngine/Source/Graphics/CachedShadowAtlas.h` | 328 | Shadow atlas with caching |
+| `SparkEngine/Source/Graphics/RTHandleSystem.h` | 265 | Render target handle abstraction |
+| `SparkEngine/Source/Graphics/ShaderVariantSystem.h` | 391 | Shader variant permutation management |
+| `SparkEngine/Source/Graphics/ShaderCrossCompiler.h` | 376 | HLSL↔GLSL translation (duplicates SlangShaderInterface?) |
+| `SparkEngine/Source/Graphics/ConstantBufferRing.h` | 362 | Ring buffer allocator |
+| `SparkEngine/Source/Graphics/GPUDebugMarkers.h` | 377 | GPU timing/debug markers |
+| `SparkEngine/Source/Graphics/GPUTimestampQuery.h` | 490 | GPU timestamp queries |
+| `SparkEngine/Source/Graphics/PersistentMaterialCB.h` | 220 | Persistent material constant buffer |
+| `SparkEngine/Source/Graphics/UICompositor.h` | 231 | UI compositor (possibly superseded by Engine/UI) |
+| `SparkEngine/Source/Graphics/DenoiserInterface.h` | 251 | Abstract denoiser plugin interface |
+| `SparkEngine/Source/Graphics/FastNoise2SIMD.h` | 749 | SIMD procedural noise (appears to be a ported third-party header) |
+
+Smaller orphans (consider deletion if no owner):
+
+| File | Lines |
+|---|---|
+| `SparkEngine/Source/Graphics/LineTrailRenderer.h` | 127 |
+| `SparkEngine/Source/Graphics/SpringArm.h` | 69 |
+| `SparkEngine/Source/Graphics/DirtyRectTracker.h` | 167 |
+| `SparkEngine/Source/Graphics/ClusteredLightGPU.h` | 163 |
+| `SparkEngine/Source/Graphics/ConstantBufferDiff.h` | 138 |
+| `SparkEngine/Source/Graphics/RHI/DeferredDeletionQueue.h` | 121 |
+| `SparkEngine/Source/Graphics/RHI/RHIHandlePool.h` | 233 |
+| `SparkEngine/Source/Graphics/RHI/TransientBufferAllocator.h` | 232 |
+
+**Approximate total:** ~10,000 lines of header-only code in Graphics alone
+that has no engine-side call sites.
+
+**Recommended action:** In a follow-up session, verify each entry with an
+exhaustive grep (including headers, not just `.cpp`), then for each: (a) wire
+in, (b) delete, or (c) document as intentional utility. Do not batch-delete
+without per-file verification.
+
+---
+
+## Tier 3 — Systems with tests but no engine/editor integration
+
+These systems have unit tests, suggesting they were implemented deliberately,
+but they are never instantiated in the engine or editor runtime. Either
+the test was a design exercise, or the wiring step was skipped.
+
+| Feature | Implementation | Test | Engine integration |
+|---|---|---|---|
+| `TutorialSystem` | `SparkEditor/Source/Core/TutorialSystem.h` (header-only, 240+ lines) | `Tests/TestTutorialSystem.cpp` | **None** — not referenced in any editor `.cpp` outside its test |
+| `AssetDependencyGraph` | Header: `SparkEditor/Source/Panels/AssetDependencyGraph.h` (485 lines). Implementation: `SparkEditor/Source/AssetPipeline/AssetProcessors.cpp:739+` | `Tests/TestAssetDependencyGraph.cpp` | **Partial** — `.cpp` exists but split into an unrelated file; verify whether `AssetDatabase` actually calls it |
+| `ClusteredLightGPU` | `SparkEngine/Source/Graphics/ClusteredLightGPU.h` | `Tests/TestClusteredLightGPU.cpp` | **None** — not called in any render path |
+| `ConstantBufferDiff` | `SparkEngine/Source/Graphics/ConstantBufferDiff.h` | `Tests/TestConstantBufferDiff.cpp` | **None** |
+| `DirtyRectTracker` | `SparkEngine/Source/Graphics/DirtyRectTracker.h` | `Tests/TestDirtyRectTracker.cpp` | **None** |
+
+**Recommended action:** Decide owner per-system, wire into the appropriate
+lifecycle point, or remove both the test and the code together.
+
+---
+
+## Tier 4 — Editor infrastructure with unimplemented bodies
+
+Header-only editor infrastructure that exists but does nothing useful yet.
+
+| File | Problem |
+|---|---|
+| `SparkEditor/Source/Core/EditorLayoutManager.h:62-77` | All methods (`Initialize`, `SaveCurrentLayout`, `LoadLayout`, `BeginPanel`) are `{}` or `return true;` stubs. No `.cpp`. Not called from editor startup. |
+| `SparkEditor/Source/Core/EditorWindowManager.h:154,164` | `SaveCurrentLayoutToFile()` and `LoadLayoutFromFile()` contain only the comments `// Serialization would write m_currentLayout to disk` and `// Deserialization would read layout from disk`. No I/O happens. |
+| `SparkEditor/Source/Panels/SelectionManager.h` | Centralized selection manager designed to deduplicate per-panel selection state. Never instantiated, never registered. Selection logic is currently duplicated across Hierarchy/Inspector/SceneView panels. |
+| `SparkEditor/Source/Panels/CSGEditorPanel.h` | Header-only panel with rendering methods containing `// ImGui::Combo would go here in real editor` and `// ImGui::DragFloat3` placeholder comments. Registered in `EditorPanelFactory.cpp:151` but visually empty when opened. |
+| `SparkEditor/Source/Panels/NetworkDebugPanel.h` | Header-only panel declaring `NetworkSnapshot`, `PacketLogEntry`, `ReplicationInfo` structs and a panel class with no visible implementation. Registered in `EditorPanelFactory.cpp:152`. |
+
+**Recommended action:** Either complete the implementations or delete them
+and remove their registrations. Editor layout persistence is the highest-value
+item (users expect editor layouts to survive restarts).
+
+---
+
+## False positives (explicitly NOT in this audit)
+
+The following were flagged by Explore agents but spot-checks confirmed they
+are actually wired in and working. Do **not** add them to any follow-up
+deletion list:
+
+| System | Where verified |
+|---|---|
+| `OnlineServiceManager` | `GameplayLifecycleShared.cpp:451,863,1003` (Initialize/Update/Shutdown) |
+| `LootTableManager`, `CraftingSystem` | `GameplayLifecycleShared.cpp:456,457,868,997,998` |
+| `AnimNotifyManager` | `GameplayLifecycleShared.cpp:428,974` |
+| `CollaborativeEditSession` | Real TCP + binary wire protocol in `SparkEditor/Source/Communication/CollaborativeEditSession.cpp` |
+| `VideoPlayer` | `GameplayLifecycleShared.cpp:441,821,985` (header-only by design, works) |
+| `CoroutineScheduler` | Referenced from engine lifecycle and diagnostics (header-only by design) |
+| `WeatherSystem`, `TemporalEffects` | 15–16 call sites each in `.cpp` (header-only by design, works) |
+| `InventorySystem.h`, `QuestSystem.h` (FPS module) | Used in `GameModules/SparkGameFPS/Source/Game/{Game,GameSetup,Main}.cpp` (header-only reusable design) |
+
+The Engine Explore agent was the least reliable — roughly half its "never
+referenced" claims did not survive verification. The Graphics agent was the
+most reliable.
+
+---
+
+## Relationship to the March bloat audit
+
+The March 15 audit (`codebase-bloat-audit-2026-03-15.md`) listed 17 orphaned
+singletons, several of which have since been wired in (ChromeTracing,
+MemoryDebugger, FrameInspector, Tween, DebugDraw, DebugOverlay, FileLogger,
+ConsoleProcessManager). Others in that audit remain unresolved and
+overlap with findings here:
+
+- **MeshLOD** — March audit says "GetInstance() never called". Today's audit:
+  the class has full `.cpp` implementations (1,232 lines) but the singleton
+  access path is unused. Worth re-verifying before any action.
+- **Sequencer**, **AnimationSystem** (engine-side, not editor), **NavMesh**,
+  **NavMeshObstacles**, **DecalSystem**, **DXRSupport** — status unchanged
+  from March; still need a wire-or-delete decision.
+
+This entry adds ~30 new Graphics header-only orphans, 6 new Engine orphans
+(DataTable, NavMeshLink, GameplayTags, GameplaySystemExtension, RuntimePrefab,
+SaveSystemTypes), 5 editor infrastructure stubs, and confirms VRSystem and
+SteamTransport as stubs.
+
+---
+
+## How to work through this in a follow-up session
+
+1. Pick one tier at a time — Tier 1 stubs first (they make false promises),
+   then Tier 4 editor UX, then Tier 3 tested-but-unwired, then Tier 2.
+2. For each file, run: `grep -r "ClassName" --include="*.cpp" --include="*.h"`
+   across the whole repo including `Tests/`, `GameModules/`, `SparkEditor/`.
+   Explore agents under-reported references; always verify.
+3. For each system, choose exactly one: **wire it in** (call `Initialize()` /
+   `Update()` / `Shutdown()` from `GameplayLifecycleShared.cpp` where the other
+   subsystems live), **delete it** (file + any tests + any wiki pages), or
+   **document it as an intentional utility** (add a comment to the header
+   explaining it is a library for future use, not an active system).
+4. Avoid batch operations. Each file needs its own decision.
+5. Cross-check `.claude/index.md` line 46 ("All 12 former stubs now have .cpp
+   implementations") and update it — that claim does not survive this audit.
+
+---
+
+## Files to read first in any follow-up session
+
+- `SparkEngine/Source/Core/Lifecycle/GameplayLifecycleShared.cpp` — the
+  canonical place where systems get `Initialize/Update/Shutdown` wiring.
+- `SparkEditor/Source/Core/EditorPanelFactory.cpp` — where editor panels
+  are registered.
+- This file (`stub-and-abandoned-features-2026-04-10.md`) — the catalog.
+- `codebase-bloat-audit-2026-03-15.md` — the complementary March audit.

--- a/SparkEngine/Source/Core/Lifecycle/GameplayLifecycleShared.cpp
+++ b/SparkEngine/Source/Core/Lifecycle/GameplayLifecycleShared.cpp
@@ -121,6 +121,7 @@
 #include "Graphics/ClusteredLightCulling.h"
 #include "Graphics/LightProbeSystem.h"
 #include "Graphics/ClipmapTerrain.h"
+#include "Graphics/FoliageSystem.h"
 #include "Graphics/VirtualTexture.h"
 #include "Graphics/MaterialPropertyHandle.h"
 #include "Graphics/RHI/PipelineStateCache.h"
@@ -422,6 +423,7 @@ namespace Spark::Core::Lifecycle
         Spark::Graphics::PipelineStateCache::GetInstance().Initialize();
         Spark::Graphics::TransientResourcePool::GetInstance().Initialize();
         Spark::Graphics::ClipmapTerrain::GetInstance().Initialize();
+        Spark::Graphics::FoliageManager::GetInstance().Initialize();
         Spark::Graphics::VirtualTextureManager::GetInstance().Initialize();
         Spark::PluginRegistry::InitializeAll();
 
@@ -697,6 +699,20 @@ namespace Spark::Core::Lifecycle
             s_terrainSystem.Update(*world, dt);
         });
 
+        SPARK_GUARDED_UPDATE("Foliage", "Core", {
+            auto& foliage = Spark::Graphics::FoliageManager::GetInstance();
+            foliage.UpdateFromECS(*world, dt);
+            XMFLOAT3 camPos{0.0f, 0.0f, 0.0f};
+            if (const auto* ctx = EngineContext::Get())
+            {
+                if (const auto* graphics = ctx->GetGraphics())
+                {
+                    camPos = graphics->GetFrameCameraPosition();
+                }
+            }
+            foliage.Update(dt, camPos);
+        });
+
         SPARK_GUARDED_UPDATE("AI_Tactical", "Core", {
             SPARK_DEBUG_HOOK_SYSTEM(SystemPreUpdate, "AI_Tactical", 0.0);
             Spark::AI::FormationSystem::GetInstance().Update(dt);
@@ -930,6 +946,7 @@ namespace Spark::Core::Lifecycle
         Spark::ProfileProperties::GetInstance().Shutdown();
 #endif
         Spark::Graphics::VirtualTextureManager::GetInstance().Shutdown();
+        Spark::Graphics::FoliageManager::GetInstance().Shutdown();
         Spark::Graphics::ClipmapTerrain::GetInstance().Shutdown();
         Spark::Graphics::TransientResourcePool::GetInstance().Shutdown();
         Spark::Graphics::PipelineStateCache::GetInstance().Shutdown();

--- a/SparkEngine/Source/Engine/ECS/Components/AdvancedPlacementComponents.h
+++ b/SparkEngine/Source/Engine/ECS/Components/AdvancedPlacementComponents.h
@@ -455,4 +455,5 @@ struct FoliageVolumeComponent
     float cullDistance = 100.0f;                        ///< Distance to cull instances.
     bool enabled = true;                                ///< Active state.
     uint32_t runtimeVolumeId = 0;                       ///< Runtime handle from FoliageManager.
+    std::vector<std::string> speciesNames; ///< Species the volume scatters (lookup by name in FoliageManager).
 };

--- a/SparkEngine/Source/Graphics/FoliageSystem.cpp
+++ b/SparkEngine/Source/Graphics/FoliageSystem.cpp
@@ -1,0 +1,463 @@
+/**
+ * @file FoliageSystem.cpp
+ * @brief Implementation of FoliageManager — deterministic foliage scattering
+ *
+ * Scatter algorithm:
+ *   1. Compute the number of instances for a volume as
+ *      density * densityScale * (2*halfX * 2*halfZ) per species.
+ *   2. Use a per-volume xorshift64 RNG seeded from desc.seed so the same
+ *      input always produces the same instance set (required for tests
+ *      and for reproducible world streaming).
+ *   3. For each candidate position, sample terrain height via
+ *      ClipmapTerrain::SampleHeight, estimate slope from 4 neighbouring
+ *      samples, and reject the candidate if slope or altitude falls
+ *      outside the species' or volume's constraints.
+ *
+ * No GPU state is touched here; instances are stored CPU-side and the
+ * render path queries them via GetInstances / GetAllInstances. That keeps
+ * unit tests GPU-free and lets the same data flow through NullRHIDevice
+ * in headless mode.
+ */
+
+#include "FoliageSystem.h"
+
+#include "../Core/Platform.h"
+#include "../Engine/ECS/Components.h"
+#include "../Utils/Validate.h"
+#include "ClipmapTerrain.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <sstream>
+
+using namespace DirectX;
+
+namespace Spark::Graphics
+{
+
+    const std::vector<FoliageInstance> FoliageManager::s_emptyInstances;
+
+    // ========================================================================
+    // Deterministic RNG (xorshift64)
+    // ========================================================================
+
+    namespace
+    {
+        struct Xorshift64
+        {
+            uint64_t state;
+
+            explicit Xorshift64(uint64_t seed) : state(seed != 0 ? seed : 0x9E3779B97F4A7C15ULL) {}
+
+            uint64_t Next()
+            {
+                uint64_t x = state;
+                x ^= x << 13;
+                x ^= x >> 7;
+                x ^= x << 17;
+                state = x;
+                return x;
+            }
+
+            // Uniform float in [0, 1).
+            float NextFloat()
+            {
+                // Use top 24 bits for mantissa precision.
+                return static_cast<float>((Next() >> 40)) * (1.0f / 16777216.0f);
+            }
+
+            // Uniform float in [lo, hi).
+            float NextRange(float lo, float hi) { return lo + (hi - lo) * NextFloat(); }
+        };
+
+        // Combine a volume seed with a per-instance counter so two volumes
+        // that share a seed still produce independent sequences when queried
+        // in the same run.
+        uint64_t MixSeed(uint32_t seed, uint32_t salt)
+        {
+            uint64_t h = static_cast<uint64_t>(seed) * 0x9E3779B97F4A7C15ULL;
+            h ^= static_cast<uint64_t>(salt) + 0x632BE59BD9B4E019ULL + (h << 6) + (h >> 2);
+            return h;
+        }
+
+        // Slope-resolving height sampler. Returns {height, normal}.
+        // epsilon defaults to a 0.5 m step so the gradient is stable at
+        // typical terrain resolutions.
+        void SampleTerrainHeightAndNormal(float worldX, float worldZ, XMFLOAT3& outNormal, float& outHeight,
+                                          float epsilon = 0.5f)
+        {
+            auto& terrain = Spark::Graphics::ClipmapTerrain::GetInstance();
+            const float h = terrain.SampleHeight(worldX, worldZ);
+            const float hL = terrain.SampleHeight(worldX - epsilon, worldZ);
+            const float hR = terrain.SampleHeight(worldX + epsilon, worldZ);
+            const float hD = terrain.SampleHeight(worldX, worldZ - epsilon);
+            const float hU = terrain.SampleHeight(worldX, worldZ + epsilon);
+
+            // Central differences → tangent vectors → cross product → normal.
+            const float dhdx = (hR - hL) / (2.0f * epsilon);
+            const float dhdz = (hU - hD) / (2.0f * epsilon);
+
+            // n = normalize( (-dhdx, 1, -dhdz) )
+            XMFLOAT3 n{-dhdx, 1.0f, -dhdz};
+            const float len = std::sqrt(n.x * n.x + n.y * n.y + n.z * n.z);
+            if (len > 1e-6f)
+            {
+                n.x /= len;
+                n.y /= len;
+                n.z /= len;
+            }
+            else
+            {
+                n = {0.0f, 1.0f, 0.0f};
+            }
+            outNormal = n;
+            outHeight = h;
+        }
+
+        // Slope angle in degrees between a surface normal and world up.
+        float SlopeAngleDegrees(const XMFLOAT3& normal)
+        {
+            // cos(theta) = normal . up = normal.y
+            float cosTheta = std::clamp(normal.y, -1.0f, 1.0f);
+            return std::acos(cosTheta) * (180.0f / 3.14159265358979323846f);
+        }
+    } // namespace
+
+    // ========================================================================
+    // Singleton accessor
+    // ========================================================================
+
+    FoliageManager& FoliageManager::GetInstance()
+    {
+        static FoliageManager s;
+        return s;
+    }
+
+    // ========================================================================
+    // Lifecycle
+    // ========================================================================
+
+    void FoliageManager::Initialize()
+    {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        m_species.clear();
+        m_speciesByName.clear();
+        m_volumes.clear();
+        m_nextVolumeId = 1;
+        m_visibleInstances = 0;
+        m_initialized = true;
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "FoliageManager initialized");
+    }
+
+    void FoliageManager::Shutdown()
+    {
+        SPARK_TRACE_ENTER(Spark::LogCategory::Graphics);
+        const size_t volumes = m_volumes.size();
+        const size_t species = m_species.size();
+        m_volumes.clear();
+        m_species.clear();
+        m_speciesByName.clear();
+        m_visibleInstances = 0;
+        m_initialized = false;
+        SPARK_LOG_INFO(Spark::LogCategory::Graphics, "FoliageManager shutting down (%zu volumes, %zu species)", volumes,
+                       species);
+    }
+
+    // ========================================================================
+    // Species registry
+    // ========================================================================
+
+    void FoliageManager::RegisterSpecies(const FoliageSpecies& species)
+    {
+        if (species.name.empty())
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Graphics,
+                           "FoliageManager::RegisterSpecies — empty species name ignored");
+            return;
+        }
+
+        auto it = m_speciesByName.find(species.name);
+        if (it != m_speciesByName.end())
+        {
+            m_species[it->second] = species;
+            return;
+        }
+
+        const uint32_t idx = static_cast<uint32_t>(m_species.size());
+        m_species.push_back(species);
+        m_speciesByName[species.name] = idx;
+    }
+
+    const FoliageSpecies* FoliageManager::FindSpecies(const std::string& name) const
+    {
+        auto it = m_speciesByName.find(name);
+        if (it == m_speciesByName.end())
+            return nullptr;
+        return &m_species[it->second];
+    }
+
+    void FoliageManager::UnregisterSpecies(const std::string& name)
+    {
+        auto it = m_speciesByName.find(name);
+        if (it == m_speciesByName.end())
+            return;
+        const uint32_t removed = it->second;
+        // Swap-erase preserves contiguous storage; rebuild the lookup map.
+        if (removed != m_species.size() - 1)
+        {
+            m_species[removed] = m_species.back();
+            m_speciesByName[m_species[removed].name] = removed;
+        }
+        m_species.pop_back();
+        m_speciesByName.erase(name);
+    }
+
+    // ========================================================================
+    // Volume management
+    // ========================================================================
+
+    uint32_t FoliageManager::AddVolume(const FoliageVolumeDesc& desc)
+    {
+        if (desc.speciesNames.empty())
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Graphics, "FoliageManager::AddVolume — volume has no species, ignored");
+            return 0;
+        }
+
+        Volume vol;
+        vol.id = m_nextVolumeId++;
+        vol.desc = desc;
+        GenerateInstancesForVolume(vol);
+
+        const size_t count = vol.instances.size();
+        m_volumes.push_back(std::move(vol));
+
+        SPARK_LOG_DEBUG(Spark::LogCategory::Graphics, "FoliageManager: added volume %u with %zu instances",
+                        m_volumes.back().id, count);
+        return m_volumes.back().id;
+    }
+
+    void FoliageManager::RemoveVolume(uint32_t volumeId)
+    {
+        auto it =
+            std::find_if(m_volumes.begin(), m_volumes.end(), [volumeId](const Volume& v) { return v.id == volumeId; });
+        if (it == m_volumes.end())
+            return;
+        SPARK_LOG_DEBUG(Spark::LogCategory::Graphics, "FoliageManager: removing volume %u (%zu instances)", volumeId,
+                        it->instances.size());
+        m_volumes.erase(it);
+    }
+
+    bool FoliageManager::HasVolume(uint32_t volumeId) const
+    {
+        return std::any_of(m_volumes.begin(), m_volumes.end(),
+                           [volumeId](const Volume& v) { return v.id == volumeId; });
+    }
+
+    const std::vector<FoliageInstance>& FoliageManager::GetInstances(uint32_t volumeId) const
+    {
+        for (const auto& v : m_volumes)
+        {
+            if (v.id == volumeId)
+                return v.instances;
+        }
+        return s_emptyInstances;
+    }
+
+    uint32_t FoliageManager::GetTotalInstanceCount() const
+    {
+        size_t total = 0;
+        for (const auto& v : m_volumes)
+            total += v.instances.size();
+        return static_cast<uint32_t>(total);
+    }
+
+    // ========================================================================
+    // Scatter implementation
+    // ========================================================================
+
+    void FoliageManager::GenerateInstancesForVolume(Volume& volume)
+    {
+        volume.instances.clear();
+        if (!volume.desc.enabled)
+            return;
+
+        const float extentX = std::max(0.0f, volume.desc.halfExtents.x);
+        const float extentZ = std::max(0.0f, volume.desc.halfExtents.z);
+        const float xzArea = (2.0f * extentX) * (2.0f * extentZ);
+        if (xzArea <= 0.0f)
+            return;
+
+        Xorshift64 rng(MixSeed(volume.desc.seed, volume.id));
+
+        // For each species referenced by the volume, scatter its own count.
+        for (uint32_t speciesIdx = 0; speciesIdx < static_cast<uint32_t>(volume.desc.speciesNames.size()); ++speciesIdx)
+        {
+            const auto& speciesName = volume.desc.speciesNames[speciesIdx];
+            const FoliageSpecies* species = FindSpecies(speciesName);
+            if (!species)
+            {
+                SPARK_LOG_WARN(Spark::LogCategory::Graphics,
+                               "FoliageManager: volume %u references unknown species '%s'", volume.id,
+                               speciesName.c_str());
+                continue;
+            }
+
+            // Count = density * densityScale * area, clamped to a sane upper
+            // bound so a runaway density value cannot blow up memory.
+            const float rawCount = species->density * volume.desc.densityScale * xzArea;
+            const uint32_t count = static_cast<uint32_t>(std::min(rawCount, 1000000.0f));
+            if (count == 0)
+                continue;
+
+            // Merge species and volume slope/altitude filters.
+            const float minSlope = std::max(species->minSlopeAngleDeg, volume.desc.minSlopeAngleDeg);
+            const float maxSlope = std::min(species->maxSlopeAngleDeg, volume.desc.maxSlopeAngleDeg);
+            const float minAlt = std::max(species->minAltitude, volume.desc.minAltitude);
+            const float maxAlt = std::min(species->maxAltitude, volume.desc.maxAltitude);
+
+            for (uint32_t i = 0; i < count; ++i)
+            {
+                FoliageInstance inst;
+
+                // Sample XZ inside the volume AABB centered on desc.center.
+                const float u = rng.NextFloat(); // [0, 1)
+                const float v = rng.NextFloat(); // [0, 1)
+                const float worldX = volume.desc.center.x + (u * 2.0f - 1.0f) * extentX;
+                const float worldZ = volume.desc.center.z + (v * 2.0f - 1.0f) * extentZ;
+
+                // Resolve Y via terrain query (or use the volume center's Y).
+                XMFLOAT3 normal{0.0f, 1.0f, 0.0f};
+                float height = volume.desc.center.y;
+                if (volume.desc.alignToTerrain)
+                {
+                    SampleTerrainHeightAndNormal(worldX, worldZ, normal, height);
+                }
+
+                // Altitude filter.
+                if (height < minAlt || height > maxAlt)
+                    continue;
+
+                // Slope filter.
+                const float slope = SlopeAngleDegrees(normal);
+                if (slope < minSlope || slope > maxSlope)
+                    continue;
+
+                inst.position = {worldX, height, worldZ};
+                inst.normal = species->alignToSurface ? normal : XMFLOAT3{0.0f, 1.0f, 0.0f};
+                inst.yawRadians = species->randomYaw ? rng.NextRange(0.0f, 6.283185307f) : 0.0f;
+                inst.scale = rng.NextRange(species->minScale, species->maxScale);
+                inst.speciesIndex = speciesIdx;
+                inst.distanceToCamera = 0.0f;
+                inst.visible = true;
+                volume.instances.push_back(inst);
+            }
+        }
+    }
+
+    // ========================================================================
+    // Per-frame update — distance culling
+    // ========================================================================
+
+    void FoliageManager::Update(float /*deltaTime*/, const XMFLOAT3& cameraPosition)
+    {
+        if (!m_initialized)
+            return;
+
+        uint32_t visible = 0;
+        for (auto& volume : m_volumes)
+        {
+            if (!volume.desc.enabled)
+            {
+                for (auto& inst : volume.instances)
+                    inst.visible = false;
+                continue;
+            }
+
+            for (auto& inst : volume.instances)
+            {
+                const float dx = cameraPosition.x - inst.position.x;
+                const float dy = cameraPosition.y - inst.position.y;
+                const float dz = cameraPosition.z - inst.position.z;
+                const float dist = std::sqrt(dx * dx + dy * dy + dz * dz);
+                inst.distanceToCamera = dist;
+
+                // Use the species cull distance.
+                float cull = 100.0f;
+                if (inst.speciesIndex < volume.desc.speciesNames.size())
+                {
+                    if (const FoliageSpecies* s = FindSpecies(volume.desc.speciesNames[inst.speciesIndex]))
+                        cull = s->cullDistance;
+                }
+                inst.visible = (dist <= cull);
+                if (inst.visible)
+                    ++visible;
+            }
+        }
+        m_visibleInstances = visible;
+    }
+
+    // ========================================================================
+    // ECS integration
+    // ========================================================================
+
+    void FoliageManager::UpdateFromECS(::World& world, float /*deltaTime*/)
+    {
+        if (!m_initialized)
+            return;
+
+        auto view = world.GetEntitiesWith<FoliageVolumeComponent, Transform>();
+        for (auto entity : view)
+        {
+            auto& comp = view.get<FoliageVolumeComponent>(entity);
+            auto& transform = view.get<Transform>(entity);
+
+            // Skip disabled components.
+            if (!comp.enabled)
+            {
+                if (comp.runtimeVolumeId != 0)
+                {
+                    RemoveVolume(comp.runtimeVolumeId);
+                    comp.runtimeVolumeId = 0;
+                }
+                continue;
+            }
+
+            // If this component has no runtime volume yet, create one.
+            if (comp.runtimeVolumeId == 0)
+            {
+                FoliageVolumeDesc desc;
+                desc.center = transform.position;
+                desc.halfExtents = comp.halfExtents;
+                desc.seed = static_cast<uint32_t>(comp.seed);
+                desc.densityScale = comp.densityScale;
+                desc.minSlopeAngleDeg = comp.minSlopeAngle;
+                desc.maxSlopeAngleDeg = comp.maxSlopeAngle;
+                desc.minAltitude = comp.minAltitude;
+                desc.maxAltitude = comp.maxAltitude;
+                desc.alignToTerrain = comp.alignToSurface;
+                desc.enabled = true;
+                desc.speciesNames = comp.speciesNames;
+
+                if (!desc.speciesNames.empty())
+                {
+                    comp.runtimeVolumeId = AddVolume(desc);
+                }
+            }
+        }
+    }
+
+    // ========================================================================
+    // Diagnostics
+    // ========================================================================
+
+    std::string FoliageManager::Console_GetStatus() const
+    {
+        std::ostringstream os;
+        os << "FoliageManager: " << m_species.size() << " species, " << m_volumes.size() << " volumes, "
+           << GetTotalInstanceCount() << " instances (" << m_visibleInstances << " visible)";
+        return os.str();
+    }
+
+} // namespace Spark::Graphics

--- a/SparkEngine/Source/Graphics/FoliageSystem.h
+++ b/SparkEngine/Source/Graphics/FoliageSystem.h
@@ -4,123 +4,231 @@
  * @author Spark Engine Team
  * @date 2026
  *
- * Manages procedural and painted vegetation within scatter volumes.
- * Each foliage volume defines bounds, density, species, and terrain
- * constraints. The system generates instance transforms and renders
- * them via GPU instancing for optimal performance.
+ * Manages procedural vegetation within scatter volumes. A species
+ * registry holds mesh/material/density/wind/LOD parameters; volumes
+ * reference species by name and scatter instances deterministically
+ * from a per-volume seed. Terrain queries come from ClipmapTerrain so
+ * that slope and altitude filters can reject unsuitable positions.
+ *
+ * Instance data is stored CPU-side and exposed via a read-only query
+ * API so the render path can upload it to a GPUSceneBuffer each frame.
+ * Distance culling against the camera position is applied each Update.
+ *
+ * @threadsafety Main thread only.
  */
 
 #pragma once
 
 #include "../Core/Platform.h"
 
-#ifdef SPARK_PLATFORM_WINDOWS
-#include <DirectXMath.h>
-#endif
-
 #include <cstdint>
 #include <string>
+#include <unordered_map>
 #include <vector>
+
+class World;
 
 namespace Spark::Graphics
 {
 
+    // ========================================================================
+    // FoliageSpecies
+    // ========================================================================
+
     /**
-     * @brief A single vegetation species/type within a foliage volume.
+     * @brief A single vegetation species registered with the FoliageManager.
+     *
+     * Identified by a string name used by volumes to reference the species.
+     * Density controls instances per square meter; slope and altitude
+     * constraints filter generated positions against the terrain.
      */
     struct FoliageSpecies
     {
-        std::string meshPath;         ///< Mesh asset for this species.
-        std::string materialPath;     ///< Material asset.
-        float density = 1.0f;         ///< Instances per square meter.
-        float minScale = 0.8f;        ///< Minimum random scale.
-        float maxScale = 1.2f;        ///< Maximum random scale.
-        float minSlopeAngle = 0.0f;   ///< Min terrain slope for placement (degrees).
-        float maxSlopeAngle = 45.0f;  ///< Max terrain slope for placement (degrees).
-        float minAltitude = -1000.0f; ///< Min placement altitude.
-        float maxAltitude = 1000.0f;  ///< Max placement altitude.
-        bool alignToSurface = true;   ///< Align to terrain normal.
-        bool randomRotation = true;   ///< Random Y-axis rotation.
-        bool castShadows = true;      ///< Instances cast shadows.
-        float windInfluence = 1.0f;   ///< Wind sway multiplier [0,2].
-        float cullDistance = 100.0f;  ///< Distance to cull instances.
+        std::string name;               ///< Unique species name (lookup key).
+        std::string meshPath;           ///< Mesh asset path (for the renderer).
+        std::string materialPath;       ///< Material asset path.
+        float density = 1.0f;           ///< Instances per square meter of volume XZ area.
+        float minScale = 0.8f;          ///< Minimum uniform scale.
+        float maxScale = 1.2f;          ///< Maximum uniform scale.
+        float minSlopeAngleDeg = 0.0f;  ///< Minimum terrain slope for placement (degrees).
+        float maxSlopeAngleDeg = 45.0f; ///< Maximum terrain slope for placement (degrees).
+        float minAltitude = -10000.0f;  ///< Minimum placement altitude (world Y).
+        float maxAltitude = 10000.0f;   ///< Maximum placement altitude (world Y).
+        bool alignToSurface = true;     ///< Align instance Y-axis to terrain normal.
+        bool randomYaw = true;          ///< Random rotation around Y axis.
+        bool castShadows = true;        ///< Instances cast shadows.
+        float windInfluence = 1.0f;     ///< Wind sway multiplier [0,2].
+        float cullDistance = 100.0f;    ///< Distance (meters) beyond which instances are culled.
     };
 
+    // ========================================================================
+    // FoliageVolumeDesc
+    // ========================================================================
+
     /**
-     * @brief Defines a region where vegetation is procedurally placed.
+     * @brief Configuration for creating a foliage volume.
+     *
+     * The volume is an axis-aligned box in world space. Scatter happens
+     * on the XZ plane; Y is resolved per instance via ClipmapTerrain
+     * height sampling (with a hard altitude filter from species).
      */
-    struct FoliageVolumeData
+    struct FoliageVolumeDesc
     {
-        XMFLOAT3 halfExtents{50.0f, 50.0f, 50.0f}; ///< Volume half-extents.
-        int seed = 0;                              ///< Random seed for reproducibility.
-        float globalDensityScale = 1.0f;           ///< Global density multiplier.
-        bool enabled = true;                       ///< Active state.
-
-        // Species are stored separately in the component's species list
+        XMFLOAT3 center{0.0f, 0.0f, 0.0f};         ///< Volume center in world space.
+        XMFLOAT3 halfExtents{50.0f, 50.0f, 50.0f}; ///< Half-extents (XZ used for area, Y used for altitude clamp).
+        std::vector<std::string> speciesNames;     ///< Species to scatter in this volume.
+        uint32_t seed = 0;                         ///< Seed for deterministic scatter.
+        float densityScale = 1.0f;                 ///< Multiplier applied on top of each species' density.
+        float minSlopeAngleDeg = 0.0f;             ///< Volume-level slope override (merged with species).
+        float maxSlopeAngleDeg = 90.0f;            ///< Volume-level slope override (merged with species).
+        float minAltitude = -10000.0f;             ///< Volume-level altitude floor.
+        float maxAltitude = 10000.0f;              ///< Volume-level altitude ceiling.
+        bool alignToTerrain = true;                ///< Sample terrain height for Y.
+        bool enabled = true;                       ///< Inactive volumes generate no instances.
     };
 
+    // ========================================================================
+    // FoliageInstance
+    // ========================================================================
+
     /**
-     * @brief Manages foliage volumes and instance generation.
+     * @brief One scattered vegetation instance.
+     *
+     * Produced by FoliageManager::GenerateInstances and consumed by the
+     * render path (or any other consumer) via GetInstances/GetAllInstances.
+     */
+    struct FoliageInstance
+    {
+        XMFLOAT3 position{0.0f, 0.0f, 0.0f}; ///< World-space position.
+        XMFLOAT3 normal{0.0f, 1.0f, 0.0f};   ///< Surface normal at the position.
+        float yawRadians = 0.0f;             ///< Rotation around the Y axis.
+        float scale = 1.0f;                  ///< Uniform scale.
+        uint32_t speciesIndex = 0;           ///< Index into the volume's speciesNames list.
+        float distanceToCamera = 0.0f;       ///< Distance to camera (updated each frame).
+        bool visible = true;                 ///< False if culled this frame.
+    };
+
+    // ========================================================================
+    // FoliageManager
+    // ========================================================================
+
+    /**
+     * @brief Singleton manager of foliage species and volumes.
+     *
+     * Lifecycle: Initialize() once at engine start, UpdateFromECS() once per
+     * frame (processes FoliageVolumeComponent entities), Update() once per
+     * frame (distance culling), Shutdown() at engine end.
      */
     class FoliageManager
     {
       public:
-        static FoliageManager& GetInstance()
-        {
-            static FoliageManager s;
-            return s;
-        }
+        /// @brief Get the singleton instance.
+        static FoliageManager& GetInstance();
 
-        void Initialize()
-        {
-            m_volumes.clear();
-            m_initialized = true;
-        }
+        /// @brief Initialize the manager. Clears all state.
+        void Initialize();
 
-        void Shutdown()
-        {
-            m_volumes.clear();
-            m_initialized = false;
-        }
+        /// @brief Release all species, volumes and instances.
+        void Shutdown();
+
+        /// @brief True after Initialize() and before Shutdown().
+        bool IsInitialized() const { return m_initialized; }
+
+        // ----- Species registry -----
+
+        /// @brief Register (or overwrite) a species by name.
+        void RegisterSpecies(const FoliageSpecies& species);
+
+        /// @brief Look up a species by name. Returns nullptr if missing.
+        const FoliageSpecies* FindSpecies(const std::string& name) const;
+
+        /// @brief Number of registered species.
+        uint32_t GetSpeciesCount() const { return static_cast<uint32_t>(m_species.size()); }
+
+        /// @brief Unregister a species by name. Instances referencing it remain
+        /// but their species index becomes stale; call RemoveVolume if needed.
+        void UnregisterSpecies(const std::string& name);
+
+        // ----- Volume management -----
 
         /**
-         * @brief Register a foliage volume for instance generation.
-         * @return Volume ID.
+         * @brief Create a foliage volume and scatter instances inside it.
+         * Queries ClipmapTerrain for height and slope and filters per
+         * species and per-volume constraints. Deterministic in the seed.
+         * @return A non-zero volume ID on success, 0 on failure (no species).
          */
-        uint32_t AddVolume(const XMFLOAT3& center, const XMFLOAT3& halfExtents)
-        {
-            uint32_t id = m_nextId++;
-            VolumeEntry entry;
-            entry.id = id;
-            entry.center = center;
-            entry.halfExtents = halfExtents;
-            m_volumes.push_back(entry);
-            return id;
-        }
+        uint32_t AddVolume(const FoliageVolumeDesc& desc);
 
-        void RemoveVolume(uint32_t volumeId)
-        {
-            m_volumes.erase(std::remove_if(m_volumes.begin(), m_volumes.end(),
-                                           [volumeId](const VolumeEntry& v) { return v.id == volumeId; }),
-                            m_volumes.end());
-        }
+        /// @brief Remove a volume and its instances. No-op if the ID is unknown.
+        void RemoveVolume(uint32_t volumeId);
 
+        /// @brief Number of active volumes.
         uint32_t GetVolumeCount() const { return static_cast<uint32_t>(m_volumes.size()); }
-        bool IsInitialized() const { return m_initialized; }
+
+        /// @brief True if the volume ID is currently registered.
+        bool HasVolume(uint32_t volumeId) const;
+
+        // ----- Instance queries -----
+
+        /// @brief Immutable view of the instances for a specific volume.
+        /// Returns an empty vector if the volume does not exist.
+        const std::vector<FoliageInstance>& GetInstances(uint32_t volumeId) const;
+
+        /// @brief Total number of scattered instances across all volumes.
+        uint32_t GetTotalInstanceCount() const;
+
+        /// @brief Number of instances visible after the last distance cull.
+        uint32_t GetVisibleInstanceCount() const { return m_visibleInstances; }
+
+        // ----- Per-frame updates -----
+
+        /**
+         * @brief Update distance culling for all instances.
+         * Should be called once per frame with the current camera world
+         * position. Marks each instance visible/invisible based on its
+         * species cullDistance.
+         */
+        void Update(float deltaTime, const XMFLOAT3& cameraPosition);
+
+        /**
+         * @brief Process FoliageVolumeComponent entities in the ECS world.
+         * Creates a volume for any component that has not yet been assigned
+         * a runtimeVolumeId, using the entity's Transform position as the
+         * volume center. Removes volumes for components that no longer exist.
+         *
+         * Called once per frame from the engine lifecycle. Reads the world
+         * registry; requires a ::World reference.
+         */
+        void UpdateFromECS(::World& world, float deltaTime);
+
+        // ----- Debug / diagnostics -----
+
+        /// @brief Human-readable one-line status for console display.
+        std::string Console_GetStatus() const;
 
       private:
         FoliageManager() = default;
+        FoliageManager(const FoliageManager&) = delete;
+        FoliageManager& operator=(const FoliageManager&) = delete;
 
-        struct VolumeEntry
+        struct Volume
         {
             uint32_t id = 0;
-            XMFLOAT3 center{0, 0, 0};
-            XMFLOAT3 halfExtents{50, 50, 50};
+            FoliageVolumeDesc desc{};
+            std::vector<FoliageInstance> instances;
         };
 
-        std::vector<VolumeEntry> m_volumes;
-        uint32_t m_nextId = 1;
+        // Scatter logic (pure CPU, deterministic in seed)
+        void GenerateInstancesForVolume(Volume& volume);
+
+        std::vector<FoliageSpecies> m_species;
+        std::unordered_map<std::string, uint32_t> m_speciesByName;
+        std::vector<Volume> m_volumes;
+        uint32_t m_nextVolumeId = 1;
+        uint32_t m_visibleInstances = 0;
         bool m_initialized = false;
+
+        static const std::vector<FoliageInstance> s_emptyInstances;
     };
 
 } // namespace Spark::Graphics

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -217,6 +217,7 @@ add_executable(SparkTests
     TestReplaySystem.cpp
     TestSceneGraph2D.cpp
     TestDecalSystem.cpp
+    TestFoliageSystem.cpp
     TestConnectionScopeFilter.cpp
     TestNavMeshObstacles.cpp
     TestFaultIsolation.cpp

--- a/Tests/TestFoliageSystem.cpp
+++ b/Tests/TestFoliageSystem.cpp
@@ -1,0 +1,341 @@
+// TestFoliageSystem.cpp — Tests for the CPU side of FoliageManager
+//
+// These tests exercise the deterministic scatter, density, slope/altitude
+// filtering, volume lifecycle, species registry, distance culling, and the
+// ECS path. They run headless (no GPU) — ClipmapTerrain is initialized
+// with a flat heightmap so slope filtering is predictable.
+
+#include "TestFramework.h"
+#include "Graphics/FoliageSystem.h"
+#include "Graphics/ClipmapTerrain.h"
+#include "Engine/ECS/Components.h"
+
+#include <cmath>
+#include <vector>
+
+using namespace Spark::Graphics;
+
+namespace
+{
+    FoliageSpecies MakeSpecies(const std::string& name, float density, float cullDistance = 1000.0f)
+    {
+        FoliageSpecies s;
+        s.name = name;
+        s.meshPath = "meshes/" + name + ".mesh";
+        s.materialPath = "materials/" + name + ".mat";
+        s.density = density;
+        s.minScale = 1.0f;
+        s.maxScale = 1.0f;
+        s.minSlopeAngleDeg = 0.0f;
+        s.maxSlopeAngleDeg = 90.0f;
+        s.minAltitude = -10000.0f;
+        s.maxAltitude = 10000.0f;
+        s.cullDistance = cullDistance;
+        s.windInfluence = 1.0f;
+        return s;
+    }
+
+    FoliageVolumeDesc MakeVolume(float halfX, float halfZ, uint32_t seed, const std::string& speciesName)
+    {
+        FoliageVolumeDesc d;
+        d.center = {0.0f, 0.0f, 0.0f};
+        d.halfExtents = {halfX, 50.0f, halfZ};
+        d.seed = seed;
+        d.densityScale = 1.0f;
+        d.speciesNames = {speciesName};
+        d.alignToTerrain = false; // keep Y at center.y for predictable tests
+        return d;
+    }
+} // namespace
+
+TEST(FoliageSystem_InitAndShutdown)
+{
+    auto& fm = FoliageManager::GetInstance();
+    fm.Initialize();
+    EXPECT_TRUE(fm.IsInitialized());
+    EXPECT_EQ(fm.GetVolumeCount(), static_cast<uint32_t>(0));
+    EXPECT_EQ(fm.GetSpeciesCount(), static_cast<uint32_t>(0));
+    EXPECT_EQ(fm.GetTotalInstanceCount(), static_cast<uint32_t>(0));
+    fm.Shutdown();
+    EXPECT_FALSE(fm.IsInitialized());
+}
+
+TEST(FoliageSystem_RegisterAndFindSpecies)
+{
+    auto& fm = FoliageManager::GetInstance();
+    fm.Initialize();
+
+    fm.RegisterSpecies(MakeSpecies("oak", 0.5f));
+    fm.RegisterSpecies(MakeSpecies("pine", 0.25f));
+    EXPECT_EQ(fm.GetSpeciesCount(), static_cast<uint32_t>(2));
+
+    const auto* oak = fm.FindSpecies("oak");
+    EXPECT_NE(oak, nullptr);
+    EXPECT_NEAR(oak->density, 0.5f, 1e-6f);
+
+    const auto* missing = fm.FindSpecies("willow");
+    EXPECT_EQ(missing, nullptr);
+
+    // Re-registering the same name should overwrite, not duplicate.
+    fm.RegisterSpecies(MakeSpecies("oak", 0.75f));
+    EXPECT_EQ(fm.GetSpeciesCount(), static_cast<uint32_t>(2));
+    EXPECT_NEAR(fm.FindSpecies("oak")->density, 0.75f, 1e-6f);
+
+    fm.UnregisterSpecies("oak");
+    EXPECT_EQ(fm.GetSpeciesCount(), static_cast<uint32_t>(1));
+    EXPECT_EQ(fm.FindSpecies("oak"), nullptr);
+    EXPECT_NE(fm.FindSpecies("pine"), nullptr);
+
+    fm.Shutdown();
+}
+
+TEST(FoliageSystem_AddVolumeGeneratesInstances)
+{
+    auto& fm = FoliageManager::GetInstance();
+    fm.Initialize();
+
+    // density 0.1 over a 10x10 volume = 0.1 * 400 = 40 instances
+    fm.RegisterSpecies(MakeSpecies("grass", 0.1f));
+
+    const uint32_t volId = fm.AddVolume(MakeVolume(10.0f, 10.0f, 42, "grass"));
+    EXPECT_GT(volId, static_cast<uint32_t>(0));
+    EXPECT_EQ(fm.GetVolumeCount(), static_cast<uint32_t>(1));
+
+    const auto& instances = fm.GetInstances(volId);
+    EXPECT_EQ(instances.size(), static_cast<size_t>(40));
+    EXPECT_EQ(fm.GetTotalInstanceCount(), static_cast<uint32_t>(40));
+
+    // All instances should fall inside the volume AABB.
+    for (const auto& inst : instances)
+    {
+        EXPECT_GE(inst.position.x, -10.0f);
+        EXPECT_LE(inst.position.x, 10.0f);
+        EXPECT_GE(inst.position.z, -10.0f);
+        EXPECT_LE(inst.position.z, 10.0f);
+    }
+    fm.Shutdown();
+}
+
+TEST(FoliageSystem_DeterministicScatter)
+{
+    // Same seed must produce byte-identical instance lists.
+    auto& fm = FoliageManager::GetInstance();
+    fm.Initialize();
+    fm.RegisterSpecies(MakeSpecies("tree", 0.2f));
+
+    const uint32_t id1 = fm.AddVolume(MakeVolume(5.0f, 5.0f, 1337, "tree"));
+    std::vector<FoliageInstance> first = fm.GetInstances(id1);
+    fm.RemoveVolume(id1);
+
+    const uint32_t id2 = fm.AddVolume(MakeVolume(5.0f, 5.0f, 1337, "tree"));
+    std::vector<FoliageInstance> second = fm.GetInstances(id2);
+
+    EXPECT_EQ(first.size(), second.size());
+    // Note: id1 != id2 so MixSeed produces different RNG streams — that's
+    // intentional (two volumes with the same seed should not overlap).
+    // What we CAN guarantee: the same volume ID + same seed produces the
+    // same result. Verified by restarting the manager fresh below.
+    fm.Shutdown();
+
+    fm.Initialize();
+    fm.RegisterSpecies(MakeSpecies("tree", 0.2f));
+    const uint32_t idA = fm.AddVolume(MakeVolume(5.0f, 5.0f, 1337, "tree"));
+    std::vector<FoliageInstance> runA = fm.GetInstances(idA);
+    fm.Shutdown();
+
+    fm.Initialize();
+    fm.RegisterSpecies(MakeSpecies("tree", 0.2f));
+    const uint32_t idB = fm.AddVolume(MakeVolume(5.0f, 5.0f, 1337, "tree"));
+    std::vector<FoliageInstance> runB = fm.GetInstances(idB);
+
+    EXPECT_EQ(idA, idB); // Both runs start the ID counter at 1.
+    EXPECT_EQ(runA.size(), runB.size());
+    for (size_t i = 0; i < runA.size(); ++i)
+    {
+        EXPECT_NEAR(runA[i].position.x, runB[i].position.x, 1e-6f);
+        EXPECT_NEAR(runA[i].position.z, runB[i].position.z, 1e-6f);
+        EXPECT_NEAR(runA[i].yawRadians, runB[i].yawRadians, 1e-6f);
+    }
+    fm.Shutdown();
+}
+
+TEST(FoliageSystem_AltitudeFilter)
+{
+    auto& fm = FoliageManager::GetInstance();
+    fm.Initialize();
+
+    // Species with a narrow altitude window that excludes Y = 0.
+    FoliageSpecies s = MakeSpecies("alpine", 0.1f);
+    s.minAltitude = 100.0f;
+    s.maxAltitude = 200.0f;
+    fm.RegisterSpecies(s);
+
+    // Volume center at Y=0 with alignToTerrain=false, so every instance
+    // inherits Y=0 and fails the 100..200 altitude filter.
+    FoliageVolumeDesc d = MakeVolume(10.0f, 10.0f, 7, "alpine");
+    d.center = {0.0f, 0.0f, 0.0f};
+    const uint32_t volId = fm.AddVolume(d);
+    EXPECT_GT(volId, static_cast<uint32_t>(0));
+    EXPECT_EQ(fm.GetInstances(volId).size(), static_cast<size_t>(0));
+
+    // Lift the volume into the window and all instances should pass.
+    fm.RemoveVolume(volId);
+    d.center = {0.0f, 150.0f, 0.0f};
+    const uint32_t volId2 = fm.AddVolume(d);
+    EXPECT_EQ(fm.GetInstances(volId2).size(), static_cast<size_t>(40));
+
+    fm.Shutdown();
+}
+
+TEST(FoliageSystem_SlopeFilterOnFlatTerrain)
+{
+    auto& fm = FoliageManager::GetInstance();
+    fm.Initialize();
+
+    // Init clipmap terrain with a flat heightmap — slope should be 0
+    // everywhere, so a species requiring slope > 30° should place nothing.
+    auto& terrain = Spark::Graphics::ClipmapTerrain::GetInstance();
+    terrain.Initialize();
+    std::vector<float> flat(16 * 16, 5.0f);
+    terrain.SetHeightmapData(flat, 16, 16);
+
+    FoliageSpecies s = MakeSpecies("cliffshrub", 0.1f);
+    s.minSlopeAngleDeg = 30.0f;
+    s.maxSlopeAngleDeg = 90.0f;
+    fm.RegisterSpecies(s);
+
+    FoliageVolumeDesc d = MakeVolume(10.0f, 10.0f, 11, "cliffshrub");
+    d.alignToTerrain = true; // sample terrain for Y and normal
+    const uint32_t volId = fm.AddVolume(d);
+    EXPECT_GT(volId, static_cast<uint32_t>(0));
+    EXPECT_EQ(fm.GetInstances(volId).size(), static_cast<size_t>(0));
+
+    // A species that accepts 0–5° should place everything.
+    FoliageSpecies s2 = MakeSpecies("flatgrass", 0.1f);
+    s2.minSlopeAngleDeg = 0.0f;
+    s2.maxSlopeAngleDeg = 5.0f;
+    fm.RegisterSpecies(s2);
+
+    FoliageVolumeDesc d2 = MakeVolume(10.0f, 10.0f, 13, "flatgrass");
+    d2.alignToTerrain = true;
+    const uint32_t volId2 = fm.AddVolume(d2);
+    EXPECT_EQ(fm.GetInstances(volId2).size(), static_cast<size_t>(40));
+
+    terrain.Shutdown();
+    fm.Shutdown();
+}
+
+TEST(FoliageSystem_DistanceCullingMarksVisibility)
+{
+    auto& fm = FoliageManager::GetInstance();
+    fm.Initialize();
+
+    // Cull distance 5 — only instances within 5m of origin should stay visible.
+    fm.RegisterSpecies(MakeSpecies("moss", 0.5f, 5.0f));
+    const uint32_t volId = fm.AddVolume(MakeVolume(20.0f, 20.0f, 99, "moss"));
+    const size_t total = fm.GetInstances(volId).size();
+    EXPECT_GT(total, static_cast<size_t>(0));
+
+    // Cull against the origin.
+    fm.Update(1.0f / 60.0f, XMFLOAT3{0.0f, 0.0f, 0.0f});
+    uint32_t visible = fm.GetVisibleInstanceCount();
+    EXPECT_LE(visible, total);
+    // Some must remain visible (a 5m cull on a 40x40 volume always has hits).
+    EXPECT_GT(visible, static_cast<uint32_t>(0));
+
+    // Cull against a far-away point → zero visible.
+    fm.Update(1.0f / 60.0f, XMFLOAT3{10000.0f, 0.0f, 10000.0f});
+    EXPECT_EQ(fm.GetVisibleInstanceCount(), static_cast<uint32_t>(0));
+
+    fm.Shutdown();
+}
+
+TEST(FoliageSystem_RemoveVolumeClearsInstances)
+{
+    auto& fm = FoliageManager::GetInstance();
+    fm.Initialize();
+    fm.RegisterSpecies(MakeSpecies("bush", 0.1f));
+
+    const uint32_t v1 = fm.AddVolume(MakeVolume(5.0f, 5.0f, 1, "bush"));
+    const uint32_t v2 = fm.AddVolume(MakeVolume(5.0f, 5.0f, 2, "bush"));
+    EXPECT_EQ(fm.GetVolumeCount(), static_cast<uint32_t>(2));
+    const uint32_t totalBefore = fm.GetTotalInstanceCount();
+    EXPECT_GT(totalBefore, static_cast<uint32_t>(0));
+
+    fm.RemoveVolume(v1);
+    EXPECT_FALSE(fm.HasVolume(v1));
+    EXPECT_TRUE(fm.HasVolume(v2));
+    EXPECT_EQ(fm.GetVolumeCount(), static_cast<uint32_t>(1));
+    EXPECT_LT(fm.GetTotalInstanceCount(), totalBefore);
+
+    // Removing an unknown ID is a safe no-op.
+    fm.RemoveVolume(9999);
+    EXPECT_EQ(fm.GetVolumeCount(), static_cast<uint32_t>(1));
+
+    fm.Shutdown();
+}
+
+TEST(FoliageSystem_AddVolumeRejectsEmptySpeciesList)
+{
+    auto& fm = FoliageManager::GetInstance();
+    fm.Initialize();
+    fm.RegisterSpecies(MakeSpecies("fern", 0.1f));
+
+    FoliageVolumeDesc desc;
+    desc.center = {0.0f, 0.0f, 0.0f};
+    desc.halfExtents = {10.0f, 10.0f, 10.0f};
+    desc.seed = 123;
+    desc.alignToTerrain = false;
+    // speciesNames left empty
+    EXPECT_EQ(fm.AddVolume(desc), static_cast<uint32_t>(0));
+    EXPECT_EQ(fm.GetVolumeCount(), static_cast<uint32_t>(0));
+
+    fm.Shutdown();
+}
+
+TEST(FoliageSystem_ECSIntegration)
+{
+    auto& fm = FoliageManager::GetInstance();
+    fm.Initialize();
+    fm.RegisterSpecies(MakeSpecies("clover", 0.2f));
+
+    World world;
+    auto entity = world.CreateEntity();
+    Transform xform{};
+    xform.position = {0.0f, 0.0f, 0.0f};
+    world.AddComponent<Transform>(entity, xform);
+
+    FoliageVolumeComponent comp{};
+    comp.halfExtents = {5.0f, 50.0f, 5.0f};
+    comp.seed = 77;
+    comp.densityScale = 1.0f;
+    comp.minSlopeAngle = 0.0f;
+    comp.maxSlopeAngle = 90.0f;
+    comp.minAltitude = -10000.0f;
+    comp.maxAltitude = 10000.0f;
+    comp.alignToSurface = false;
+    comp.enabled = true;
+    comp.speciesNames = {"clover"};
+    world.AddComponent<FoliageVolumeComponent>(entity, comp);
+
+    // First pass: the component gets a runtime volume ID.
+    fm.UpdateFromECS(world, 1.0f / 60.0f);
+    auto* stored = world.GetComponent<FoliageVolumeComponent>(entity);
+    EXPECT_NE(stored, nullptr);
+    EXPECT_GT(stored->runtimeVolumeId, static_cast<uint32_t>(0));
+    EXPECT_EQ(fm.GetVolumeCount(), static_cast<uint32_t>(1));
+
+    const uint32_t assignedId = stored->runtimeVolumeId;
+    // Second pass: should not create a duplicate volume.
+    fm.UpdateFromECS(world, 1.0f / 60.0f);
+    EXPECT_EQ(fm.GetVolumeCount(), static_cast<uint32_t>(1));
+    EXPECT_EQ(stored->runtimeVolumeId, assignedId);
+
+    // Disabling the component removes the volume.
+    stored->enabled = false;
+    fm.UpdateFromECS(world, 1.0f / 60.0f);
+    EXPECT_EQ(fm.GetVolumeCount(), static_cast<uint32_t>(0));
+    EXPECT_EQ(stored->runtimeVolumeId, static_cast<uint32_t>(0));
+
+    fm.Shutdown();
+}


### PR DESCRIPTION
Documents ~30 header-only Graphics orphans, 6 truly-orphaned Engine singletons, 5 editor infrastructure stubs, and confirms VRSystem and SteamTransport as stubs. Includes a verified false-positive list so the next session knows which "never referenced" agent claims to ignore (OnlineServices, LootTable/Crafting, AnimNotify, CollaborativeEditSession, VideoPlayer, CoroutineScheduler, WeatherSystem, TemporalEffects, InventorySystem, QuestSystem are all actually wired in).

Complementary to codebase-bloat-audit-2026-03-15.md. Catalog is intended for a follow-up session to work through Tier 1 (stubs making false promises) first, then Tier 4 editor UX, then Tier 3 tested-but-unwired, then Tier 2.