### PR TITLE
Harden unavailable online/network backends with explicit fail-fast behavior

### DIFF
--- a/SparkEngine/Source/Engine/Networking/NetworkIntegration.h
+++ b/SparkEngine/Source/Engine/Networking/NetworkIntegration.h
@@ -37,6 +37,7 @@
 #include <memory>
 #include <string>
 #include <sstream>
+#include "Utils/LogMacros.h"
 
 namespace Spark::Net
 {
@@ -108,6 +109,17 @@ namespace Spark::Net
 
             if (!m_transport)
                 return false;
+
+            if (!m_transport->Initialize(config.serverPort))
+            {
+                SPARK_LOG_ERROR(Spark::LogCategory::Network,
+                                "NetworkStack::Initialize failed: transport '%s' could not initialize on port %u",
+                                m_transport->GetTransportName().c_str(), static_cast<unsigned>(config.serverPort));
+                m_transport.reset();
+                m_security.reset();
+                m_initialized = false;
+                return false;
+            }
 
             // Initialize security layer
             if (config.enableEncryption)
@@ -217,6 +229,7 @@ namespace Spark::Net
                 break;
             }
             ss << "\n";
+            ss << "  Ready:          " << ((m_transport && m_transport->IsReady()) ? "YES" : "NO") << "\n";
             ss << "  Encryption:     " << (m_security ? "ENABLED" : "DISABLED") << "\n";
             ss << "  Server:         " << m_config.serverAddress << ":" << m_config.serverPort << "\n";
             ss << "  Token Lifetime: " << m_config.tokenLifetimeSeconds << "s\n";

--- a/SparkEngine/Source/Engine/Networking/SteamTransport.h
+++ b/SparkEngine/Source/Engine/Networking/SteamTransport.h
@@ -32,6 +32,7 @@
 
 #pragma once
 #include "ITransport.h"
+#include "Utils/LogMacros.h"
 
 #ifdef ENABLE_NETWORKING
 
@@ -56,8 +57,10 @@ namespace Spark::Net
 
         bool Initialize(uint16_t /*port*/) override
         {
-            // Stub: returns false until Steamworks SDK is linked.
-            // With SDK: SteamNetworkingSockets()->InitAuthentication() on the given port.
+            // Stub fallback when Steamworks SDK is not integrated in this build.
+            SPARK_LOG_ERROR(Spark::LogCategory::Network,
+                            "SteamTransport::Initialize failed: Steamworks SDK not linked. "
+                            "Rebuild with ENABLE_STEAMWORKS and SteamNetworkingSockets support.");
             return false;
         }
 
@@ -69,16 +72,16 @@ namespace Spark::Net
 
         bool Send(const uint8_t* /*data*/, size_t /*size*/, const std::string& /*address*/, uint16_t /*port*/) override
         {
-            // Stub: returns false until Steamworks SDK is linked.
-            // With SDK: ISteamNetworkingSockets::SendMessageToConnection().
+            SPARK_LOG_ERROR(Spark::LogCategory::Network,
+                            "SteamTransport::Send failed: transport unavailable (Steamworks SDK not linked).");
             return false;
         }
 
         int Receive(uint8_t* /*buffer*/, size_t /*bufferSize*/, std::string& /*fromAddress*/,
                     uint16_t& /*fromPort*/) override
         {
-            // Stub: returns -1 until Steamworks SDK is linked.
-            // With SDK: ISteamNetworkingSockets::ReceiveMessagesOnConnection().
+            SPARK_LOG_ERROR(Spark::LogCategory::Network,
+                            "SteamTransport::Receive failed: transport unavailable (Steamworks SDK not linked).");
             return -1;
         }
 

--- a/SparkEngine/Source/Engine/OnlineServices/OnlineServices.h
+++ b/SparkEngine/Source/Engine/OnlineServices/OnlineServices.h
@@ -112,6 +112,18 @@ namespace Spark::OnlineServices
         std::string presence; ///< Status text (e.g. "In Game — Level 5")
     };
 
+    /** @brief Feature capability mask for a platform backend */
+    struct PlatformCapabilities
+    {
+        bool authentication = false;
+        bool sessions = false;
+        bool leaderboards = false;
+        bool achievements = false;
+        bool cloudSave = false;
+        bool friends = false;
+        bool presence = false;
+    };
+
     // ========================================================================
     // Abstract platform interface
     // ========================================================================
@@ -129,6 +141,10 @@ namespace Spark::OnlineServices
 
         /** @brief Get the platform name (e.g. "Steam", "Null") */
         virtual std::string GetPlatformName() const = 0;
