### PR TITLE
launcher: add standalone SparkLauncher project-browser executable

### DIFF
--- a/.claude/index.md
+++ b/.claude/index.md
@@ -46,7 +46,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 
 ## Quick Reference
 
-### Current Engine State (2026-04-18)
+### Current Engine State (2026-04-19)
 
 - **Physics**: Jolt Physics (migrated from Bullet3). Use `EngineContext::Get()->GetPhysics()`.
 - **Networking**: Enabled by default (`ENABLE_NETWORKING=ON`), UDP sockets, no external deps.
@@ -60,7 +60,7 @@ _Read this at every session start (after git sync). Each row links to a detailed
 - **Game modules**: 10 (SparkGame, FPS, MMO, RPG, ARPG, RTS, Racing, Platformer, OpenWorld, VisualScript).
 - **Infrastructure**: JobSystem wired, DeferredDeletionQueue in RHI, collision layer filtering, EntityEventBus cleanup, archetype spawn overrides.
 - **Gameplay**: TimeOfDaySystem, AI enemies in SparkGame (driven by `AIBudgetLimiter` distance-prioritised tick), WeatherSystem integration.
-- **Codebase**: ~566K lines of C++ across 1843 source files, 144 wiki pages.
+- **Codebase**: ~569K lines of C++ across 1855 source files, 144 wiki pages.
 
 ### Before Writing Code
 

--- a/.github/badges/files.json
+++ b/.github/badges/files.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": 1,
-  "label": "source files",
-  "message": "1853",
-  "color": "green"
+    "schemaVersion": 1,
+    "label": "source files",
+    "message": "1855",
+    "color": "green"
 }

--- a/.github/badges/loc-breakdown.json
+++ b/.github/badges/loc-breakdown.json
@@ -1,11 +1,11 @@
 {
-  "schemaVersion": 1,
-  "total": 569477,
-  "files": 1853,
-  "engine": 283708,
-  "editor": 88841,
-  "game": 58618,
-  "tests": 135909,
-  "tools": 2401,
-  "updated": "2026-04-19T01:20:25Z"
+    "schemaVersion": 1,
+    "total": 569524,
+    "files": 1855,
+    "engine": 283708,
+    "editor": 88888,
+    "game": 58618,
+    "tests": 135909,
+    "tools": 2401,
+    "updated": "2026-04-19T01:51:53Z"
 }

