### PR TITLE
Wire trigger edge detection for gamepad action bindings

### DIFF
--- a/SparkEngine/Source/Input/GamepadInput.cpp
+++ b/SparkEngine/Source/Input/GamepadInput.cpp
@@ -305,7 +305,19 @@ bool GamepadInput::WasActionPressed(const std::string& action, int controllerInd
     const auto& binding = it->second;
     if (binding.type == ActionBinding::Type::Button)
         return WasButtonPressed(binding.button, controllerIndex);
-    return false; // Trigger "pressed" detection would need previous state comparison
+
+    if (!IsConnected(controllerIndex))
+        return false;
+
+    const auto& state = m_states[controllerIndex];
+    const BYTE currentRaw = (binding.trigger == GamepadTrigger::Left) ? state.xinputState.Gamepad.bLeftTrigger
+                                                                      : state.xinputState.Gamepad.bRightTrigger;
+    const BYTE previousRaw = (binding.trigger == GamepadTrigger::Left) ? state.prevXinputState.Gamepad.bLeftTrigger
+                                                                       : state.prevXinputState.Gamepad.bRightTrigger;
+
+    const float current = NormalizeTrigger(currentRaw);
+    const float previous = NormalizeTrigger(previousRaw);
+    return current >= binding.triggerThreshold && previous < binding.triggerThreshold;
 }
 
 // ============================================================================


### PR DESCRIPTION
### Motivation
- Trigger-bound game actions were never reported as "pressed" because `WasActionPressed` returned a stub for trigger bindings instead of performing rising-edge detection.

### Description
- Implemented rising-edge detection in `GamepadInput::WasActionPressed` by comparing the current and previous raw XInput trigger bytes, normalizing them with `NormalizeTrigger`, and checking against the binding's `triggerThreshold` while guarding with `IsConnected` so trigger bindings fire consistently like button bindings.
- Applied `clang-format` and kept the public API unchanged; changes are limited to `SparkEngine/Source/Input/GamepadInput.cpp`.

### Testing
- `g++ -std=gnu++23 -fsyntax-only -I. -ISparkEngine/Source SparkEngine/Source/Input/GamepadInput.cpp` — succeeded.
- `clang-format --dry-run --Werror SparkEngine/Source/Input/GamepadInput.cpp` — succeeded.
- `./tools/check-wiring.sh` — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4777948f08326ba15870953c8aaec)