### PR TITLE
fix: prevent 404 error bodies from corrupting download badges

### DIFF
--- a/.github/badges/nightly-downloads.json
+++ b/.github/badges/nightly-downloads.json
@@ -1,7 +1,7 @@
 {
     "schemaVersion": 1,
     "label": "nightly downloads",
-    "message": "0{"message":"Not Found","documentation_url":"https://docs.github.com/rest/releases/releases#get-a-release-by-tag-name","status":"404"}0",
+    "message": "0",
     "color": "brightgreen",
     "namedLogo": "github",
     "logoColor": "white"

--- a/.github/badges/stable-downloads.json
+++ b/.github/badges/stable-downloads.json
@@ -1,7 +1,7 @@
 {
     "schemaVersion": 1,
     "label": "release downloads",
-    "message": "0{"message":"Not Found","documentation_url":"https://docs.github.com/rest/releases/releases#get-the-latest-release","status":"404"}0",
+    "message": "0",
     "color": "blue",
     "namedLogo": "github",
     "logoColor": "white"

--- a/.github/workflows/update-downloads.yml
+++ b/.github/workflows/update-downloads.yml
@@ -20,40 +20,58 @@ jobs:
     - name: Refresh download count badges
       env:
         GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
       run: |
+        set -u
         mkdir -p .github/badges
         NIGHTLY_BADGE=".github/badges/nightly-downloads.json"
         STABLE_BADGE=".github/badges/stable-downloads.json"
 
-        # Fetch current nightly downloads
-        NIGHTLY_DL=$(gh api repos/${{ github.repository }}/releases/tags/nightly \
-          --jq '[.assets[].download_count] | add // 0' 2>/dev/null || echo 0)
-        NIGHTLY_FMT=$(printf "%'d" "$NIGHTLY_DL" 2>/dev/null || echo "$NIGHTLY_DL")
+        # Fetch the total download count for a release endpoint. Any failure
+        # (missing release, network error, non-numeric output) collapses to 0
+        # so that corrupt data can never leak into the badge JSON. We redirect
+        # both stderr AND stdout through the validator so a 404 body cannot
+        # be captured as the "count".
+        fetch_downloads() {
+          endpoint="$1"
+          raw=$(gh api "repos/$REPO/$endpoint" \
+            --jq '[.assets[].download_count] | add // 0' 2>/dev/null) || raw=""
+          case "$raw" in
+            ''|*[!0-9]*) printf '0' ;;
+            *)           printf '%s' "$raw" ;;
+          esac
+        }
+
+        # Format an integer with thousands separators. Falls back to the raw
+        # number if the locale-aware printf is unavailable.
+        format_count() {
+          LC_ALL=en_US.UTF-8 printf "%'d" "$1" 2>/dev/null || printf '%s' "$1"
+        }
+
+        # Build the badge JSON with jq so we get guaranteed-valid output and
+        # proper escaping regardless of the message contents.
+        write_badge() {
+          jq -n \
+            --arg label "$2" \
+            --arg message "$3" \
+            --arg color "$4" \
+            '{schemaVersion: 1, label: $label, message: $message, color: $color, namedLogo: "github", logoColor: "white"}' \
+            > "$1"
+        }
+
+        NIGHTLY_DL=$(fetch_downloads "releases/tags/nightly")
+        NIGHTLY_FMT=$(format_count "$NIGHTLY_DL")
         echo "Nightly downloads: $NIGHTLY_DL"
+        write_badge "$NIGHTLY_BADGE" "nightly downloads" "$NIGHTLY_FMT" "brightgreen"
 
-        echo "{
-            \"schemaVersion\": 1,
-            \"label\": \"nightly downloads\",
-            \"message\": \"$NIGHTLY_FMT\",
-            \"color\": \"brightgreen\",
-            \"namedLogo\": \"github\",
-            \"logoColor\": \"white\"
-        }" > "$NIGHTLY_BADGE"
-
-        # Fetch current stable (latest) downloads
-        STABLE_DL=$(gh api repos/${{ github.repository }}/releases/latest \
-          --jq '[.assets[].download_count] | add // 0' 2>/dev/null || echo 0)
-        STABLE_FMT=$(printf "%'d" "$STABLE_DL" 2>/dev/null || echo "$STABLE_DL")
+        STABLE_DL=$(fetch_downloads "releases/latest")
+        STABLE_FMT=$(format_count "$STABLE_DL")
         echo "Stable downloads: $STABLE_DL"
+        write_badge "$STABLE_BADGE" "release downloads" "$STABLE_FMT" "blue"
 
-        echo "{
-            \"schemaVersion\": 1,
-            \"label\": \"release downloads\",
-            \"message\": \"$STABLE_FMT\",
-            \"color\": \"blue\",
-            \"namedLogo\": \"github\",
-            \"logoColor\": \"white\"
-        }" > "$STABLE_BADGE"
+        # Sanity-check: both badge files must parse as JSON before we commit.
+        jq empty "$NIGHTLY_BADGE" "$STABLE_BADGE" \
+          || { echo "Generated badge JSON is invalid; aborting." >&2; exit 1; }
 
         # Commit if changed
         git config user.name "github-actions[bot]"


### PR DESCRIPTION
The update-downloads workflow captured gh api output with `2>/dev/null || echo 0`, which suppressed stderr but still let the 404 response body land in stdout when no nightly/latest release existed. The `printf "%'d"` fallback then echoed the garbage into NIGHTLY_FMT/STABLE_FMT, producing badge JSON like
`"message": "0{\"message\":\"Not Found\",...}0"` — which shields.io rendered as "unparseable json response".

Fix:
- fetch_downloads() validates the captured value is purely numeric and collapses anything else (including 404 bodies) to 0.
- write_badge() constructs the JSON via jq, guaranteeing proper escaping regardless of message contents, and avoiding the YAML heredoc pitfall that earlier commits worked around.
- A final `jq empty` pass validates both badge files before commit, so the workflow will fail loudly instead of shipping broken JSON.
- Reset the currently corrupted nightly-downloads.json and stable-downloads.json to a clean "0" state.

https://claude.ai/code/session_01VVBsv2meF8ZCKU1x28Aaby