### PR TITLE
fix(wine-upstream): address Codex review on set_gs_base without regre…

### DIFF
--- a/.claude/knowledge/wine-gvisor-root-cause-found-2026-04-14.md
+++ b/.claude/knowledge/wine-gvisor-root-cause-found-2026-04-14.md
@@ -1,9 +1,26 @@
 # Wine + gVisor: root cause found and fixed
 
-**Date:** 2026-04-14
+**Date:** 2026-04-14 (updated later the same day to address Codex review)
 **Type:** Observation + Fix
-**Status:** **RESOLVED**
-**Session:** deep investigation + empirical fix + verified working
+**Status:** **RESOLVED (iteration 3 — final)**
+**Session:** deep investigation + empirical fix + Codex review round-trip + verified working
+
+## Iteration history
+
+| Rev | Commit | Strategy | Outcome |
+|-----|--------|----------|---------|
+| 1 | `f0f9846` | wrgsbase first, arch_prctl fallback, unconditional | Fixes gVisor but flagged by Codex review for SIGILL risk on hosts with `CR4.FSGSBASE` cleared |
+| 2 | `be4282b` | Guard wrgsbase on `PF_RDWRFSGSBASE_AVAILABLE`, arch_prctl fallback | Addresses Codex, but **silently no-ops on gVisor** because gVisor under-reports `AT_HWCAP2` and Wine's feature flag is AND-gated on that bit |
+| 3 | `6db9694` (this version) | **arch_prctl first, verify via `%gs:0x30`, wrgsbase fallback only on failure** | Fixes gVisor AND avoids unconditional SIGILL on bare-metal hosts. Final. |
+
+Key insight for iteration 3: on bare-metal Linux `arch_prctl`
+succeeds, verification passes, and the `wrgsbase` fallback is
+**never executed** — so hosts with `CR4.FSGSBASE` disabled simply
+never reach the problematic instruction. The only hosts that get
+to `wrgsbase` are those where `arch_prctl` has already been proven
+broken at runtime, which in practice means user-mode Linux kernels
+that do expose the fsgsbase feature to user mode (such as gVisor).
+This gets correctness and safety without the Codex trade-off.
 
 ## Executive summary
 

--- a/docs/wine-upstream/0003-ntdll-use-wrgsbase-when-arch_prctl-is-broken.patch
+++ b/docs/wine-upstream/0003-ntdll-use-wrgsbase-when-arch_prctl-is-broken.patch
@@ -1,61 +1,78 @@
 From: SparkEngine Wine Compatibility <spark-wine@example.invalid>
-Date: Tue, 14 Apr 2026 07:00:00 +0000
-Subject: [PATCH] ntdll: use wrgsbase to set gs.base on Linux x86_64 when
- arch_prctl is broken
+Date: Tue, 14 Apr 2026 09:00:00 +0000
+Subject: [PATCH] ntdll: use wrgsbase as a fallback when arch_prctl(ARCH_SET_GS)
+ is broken
 
-On some user-mode Linux kernel emulators, arch_prctl(ARCH_SET_GS)
-silently does nothing: the syscall returns success but the gs.base
-MSR is never written. The most visible offender is gVisor's runsc
-sentry, which implements fsgsbase instructions (wrgsbase/rdgsbase)
-correctly but has a long-standing gap in its arch_prctl emulation
-for the ARCH_SET_GS and ARCH_GET_GS codes. Under such a kernel,
-Wine's x86_64 thread startup path calls
-`arch_prctl(ARCH_SET_GS, teb)` in init_syscall_frame, sees a
+On some user-mode Linux kernel emulators - notably gVisor's runsc
+sentry - `arch_prctl(ARCH_SET_GS)` either returns failure or
+silently discards the write while still returning success. Wine's
+x86_64 thread-startup path currently calls
+`arch_prctl(ARCH_SET_GS, teb)` in `init_syscall_frame`, sees the
 success return, and proceeds into PE ntdll. The new thread then
-resumes execution with gs.base left at whatever the emulator
-initially chose (in practice a glibc-private address such as
-0x7ff7_3491_0000).
+resumes execution with `gs.base` left at whatever the emulator
+initially chose - in practice a glibc-private address such as
+`0x7ff7_3491_0000` - instead of the TEB that was just allocated
+for it.
 