--- a/.github/badges/loc.json
+++ b/.github/badges/loc.json
@@ -1,8 +1,8 @@
 {
-  "schemaVersion": 1,
-  "label": "C++ lines of code",
-  "message": "569477",
-  "color": "blue",
-  "namedLogo": "cplusplus",
-  "logoColor": "white"
+    "schemaVersion": 1,
+    "label": "C++ lines of code",
+    "message": "569524",
+    "color": "blue",
+    "namedLogo": "cplusplus",
+    "logoColor": "white"
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,7 @@ SparkConsole/        ← External debug console app (named pipe communication)
 
 Shaders/HLSL/        ← DirectX shaders (PBR, post-processing, compute)
 Shaders/GLSL/        ← OpenGL shaders (experimental)
-Tests/               ← 5930 unit tests across 482 files, CTest integration
+Tests/               ← 5962 unit tests across 484 files, CTest integration
 Templates/           ← Game module templates
 Assets/              ← Demo scenes, models, scripts
 ```

--- a/.github/prompts/build-test.prompt.md
+++ b/.github/prompts/build-test.prompt.md
@@ -65,7 +65,7 @@ Builds on every push/PR: Windows MSVC + Linux GCC + Linux Clang (Debug + Release
 
 ## Testing
 
-5930 unit tests across 482 files in `Tests/` with internal framework + CTest.
+5962 unit tests across 484 files in `Tests/` with internal framework + CTest.
 
 ```bash
 cd build && ctest --output-on-failure          # all tests

--- a/.github/prompts/copilot-instructions.md
+++ b/.github/prompts/copilot-instructions.md
@@ -40,7 +40,7 @@ SparkConsole/        ← External debug console app (named pipe communication)
 
 Shaders/HLSL/        ← DirectX shaders (PBR, post-processing, compute)
 Shaders/GLSL/        ← OpenGL shaders (experimental)
-Tests/               ← 5930 unit tests across 482 files, CTest integration
+Tests/               ← 5962 unit tests across 484 files, CTest integration
 Templates/           ← Game module templates
 Assets/              ← Demo scenes, models, scripts
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ GameModules/SparkGameVisualScript/Source/ — Visual script game module (DLL)
 SparkConsole/src/                        — Standalone console application
 SparkShaderCompiler/src/                 — Shader compilation tool
 SparkSDK/                                — Public SDK/interface headers
-Tests/                                   — 5930 unit tests across 482 files, CTest
+Tests/                                   — 5962 unit tests across 484 files, CTest
 ```
 
 NullRHIDevice automatically activates when no GPU backend is available — engine continues in headless mode. GLAD (OpenGL loader) and SDL2 are bundled in `ThirdParty/`. SDL2 requires `libgl-dev` before CMake configure on Linux.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ option(SPARK_DOUBLE_PRECISION_PHYSICS "Enable double precision physics (JPH_DOUB
 
 # Editor available on Windows (Win32+DX11) and Linux (SDL2+OpenGL3)
 option(ENABLE_EDITOR "Enable editor features" ON)
+option(ENABLE_LAUNCHER "Build SparkLauncher (Unity-Hub-style project picker)" ON)
 
 # Build profile options — controls what ships in the final binary
 option(ENABLE_CONSOLE_IN_SHIPPING "Include SparkConsole in Shipping builds" OFF)
@@ -1380,6 +1381,11 @@ elseif(ENABLE_EDITOR AND NOT SPARK_EDITOR_DEPS_OK)
     endif()
 endif()
 
+if(ENABLE_LAUNCHER AND EXISTS "${CMAKE_SOURCE_DIR}/SparkLauncher/CMakeLists.txt")
+    message(STATUS "Adding SparkLauncher to build...")
+    add_subdirectory(SparkLauncher)
+endif()
+
 # ---------------------------------------------------------------------
 # 10) Asset Management - Copy shaders and assets to engine output
 # ---------------------------------------------------------------------
@@ -2142,6 +2148,7 @@ else()
     message(STATUS "Game Modules: OFF (engine-only build)")
 endif()
 message(STATUS "Editor: ${ENABLE_EDITOR}")
+message(STATUS "Launcher: ${ENABLE_LAUNCHER}")
 message(STATUS "Shader Compiler Tool: ENABLED")
 message(STATUS "Tests: ${BUILD_TESTS}")
 message(STATUS "Networking: ${ENABLE_NETWORKING}")

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 **Quality & Testing:**
 
-[![Tests](https://img.shields.io/badge/tests-5930_cases-brightgreen)](https://github.com/Krilliac/SparkEngine/tree/Working/Tests)
+[![Tests](https://img.shields.io/badge/tests-5962_cases-brightgreen)](https://github.com/Krilliac/SparkEngine/tree/Working/Tests)
 [![clang--format](https://img.shields.io/badge/style-clang--format-blue)](https://github.com/Krilliac/SparkEngine/blob/Working/.clang-format)
 [![clang--tidy](https://img.shields.io/badge/analysis-clang--tidy-blue)](https://github.com/Krilliac/SparkEngine/blob/Working/.clang-tidy)
 
@@ -427,7 +427,7 @@ SparkEngine/
 |   |-- Scenes/             # Level/scene JSON files
 |   |-- Scripts/            # AngelScript game scripts
 |-- Templates/               # Game module project templates
-|-- Tests/                   # 5930 unit tests across 482 files (CTest + 5 sanitizers)
+|-- Tests/                   # 5962 unit tests across 484 files (CTest + 5 sanitizers)
 |-- tools/
 |   |-- SparkBuild.exe       # Pre-built SparkBuild binary
 |   |-- update-sparkbuild.*  # Manual update scripts (ps1/sh)
@@ -472,7 +472,7 @@ The following libraries are included directly in the source tree:
 
 ## Tests
 
-5930 unit tests across 482 test files covering all major engine systems, built with a lightweight internal test framework (no external test dependencies). Integrated with CMake's CTest.
+5962 unit tests across 484 test files covering all major engine systems, built with a lightweight internal test framework (no external test dependencies). Integrated with CMake's CTest.
 
 ```bash
 # Build and run tests

--- a/SparkEditor/CMakeLists.txt
+++ b/SparkEditor/CMakeLists.txt
@@ -6,95 +6,11 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Find ImGui
-# NO_CMAKE_FIND_ROOT_PATH is needed for MinGW cross-compilation where the
-# toolchain restricts find_path to the sysroot, but ImGui lives in our source tree.
-find_path(IMGUI_INCLUDE_DIR
-    NAMES imgui.h
-    PATHS
-        "${CMAKE_SOURCE_DIR}/ThirdParty/imgui"
-        "${CMAKE_SOURCE_DIR}/ThirdParty/UI/imgui"
-        "${CMAKE_SOURCE_DIR}/External/imgui"
-        "${CMAKE_SOURCE_DIR}/Vendor/imgui"
-    DOC "Dear ImGui include directory"
-    NO_CMAKE_FIND_ROOT_PATH
-)
+# Shared ImGui target (used by SparkEditor and SparkLauncher).
+include("${CMAKE_SOURCE_DIR}/cmake/BuildImGui.cmake")
 
-if(IMGUI_INCLUDE_DIR)
-    message(STATUS "Found Dear ImGui at: ${IMGUI_INCLUDE_DIR}")
-
-    # Only create the imgui target if it doesn't already exist (may be defined in ThirdParty)
-    if(NOT TARGET imgui)
-        set(IMGUI_CORE_SOURCES
-            "${IMGUI_INCLUDE_DIR}/imgui.cpp"
-            "${IMGUI_INCLUDE_DIR}/imgui_demo.cpp"
-            "${IMGUI_INCLUDE_DIR}/imgui_draw.cpp"
-            "${IMGUI_INCLUDE_DIR}/imgui_tables.cpp"
-            "${IMGUI_INCLUDE_DIR}/imgui_widgets.cpp"
-        )
-
-        if(WIN32)
-            # Windows: Win32 + DirectX 11 backends
-            add_library(imgui STATIC
-                ${IMGUI_CORE_SOURCES}
-                "${IMGUI_INCLUDE_DIR}/backends/imgui_impl_win32.cpp"
-                "${IMGUI_INCLUDE_DIR}/backends/imgui_impl_dx11.cpp"
-            )
-
-            target_compile_definitions(imgui PUBLIC
-                IMGUI_IMPL_WIN32_DISABLE_GAMEPAD
-                IMGUI_IMPL_WIN32_DISABLE_LINKING_XINPUT
-            )
-
-            target_link_libraries(imgui PUBLIC
-                d3d11 dxgi user32 gdi32 shell32 ole32 oleaut32 uuid comdlg32 advapi32
-            )
-        else()
-            # Linux: SDL2 + OpenGL3 backends (ImGui ships its own GL loader)
-            # SDL2 may come from ThirdParty submodule or system install
-            if(NOT TARGET SDL2::SDL2 AND NOT TARGET SDL2)
-                find_package(SDL2 REQUIRED)
-            endif()
-            find_package(OpenGL REQUIRED)
-
-            add_library(imgui STATIC
-                ${IMGUI_CORE_SOURCES}
-                "${IMGUI_INCLUDE_DIR}/backends/imgui_impl_sdl2.cpp"
-                "${IMGUI_INCLUDE_DIR}/backends/imgui_impl_opengl3.cpp"
-            )
-
-            if(TARGET SDL2::SDL2)
-                target_link_libraries(imgui PUBLIC SDL2::SDL2)
-            elseif(TARGET SDL2)
-                target_link_libraries(imgui PUBLIC SDL2)
-            else()
-                target_include_directories(imgui PUBLIC ${SDL2_INCLUDE_DIRS})
-                target_link_libraries(imgui PUBLIC ${SDL2_LIBRARIES})
-            endif()
-
-            target_link_libraries(imgui PUBLIC OpenGL::GL)
-        endif()
-
-        target_include_directories(imgui PUBLIC
-            "${IMGUI_INCLUDE_DIR}"
-            "${IMGUI_INCLUDE_DIR}/backends"
-        )
-
-        if(MSVC)
-            target_compile_options(imgui PRIVATE /W2)
-            target_compile_definitions(imgui PRIVATE
-                WIN32_LEAN_AND_MEAN
-                NOMINMAX
-                _CRT_SECURE_NO_WARNINGS
-            )
-            set_property(TARGET imgui PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-        endif()
-    endif()
-
-    set(IMGUI_FOUND TRUE)
-else()
+if(NOT IMGUI_FOUND)
     message(FATAL_ERROR "Dear ImGui is required for SparkEditor but was not found!")
-    set(IMGUI_FOUND FALSE)
 endif()
 
 # Collect source files

--- a/SparkEditor/Source/Panels/ProjectBrowserPanel.cpp
+++ b/SparkEditor/Source/Panels/ProjectBrowserPanel.cpp
@@ -7,6 +7,7 @@
 
 #include "ProjectBrowserPanel.h"
 #include "Utils/LogMacros.h"
+#include "../Utils/FolderDialog.h"
 #include "../../../SparkEngine/Source/Utils/Validate.h"
 #include <imgui.h>
 #include <imgui_internal.h>
@@ -15,12 +16,6 @@
 #include <chrono>
 #include <ctime>
 #include <cstring>
-#include <cstdio>
-
-#ifdef _WIN32
-#include <windows.h>
-#include <shlobj.h>
-#endif
 
 namespace fs = std::filesystem;
 
@@ -494,58 +489,7 @@ namespace SparkEditor
 
     bool ProjectBrowserPanel::BrowseForFolder(std::string& outPath)
     {
-#ifdef _WIN32
-        BROWSEINFOA bi = {};
-        bi.lpszTitle = "Select Project Folder";
-        bi.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE;
-
-        LPITEMIDLIST pidl = SHBrowseForFolderA(&bi);
-        if (pidl)
-        {
-            char path[MAX_PATH];
-            if (SHGetPathFromIDListA(pidl, path))
-            {
-                outPath = path;
-                CoTaskMemFree(pidl);
-                return true;
-            }
-            CoTaskMemFree(pidl);
-        }
-        return false;
-#else
-        // On Linux/macOS, try zenity or kdialog for a native folder chooser
-        FILE* pipe = popen("zenity --file-selection --directory --title=\"Select Project Folder\" 2>/dev/null", "r");
-        if (!pipe)
-        {
-            // Try kdialog as fallback
-            pipe = popen("kdialog --getexistingdirectory ~ 2>/dev/null", "r");
-        }
-        if (pipe)
-        {
-            char buf[1024];
-            std::string result;
-            while (fgets(buf, sizeof(buf), pipe) != nullptr)
-            {
-                result += buf;
-            }
-            int status = pclose(pipe);
-            // Remove trailing newline
-            while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
-            {
-                result.pop_back();
-            }
-            if (status == 0 && !result.empty())
-            {
-                // Validate that the returned path is an existing directory
-                if (std::filesystem::is_directory(result))
-                {
-                    outPath = result;
-                    return true;
-                }
-            }
-        }
-        return false;
-#endif
+        return SparkEditor::Utils::BrowseForFolder(outPath, "Select Project Folder");
     }
 
 } // namespace SparkEditor

--- a/SparkEditor/Source/Utils/FolderDialog.cpp
+++ b/SparkEditor/Source/Utils/FolderDialog.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file FolderDialog.cpp
+ * @brief Cross-platform native folder-picker dialog implementation.
+ * @author Spark Engine Team
+ * @date 2025
+ */
+
+#include "FolderDialog.h"
+
+#include <filesystem>
+#include <string>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <shlobj.h>
+#else
+#include <cstdio>
+#include <cstdlib>
+#endif
+
+namespace SparkEditor::Utils
+{
+    bool BrowseForFolder(std::string& outPath, const char* title)
+    {
+#ifdef _WIN32
+        BROWSEINFOA bi = {};
+        bi.lpszTitle = title;
+        bi.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE;
+
+        LPITEMIDLIST pidl = SHBrowseForFolderA(&bi);
+        if (pidl)
+        {
+            char path[MAX_PATH];
+            if (SHGetPathFromIDListA(pidl, path))
+            {
+                outPath = path;
+                CoTaskMemFree(pidl);
+                return true;
+            }
+            CoTaskMemFree(pidl);
+        }
+        return false;
+#else
+        std::string cmd = "zenity --file-selection --directory --title=\"";
+        cmd += title ? title : "Select Folder";
+        cmd += "\" 2>/dev/null";
+
+        FILE* pipe = popen(cmd.c_str(), "r");
+        if (!pipe)
+        {
+            pipe = popen("kdialog --getexistingdirectory ~ 2>/dev/null", "r");
+        }
+        if (!pipe)
+        {
+            return false;
+        }
+
+        char buf[1024];
+        std::string result;
+        while (fgets(buf, sizeof(buf), pipe) != nullptr)
+        {
+            result += buf;
+        }
+        int status = pclose(pipe);
+        while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
+        {
+            result.pop_back();
+        }
+        if (status == 0 && !result.empty() && std::filesystem::is_directory(result))
+        {
+            outPath = result;
+            return true;
+        }
+        return false;
+#endif
+    }
+} // namespace SparkEditor::Utils

--- a/SparkEditor/Source/Utils/FolderDialog.h
+++ b/SparkEditor/Source/Utils/FolderDialog.h
@@ -1,0 +1,20 @@
+/**
+ * @file FolderDialog.h
+ * @brief Cross-platform native folder-picker dialog.
+ * @author Spark Engine Team
+ * @date 2025
+ */
+
+#pragma once
+
+#include <string>
+
+namespace SparkEditor::Utils
+{
+    /**
+     * Opens a native folder-chooser dialog and writes the chosen path to outPath.
+     * Windows: SHBrowseForFolderA. Linux/macOS: zenity, falling back to kdialog.
+     * @return true on success, false if the user cancelled or no dialog backend is available.
+     */
+    bool BrowseForFolder(std::string& outPath, const char* title = "Select Folder");
+} // namespace SparkEditor::Utils

--- a/SparkEditor/Source/main.cpp
+++ b/SparkEditor/Source/main.cpp
@@ -143,6 +143,8 @@ int main(int argc, char* argv[])
     bool testMode = false;
     int testFrameLimit = 0; // 0 = run indefinitely
 
+    std::string projectPathArg;
+
     // Check command line arguments
     for (int i = 1; i < argc; i++)
     {
@@ -170,6 +172,10 @@ int main(int argc, char* argv[])
         else if (strcmp(argv[i], "--test-frames") == 0 && i + 1 < argc)
         {
             testFrameLimit = std::atoi(argv[++i]);
+        }
+        else if (strcmp(argv[i], "--project") == 0 && i + 1 < argc)
+        {
+            projectPathArg = argv[++i];
         }
     }
 
@@ -239,7 +245,7 @@ int main(int argc, char* argv[])
 
         // Initialize with basic configuration
         SparkEditor::EditorConfig config;
-        config.projectPath = ".";
+        config.projectPath = projectPathArg.empty() ? "." : projectPathArg;
         config.enableLogging = true;
         config.startMaximized = false; // Don't start maximized in debug mode
         config.windowWidth = 1600;

--- a/SparkLauncher/CMakeLists.txt
+++ b/SparkLauncher/CMakeLists.txt
@@ -1,0 +1,70 @@
+cmake_minimum_required(VERSION 3.25)
+
+project(SparkLauncher VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+endif()
+
+# Share the imgui target with SparkEditor (safe if already included).
+include("${CMAKE_SOURCE_DIR}/cmake/BuildImGui.cmake")
+if(NOT IMGUI_FOUND)
+    message(WARNING "SparkLauncher: Dear ImGui not found — skipping build")
+    return()
+endif()
+
+set(LAUNCHER_SOURCES
+    src/main.cpp
+    src/LauncherApp.cpp
+    src/LauncherApp.h
+    src/LauncherBackend.h
+)
+if(WIN32)
+    list(APPEND LAUNCHER_SOURCES src/LauncherBackendWindows.cpp)
+    add_executable(SparkLauncher WIN32 ${LAUNCHER_SOURCES})
+    target_link_libraries(SparkLauncher PRIVATE d3d11 dxgi user32 gdi32 shell32 ole32 oleaut32 uuid comdlg32 advapi32)
+else()
+    list(APPEND LAUNCHER_SOURCES src/LauncherBackendLinux.cpp)
+    add_executable(SparkLauncher ${LAUNCHER_SOURCES})
+    find_package(Threads REQUIRED)
+    target_link_libraries(SparkLauncher PRIVATE Threads::Threads)
+endif()
+
+# Pull ProjectManager + FolderDialog directly from the editor tree — no copy, no new lib.
+target_sources(SparkLauncher PRIVATE
+    "${CMAKE_SOURCE_DIR}/SparkEditor/Source/Core/ProjectManager.cpp"
+    "${CMAKE_SOURCE_DIR}/SparkEditor/Source/Utils/FolderDialog.cpp"
+)
+
+target_include_directories(SparkLauncher PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    "${CMAKE_SOURCE_DIR}/SparkEditor/Source"
+    "${CMAKE_SOURCE_DIR}/SparkEngine/Source"
+)
+
+target_link_libraries(SparkLauncher PRIVATE imgui)
+if(TARGET SparkEngineLib)
+    target_link_libraries(SparkLauncher PRIVATE SparkEngineLib)
+endif()
+
+# Match the version macros SparkEditor defines so the shared ProjectManager.cpp compiles here.
+target_compile_definitions(SparkLauncher PRIVATE
+    EDITOR_VERSION_MAJOR=1
+    EDITOR_VERSION_MINOR=0
+    EDITOR_VERSION_PATCH=0
+)
+
+if(MSVC)
+    target_compile_definitions(SparkLauncher PRIVATE
+        WIN32_LEAN_AND_MEAN
+        NOMINMAX
+        _CRT_SECURE_NO_WARNINGS)
+    set_property(TARGET SparkLauncher PROPERTY MSVC_RUNTIME_LIBRARY
+        "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+endif()
+
+install(TARGETS SparkLauncher RUNTIME DESTINATION bin)

--- a/SparkLauncher/src/LauncherApp.cpp
+++ b/SparkLauncher/src/LauncherApp.cpp
@@ -1,0 +1,460 @@
+/**
+ * @file LauncherApp.cpp
+ * @brief Standalone SparkLauncher UI + editor-spawn logic.
+ * @author Spark Engine Team
+ * @date 2025
+ */
+
+#include "LauncherApp.h"
+
+#include "Utils/FolderDialog.h"
+
+#include <imgui.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace SparkLauncher
+{
+    namespace
+    {
+        // Location of the Templates/ directory, relative to the launcher binary or CWD.
+        fs::path FindTemplatesDirectory()
+        {
+            const fs::path candidates[] = {
+                fs::current_path() / "Templates",
+                fs::current_path().parent_path() / "Templates",
+                fs::current_path() / ".." / "Templates",
+            };
+            for (const auto& c : candidates)
+            {
+                if (fs::exists(c) && fs::is_directory(c))
+                {
+                    return fs::canonical(c);
+                }
+            }
+            return {};
+        }
+
+        fs::path OwnExecutablePath()
+        {
+#ifdef _WIN32
+            char buf[MAX_PATH] = {};
+            DWORD n = GetModuleFileNameA(nullptr, buf, MAX_PATH);
+            return (n > 0) ? fs::path(buf) : fs::path{};
+#else
+            char buf[4096] = {};
+            ssize_t n = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+            if (n > 0)
+            {
+                buf[n] = '\0';
+                return fs::path(buf);
+            }
+            return {};
+#endif
+        }
+
+        std::string ReadSmallFile(const fs::path& p)
+        {
+            std::ifstream in(p);
+            if (!in)
+                return {};
+            std::ostringstream ss;
+            ss << in.rdbuf();
+            return ss.str();
+        }
+
+        // Very small JSON string-field extractor — matches ProjectManager.cpp's approach.
+        std::string ExtractJsonString(const std::string& json, const std::string& key)
+        {
+            const std::string search = "\"" + key + "\"";
+            size_t pos = json.find(search);
+            if (pos == std::string::npos)
+                return {};
+            pos = json.find(':', pos);
+            if (pos == std::string::npos)
+                return {};
+            pos = json.find('"', pos + 1);
+            if (pos == std::string::npos)
+                return {};
+            size_t end = json.find('"', pos + 1);
+            if (end == std::string::npos)
+                return {};
+            return json.substr(pos + 1, end - pos - 1);
+        }
+
+        std::string FormatTimestamp(uint64_t epochSeconds)
+        {
+            if (epochSeconds == 0)
+                return "never";
+            std::time_t t = static_cast<std::time_t>(epochSeconds);
+            char buf[64] = {};
+            std::tm tm{};
+#ifdef _WIN32
+            localtime_s(&tm, &t);
+#else
+            localtime_r(&t, &tm);
+#endif
+            std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M", &tm);
+            return buf;
+        }
+    } // namespace
+
+    LauncherApp::LauncherApp() = default;
+    LauncherApp::~LauncherApp() = default;
+
+    bool LauncherApp::Initialize()
+    {
+        m_projectManager = std::make_unique<SparkEditor::ProjectManager>();
+        if (!m_projectManager->Initialize())
+        {
+            m_statusMessage = "Failed to initialize ProjectManager";
+            m_statusIsError = true;
+            return false;
+        }
+        LoadTemplates();
+        DefaultNewProjectLocation();
+        return true;
+    }
+
+    void LauncherApp::LoadTemplates()
+    {
+        m_templates.clear();
+        const fs::path templatesDir = FindTemplatesDirectory();
+        if (templatesDir.empty())
+        {
+            return;
+        }
+        for (const auto& entry : fs::directory_iterator(templatesDir))
+        {
+            if (!entry.is_directory())
+                continue;
+            const fs::path manifest = entry.path() / "template.json";
+            if (!fs::exists(manifest))
+                continue;
+
+            const std::string json = ReadSmallFile(manifest);
+            TemplateEntry t;
+            t.directoryName = entry.path().filename().string();
+            t.displayName = ExtractJsonString(json, "name");
+            if (t.displayName.empty())
+                t.displayName = t.directoryName;
+            t.description = ExtractJsonString(json, "description");
+            t.genre = ExtractJsonString(json, "genre");
+            t.gameModule = ExtractJsonString(json, "gameModule");
+            m_templates.push_back(std::move(t));
+        }
+        std::sort(m_templates.begin(), m_templates.end(),
+                  [](const TemplateEntry& a, const TemplateEntry& b) { return a.displayName < b.displayName; });
+    }
+
+    void LauncherApp::DefaultNewProjectLocation()
+    {
+#ifdef _WIN32
+        const char* home = std::getenv("USERPROFILE");
+#else
+        const char* home = std::getenv("HOME");
+#endif
+        fs::path base = home ? fs::path(home) / "SparkProjects" : fs::current_path();
+        std::string s = base.string();
+        std::strncpy(m_newProjectLocation, s.c_str(), sizeof(m_newProjectLocation) - 1);
+        m_newProjectLocation[sizeof(m_newProjectLocation) - 1] = '\0';
+    }
+
+    void LauncherApp::DrawUI()
+    {
+        const ImGuiViewport* vp = ImGui::GetMainViewport();
+        ImGui::SetNextWindowPos(vp->WorkPos);
+        ImGui::SetNextWindowSize(vp->WorkSize);
+
+        ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize |
+                                 ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoBringToFrontOnFocus;
+
+        ImGui::Begin("SparkLauncher", nullptr, flags);
+
+        ImGui::TextUnformatted("Spark Engine Launcher");
+        ImGui::SameLine();
+        ImGui::TextDisabled("(pick a project to launch the editor)");
+        ImGui::Separator();
+
+        if (ImGui::BeginTabBar("##LauncherTabs"))
+        {
+            if (ImGui::BeginTabItem("Projects"))
+            {
+                m_activeTab = Tab::Projects;
+                DrawProjectsTab();
+                ImGui::EndTabItem();
+            }
+            if (ImGui::BeginTabItem("New Project"))
+            {
+                m_activeTab = Tab::NewProject;
+                DrawNewProjectTab();
+                ImGui::EndTabItem();
+            }
+            ImGui::EndTabBar();
+        }
+
+        if (!m_statusMessage.empty())
+        {
+            ImGui::Separator();
+            ImVec4 color = m_statusIsError ? ImVec4(1.0f, 0.4f, 0.4f, 1.0f) : ImVec4(0.5f, 1.0f, 0.5f, 1.0f);
+            ImGui::TextColored(color, "%s", m_statusMessage.c_str());
+        }
+
+        ImGui::End();
+    }
+
+    void LauncherApp::DrawProjectsTab()
+    {
+        if (ImGui::Button("Open Existing Project..."))
+        {
+            std::string folder;
+            if (SparkEditor::Utils::BrowseForFolder(folder, "Select Project Folder"))
+            {
+                // A project directory contains a single .sparkproject file.
+                fs::path chosen;
+                for (const auto& entry : fs::directory_iterator(folder))
+                {
+                    if (entry.is_regular_file() && entry.path().extension() == ".sparkproject")
+                    {
+                        chosen = entry.path();
+                        break;
+                    }
+                }
+                if (chosen.empty())
+                {
+                    m_statusMessage = "No .sparkproject file found in " + folder;
+                    m_statusIsError = true;
+                }
+                else if (!m_projectManager->OpenProject(chosen.string()))
+                {
+                    m_statusMessage = "Failed to open " + chosen.string();
+                    m_statusIsError = true;
+                }
+                else
+                {
+                    SpawnEditor(chosen.string());
+                }
+            }
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Refresh"))
+        {
+            m_projectManager->RefreshRecentProjects();
+        }
+
+        ImGui::Separator();
+
+        const auto recent = m_projectManager->GetRecentProjects();
+        if (recent.empty())
+        {
+            ImGui::TextDisabled("No recent projects — create a new one or open an existing project.");
+            return;
+        }
+
+        ImGui::TextDisabled("Recent Projects");
+        if (ImGui::BeginTable("##RecentProjects", 4,
+                              ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders | ImGuiTableFlags_Resizable))
+        {
+            ImGui::TableSetupColumn("Name");
+            ImGui::TableSetupColumn("Last Opened");
+            ImGui::TableSetupColumn("Engine");
+            ImGui::TableSetupColumn("Actions");
+            ImGui::TableHeadersRow();
+
+            for (const auto& rp : recent)
+            {
+                ImGui::TableNextRow();
+                ImGui::PushID(rp.path.c_str());
+
+                ImGui::TableNextColumn();
+                const ImVec4 color = rp.valid ? ImVec4(1, 1, 1, 1) : ImVec4(1.0f, 0.5f, 0.5f, 1.0f);
+                ImGui::TextColored(color, "%s", rp.name.c_str());
+                if (ImGui::IsItemHovered())
+                    ImGui::SetTooltip("%s", rp.path.c_str());
+
+                ImGui::TableNextColumn();
+                ImGui::TextUnformatted(FormatTimestamp(rp.lastOpened).c_str());
+
+                ImGui::TableNextColumn();
+                ImGui::TextUnformatted(rp.engineVersion.c_str());
+
+                ImGui::TableNextColumn();
+                if (rp.valid && ImGui::SmallButton("Launch"))
+                {
+                    if (m_projectManager->OpenProject(rp.path))
+                        SpawnEditor(rp.path);
+                    else
+                    {
+                        m_statusMessage = "Failed to open " + rp.path;
+                        m_statusIsError = true;
+                    }
+                }
+                ImGui::SameLine();
+                if (ImGui::SmallButton("Remove"))
+                {
+                    m_projectManager->RemoveRecentProject(rp.path);
+                }
+
+                ImGui::PopID();
+            }
+            ImGui::EndTable();
+        }
+    }
+
+    void LauncherApp::DrawNewProjectTab()
+    {
+        ImGui::TextDisabled("Template");
+        if (m_templates.empty())
+        {
+            ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f),
+                               "No templates found. Expected Templates/ directory next to the launcher binary.");
+            return;
+        }
+
+        if (ImGui::BeginCombo("##Template", m_templates[m_selectedTemplate].displayName.c_str()))
+        {
+            for (int i = 0; i < static_cast<int>(m_templates.size()); ++i)
+            {
+                const bool selected = (i == m_selectedTemplate);
+                if (ImGui::Selectable(m_templates[i].displayName.c_str(), selected))
+                    m_selectedTemplate = i;
+                if (selected)
+                    ImGui::SetItemDefaultFocus();
+            }
+            ImGui::EndCombo();
+        }
+
+        const TemplateEntry& tpl = m_templates[m_selectedTemplate];
+        ImGui::TextWrapped("%s", tpl.description.c_str());
+        if (!tpl.genre.empty())
+            ImGui::Text("Genre: %s   Module: %s", tpl.genre.c_str(), tpl.gameModule.c_str());
+
+        ImGui::Separator();
+        ImGui::InputText("Project Name", m_newProjectName, sizeof(m_newProjectName));
+        ImGui::InputText("Location", m_newProjectLocation, sizeof(m_newProjectLocation));
+        ImGui::SameLine();
+        if (ImGui::Button("Browse..."))
+        {
+            std::string folder;
+            if (SparkEditor::Utils::BrowseForFolder(folder, "Select Parent Folder"))
+            {
+                std::strncpy(m_newProjectLocation, folder.c_str(), sizeof(m_newProjectLocation) - 1);
+                m_newProjectLocation[sizeof(m_newProjectLocation) - 1] = '\0';
+            }
+        }
+        ImGui::InputTextMultiline("Description", m_newProjectDescription, sizeof(m_newProjectDescription),
+                                  ImVec2(0, ImGui::GetTextLineHeight() * 3));
+
+        const fs::path projectRoot = fs::path(m_newProjectLocation) / m_newProjectName;
+        ImGui::TextDisabled("Will be created at: %s", projectRoot.string().c_str());
+
+        ImGui::Separator();
+        if (ImGui::Button("Create Project", ImVec2(160, 0)))
+        {
+            if (std::strlen(m_newProjectName) == 0 || std::strlen(m_newProjectLocation) == 0)
+            {
+                m_statusMessage = "Name and location are required";
+                m_statusIsError = true;
+                return;
+            }
+            std::error_code ec;
+            fs::create_directories(projectRoot, ec);
+            if (ec)
+            {
+                m_statusMessage = "Cannot create directory: " + ec.message();
+                m_statusIsError = true;
+                return;
+            }
+
+            if (!m_projectManager->CreateProjectFromTemplate(m_newProjectName, projectRoot.string(), tpl.directoryName))
+            {
+                m_statusMessage = "CreateProjectFromTemplate failed for " + tpl.directoryName;
+                m_statusIsError = true;
+                return;
+            }
+
+            const std::string sparkproj = (projectRoot / (std::string(m_newProjectName) + ".sparkproject")).string();
+            if (!fs::exists(sparkproj))
+            {
+                m_statusMessage = "Project file not produced: " + sparkproj;
+                m_statusIsError = true;
+                return;
+            }
+
+            SpawnEditor(sparkproj);
+        }
+    }
+
+    bool LauncherApp::SpawnEditor(const std::string& projectFilePath)
+    {
+        const fs::path ownPath = OwnExecutablePath();
+        if (ownPath.empty())
+        {
+            m_statusMessage = "Could not determine launcher path";
+            m_statusIsError = true;
+            return false;
+        }
+        const fs::path binDir = ownPath.parent_path();
+#ifdef _WIN32
+        const fs::path editor = binDir / "SparkEditor.exe";
+#else
+        const fs::path editor = binDir / "SparkEditor";
+#endif
+        if (!fs::exists(editor))
+        {
+            m_statusMessage = "SparkEditor binary not found: " + editor.string();
+            m_statusIsError = true;
+            return false;
+        }
+
+#ifdef _WIN32
+        std::string cmdLine = "\"" + editor.string() + "\" --project \"" + projectFilePath + "\"";
+        STARTUPINFOA si{};
+        si.cb = sizeof(si);
+        PROCESS_INFORMATION pi{};
+        BOOL ok = CreateProcessA(editor.string().c_str(), cmdLine.data(), nullptr, nullptr, FALSE, DETACHED_PROCESS,
+                                 nullptr, nullptr, &si, &pi);
+        if (!ok)
+        {
+            m_statusMessage = "CreateProcess failed (err " + std::to_string(GetLastError()) + ")";
+            m_statusIsError = true;
+            return false;
+        }
+        CloseHandle(pi.hThread);
+        CloseHandle(pi.hProcess);
+#else
+        pid_t pid = fork();
+        if (pid < 0)
+        {
+            m_statusMessage = "fork() failed";
+            m_statusIsError = true;
+            return false;
+        }
+        if (pid == 0)
+        {
+            // Detach from launcher so it can exit cleanly.
+            setsid();
+            execl(editor.c_str(), editor.c_str(), "--project", projectFilePath.c_str(), static_cast<char*>(nullptr));
+            _exit(127); // execl only returns on failure
+        }
+#endif
+        m_shouldClose = true;
+        return true;
+    }
+} // namespace SparkLauncher

--- a/SparkLauncher/src/LauncherApp.h
+++ b/SparkLauncher/src/LauncherApp.h
@@ -1,0 +1,63 @@
+/**
+ * @file LauncherApp.h
+ * @brief Standalone SparkLauncher — project browser that spawns SparkEditor.
+ * @author Spark Engine Team
+ * @date 2025
+ */
+
+#pragma once
+
+#include "Core/ProjectManager.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace SparkLauncher
+{
+    struct TemplateEntry
+    {
+        std::string directoryName;
+        std::string displayName;
+        std::string description;
+        std::string genre;
+        std::string gameModule;
+    };
+
+    class LauncherApp
+    {
+      public:
+        LauncherApp();
+        ~LauncherApp();
+
+        bool Initialize();
+        void DrawUI();
+        bool ShouldClose() const { return m_shouldClose; }
+
+      private:
+        enum class Tab
+        {
+            Projects,
+            NewProject
+        };
+
+        void DrawProjectsTab();
+        void DrawNewProjectTab();
+        void LoadTemplates();
+        void DefaultNewProjectLocation();
+        bool SpawnEditor(const std::string& projectFilePath);
+
+        std::unique_ptr<SparkEditor::ProjectManager> m_projectManager;
+        std::vector<TemplateEntry> m_templates;
+        int m_selectedTemplate = 0;
+
+        char m_newProjectName[256] = "MyProject";
+        char m_newProjectLocation[1024] = "";
+        char m_newProjectDescription[512] = "";
+
+        std::string m_statusMessage;
+        bool m_statusIsError = false;
+        bool m_shouldClose = false;
+        Tab m_activeTab = Tab::Projects;
+    };
+} // namespace SparkLauncher

--- a/SparkLauncher/src/LauncherBackend.h
+++ b/SparkLauncher/src/LauncherBackend.h
@@ -1,0 +1,16 @@
+/**
+ * @file LauncherBackend.h
+ * @brief Platform backend API for SparkLauncher (Win32/D3D11 or SDL2/OpenGL).
+ * @author Spark Engine Team
+ * @date 2025
+ */
+
+#pragma once
+
+namespace SparkLauncher
+{
+    bool Backend_Init(int width, int height, const char* title);
+    void Backend_Shutdown();
+    bool Backend_BeginFrame(); // returns false when user requested quit
+    void Backend_EndFrame();
+} // namespace SparkLauncher

--- a/SparkLauncher/src/LauncherBackendLinux.cpp
+++ b/SparkLauncher/src/LauncherBackendLinux.cpp
@@ -1,0 +1,129 @@
+/**
+ * @file LauncherBackendLinux.cpp
+ * @brief SDL2 + OpenGL3 backend for SparkLauncher (Linux/macOS).
+ * @author Spark Engine Team
+ * @date 2025
+ */
+
+#ifndef _WIN32
+
+#include "LauncherBackend.h"
+
+#include <imgui.h>
+#include <imgui_impl_opengl3.h>
+#include <imgui_impl_sdl2.h>
+
+#include <SDL.h>
+#include <SDL_opengl.h>
+
+#include <cstdio>
+
+namespace SparkLauncher
+{
+    namespace
+    {
+        SDL_Window* g_window = nullptr;
+        SDL_GLContext g_glContext = nullptr;
+        bool g_quit = false;
+    } // namespace
+
+    bool Backend_Init(int width, int height, const char* title)
+    {
+        if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) != 0)
+        {
+            std::fprintf(stderr, "SDL_Init failed: %s\n", SDL_GetError());
+            return false;
+        }
+
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+
+        g_window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height,
+                                    SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+        if (!g_window)
+        {
+            std::fprintf(stderr, "SDL_CreateWindow failed: %s\n", SDL_GetError());
+            return false;
+        }
+
+        g_glContext = SDL_GL_CreateContext(g_window);
+        if (!g_glContext)
+        {
+            std::fprintf(stderr, "SDL_GL_CreateContext failed: %s\n", SDL_GetError());
+            return false;
+        }
+        SDL_GL_MakeCurrent(g_window, g_glContext);
+        SDL_GL_SetSwapInterval(1);
+
+        IMGUI_CHECKVERSION();
+        ImGui::CreateContext();
+        ImGui::StyleColorsDark();
+        ImGuiIO& io = ImGui::GetIO();
+        io.IniFilename = nullptr; // don't persist window layout for a modal launcher
+        io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+
+        if (!ImGui_ImplSDL2_InitForOpenGL(g_window, g_glContext))
+            return false;
+        if (!ImGui_ImplOpenGL3_Init("#version 330 core"))
+            return false;
+        return true;
+    }
+
+    bool Backend_BeginFrame()
+    {
+        SDL_Event e;
+        while (SDL_PollEvent(&e))
+        {
+            ImGui_ImplSDL2_ProcessEvent(&e);
+            if (e.type == SDL_QUIT)
+                g_quit = true;
+            else if (e.type == SDL_WINDOWEVENT && e.window.event == SDL_WINDOWEVENT_CLOSE &&
+                     e.window.windowID == SDL_GetWindowID(g_window))
+                g_quit = true;
+        }
+        if (g_quit)
+            return false;
+
+        ImGui_ImplOpenGL3_NewFrame();
+        ImGui_ImplSDL2_NewFrame();
+        ImGui::NewFrame();
+        return true;
+    }
+
+    void Backend_EndFrame()
+    {
+        ImGui::Render();
+        int w = 0, h = 0;
+        SDL_GetWindowSize(g_window, &w, &h);
+        glViewport(0, 0, w, h);
+        glClearColor(0.10f, 0.10f, 0.12f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+        SDL_GL_SwapWindow(g_window);
+    }
+
+    void Backend_Shutdown()
+    {
+        if (ImGui::GetCurrentContext())
+        {
+            ImGui_ImplOpenGL3_Shutdown();
+            ImGui_ImplSDL2_Shutdown();
+            ImGui::DestroyContext();
+        }
+        if (g_glContext)
+        {
+            SDL_GL_DeleteContext(g_glContext);
+            g_glContext = nullptr;
+        }
+        if (g_window)
+        {
+            SDL_DestroyWindow(g_window);
+            g_window = nullptr;
+        }
+        SDL_Quit();
+    }
+} // namespace SparkLauncher
+
+#endif // !_WIN32

--- a/SparkLauncher/src/LauncherBackendWindows.cpp
+++ b/SparkLauncher/src/LauncherBackendWindows.cpp
@@ -1,0 +1,198 @@
+/**
+ * @file LauncherBackendWindows.cpp
+ * @brief Win32 + D3D11 backend for SparkLauncher (Windows).
+ * @author Spark Engine Team
+ * @date 2025
+ */
+
+#ifdef _WIN32
+
+#include "LauncherBackend.h"
+
+#include <imgui.h>
+#include <imgui_impl_dx11.h>
+#include <imgui_impl_win32.h>
+
+#include <d3d11.h>
+#include <tchar.h>
+#include <windows.h>
+
+#include <cstdio>
+
+extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND, UINT, WPARAM, LPARAM);
+
+namespace SparkLauncher
+{
+    namespace
+    {
+        HWND g_hwnd = nullptr;
+        WNDCLASSEXW g_wc{};
+        ID3D11Device* g_d3dDevice = nullptr;
+        ID3D11DeviceContext* g_d3dContext = nullptr;
+        IDXGISwapChain* g_swapChain = nullptr;
+        ID3D11RenderTargetView* g_mainRTV = nullptr;
+        bool g_quit = false;
+
+        void CreateRenderTarget()
+        {
+            ID3D11Texture2D* backBuffer = nullptr;
+            g_swapChain->GetBuffer(0, IID_PPV_ARGS(&backBuffer));
+            if (backBuffer)
+            {
+                g_d3dDevice->CreateRenderTargetView(backBuffer, nullptr, &g_mainRTV);
+                backBuffer->Release();
+            }
+        }
+
+        void CleanupRenderTarget()
+        {
+            if (g_mainRTV)
+            {
+                g_mainRTV->Release();
+                g_mainRTV = nullptr;
+            }
+        }
+
+        LRESULT WINAPI WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+        {
+            if (ImGui_ImplWin32_WndProcHandler(hwnd, msg, wParam, lParam))
+                return true;
+            switch (msg)
+            {
+            case WM_SIZE:
+                if (g_d3dDevice && wParam != SIZE_MINIMIZED)
+                {
+                    CleanupRenderTarget();
+                    g_swapChain->ResizeBuffers(0, (UINT)LOWORD(lParam), (UINT)HIWORD(lParam), DXGI_FORMAT_UNKNOWN, 0);
+                    CreateRenderTarget();
+                }
+                return 0;
+            case WM_SYSCOMMAND:
+                if ((wParam & 0xfff0) == SC_KEYMENU)
+                    return 0;
+                break;
+            case WM_DESTROY:
+                g_quit = true;
+                PostQuitMessage(0);
+                return 0;
+            }
+            return DefWindowProcW(hwnd, msg, wParam, lParam);
+        }
+    } // namespace
+
+    bool Backend_Init(int width, int height, const char* title)
+    {
+        g_wc = {sizeof(g_wc), CS_CLASSDC,          WndProc, 0L, 0L, GetModuleHandle(nullptr), nullptr, nullptr, nullptr,
+                nullptr,      L"SparkLauncherWnd", nullptr};
+        RegisterClassExW(&g_wc);
+        wchar_t wtitle[256] = {};
+        MultiByteToWideChar(CP_UTF8, 0, title, -1, wtitle, 256);
+        g_hwnd = CreateWindowW(g_wc.lpszClassName, wtitle, WS_OVERLAPPEDWINDOW, 100, 100, width, height, nullptr,
+                               nullptr, g_wc.hInstance, nullptr);
+
+        DXGI_SWAP_CHAIN_DESC sd{};
+        sd.BufferCount = 2;
+        sd.BufferDesc.Width = 0;
+        sd.BufferDesc.Height = 0;
+        sd.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        sd.BufferDesc.RefreshRate.Numerator = 60;
+        sd.BufferDesc.RefreshRate.Denominator = 1;
+        sd.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+        sd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        sd.OutputWindow = g_hwnd;
+        sd.SampleDesc.Count = 1;
+        sd.Windowed = TRUE;
+        sd.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+
+        UINT createFlags = 0;
+        D3D_FEATURE_LEVEL featureLevel;
+        const D3D_FEATURE_LEVEL levels[] = {D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_0};
+        if (D3D11CreateDeviceAndSwapChain(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, createFlags, levels, 2,
+                                          D3D11_SDK_VERSION, &sd, &g_swapChain, &g_d3dDevice, &featureLevel,
+                                          &g_d3dContext) != S_OK)
+        {
+            std::fprintf(stderr, "D3D11CreateDeviceAndSwapChain failed\n");
+            return false;
+        }
+
+        CreateRenderTarget();
+        ShowWindow(g_hwnd, SW_SHOWDEFAULT);
+        UpdateWindow(g_hwnd);
+
+        IMGUI_CHECKVERSION();
+        ImGui::CreateContext();
+        ImGui::StyleColorsDark();
+        ImGuiIO& io = ImGui::GetIO();
+        io.IniFilename = nullptr;
+        io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+
+        if (!ImGui_ImplWin32_Init(g_hwnd))
+            return false;
+        if (!ImGui_ImplDX11_Init(g_d3dDevice, g_d3dContext))
+            return false;
+        return true;
+    }
+
+    bool Backend_BeginFrame()
+    {
+        MSG msg;
+        while (PeekMessage(&msg, nullptr, 0U, 0U, PM_REMOVE))
+        {
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
+            if (msg.message == WM_QUIT)
+                g_quit = true;
+        }
+        if (g_quit)
+            return false;
+
+        ImGui_ImplDX11_NewFrame();
+        ImGui_ImplWin32_NewFrame();
+        ImGui::NewFrame();
+        return true;
+    }
+
+    void Backend_EndFrame()
+    {
+        ImGui::Render();
+        const float clear[] = {0.10f, 0.10f, 0.12f, 1.0f};
+        g_d3dContext->OMSetRenderTargets(1, &g_mainRTV, nullptr);
+        g_d3dContext->ClearRenderTargetView(g_mainRTV, clear);
+        ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
+        g_swapChain->Present(1, 0);
+    }
+
+    void Backend_Shutdown()
+    {
+        if (ImGui::GetCurrentContext())
+        {
+            ImGui_ImplDX11_Shutdown();
+            ImGui_ImplWin32_Shutdown();
+            ImGui::DestroyContext();
+        }
+        CleanupRenderTarget();
+        if (g_swapChain)
+        {
+            g_swapChain->Release();
+            g_swapChain = nullptr;
+        }
+        if (g_d3dContext)
+        {
+            g_d3dContext->Release();
+            g_d3dContext = nullptr;
+        }
+        if (g_d3dDevice)
+        {
+            g_d3dDevice->Release();
+            g_d3dDevice = nullptr;
+        }
+        if (g_hwnd)
+        {
+            DestroyWindow(g_hwnd);
+            g_hwnd = nullptr;
+        }
+        UnregisterClassW(g_wc.lpszClassName, g_wc.hInstance);
+    }
+} // namespace SparkLauncher
+
+#endif // _WIN32