+        /** @brief Query which online features the active backend supports. */
+        virtual PlatformCapabilities GetCapabilities() const = 0;
+        /** @brief Last human-readable failure reason from this backend (empty if none). */
+        virtual std::string GetLastError() const = 0;
 
         // --- Authentication ---
         virtual bool Login(const std::string& username, const std::string& token) = 0;
@@ -179,6 +195,19 @@ namespace Spark::OnlineServices
     {
       public:
         std::string GetPlatformName() const override { return "Null (Offline)"; }
+        PlatformCapabilities GetCapabilities() const override
+        {
+            PlatformCapabilities c;
+            c.authentication = true;
+            c.sessions = true;
+            c.leaderboards = true;
+            c.achievements = true;
+            c.cloudSave = true;
+            c.friends = true;
+            c.presence = true;
+            return c;
+        }
+        std::string GetLastError() const override { return m_lastError; }
 
         bool Login(const std::string& username, const std::string& /*token*/) override
         {
@@ -186,6 +215,7 @@ namespace Spark::OnlineServices
             m_player.displayName = username;
             m_player.isOnline = true;
             m_loggedIn = true;
+            m_lastError.clear();
             SPARK_LOG_INFO(Spark::LogCategory::Network, "Online: Login as '%s' (offline mode)", username.c_str());
             return true;
         }
@@ -220,6 +250,7 @@ namespace Spark::OnlineServices
                     return true;
                 }
             }
+            m_lastError = "Session not found: " + sessionId;
             return false;
         }
 
@@ -293,7 +324,13 @@ namespace Spark::OnlineServices
         std::vector<uint8_t> LoadFromCloud(const std::string& slotName) override
         {
             auto it = m_cloudSaves.find(slotName);
-            return (it != m_cloudSaves.end()) ? it->second : std::vector<uint8_t>{};
+            if (it == m_cloudSaves.end())
+            {
+                m_lastError = "Cloud slot not found: " + slotName;
+                return {};
+            }
+            m_lastError.clear();
+            return it->second;
         }
 
         bool DeleteCloudSave(const std::string& slotName) override { return m_cloudSaves.erase(slotName) > 0; }
@@ -318,6 +355,7 @@ namespace Spark::OnlineServices
 
       private:
         bool m_loggedIn = false;
+        std::string m_lastError;
         OnlinePlayerInfo m_player;
         SessionInfo m_currentSession;
         std::vector<SessionInfo> m_sessions;