-Every subsequent `%gs:0x30` read in the PE ntdll - which is how
-`NtCurrentTeb()` is implemented - then returns garbage. The very
-first casualty is `loader_init()` in dlls/ntdll/loader.c:
+Every subsequent `%gs:0x30` read in PE ntdll (which is how
+`NtCurrentTeb()` is implemented on x86_64 Linux) then returns
+garbage. The very first casualty is `loader_init()` in
+`dlls/ntdll/loader.c`:
 
     mov 0x60(%r12),%rdi        ; rdi = teb->Peb, but r12 is bogus
     ...
     mov %rax,0x18(%rdi)        ; peb->LdrData = &ldr, faults at 0x18
 
-where r12 was loaded from `%gs:0x30` earlier. Because the value
-loaded by `mov %gs:0x30,%r12` happens to point to a partially
-mapped memory region in gVisor's layout, the earlier instructions
-do not fault; the cascade only blows up at the first dereference
-that actually reads a NULL-derived pointer. The failure then
-snowballs inside the exception dispatcher (__wine_dbg_get_channel_flags
-reads debug_options[] from a bogus debug_options pointer, each
-iteration pushes another exception frame, and the thread is
-eventually killed by virtual_setup_exception when the stack
-runs out).
+where `r12` was loaded from `%gs:0x30` earlier and the "TEB" it
+points at has `Peb == NULL`. Because the bogus `r12` value
+happens to land inside a partially mapped glibc-private region,
+the earlier reads succeed and the cascade only blows up at the
+first `NULL`-derived pointer write. The exception dispatcher then
+faults again inside `__wine_dbg_get_channel_flags` (which reads
+`debug_options[]` through a pointer that's also derived from
+%gs), each iteration pushes a new exception frame onto the user
+stack, and the thread is eventually killed by
+`virtual_setup_exception` when the stack runs out.
 
-Fix the root cause: introduce a small set_gs_base() helper that
-uses wrgsbase as the primary path - since wrgsbase is a direct
-instruction (no syscall), it cannot be intercepted or silently
-dropped by an emulator that still exposes the FSGSBASE feature to
-user mode - and verifies via a %gs-prefixed load. If wrgsbase had
-no effect (host has CR4.FSGSBASE cleared or traps the
-instruction), fall back to the existing arch_prctl(ARCH_SET_GS)
-path so this patch is a no-op on bare-metal Linux and on hosts
-that disable FSGSBASE entirely. Use the helper at all three
-existing call sites:
+Fix: introduce a small `set_gs_base()` helper that tries
+`arch_prctl(ARCH_SET_GS)` first and verifies the write took
+effect by reading `%gs:0x30` back. On a correctly-initialised
+TEB, `%gs:0x30` equals `teb` because `teb->NtTib.Self` is set to
+`&teb->Tib` in `init_teb()` and `Tib` lives at offset 0 of the
+TEB. If either the syscall failed or the verification mismatched,
+fall through to the `wrgsbase` instruction - a direct CPU
+instruction, not a syscall, that cannot be intercepted or
+silently dropped by an emulator that still exposes the FSGSBASE
+feature to user mode.
 
-  * init_syscall_frame - the primary thread-start path; this alone
-    is sufficient to make Wine boot correctly under gVisor.
-  * check_invalid_gsbase - the copy-protection workaround path;
-    keeping it consistent.
-  * init_handler - the signal-entry fixup path, to handle the
-    (narrow) case where the first fault on a thread arrives
-    before init_syscall_frame has run.
+Use the helper at all three existing call sites:
 
-Reproduction (on any host where arch_prctl(ARCH_SET_GS) silently
-fails, notably inside a gVisor container):
+  * `init_syscall_frame` - the primary thread-start path; this
+    alone is sufficient to make Wine boot correctly under gVisor.
+  * `check_invalid_gsbase` - the copy-protection workaround path,
+    for consistency with the primary path.
+  * `init_handler` - a signal-entry safety net: if the very first
+    fault on a thread arrives before `init_syscall_frame` gets a
+    chance to run, the signal handler can still repair `gs.base`
+    in time for the resumed user code to see the correct TEB.
+
+The layout of the helper is important for safety on hosts where
+`wrgsbase` would trap. On bare-metal Linux, `arch_prctl` works
+correctly and the verification always passes, so the `wrgsbase`
+fallback is never reached - even on kernels booted with
+`CR4.FSGSBASE` cleared or with `nofsgsbase`. A verifying
+`wrgsbase`-first layout (as tried in an earlier iteration of this
+patch) either had to be guarded on
+`PF_RDWRFSGSBASE_AVAILABLE` - which then breaks the gVisor case
+because gVisor under-reports `AT_HWCAP2`, so Wine's
+feature-detection concludes the instruction is unavailable - or
+left `wrgsbase` unguarded, which risks SIGILL on hosts with
+`CR4.FSGSBASE` cleared. Trying `arch_prctl` first and only
+reaching `wrgsbase` when `arch_prctl` has already been proven
+broken avoids both regressions.
+
+Reproduction (on any host where `arch_prctl(ARCH_SET_GS)`
+silently fails, notably inside a gVisor container):
 
     cat > hello.c <<'EOF'
     #include <stdio.h>
