### PR TITLE
fix(build): make Jolt IPO follow ENABLE_LTO, disable LTO for macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -925,6 +925,7 @@ jobs:
         cmake -B build \
           -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
           -DBUILD_TESTS=ON \
+          -DENABLE_LTO=OFF \
           -DENABLE_SDL2=ON \
           -DENABLE_VULKAN=OFF \
           -DENABLE_OPENGL=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1133,8 +1133,12 @@ if(JOLT_FOUND)
     set(TARGET_VIEWER OFF CACHE BOOL "" FORCE)
     set(ENABLE_ALL_WARNINGS OFF CACHE BOOL "" FORCE)
     set(OVERRIDE_CXX_FLAGS OFF CACHE BOOL "" FORCE)
-    # Enable Jolt's IPO in Release/Shipping so it participates in whole-program LTO
-    if(CMAKE_BUILD_TYPE MATCHES "Release|MinSizeRel|RelWithDebInfo")
+    # Gate Jolt's IPO on our top-level ENABLE_LTO. When ENABLE_LTO=OFF the
+    # engine is compiled as plain ELF/native objects; enabling IPO only on
+    # Jolt leaves libJolt.a full of LLVM bitcode (Clang) or gcc-lto sections
+    # (GCC without the linker plugin), which GNU ld then rejects with
+    # "libJolt.a: error adding symbols: file format not recognized".
+    if(ENABLE_LTO AND CMAKE_BUILD_TYPE MATCHES "Release|MinSizeRel|RelWithDebInfo")
         set(INTERPROCEDURAL_OPTIMIZATION ON CACHE BOOL "" FORCE)
     else()
         set(INTERPROCEDURAL_OPTIMIZATION OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
Root cause of the linux-clang-Release / macos-{Debug,Release} linker failures on PR #491 was NOT a stale CI cache — a fresh local build reproduced it. Extracting any member of build/lib/libJolt.a showed LLVM IR bitcode, not ELF. GNU ld / ld64 then rejects the archive with:

    libJolt.a: error adding symbols: file format not recognized
    clang++: error: linker command failed with exit code 1

Jolt's CMake wrapper was forcing `INTERPROCEDURAL_OPTIMIZATION=ON` whenever CMAKE_BUILD_TYPE was Release/MinSizeRel/RelWithDebInfo, regardless of the top-level `ENABLE_LTO` option. The linux-clang CI passes `-DENABLE_LTO=OFF` expecting native objects everywhere, but Jolt still produced bitcode — a classic ABI/format mismatch that only the thin-LTO-aware lld or llvm-ar can resolve.

Fix:
- CMakeLists.txt: gate Jolt's IPO on `ENABLE_LTO AND <release config>` so the engine and Jolt stay in the same object format.
- build.yml: add `-DENABLE_LTO=OFF` to the macOS job. The job already unconditionally purges `lib*.a` as a workaround — removing the underlying mismatch lets that step become a no-op.

Verified locally: after the fix, `ar x libJolt.a AABBTreeBuilder.cpp.o` yields ELF relocatable instead of LLVM IR bitcode.