### PR TITLE
Optimize AIBudgetLimiter agent lookups with O(1) index map

### DIFF
--- a/SparkEngine/Source/Engine/AI/AIBudgetLimiter.cpp
+++ b/SparkEngine/Source/Engine/AI/AIBudgetLimiter.cpp
@@ -47,20 +47,26 @@ namespace Spark::AI
             }
         }
 
-        // Reconcile: keep existing entries (preserving stale counters), add new ones, remove dead
+        // Reconcile: keep existing entries (preserving stale counters), add new ones, remove dead.
+        // Build a per-frame index of old entries to avoid O(n²) scans on large crowds.
+        std::unordered_map<EntityID, size_t> previousIndex;
+        previousIndex.reserve(m_agents.size());
+        for (size_t i = 0; i < m_agents.size(); ++i)
+        {
+            previousIndex[m_agents[i].entityId] = i;
+        }
+
         std::vector<AgentBudgetEntry> newAgents;
         newAgents.reserve(activeAgents.size());
 
         for (EntityID entityId : activeAgents)
         {
-            // Look for existing entry
-            auto it = std::find_if(m_agents.begin(), m_agents.end(),
-                                   [entityId](const AgentBudgetEntry& e) { return e.entityId == entityId; });
-
-            if (it != m_agents.end())
+            // Reuse existing entry if present
+            const auto oldIndex = previousIndex.find(entityId);
+            if (oldIndex != previousIndex.end())
             {
                 // Preserve stale counter, update position
-                AgentBudgetEntry entry = *it;
+                AgentBudgetEntry entry = m_agents[oldIndex->second];
                 const auto* transform = world.GetComponent<Transform>(static_cast<entt::entity>(entityId));
                 if (transform != nullptr)
                 {
@@ -91,6 +97,7 @@ namespace Spark::AI
         // Compute priorities and sort
         ComputePriorities(playerPosition);
         SortByPriority();
+        RebuildAgentIndex();
     }
 
     bool AIBudgetLimiter::HasBudgetRemaining() const
@@ -151,16 +158,16 @@ namespace Spark::AI
 
     void AIBudgetLimiter::MarkAgentProcessed(EntityID entityId)
     {
-        for (auto& agent : m_agents)
+        const auto it = m_agentIndex.find(entityId);
+        if (it == m_agentIndex.end())
         {
-            if (agent.entityId == entityId)
-            {
-                agent.processedThisFrame = true;
-                agent.framesSinceLastUpdate = 0;
-                ++m_currentFrameStats.agentsProcessed;
-                return;
-            }
+            return;
         }
+
+        auto& agent = m_agents[it->second];
+        agent.processedThisFrame = true;
+        agent.framesSinceLastUpdate = 0;
+        ++m_currentFrameStats.agentsProcessed;
     }
 
     void AIBudgetLimiter::EndFrame()
@@ -198,18 +205,17 @@ namespace Spark::AI
 
     bool AIBudgetLimiter::ShouldUpdateAgent(EntityID entityId) const
     {
-        for (const auto& agent : m_agents)
+        const auto it = m_agentIndex.find(entityId);
+        if (it != m_agentIndex.end())
         {
-            if (agent.entityId == entityId)
+            const auto& agent = m_agents[it->second];
+            // Force-update if starved
+            if (agent.framesSinceLastUpdate >= m_maxStaleFrames)
             {
-                // Force-update if starved
-                if (agent.framesSinceLastUpdate >= m_maxStaleFrames)
-                {
-                    return true;
-                }
-                // Otherwise only if budget remains
-                return HasBudgetRemaining();
+                return true;
             }
+            // Otherwise only if budget remains
+            return HasBudgetRemaining();
         }
         // Unknown agent -- default to updating if budget allows
         return HasBudgetRemaining();
@@ -247,6 +253,16 @@ namespace Spark::AI
     {
         std::sort(m_agents.begin(), m_agents.end(),
                   [](const AgentBudgetEntry& a, const AgentBudgetEntry& b) { return a.priority > b.priority; });
+    }
+
+    void AIBudgetLimiter::RebuildAgentIndex()
+    {
+        m_agentIndex.clear();
+        m_agentIndex.reserve(m_agents.size());
+        for (size_t i = 0; i < m_agents.size(); ++i)
+        {
+            m_agentIndex[m_agents[i].entityId] = i;
+        }
     }
 
     // =========================================================================

--- a/SparkEngine/Source/Engine/AI/AIBudgetLimiter.h
+++ b/SparkEngine/Source/Engine/AI/AIBudgetLimiter.h
@@ -51,6 +51,7 @@
 #include "../ECS/Components/CoreComponents.h"
 
 #include <vector>
+#include <unordered_map>
 #include <chrono>
 #include <cstdint>
 #include <optional>
@@ -265,6 +266,11 @@ namespace Spark::AI
         void SortByPriority();
 
         /**
+         * @brief Rebuild the entity-to-index lookup table for O(1) agent lookups.
+         */
+        void RebuildAgentIndex();
+
+        /**
          * @brief Get elapsed time since BeginFrame() in milliseconds.
          */
         float GetElapsedMs() const;
@@ -283,6 +289,9 @@ namespace Spark::AI
 
         /// All tracked AI agents (persists across frames for stale tracking)
         std::vector<AgentBudgetEntry> m_agents;
+
+        /// Fast lookup from entity id -> index in m_agents
+        std::unordered_map<EntityID, size_t> m_agentIndex;
 
         /// Index into m_agents for the next agent to process this frame
         uint32_t m_nextAgentIndex = 0;


### PR DESCRIPTION
### Motivation
- `AIBudgetLimiter` was performing repeated linear scans when reconciling agents and when looking up agents by id, which pushes cost toward O(n²) in crowd-heavy scenes and adds per-agent overhead on hot paths.
- Reduce per-frame CPU and allocation overhead while preserving existing prioritization and starvation behavior.

### Description
- Added a persistent `m_agentIndex` (`std::unordered_map<EntityID, size_t>`) and a helper `RebuildAgentIndex()` to provide O(1) entity→vector-index lookups after sorting; changes are internal and do not affect the public API (`AIBudgetLimiter`).
- In `BeginFrame` replaced per-agent linear `find_if` scans with a temporary `previousIndex` map to reuse prior entries in O(1) and avoid O(n²) reconciliation work.
- Updated `MarkAgentProcessed` and `ShouldUpdateAgent` to use the `m_agentIndex` lookup instead of scanning the `m_agents` vector.
- Kept existing priority computation, sorting, starvation and budgeting semantics unchanged and call `RebuildAgentIndex()` after sorting.

### Testing
- Ran `clang-format --dry-run --Werror` on the modified files and it passed.
- Ran `cmake --preset linux-gcc-release` and configuration completed successfully.
- Attempted `cmake --build ... --target SparkTests` to validate the test build but the environment build failed while archiving Jolt (`ranlib ... libJolt.a: error reading ObjectStreamOut.cpp.o: file truncated`), so the full test suite could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e47befc9708326adcced3c10e80062)