--- a/SparkLauncher/src/main.cpp
+++ b/SparkLauncher/src/main.cpp
@@ -1,0 +1,67 @@
+/**
+ * @file main.cpp
+ * @brief SparkLauncher entry point — Unity-Hub-style project picker that spawns SparkEditor.
+ * @author Spark Engine Team
+ * @date 2025
+ */
+
+#include "LauncherApp.h"
+#include "LauncherBackend.h"
+
+#include <cstring>
+#include <iostream>
+
+namespace
+{
+    constexpr const char* kVersion = "SparkLauncher 1.0.0";
+}
+
+#ifdef _WIN32
+#include <windows.h>
+int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR cmdLine, int)
+{
+    if (cmdLine && std::strstr(cmdLine, "--version"))
+    {
+        MessageBoxA(nullptr, kVersion, "SparkLauncher", MB_OK);
+        return 0;
+    }
+#else
+int main(int argc, char** argv)
+{
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--version") == 0 || std::strcmp(argv[i], "-v") == 0)
+        {
+            std::cout << kVersion << '\n';
+            return 0;
+        }
+        if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
+        {
+            std::cout << kVersion << "\nUsage: SparkLauncher [--version]\n";
+            return 0;
+        }
+    }
+#endif
+
+    if (!SparkLauncher::Backend_Init(1000, 640, "Spark Launcher"))
+    {
+        std::cerr << "Failed to initialize launcher backend\n";
+        return 1;
+    }
+
+    SparkLauncher::LauncherApp app;
+    if (!app.Initialize())
+    {
+        SparkLauncher::Backend_Shutdown();
+        return 2;
+    }
+
+    while (!app.ShouldClose() && SparkLauncher::Backend_BeginFrame())
+    {
+        app.DrawUI();
+        SparkLauncher::Backend_EndFrame();
+    }
+
+    SparkLauncher::Backend_Shutdown();
+    return 0;
+}