@@ -64,64 +81,84 @@ fails, notably inside a gVisor container):
     x86_64-w64-mingw32-gcc hello.c -o hello.exe
     wine64 hello.exe; echo rc=$?
 
-Before this patch: wine locks up looping on
-`err:seh:segv_handler Got unexpected trap 0` (already fixed by a
-previous patch in this series) and/or
-`err:virtual:virtual_setup_exception stack overflow N bytes` and
-exits with a SIGSEGV in the Wine loader itself (rc=139); hello's
-stdout never appears.
+Before this patch: wine either loops forever on
+`err:seh:segv_handler Got unexpected trap 0` (fixed separately by
+the trap-siginfo-fallback patch) and/or crashes the Wine loader
+itself in a NULL-pointer-write cascade inside `loader_init`; the
+guest binary never prints and rc != 42.
 
-After this patch: wine runs hello to completion, prints "hello",
-and returns rc=42.
+After this patch: wine runs `hello` to completion, prints
+`"hello"`, and returns `rc=42`.
+
+Verified by rebuilding wine-11.6 with this patch inside a gVisor
+sandbox and running the above reproducer.
 
 Signed-off-by: SparkEngine Wine Compatibility <spark-wine@example.invalid>
 ---
- dlls/ntdll/unix/signal_x86_64.c | 49 +++++++++++++++++++++++++++++++--
- 1 file changed, 46 insertions(+), 3 deletions(-)
+ dlls/ntdll/unix/signal_x86_64.c | 68 +++++++++++++++++++++++++++++++--
+ 1 file changed, 65 insertions(+), 3 deletions(-)
 
 diff --git a/dlls/ntdll/unix/signal_x86_64.c b/dlls/ntdll/unix/signal_x86_64.c
-index fd4d72e..be405a7 100644
+index c321b98..912c090 100644
 --- a/dlls/ntdll/unix/signal_x86_64.c
 +++ b/dlls/ntdll/unix/signal_x86_64.c
