### PR TITLE
fix(macos): add missing <limits> include to SeamlessAreaManager.cpp

### DIFF
--- a/SparkEngine/Source/Engine/Streaming/SeamlessAreaManager.cpp
+++ b/SparkEngine/Source/Engine/Streaming/SeamlessAreaManager.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cmath>
 #include <format>
+#include <limits>
 
 namespace Spark::Streaming
 {


### PR DESCRIPTION
Line 342 calls `std::numeric_limits<float>::max()` but the source file only pulls in `<algorithm>`, `<cmath>`, and `<format>` directly, relying on transitive inclusion of `<limits>` from other standard headers.

libstdc++ transitively pulls `<limits>` in via `<format>`, so linux-gcc, linux-clang (with libstdc++), and MSVC all compile cleanly. libc++ on Apple Clang (macos-latest) does NOT guarantee that transitive chain, which surfaces as an implicit-declaration error for `std::numeric_limits` when `<limits>` isn't explicitly included.

Add the explicit `#include <limits>` so the translation unit is self-contained on every standard library.

https://claude.ai/code/session_01Mh7upMC6QDG26iNfMARkwP