--- a/cmake/BuildImGui.cmake
+++ b/cmake/BuildImGui.cmake
@@ -1,0 +1,88 @@
+# Builds the `imgui` static library target shared by SparkEditor and SparkLauncher.
+# Idempotent: safe to include from multiple subdirs — the target is created at most once.
+
+if(NOT DEFINED IMGUI_INCLUDE_DIR OR NOT IMGUI_INCLUDE_DIR)
+    find_path(IMGUI_INCLUDE_DIR
+        NAMES imgui.h
+        PATHS
+            "${CMAKE_SOURCE_DIR}/ThirdParty/imgui"
+            "${CMAKE_SOURCE_DIR}/ThirdParty/UI/imgui"
+            "${CMAKE_SOURCE_DIR}/External/imgui"
+            "${CMAKE_SOURCE_DIR}/Vendor/imgui"
+        DOC "Dear ImGui include directory"
+        NO_CMAKE_FIND_ROOT_PATH
+    )
+endif()
+
+if(IMGUI_INCLUDE_DIR)
+    if(NOT TARGET imgui)
+        message(STATUS "Found Dear ImGui at: ${IMGUI_INCLUDE_DIR}")
+
+        set(_IMGUI_CORE_SOURCES
+            "${IMGUI_INCLUDE_DIR}/imgui.cpp"
+            "${IMGUI_INCLUDE_DIR}/imgui_demo.cpp"
+            "${IMGUI_INCLUDE_DIR}/imgui_draw.cpp"
+            "${IMGUI_INCLUDE_DIR}/imgui_tables.cpp"
+            "${IMGUI_INCLUDE_DIR}/imgui_widgets.cpp"
+        )
+
+        if(WIN32)
+            add_library(imgui STATIC
+                ${_IMGUI_CORE_SOURCES}
+                "${IMGUI_INCLUDE_DIR}/backends/imgui_impl_win32.cpp"
+                "${IMGUI_INCLUDE_DIR}/backends/imgui_impl_dx11.cpp"
+            )
+
+            target_compile_definitions(imgui PUBLIC
+                IMGUI_IMPL_WIN32_DISABLE_GAMEPAD
+                IMGUI_IMPL_WIN32_DISABLE_LINKING_XINPUT
+            )
+
+            target_link_libraries(imgui PUBLIC
+                d3d11 dxgi user32 gdi32 shell32 ole32 oleaut32 uuid comdlg32 advapi32
+            )
+        else()
+            if(NOT TARGET SDL2::SDL2 AND NOT TARGET SDL2)
+                find_package(SDL2 REQUIRED)
+            endif()
+            find_package(OpenGL REQUIRED)
+
+            add_library(imgui STATIC
+                ${_IMGUI_CORE_SOURCES}
+                "${IMGUI_INCLUDE_DIR}/backends/imgui_impl_sdl2.cpp"
+                "${IMGUI_INCLUDE_DIR}/backends/imgui_impl_opengl3.cpp"
+            )
+
+            if(TARGET SDL2::SDL2)
+                target_link_libraries(imgui PUBLIC SDL2::SDL2)
+            elseif(TARGET SDL2)
+                target_link_libraries(imgui PUBLIC SDL2)
+            else()
+                target_include_directories(imgui PUBLIC ${SDL2_INCLUDE_DIRS})
+                target_link_libraries(imgui PUBLIC ${SDL2_LIBRARIES})
+            endif()
+
+            target_link_libraries(imgui PUBLIC OpenGL::GL)
+        endif()
+
+        target_include_directories(imgui PUBLIC
+            "${IMGUI_INCLUDE_DIR}"
+            "${IMGUI_INCLUDE_DIR}/backends"
+        )
+
+        if(MSVC)
+            target_compile_options(imgui PRIVATE /W2)
+            target_compile_definitions(imgui PRIVATE
+                WIN32_LEAN_AND_MEAN
+                NOMINMAX
+                _CRT_SECURE_NO_WARNINGS
+            )
+            set_property(TARGET imgui PROPERTY MSVC_RUNTIME_LIBRARY
+                "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+        endif()
+    endif()
+
+    set(IMGUI_FOUND TRUE)
+else()
+    set(IMGUI_FOUND FALSE)
+endif()

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -84,12 +84,12 @@ SparkEngine is licensed under the [Spark Open License](https://github.com/Krilli
 <!-- AUTO:stats -->
 | Metric | Count |
 |--------|-------|
-| Header files | 774 |
+| Header files | 779 |
 | ECS Components | 79 |
 | Engine System Classes | 75 |
 | Editor Panels | 59 |
-| Test files | 481 |
-| Test cases | 5934+ |
+| Test files | 483 |
+| Test cases | 5966+ |
 | Wiki pages | 144 |
-| *Last synced* | *2026-04-18 14:28* |
+| *Last synced* | *2026-04-19 01:51* |
 <!-- /AUTO:stats -->

--- a/wiki/advanced/Codebase-Statistics.md
+++ b/wiki/advanced/Codebase-Statistics.md
@@ -1,6 +1,6 @@
 # Codebase Statistics
 
-Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-18.
+Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-19.
 
 ## Code Volume
 
@@ -8,33 +8,33 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 
 | Section | Lines |
 |---------|------:|
-| **SparkEngine/Source** | 281876 |
-| **SparkEditor/Source** | 88841 |
+| **SparkEngine/Source** | 283708 |
+| **SparkEditor/Source** | 88888 |
 | **GameModules** | 58618 |
-| **Tests** | 135175 |
+| **Tests** | 135909 |
 | **SparkConsole/src** | 1868 |
 | **SparkShaderCompiler/src** | 533 |
-| **Total C++ (excl. ThirdParty)** | **~566911** |
+| **Total C++ (excl. ThirdParty)** | **~569524** |
 
 ### File Counts
 
 | Category | Count |
 |----------|------:|
-| Header files (.h/.hpp) | 777 |
-| Implementation files (.cpp) | 1078 |
+| Header files (.h/.hpp) | 782 |
+| Implementation files (.cpp) | 1085 |
 | HLSL shader files | 42 |
 | GLSL shader files | 14 |
 | AngelScript files (.as) | 1 |
-| Test files (.cpp) | 482 |
+| Test files (.cpp) | 484 |
 | Wiki pages (.md) | 144 |
 
 ### Code Density
 
 | Metric | Value |
 |--------|-------|
-| Average lines per .cpp file | ~769 |
-| Average lines per .h file | ~575 |
-| Largest codebase section | Graphics (112754 lines — 40% of SparkEngine/Source) |
+| Average lines per .cpp file | ~765 |
+| Average lines per .h file | ~574 |
+| Largest codebase section | Graphics (113909 lines — 40% of SparkEngine/Source) |
 
 ## SparkEngine/Source Breakdown
 
@@ -42,14 +42,14 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 
 | Subsystem | Lines | % of Source |
 |-----------|------:|:----------:|
-| Graphics | 112754 | 40.0% |
-| Engine (all subsystems) | 80913 | 28.7% |
-| Utils | 39892 | 14.1% |
-| Core | 22772 | 8.0% |
+| Graphics | 113909 | 40.1% |
+| Engine (all subsystems) | 81262 | 28.6% |
+| Utils | 40134 | 14.1% |
+| Core | 22828 | 8.0% |
 | Physics | 10101 | 3.5% |
-| Audio | 6032 | 2.1% |
+| Audio | 6048 | 2.1% |
 | Input | 3895 | 1.3% |
-| SceneManager | 1886 | 0.6% |
+| SceneManager | 1900 | 0.6% |
 | Enums | 1423 | 0.5% |
 | Game | 1272 | 0.4% |
 | Camera | 868 | 0.3% |
@@ -58,30 +58,30 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 
 | Subsystem | Lines |
 |-----------|------:|
-| AI | 13238 |
-| Networking | 12166 |
-| ECS | 8551 |
+| AI | 13249 |
+| Networking | 12265 |
+| ECS | 8570 |
 | Gameplay | 7511 |
-| Animation | 6561 |
+| Animation | 6569 |
 | Scripting | 4543 |
-| SaveSystem | 2461 |
+| SaveSystem | 2495 |
 | UI | 2437 |
-| Streaming | 1914 |
+| Streaming | 1939 |
 | World | 1588 |
 | Editor | 1556 |
 | Cinematic | 1526 |
-| Dialogue | 1384 |
-| Modding | 1279 |
+| Dialogue | 1397 |
+| Modding | 1283 |
 | Persistence | 994 |
 | 2D | 979 |
 | Coroutine | 786 |
-| Replay | 707 |
+| Replay | 721 |
 | Tween | 523 |
 | Destruction | 509 |
-| Localization | 428 |
+| Events | 468 |
+| Localization | 440 |
 | Mobile | 424 |
 | Physics | 381 |
-| Events | 362 |
 | Loading | 355 |
 | VR | 329 |
 
@@ -99,14 +99,14 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 | Metric | Count |
 |--------|------:|
 | Editor panel classes | 59 |
-| Total editor lines | 88841 |
+| Total editor lines | 88888 |
 
 ## Testing Metrics
 
 | Metric | Count |
 |--------|------:|
-| Test files | 482 |
-| TEST() definitions | 5930 |
+| Test files | 484 |
+| TEST() definitions | 5962 |
 | Subsystems covered | All major |
 | Sanitizer coverage | ASan + UBSan + LSan + TSan + MSan |
 
@@ -114,8 +114,8 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 
 | Metric | Count |
 |--------|------:|
-| CMake option() declarations | 23 |
-| ENABLE_* feature toggles | 15 |
+| CMake option() declarations | 24 |
+| ENABLE_* feature toggles | 16 |
 | Game modules | 10 |
 | SDK public headers | 12 |
 | Supported compilers | MSVC v143/v144, GCC 13+, Clang 17+, Apple Clang, MinGW-w64 |
@@ -158,12 +158,12 @@ Comprehensive metrics and analysis of the SparkEngine codebase. Updated 2026-04-
 | `VulkanDevice.cpp` | 1991 |
 | `D3D12Device.cpp` | 1593 |
 | `PostProcessingPipeline.cpp` | 1530 |
+| `EngineSettings.cpp` | 1522 |
 | `D3D11Device.cpp` | 1481 |
 | `GraphicsEngineWindows.cpp` | 1481 |
-| `EngineSettings.cpp` | 1478 |
 | `GameplayLifecycleShared.cpp` | 1347 |
 | `CrashHandler.cpp` | 1322 |
-| `SaveSystem.cpp` | 1245 |
+| `SaveSystem.cpp` | 1279 |
 
 ### SparkEngine .h Files (by line count)
 

--- a/wiki/advanced/Testing.md
+++ b/wiki/advanced/Testing.md
@@ -517,7 +517,7 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 ## Test File Inventory
 
 <!-- AUTO:test_inventory -->
-*481 test files, 5934+ test cases*
+*483 test files, 5966+ test cases*
 
 | Test File | Test Cases |
 |-----------|------------|
@@ -536,7 +536,7 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 | `TestAccessibility` | 15 |
 | `TestAchievementSystem` | 14 |
 | `TestAchievementSystemReal` | 10 |
-| `TestAdversarialEngine` | 89 |
+| `TestAdversarialEngine` | 96 |
 | `TestAlignedHeapArray` | 6 |
 | `TestAlignedHeapArrayReal` | 6 |
 | `TestAngelScriptEngine` | 14 |
@@ -622,6 +622,7 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 | `TestCoverSystemReal` | 5 |
 | `TestCpuDebuggerPhaseGG` | 8 |
 | `TestCpuNeuralInference` | 14 |
+| `TestCpuNeuralTraining` | 13 |
 | `TestCrashReportUploader` | 8 |
 | `TestCrossSystemIntegration` | 4 |
 | `TestDXRSupport` | 13 |
@@ -813,6 +814,7 @@ SDL2 must be built with OpenGL/GLX support (install `libgl-dev` *before* buildin
 | `TestNavMeshLink` | 5 |
 | `TestNavMeshObstacles` | 7 |
 | `TestNetBuffer` | 29 |
+| `TestNetQuantize` | 12 |
 | `TestNetworkDebugPanel` | 11 |
 | `TestNetworkEncryption` | 17 |
 | `TestNetworkHealthMonitor` | 0 |


### PR DESCRIPTION
Adds a Unity-Hub-style launcher that runs before SparkEditor: lists recent projects, creates new projects from Templates/*, and spawns SparkEditor with --project <path> on selection. Reuses the existing ProjectManager (no duplicated logic) and shares the recent-projects JSON with the editor, so both stay in sync.

- New executable SparkLauncher (cross-platform: SDL2+OpenGL on Linux, Win32+D3D11 on Windows). Gated behind ENABLE_LAUNCHER (default ON).
- Extracts BrowseForFolder() to SparkEditor/Source/Utils/FolderDialog so the editor panel and launcher share one implementation.
- Extracts the imgui CMake target to cmake/BuildImGui.cmake so the launcher can build cleanly even with ENABLE_EDITOR=OFF.
- SparkEditor now accepts --project PATH; default "." behaviour preserved when absent.