-@@ -771,6 +771,37 @@ __ASM_GLOBAL_FUNC( clear_alignment_flag,
+@@ -771,6 +771,55 @@ __ASM_GLOBAL_FUNC( clear_alignment_flag,
                     "ret" )
 
 
 +/***********************************************************************
 + *           set_gs_base
 + *
-+ * Set the gs.base MSR to point at the given TEB. Normally this is done
-+ * via arch_prctl(ARCH_SET_GS), but some user-mode Linux kernel
-+ * emulators (notably gVisor's runsc sentry) silently ignore
-+ * arch_prctl(ARCH_SET_GS) calls: the syscall returns success but the
-+ * write never takes effect, leaving gs.base at whatever the emulator
-+ * initially chose (often a glibc-private address). Under those
-+ * conditions Wine's PE ntdll hits NULL-pointer faults every time it
-+ * reads NtCurrentTeb() via `%gs:0x30`.
++ * Set the gs.base MSR to point at the given TEB.
 + *
-+ * Use the wrgsbase instruction as the primary path - it modifies the
-+ * gs.base MSR directly and works on every environment that exposes
-+ * the fsgsbase feature to user mode, including gVisor. Verify by
-+ * re-reading via a %gs-prefixed load (since rdgsbase can also be
-+ * broken on emulators). Fall back to arch_prctl if wrgsbase had no
-+ * effect, so that this helper is safe on hosts that disable
-+ * CR4.FSGSBASE. If both paths fail, the caller sees a gs.base that
-+ * still doesn't match teb and can escalate.
++ * On bare-metal Linux, arch_prctl(ARCH_SET_GS) is the canonical path
++ * and always works. On user-mode Linux kernel emulators - notably
++ * gVisor's runsc sentry - arch_prctl(ARCH_SET_GS) either returns
++ * failure or lies (returns success but never writes the MSR), leaving
++ * gs.base at whatever the emulator initially chose (often a
++ * glibc-private address). Under those conditions Wine's PE ntdll hits
++ * NULL-pointer faults every time it reads NtCurrentTeb() via
++ * `%gs:0x30`.
++ *
++ * Try arch_prctl first and VERIFY the write took effect by reading
++ * `%gs:0x30` (which, on a correctly-initialised TEB, equals teb
++ * because teb->NtTib.Self is set to &teb->Tib and Tib is at offset 0
++ * inside TEB). If either the syscall failed or the verification
++ * mismatched, fall through to wrgsbase - a direct CPU instruction,
++ * not a syscall, that cannot be intercepted by an emulator.
++ *
++ * This layout keeps the pre-patch behaviour on every host that
++ * implements arch_prctl correctly, INCLUDING hosts that disable
++ * CR4.FSGSBASE. On those hosts arch_prctl works, verification
++ * passes, and the wrgsbase fallback is never executed, so there is
++ * no risk of an unconditional SIGILL from wrgsbase on a host where
++ * FSGSBASE is not enabled. The wrgsbase fallback is only reached
++ * when arch_prctl has already been proven broken, which in practice
++ * means a user-mode Linux kernel that does expose the FSGSBASE
++ * feature to user space (such as gVisor).
 + */
 +static inline void set_gs_base( TEB *teb )
 +{
 +    ULONG_PTR probe = 0;
-+    __asm__ volatile("wrgsbase %0" :: "r"((ULONG_PTR)teb));
-+    __asm__ volatile("mov %%gs:0x30, %0" : "=r"(probe));
-+    if (probe != (ULONG_PTR)teb)
-+        arch_prctl( ARCH_SET_GS, teb );
++
++    if (arch_prctl( ARCH_SET_GS, teb ) == 0)
++    {
++        __asm__ volatile( "movq %%gs:0x30, %0" : "=r"(probe) );
++        if (probe == (ULONG_PTR)teb) return;
++    }
++    /* arch_prctl failed or silently discarded the write - fall back
++     * to the wrgsbase instruction. This is only reached on broken
++     * hosts; on bare-metal Linux the early return above is always
++     * taken and wrgsbase is never executed, so hosts with
++     * CR4.FSGSBASE cleared are unaffected. */
++    __asm__ volatile( "wrgsbase %0" :: "r"((ULONG_PTR)teb) );
 +}
 +
 +
  /***********************************************************************
   *           init_handler
   */
-@@ -779,9 +810,24 @@ static inline ucontext_t *init_handler( void *sigcontext )
+@@ -779,9 +828,24 @@ static inline ucontext_t *init_handler( void *sigcontext )
      clear_alignment_flag();
  #ifdef __linux__
      {
@@ -147,7 +184,7 @@ index fd4d72e..be405a7 100644
      }
  #elif defined __APPLE__
      {
-@@ -2249,7 +2295,7 @@ static inline BOOL check_invalid_gsbase( ucontext_t *ucontext )
+@@ -2249,7 +2313,7 @@ static inline BOOL check_invalid_gsbase( ucontext_t *ucontext )
      TRACE( "gsbase %016lx teb %p at instr %p, fixing up\n", cur_gsbase, teb, instr );
 
  #ifdef __linux__
@@ -156,7 +193,7 @@ index fd4d72e..be405a7 100644
  #elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
      amd64_set_gsbase( teb );
  #elif defined(__NetBSD__)
-@@ -2873,7 +2919,7 @@ void init_syscall_frame( LPTHREAD_START_ROUTINE entry, void *arg, BOOL suspend,
+@@ -2829,7 +2893,7 @@ void init_syscall_frame( LPTHREAD_START_ROUTINE entry, void *arg, BOOL suspend,
      thread_data->instrumentation_callback = &instrumentation_callback;
 
  #if defined __linux__

--- a/docs/wine-upstream/0004-ntdll-prefer-arch_prctl-for-set_gs_base.patch
+++ b/docs/wine-upstream/0004-ntdll-prefer-arch_prctl-for-set_gs_base.patch
@@ -1,0 +1,125 @@
+From 6db96945dc59d19de720fe47805fd5e45d2d4d03 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Tue, 14 Apr 2026 08:51:04 +0000
+Subject: [PATCH] ntdll: prefer arch_prctl for set_gs_base; fall back to
+ wrgsbase only on failure.
+
+The previous guard on PF_RDWRFSGSBASE_AVAILABLE addressed an
+unconditional-SIGILL concern but inadvertently broke the exact
+gVisor scenario the patch was written for. Under gVisor's runsc
+sentry, CR4.FSGSBASE is enabled at the vCPU level and wrgsbase
+works correctly, but Wine's PF_RDWRFSGSBASE_AVAILABLE flag is
+computed as `cpuid(7).ebx[0] & (getauxval(AT_HWCAP2) & 2)`, and
+gVisor's AT_HWCAP2 does NOT set the fsgsbase bit. Wine therefore
+concludes the feature is unavailable, takes the arch_prctl
+fallback, and hits the very bug this patch was introduced to fix:
+arch_prctl(ARCH_SET_GS) under gVisor returns -1 (or silently
+discards the write on other emulators), leaving gs.base pointing
+at a glibc-private address and turning every `%gs:0x30` in PE
+ntdll into a NULL-derived dereference.
+
+Restructure set_gs_base to try arch_prctl first and verify the
+write took effect, falling through to wrgsbase only if arch_prctl
+either failed or lied. This preserves the exact pre-patch
+behaviour on every environment where arch_prctl works correctly -
+including hosts that disable CR4.FSGSBASE, where the arch_prctl
+success path is always taken and the wrgsbase fallback is never
+executed, so there is no SIGILL risk from wrgsbase. The only hosts
+that reach the wrgsbase fallback are ones where arch_prctl has
+already been proven broken at runtime, which in practice means
+user-mode Linux kernels (gVisor) that DO expose FSGSBASE to user
+mode even though they under-report AT_HWCAP2.
+
+Verified by rebuilding wine-11.6 with this refactor, installing
+to a gVisor-hosted prefix, and running a MinGW-cross-compiled
+hello.exe to completion:
+
+    $ wine /tmp/hello.exe; echo rc=$?
+    hello from wine, argc=1
+    rc=42
+
+Addresses the regression introduced by the previous commit
+(be4282b) while preserving its intent of not executing wrgsbase
+on hosts where it would trap.
+---
+ dlls/ntdll/unix/signal_x86_64.c | 57 +++++++++++++++++++++------------
+ 1 file changed, 36 insertions(+), 21 deletions(-)
+
+diff --git a/dlls/ntdll/unix/signal_x86_64.c b/dlls/ntdll/unix/signal_x86_64.c
+index c564a41..912c090 100644
+--- a/dlls/ntdll/unix/signal_x86_64.c
++++ b/dlls/ntdll/unix/signal_x86_64.c
+@@ -774,34 +774,49 @@ __ASM_GLOBAL_FUNC( clear_alignment_flag,
+ /***********************************************************************
+  *           set_gs_base
+  *
+- * Set the gs.base MSR to point at the given TEB. Normally this is done
+- * via arch_prctl(ARCH_SET_GS), but some user-mode Linux kernel
+- * emulators (notably gVisor's runsc sentry) silently ignore
+- * arch_prctl(ARCH_SET_GS) calls: the syscall returns success but the
+- * write never takes effect, leaving gs.base at whatever the emulator
+- * initially chose (often a glibc-private address). Under those
+- * conditions Wine's PE ntdll hits NULL-pointer faults every time it
+- * reads NtCurrentTeb() via `%gs:0x30`.
++ * Set the gs.base MSR to point at the given TEB.
+  *
+- * Use the wrgsbase instruction as the primary path - it modifies the
+- * gs.base MSR directly and works on every environment that exposes
+- * the fsgsbase feature to user mode, including gVisor. Verify by
+- * re-reading via a %gs-prefixed load (since rdgsbase can also be
+- * broken on emulators). Fall back to arch_prctl if wrgsbase had no
+- * effect, so that this helper is safe on hosts that disable
+- * CR4.FSGSBASE. If both paths fail, the caller sees a gs.base that
+- * still doesn't match teb and can escalate.
++ * On bare-metal Linux, arch_prctl(ARCH_SET_GS) is the canonical path
++ * and always works. On user-mode Linux kernel emulators - notably
++ * gVisor's runsc sentry - arch_prctl(ARCH_SET_GS) either returns
++ * failure or lies (returns success but never writes the MSR), leaving
++ * gs.base at whatever the emulator initially chose (often a
++ * glibc-private address). Under those conditions Wine's PE ntdll hits
++ * NULL-pointer faults every time it reads NtCurrentTeb() via
++ * `%gs:0x30`.
++ *
++ * Try arch_prctl first and VERIFY the write took effect by reading
++ * `%gs:0x30` (which, on a correctly-initialised TEB, equals teb
++ * because teb->NtTib.Self is set to &teb->Tib and Tib is at offset 0
++ * inside TEB). If either the syscall failed or the verification
++ * mismatched, fall through to wrgsbase - a direct CPU instruction,
++ * not a syscall, that cannot be intercepted by an emulator.
++ *
++ * This layout keeps the pre-patch behaviour on every host that
++ * implements arch_prctl correctly, INCLUDING hosts that disable
++ * CR4.FSGSBASE. On those hosts arch_prctl works, verification
++ * passes, and the wrgsbase fallback is never executed, so there is
++ * no risk of an unconditional SIGILL from wrgsbase on a host where
++ * FSGSBASE is not enabled. The wrgsbase fallback is only reached
++ * when arch_prctl has already been proven broken, which in practice
++ * means a user-mode Linux kernel that does expose the FSGSBASE
++ * feature to user space (such as gVisor).
+  */
+ static inline void set_gs_base( TEB *teb )
+ {
+-    if (user_shared_data->ProcessorFeatures[PF_RDWRFSGSBASE_AVAILABLE])
++    ULONG_PTR probe = 0;
++
++    if (arch_prctl( ARCH_SET_GS, teb ) == 0)
+     {
+-        ULONG_PTR probe = 0;
+-        __asm__ volatile("wrgsbase %0" :: "r"((ULONG_PTR)teb));
+-        __asm__ volatile("mov %%gs:0x30, %0" : "=r"(probe));
++        __asm__ volatile( "movq %%gs:0x30, %0" : "=r"(probe) );
+         if (probe == (ULONG_PTR)teb) return;
+     }
+-    arch_prctl( ARCH_SET_GS, teb );
++    /* arch_prctl failed or silently discarded the write - fall back
++     * to the wrgsbase instruction. This is only reached on broken
++     * hosts; on bare-metal Linux the early return above is always
++     * taken and wrgsbase is never executed, so hosts with
++     * CR4.FSGSBASE cleared are unaffected. */
++    __asm__ volatile( "wrgsbase %0" :: "r"((ULONG_PTR)teb) );
+ }
+ 
+ 
+-- 
+2.43.0
+

--- a/docs/wine-upstream/README.md
+++ b/docs/wine-upstream/README.md
@@ -3,19 +3,29 @@
 This directory holds patches against Wine that fix real bugs we hit
 running MinGW-cross-compiled SparkEngine binaries under Wine inside a
 gVisor-backed sandbox. PR #470 on this repo already landed two earlier
-patches that were merged back into `Working`. This directory now holds
-the one patch that's still pending upstream submission:
+patches that were merged back into `Working`. This directory now holds:
 
 | # | File | Target | Status |
 |---|------|--------|--------|
-| 3 | `0003-ntdll-use-wrgsbase-when-arch_prctl-is-broken.patch` | `dlls/ntdll/unix/signal_x86_64.c` | **Verified end-to-end**, ready to submit |
+| 3 | `0003-ntdll-use-wrgsbase-when-arch_prctl-is-broken.patch` | `dlls/ntdll/unix/signal_x86_64.c` | **Final squashed patch**, ready to submit |
+| 4 | `0004-ntdll-prefer-arch_prctl-for-set_gs_base.patch` | `dlls/ntdll/unix/signal_x86_64.c` | **Codex-review fix commit**, apply on top of the existing `claude/wine-wrgsbase-fallback` branch on `Krilliac/wine` |
+
+The two files capture the same fix in two forms. Use patch 3 for
+upstream submission; it is a single clean commit ready to `git am`
+onto Wine master. Use patch 4 to update the existing
+`Krilliac/wine:claude/wine-wrgsbase-fallback` branch in place: the
+branch already holds two earlier commits (`f0f9846` + `be4282b`) from
+the Codex-review iteration, and this commit sits on top of them to
+restore gVisor correctness while keeping the no-unconditional-SIGILL
+guarantee.
 
 Patches 1 and 2 from the previous session (trap-siginfo fallback and
 pthread stack refresh) are on `Krilliac/wine` branches
-`claude/wine-trap-siginfo-fallback` and `claude/wine-stack-pthread-refresh`.
-**Patch 2 should be withdrawn** — follow-up investigation (see
-`.claude/knowledge/wine-gvisor-root-cause-found-2026-04-14.md`)
-proved the diagnosis wrong. Patch 3 supersedes it.
+`claude/wine-trap-siginfo-fallback` (still correct, keep) and
+`claude/wine-stack-pthread-refresh` (wrong diagnosis, withdraw).
+`wine-mirror/wine#62` is the PR that tried to merge patch 2; it has
+already been **closed** by upstream and no further action is needed
+on it. Patch 3 supersedes patch 2 entirely.
 
 ## What patch 0003 fixes
 
@@ -29,14 +39,33 @@ which cascades into a NULL-pointer write in `loader_init` at
 
 **Fix:** Wine currently writes gs.base via `arch_prctl(ARCH_SET_GS)`
 in three places. Replace all three with a `set_gs_base()` helper that
-uses the `wrgsbase` instruction (a direct CPU instruction, not a
-syscall, cannot be intercepted), verifies the write took effect via
-`mov %gs:0x30`, and falls back to `arch_prctl` only if the read-back
-mismatches.
+tries `arch_prctl` first and **verifies** the write took effect by
+reading `%gs:0x30` back. On a correctly-initialised TEB, that read
+equals `teb` because `teb->NtTib.Self = &teb->Tib` and `Tib` is at
+offset 0 inside TEB. If the syscall failed or the verification
+mismatched, fall through to `wrgsbase` — a direct CPU instruction,
+not a syscall, that cannot be intercepted. On bare-metal Linux
+`arch_prctl` always works and verification always passes, so the
+`wrgsbase` fallback is never reached — even on kernels with
+`CR4.FSGSBASE` cleared or booted with `nofsgsbase`. **There is no
+unconditional SIGILL risk from this patch.**
+
+An earlier iteration used wrgsbase as the primary path and fell
+back to `arch_prctl`. That version was flagged by a Codex review
+for SIGILL risk on hosts without CR4.FSGSBASE enabled. A second
+iteration guarded `wrgsbase` on
+`user_shared_data->ProcessorFeatures[PF_RDWRFSGSBASE_AVAILABLE]`,
+which made the patch silent-no-op on gVisor — gVisor does expose
+fsgsbase instructions to user mode, but Wine's feature flag is
+computed as `cpuid(7).ebx[0] & (AT_HWCAP2 & 2)`, and gVisor
+under-reports `AT_HWCAP2`. The final version in this patch swaps
+the priority: arch_prctl first, verify, wrgsbase only on failure.
+This gets both correctness (gVisor works) and safety (bare-metal
+hosts never execute `wrgsbase` on a disabled CR4.FSGSBASE).
 
 **Verified working:** after this patch, a minimal MinGW-compiled
 `hello` program runs under Wine inside gVisor, prints its output, and
-returns the correct exit code. Before the patch it either loops
+returns the correct exit code 42. Before the patch it either loops
 forever or crashes the Wine loader.
 
 ## Applying the patch
@@ -54,6 +83,47 @@ patch -p1 < /path/to/SparkEngine/docs/wine-upstream/0003-ntdll-use-wrgsbase-when
 git add dlls/ntdll/unix/signal_x86_64.c
 git commit -F <(sed -n '/^Subject:/,/^---$/p' /path/to/SparkEngine/docs/wine-upstream/0003-ntdll-use-wrgsbase-when-arch_prctl-is-broken.patch | head -n -1)
 ```
+
+## Updating the Krilliac/wine fork's existing wrgsbase branch
+
+The fork at `https://github.com/Krilliac/wine` already has a branch
+`claude/wine-wrgsbase-fallback` that holds two earlier iterations of
+this fix:
+
+```
+be4282b ntdll: guard wrgsbase with PF_RDWRFSGSBASE_AVAILABLE in set_gs_base.
+f0f9846 ntdll: use wrgsbase to set gs.base on Linux x86_64 when arch_prctl is broken.
+```
+
+Both commits have the **silent-no-op-on-gVisor** regression described
+above. To fix that branch without rewriting history, apply patch 0004
+on top of `be4282b` — it adds a third commit that restructures
+`set_gs_base()` to the final arch_prctl-first-then-wrgsbase layout:
+
+```bash
+cd /path/to/wine-fork
+git fetch origin claude/wine-wrgsbase-fallback
+git checkout claude/wine-wrgsbase-fallback
+git am /path/to/SparkEngine/docs/wine-upstream/0004-ntdll-prefer-arch_prctl-for-set_gs_base.patch
+git push origin HEAD:claude/wine-wrgsbase-fallback
+```
+
+After push, the branch will have three commits:
+
+```
+XXXXXXX ntdll: prefer arch_prctl for set_gs_base; fall back to wrgsbase only on failure.  [new]
+be4282b ntdll: guard wrgsbase with PF_RDWRFSGSBASE_AVAILABLE in set_gs_base.
+f0f9846 ntdll: use wrgsbase to set gs.base on Linux x86_64 when arch_prctl is broken.
+```
+
+For upstream submission, use the squashed patch 0003 instead — it
+collapses all three iterations into a single clean commit that
+represents the final state.
+
+Alternative: if you're willing to rewrite the branch history,
+`git reset --hard f0f9846^` then `git am` patch 0003 to produce a
+single clean commit on the branch. **Do not** force-push over a
+branch that has open PRs unless you've coordinated with reviewers.
 
 ## Building a patched Wine
 


### PR DESCRIPTION
…ssing gVisor

Codex flagged the first iteration of the wrgsbase patch (committed as f0f9846 on Krilliac/wine:claude/wine-wrgsbase-fallback) for an unconditional-SIGILL risk on hosts where CR4.FSGSBASE is disabled. The second iteration (be4282b) guarded wrgsbase on `user_shared_data->ProcessorFeatures[PF_RDWRFSGSBASE_AVAILABLE]`, which silenced the Codex warning but silently broke the gVisor case — gVisor does expose fsgsbase instructions to user mode, but Wine's feature flag is computed as `cpuid(7).ebx[0] & (AT_HWCAP2 & 2)` and gVisor under-reports AT_HWCAP2. Wine on gVisor therefore concluded fsgsbase was unavailable, took the arch_prctl fallback, and hit the very bug the patch was written to fix.

Third iteration (this commit): swap the priority inside `set_gs_base()`. Try arch_prctl first and **verify** the write took effect by reading `%gs:0x30` back (which equals `teb` on a correctly-initialised TEB because `teb->NtTib.Self = &teb->Tib` and Tib is at offset 0 inside TEB). Only fall through to wrgsbase if arch_prctl failed or lied. On every bare-metal Linux host arch_prctl succeeds and verification passes, so wrgsbase is never executed — even on kernels with CR4.FSGSBASE cleared or booted with `nofsgsbase`. The wrgsbase fallback is only reached on hosts where arch_prctl is already proven broken at runtime, which in practice means user-mode Linux kernels that DO support fsgsbase (such as gVisor). This gets both correctness and Codex-review safety without the trade-off.

Re-verified end-to-end by rebuilding wine-11.6 locally with the refactor applied and running MinGW-compiled hello.exe inside gVisor:

    $ wine /tmp/hello2.exe; echo rc=$?
    hello from wine, argc=1
    rc=42

Drops in this commit:

  * docs/wine-upstream/0003-ntdll-use-wrgsbase-when-arch_prctl-is-broken.patch — The squashed final patch for upstream submission. Single clean commit ready to `git am` onto Wine master. Replaces the version merged in PR #472 (which had the wrgsbase-first layout).

  * docs/wine-upstream/0004-ntdll-prefer-arch_prctl-for-set_gs_base.patch — A standalone fix commit for applying on top of the existing Krilliac/wine:claude/wine-wrgsbase-fallback branch (which holds f0f9846 + be4282b). Lets the fork branch be updated in place without rewriting history.

  * docs/wine-upstream/README.md — updated to explain the two patch forms, the Codex review loop, and how to update the Krilliac/wine fork's existing branch vs. submitting the squashed patch upstream.

  * .claude/knowledge/wine-gvisor-root-cause-found-2026-04-14.md — added an "Iteration history" table that captures the three versions of the fix and the Codex review round-trip, so future sessions don't re-walk the same trap.

Also notes that wine-mirror/wine#62 (the pthread-refresh PR from the earlier session) has been closed upstream, so no further action is needed on that PR; patch 3 supersedes it entirely.