@@ -381,6 +419,8 @@ namespace Spark::OnlineServices
     {
       public:
         std::string GetPlatformName() const override { return "Steam (Stub)"; }
+        PlatformCapabilities GetCapabilities() const override { return {}; }
+        std::string GetLastError() const override { return "Steamworks SDK unavailable in this build"; }
         bool Login(const std::string&, const std::string&) override { return false; /* SteamAPI_Init() */ }
         void Logout() override { /* SteamAPI_Shutdown() */ }
         bool IsLoggedIn() const override { return false; }
@@ -433,6 +473,8 @@ namespace Spark::OnlineServices
     {
       public:
         std::string GetPlatformName() const override { return "Epic (Stub)"; }
+        PlatformCapabilities GetCapabilities() const override { return {}; }
+        std::string GetLastError() const override { return "EOS SDK unavailable in this build"; }
         bool Login(const std::string&, const std::string&) override { return false; }
         void Logout() override {}
         bool IsLoggedIn() const override { return false; }
@@ -482,6 +524,11 @@ namespace Spark::OnlineServices
     {
       public:
         std::string GetPlatformName() const override { return "Console (Stub)"; }
+        PlatformCapabilities GetCapabilities() const override { return {}; }
+        std::string GetLastError() const override
+        {
+            return "Console SDK unavailable in this build (NDA platform integration required)";
+        }
         bool Login(const std::string&, const std::string&) override { return false; }
         void Logout() override {}
         bool IsLoggedIn() const override { return false; }
@@ -560,6 +607,13 @@ namespace Spark::OnlineServices
          */
         void SetPlatform(std::unique_ptr<IOnlinePlatform> platform)
         {
+            if (!platform)
+            {
+                SPARK_LOG_WARN(Spark::LogCategory::Core,
+                               "OnlineServiceManager::SetPlatform called with null platform, reverting to Null");
+                ResetToNullPlatform();
+                return;
+            }
             m_customPlatform = std::move(platform);
             m_activePlatform = m_customPlatform.get();
             SPARK_LOG_INFO(Spark::LogCategory::Core, "Online platform changed to: %s",
@@ -580,6 +634,18 @@ namespace Spark::OnlineServices
                 return "[OnlineServices] Not initialized";
             std::string status = "[OnlineServices] Platform: ";
             status += m_activePlatform ? m_activePlatform->GetPlatformName() : "None";
+            if (m_activePlatform)
+            {
+                const auto caps = m_activePlatform->GetCapabilities();
+                const bool hasAnyCapability = caps.authentication || caps.sessions || caps.leaderboards ||
+                                              caps.achievements || caps.cloudSave || caps.friends || caps.presence;
+                status += hasAnyCapability ? " | Capabilities: active" : " | Capabilities: none";
+                const std::string error = m_activePlatform->GetLastError();
+                if (!error.empty())
+                {
+                    status += " | LastError: " + error;
+                }
+            }
             if (m_activePlatform && m_activePlatform->IsLoggedIn())
             {
                 auto player = m_activePlatform->GetLocalPlayer();

--- a/SparkEngine/Source/Engine/VR/VRSystem.cpp
+++ b/SparkEngine/Source/Engine/VR/VRSystem.cpp
@@ -32,9 +32,10 @@ namespace Spark::VR
         //
         // For now, provide the framework stub
         m_initialized = false; // Set to true when OpenXR is linked
+        m_runtimeStatus = "OpenXR runtime not linked in this build (ENABLE_VR currently provides stub backend).";
         if (!m_initialized)
         {
-            SPARK_LOG_WARN(Spark::LogCategory::Core, "VRSystem::Initialize — OpenXR not linked, VR unavailable");
+            SPARK_LOG_WARN(Spark::LogCategory::Core, "VRSystem::Initialize — %s", m_runtimeStatus.c_str());
         }
         return m_initialized;
     }
@@ -65,8 +66,17 @@ namespace Spark::VR
 
     void VRSystem::TriggerHaptic(bool isLeft, float amplitude, float duration)
     {
+        if (amplitude < 0.0f || amplitude > 1.0f || duration < 0.0f)
+        {
+            SPARK_LOG_WARN(Spark::LogCategory::Core,
+                           "VRSystem::TriggerHaptic invalid params (left=%d amplitude=%.3f duration=%.3f)",
+                           isLeft ? 1 : 0, amplitude, duration);
+            return;
+        }
         if (!m_initialized)
         {
+            SPARK_LOG_DEBUG(Spark::LogCategory::Core, "VRSystem::TriggerHaptic ignored; runtime unavailable: %s",
+                            m_runtimeStatus.c_str());
             return;
         }
         (void)isLeft;
@@ -102,7 +112,7 @@ namespace Spark::VR
         }
         else
         {
-            oss << "VR hardware not detected or OpenXR not linked.\n";
+            oss << "Unavailable reason: " << m_runtimeStatus << "\n";
         }
         return oss.str();
     }

--- a/SparkEngine/Source/Engine/VR/VRSystem.h
+++ b/SparkEngine/Source/Engine/VR/VRSystem.h
@@ -193,6 +193,7 @@ namespace Spark::VR
         std::string Console_GetStatus() const;
 
       private:
+        std::string m_runtimeStatus = "OpenXR runtime not linked in this build."; ///< Human-readable backend state.
         std::atomic<bool> m_initialized{false};                       ///< Whether VR hardware is connected and ready.
         DirectX::XMFLOAT3 m_headPosition{0, 0, 0};                    ///< HMD position in tracking space (meters).
         DirectX::XMFLOAT4 m_headOrientation{0, 0, 0, 1};              ///< HMD orientation quaternion (x, y, z, w).

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -111,6 +111,7 @@ add_executable(SparkTests
     TestModuleHotReload.cpp
     TestConsoleRBAC.cpp
     TestNetworkIntegration.cpp
+    TestNetworkStack.cpp
     TestConnectionTimeout.cpp
     TestRecastIntegration.cpp
     TestAudioBackendFactory.cpp

--- a/Tests/TestNetworkStack.cpp
+++ b/Tests/TestNetworkStack.cpp
@@ -1,0 +1,38 @@
+#include "TestFramework.h"
+
+#include "Engine/Networking/NetworkIntegration.h"
+
+TEST(NetworkStack_UDPInitializeSucceeds)
+{
+    Spark::Net::NetworkStack stack;
+
+    Spark::Net::NetworkStackConfig config;
+    config.transport = Spark::Net::NetworkStackConfig::TransportType::UDP;
+    config.serverPort = 0; // Let OS pick an ephemeral port.
+    config.enableEncryption = false;
+
+    EXPECT_TRUE(stack.Initialize(config));
+    EXPECT_TRUE(stack.IsInitialized());
+    EXPECT_TRUE(stack.GetTransport() != nullptr);
+    EXPECT_EQ(stack.GetTransport()->GetTransportName(), std::string("UDP"));
+
+    const std::string status = stack.Console_GetStatus();
+    EXPECT_TRUE(status.find("Ready:          YES") != std::string::npos);
+
+    stack.Shutdown();
+    EXPECT_FALSE(stack.IsInitialized());
+}
+
+TEST(NetworkStack_SteamInitializeFailsFastWithoutSDK)
+{
+    Spark::Net::NetworkStack stack;
+
+    Spark::Net::NetworkStackConfig config;
+    config.transport = Spark::Net::NetworkStackConfig::TransportType::Steam;
+    config.serverPort = 27015;
+    config.enableEncryption = true;
+
+    EXPECT_FALSE(stack.Initialize(config));
+    EXPECT_FALSE(stack.IsInitialized());
+    EXPECT_TRUE(stack.GetTransport() == nullptr);
+}

--- a/Tests/TestOnlineServices.cpp
+++ b/Tests/TestOnlineServices.cpp
@@ -134,6 +134,10 @@ TEST(OnlineServices_SteamStub)
     EXPECT_EQ(steam.GetPlatformName(), std::string("Steam (Stub)"));
     EXPECT_FALSE(steam.Login("test", ""));
     EXPECT_FALSE(steam.IsLoggedIn());
+    EXPECT_TRUE(steam.GetLastError().find("Steamworks SDK unavailable") != std::string::npos);
+    const auto caps = steam.GetCapabilities();
+    EXPECT_FALSE(caps.authentication);
+    EXPECT_FALSE(caps.sessions);
 }
 
 TEST(OnlineServices_EpicStub)
@@ -160,5 +164,8 @@ TEST(OnlineServices_SetPlatform)
 
     mgr.ResetToNullPlatform();
     EXPECT_TRUE(mgr.GetPlatform()->GetPlatformName().find("Null") != std::string::npos);
+    const auto caps = mgr.GetPlatform()->GetCapabilities();
+    EXPECT_TRUE(caps.authentication);
+    EXPECT_TRUE(caps.sessions);
     mgr.Shutdown();
 }


### PR DESCRIPTION
### Motivation

- Make SDK-dependent subsystems (Steam transport, OpenXR VR, console/EOS backends) fail loudly and deterministically when the vendor SDKs are not present so runtime selection does not silently succeed with broken behavior.
- Surface clear, machine-parseable diagnostics and capability metadata so callers and the console can reason about which online features are actually available.
- Ensure the network stack does not bring up a partial/empty transport silently by verifying transport startup and reporting readiness immediately.

### Description

- Network stack: `NetworkStack::Initialize` now calls `ITransport::Initialize(port)`, fails fast and tears down the stack when the transport cannot initialize, and `Console_GetStatus()` includes a `Ready: YES/NO` field; changes in `SparkEngine/Source/Engine/Networking/NetworkIntegration.h`.
- Steam transport stub: added explicit error logging on `Initialize`, `Send`, and `Receive` to make missing Steamworks SDK failures visible; changes in `SparkEngine/Source/Engine/Networking/SteamTransport.h`.
- Online services: added `PlatformCapabilities` and `IOnlinePlatform` methods `GetCapabilities()` and `GetLastError()` and implemented capability/error reporting for `NullOnlinePlatform`, `SteamPlatform`, `EpicPlatform`, and `ConsolePlatform`, and enriched `OnlineServiceManager::SetPlatform` and `Console_GetStatus()` to show capability/error state; changes in `SparkEngine/Source/Engine/OnlineServices/OnlineServices.h`.
- VR system: record an explicit runtime-unavailable reason, validate haptic parameters in `TriggerHaptic`, and surface the unavailable reason in `Console_GetStatus()` to improve diagnostics when OpenXR is not linked; changes in `SparkEngine/Source/Engine/VR/VRSystem.h` and `VRSystem.cpp`.
- Tests and CI wiring: added `Tests/TestNetworkStack.cpp` covering UDP success and Steam fail-fast behavior, and augmented `Tests/TestOnlineServices.cpp` assertions to verify capability/error reporting; registered the new test in `Tests/CMakeLists.txt`.

### Testing

- Ran configuration with `cmake --preset linux-gcc-release`, which completed successfully.
- Ran `clang-format -i` across modified files to satisfy formatting rules, which succeeded.
- Started a full build of the test target with `cmake --build build/linux-gcc-release --config Release --target SparkTests -j 4`, which began compiling successfully but was manually terminated before completion due to environment resource constraints (build did not finish in this session).
- New unit tests were added (`Tests/TestNetworkStack.cpp`) and unit assertions in `Tests/TestOnlineServices.cpp` were updated, but the full test run (`ctest`) was not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e237876d548326a9754271dd767dfb)