### PR TITLE
Add runtime log health diagnostic and expose detector checks via console commands

### DIFF
--- a/SparkEngine/Source/Core/EngineDiagnostics.cpp
+++ b/SparkEngine/Source/Core/EngineDiagnostics.cpp
@@ -851,6 +851,50 @@ namespace Spark
     }
 
     // ========================================================================
+    // Runtime log health (warnings/errors)
+    // ========================================================================
+
+    void DiagLogHealth(DiagReport& report)
+    {
+        const std::string sub = "RuntimeLogs";
+
+        auto logs = SimpleConsole::GetInstance().GetLogHistory();
+        report.Add(sub, "Log history available", true, std::to_string(logs.size()) + " entries");
+
+        size_t warningCount = 0;
+        size_t errorCount = 0;
+        size_t criticalCount = 0;
+        for (const auto& entry : logs)
+        {
+            switch (entry.severity)
+            {
+            case ConsoleSeverity::Warning:
+                ++warningCount;
+                break;
+            case ConsoleSeverity::Error:
+                ++errorCount;
+                break;
+            case ConsoleSeverity::Critical:
+                ++criticalCount;
+                break;
+            default:
+                break;
+            }
+        }
+
+        report.Add(sub, "No critical logs", criticalCount == 0, std::format("{} critical", criticalCount));
+        report.Add(sub, "No error logs", errorCount == 0, std::format("{} errors", errorCount));
+        report.Add(sub, "Warning budget", warningCount <= 25, std::format("{} warnings (budget <= 25)", warningCount));
+
+        if (!logs.empty())
+        {
+            const auto& tail = logs.back();
+            report.Add(sub, "Latest log sequence monotonic", tail.sequenceNumber + 1 >= logs.size(),
+                       std::format("latest seq={} entries={}", tail.sequenceNumber, logs.size()));
+        }
+    }
+
+    // ========================================================================
     // Console command registration
     // ========================================================================
 
@@ -945,6 +989,10 @@ namespace Spark
             "diag_memory", [](const std::vector<std::string>&) -> std::string { return RunSingleDiag(DiagMemory); },
             "Diagnose memory monitor (snapshot, anomalies)", "Diagnostics");
 
+        console.RegisterCommand(
+            "diag_logs", [](const std::vector<std::string>&) -> std::string { return RunSingleDiag(DiagLogHealth); },
+            "Diagnose runtime warning/error/critical log health", "Diagnostics");
+
         // Extended subsystem commands
         console.RegisterCommand(
             "diag_rhi", [](const std::vector<std::string>&) -> std::string { return RunSingleDiag(DiagRHI); },
@@ -1005,6 +1053,26 @@ namespace Spark
         console.RegisterCommand(
             "diag_watchdog", [](const std::vector<std::string>&) -> std::string { return RunSingleDiag(DiagWatchdog); },
             "Diagnose freeze detector watchdog (heartbeat, state)", "Diagnostics");
+
+        console.RegisterCommand(
+            "diag_hitch",
+            [](const std::vector<std::string>&) -> std::string { return RunSingleDiag(DiagHitchDetector); },
+            "Diagnose hitch detector (frame hitch severity)", "Diagnostics");
+
+        console.RegisterCommand(
+            "diag_assetstall",
+            [](const std::vector<std::string>&) -> std::string { return RunSingleDiag(DiagAssetStall); },
+            "Diagnose asset stall detector (active/stalled/failed loads)", "Diagnostics");
+
+        console.RegisterCommand(
+            "diag_nethealth",
+            [](const std::vector<std::string>&) -> std::string { return RunSingleDiag(DiagNetworkHealth); },
+            "Diagnose network health monitor (state, disconnects)", "Diagnostics");
+
+        console.RegisterCommand(
+            "diag_gpuleaks",
+            [](const std::vector<std::string>&) -> std::string { return RunSingleDiag(DiagGPUResourceLeak); },
+            "Diagnose GPU resource leak detector (suspected leaks, memory)", "Diagnostics");
     }
 
 } // namespace Spark

--- a/SparkEngine/Source/Core/EngineDiagnostics.h
+++ b/SparkEngine/Source/Core/EngineDiagnostics.h
@@ -63,6 +63,7 @@ namespace Spark
     void DiagFileCache(DiagReport& report);
     void DiagVFS(DiagReport& report);
     void DiagMemory(DiagReport& report);
+    void DiagLogHealth(DiagReport& report);
 
     // --- Extended subsystem diagnostics (EngineDiagnosticsExtended.cpp) ---
     void DiagRHI(DiagReport& report);

--- a/SparkEngine/Source/Core/EngineDiagnosticsExtended.cpp
+++ b/SparkEngine/Source/Core/EngineDiagnosticsExtended.cpp
@@ -511,6 +511,7 @@ namespace Spark
         DiagFileCache(report);
         DiagVFS(report);
         DiagMemory(report);
+        DiagLogHealth(report);
 
         // Extended diagnostics
         DiagRHI(report);


### PR DESCRIPTION
### Motivation
- Provide a lightweight runtime check that surfaces recent warning/error/critical log health to help triage engine issues quickly.
- Make existing detector diagnostics callable individually so operators can run focused checks (`HitchDetector`, `AssetStallDetector`, `NetworkHealthMonitor`, `GPUResourceLeakDetector`).

### Description
- Added `DiagLogHealth(DiagReport&)` to audit `SimpleConsole::GetInstance().GetLogHistory()` and count warnings, errors, and critical entries and perform a simple sequence sanity check (file: `EngineDiagnostics.cpp`).
- Declared the new diagnostic in the public diagnostics header as `void DiagLogHealth(DiagReport& report);` (`EngineDiagnostics.h`).
- Wired `DiagLogHealth` into the full sweep `DiagRunAll` so `diag_all` includes runtime log health (`EngineDiagnosticsExtended.cpp`).
- Registered a new console command `diag_logs` to run the logging health check, and registered standalone commands `diag_hitch`, `diag_assetstall`, `diag_nethealth`, and `diag_gpuleaks` to expose detector diagnostics individually (`EngineDiagnostics.cpp`).

### Testing
- Ran formatting on modified files with `clang-format -i SparkEngine/Source/Core/EngineDiagnostics.h SparkEngine/Source/Core/EngineDiagnostics.cpp SparkEngine/Source/Core/EngineDiagnosticsExtended.cpp` (succeeded).
- Configured the build with `cmake --preset linux-gcc-release` (configured successfully; some optional dependency warnings were reported).
- Built the affected translation units with `cmake --build build/linux-gcc-release --target SparkEngine/Source/Core/EngineDiagnostics.o SparkEngine/Source/Core/EngineDiagnosticsExtended.o -j4` and observed successful compilation of those targets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e471eaad4c8326b1b73e7a5bf9f78d)