### PR TITLE
docs(skills): add SparkEngine project-local skill library (14 skills)

### DIFF
--- a/.claude/skills/sparkengine-architecture-contract/SKILL.md
+++ b/.claude/skills/sparkengine-architecture-contract/SKILL.md
@@ -1,0 +1,376 @@
+---
+name: sparkengine-architecture-contract
+description: >-
+  The load-bearing design decisions of the SparkEngine C++23 game engine: the
+  invariants that MUST hold, WHY each exists, what breaks if you violate it, and
+  the OPEN known-weak-points. TRIGGER when you are about to add or wire a
+  subsystem, touch the service locator / EngineContext, change ECS system
+  ordering or the system-manager plumbing, add a global, change RHI backend
+  selection, cross the DLL/game-module boundary, or you catch yourself asking
+  "how is this engine supposed to fit together / where does X live / can I add a
+  g_ global / why is my subsystem null in a module". DO NOT TRIGGER for pure
+  build/CMake/CI failures (use the global cmake-msvc / ci-troubleshoot skills),
+  pure formatting, or a self-contained bug fix that touches no cross-subsystem
+  boundary and adds no new system.
+trilobite_compatible: true
+trilobite_role: architecture
+---
+
+# SparkEngine Architecture Contract
+
+This is the **contract**, not a tutorial. It states the engine's load-bearing
+design decisions as **invariants** (rules that must hold), the **WHY** behind
+each, and the **failure mode** you cause by breaking it. It assumes you have
+already read `D:\SparkEngine\CLAUDE.md` (the project manifest with the Anti-Bloat
+table and "Before Writing Code" checklist). This skill does not restate those;
+it documents the *design* those rules protect.
+
+**Definitions used once here:**
+- **Subsystem** — an engine-lifetime service (e.g. `GraphicsEngine`,
+  `PhysicsSystem`, `AudioEngine`, `NetworkManager`).
+- **Service locator** — the `EngineContext` object every subsystem is fetched
+  through instead of a global.
+- **Game module** — a genre DLL under `GameModules/*` (SparkGame, SparkGameFPS,
+  SparkGameMMO, ...) that links `SparkEngineLib` statically and is loaded at
+  runtime by the host.
+- **RHI** — Render Hardware Interface, the backend-agnostic GPU abstraction.
+- **ECS** — Entity Component System (EnTT-backed); systems run each frame in a
+  fixed phase order.
+
+## When to use / when not to
+
+| Use this skill when... | Use instead... |
+|---|---|
+| Adding a new subsystem and deciding how it is owned/accessed | this skill |
+| A subsystem pointer is null inside a game-module DLL | this skill (Invariant 2) |
+| Changing ECS system order, or picking a system-manager class | this skill (Invariant 3) |
+| Tempted to add a `g_`/file-scope global for a subsystem | this skill (Invariant 1) |
+| Adding code and unsure if it must be wired into startup/loop | this skill (Invariant 4) |
+| Build/link/CMake/CI is red | global `cmake-msvc` (toolchain) / `ci-troubleshoot` (CI) |
+| Formatting-only or a localized bug fix crossing no boundary | just fix it; no skill needed |
+| You need the runtime module/DLL loading mechanics in depth | `sparkengine-plugin-abi` |
+
+If a change would violate one of the invariants below, **stop and reconsider the
+design** — do not route around it. If the invariant itself is wrong, that is a
+design change: say so explicitly and get sign-off, don't silently break it.
+
+---
+
+## Invariant 1 — Subsystems are owned by `EngineRuntime`, accessed via `EngineContext`. No new `g_*` subsystem globals.
+
+**Rule.** Engine-lifetime ownership lives in one struct, `EngineRuntime`
+(`SparkEngine/Source/Core/EngineRuntime.h`), which holds the owning
+`std::unique_ptr`s. Access to a *live* subsystem is always through the service
+locator: `EngineContext::Get()->GetX()` (e.g. `GetPhysics()`, `GetAudio()`), or
+the generic `GetSystem<T>()` for subsystems without a named getter. You may
+**not** introduce a new file-scope `g_*` subsystem global.
+
+**Why.** `EngineContext` uses a single generic registry (`TypeId -> void*`,
+guarded by a `shared_mutex`) as the *single source of truth*; the ~50 named
+getters (`GetGraphics()`, etc.) all delegate to `GetSystem<T>()`
+(`Core/EngineContext.h`, lines 169-372). One registry means:
+- One place to inject across the DLL boundary (Invariant 2).
+- One place that is lock-guarded for runtime hot-reload registration.
+- No duplicated/desynced pointer state to keep coherent.
+
+A parallel `g_thing` global reintroduces exactly the desync + per-image-copy
+problems the registry was built to kill.
+
+**Failure mode if violated.** A `g_*` global is **per translation-image**: it is
+null (or a dead duplicate) inside every game-module DLL, because the DLL links
+its own copy of `SparkEngineLib`. You get a null-deref or, worse, a *second live
+instance* of a subsystem that silently diverges from the host's. This is the
+same class of bug Invariant 2 exists to prevent.
+
+**Non-obvious detail — the type-id trick (do not "clean up").**
+`GetTypeId<T>()` returns the address of a **non-`const`** function-local
+`static char id;` (`Core/EngineContext.h`, lines 58-68). It must stay
+non-`const`. A `static const char id = 0` compiles to an identical read-only
+COMDAT for every `T`, which MSVC's `/OPT:ICF` (on in Release, off in Debug)
+folds to a **single address** — collapsing every type id to the same key so the
+locator returns the *wrong subsystem in Release only*. Writable data is not
+ICF-folded. Adding `const` back is a silent Release-only correctness bug.
+(Cross-ref: user memory `opt-icf-typeid-gate.md`.)
+
+**How to add a subsystem correctly:**
+1. Add the owning `std::unique_ptr<T>` field to `EngineRuntime` (or, for
+   optional/feature-gated systems, guard it like `physics` is behind
+   `SPARK_BULLET_PHYSICS_AVAILABLE`).
+2. Create it during startup (`SparkEngine.cpp` /
+   `SparkEngine{Windows,Linux}.cpp`) and register the raw pointer:
+   `ctx.RegisterSystem<T>(ptr)` or a named `SetX()`.
+3. If it has init/shutdown or dependencies, prefer
+   `RegisterSubsystem<T>(ptr, DependsOn<Dep1, Dep2>{}, initFn, shutdownFn)` so
+   `InitializeAll()`/`ShutdownAll()` order it topologically (see `EngineSetup.h`
+   for the existing dependency wiring, e.g. UISystem/DialogueSystem
+   `DependsOn<Timer, EventBus>`).
+4. Never store the returned pointer in a file-scope global. Fetch via
+   `EngineContext::Get()->GetSystem<T>()` at the call site.
+
+---
+
+## Invariant 2 — Inside a game-module DLL, resolve subsystems through the **injected** EngineContext, never a per-module singleton.
+
+**Rule.** `SparkEngineLib` is a **static** library linked into every game-module
+DLL, so the owning `g_engineContext` global is per-image and is null inside a
+module. The host injects its live context across the DLL boundary via
+`EngineContext::SetInjected(ctx)`, and `EngineContext::Get()` **prefers the
+injected pointer** when one is set (`Core/EngineContext.cpp`: `if
+(g_injectedContext) return g_injectedContext;`). Module code must call
+`EngineContext::Get()` — never a subsystem's own `GetInstance()`/per-module
+singleton fallback.
+
+**Why.** Without injection, a module either sees `nullptr` or constructs its own
+second copy of a subsystem. Injection passes a **raw, non-owning** pointer on
+purpose (`SetInjected` doc, `EngineContext.h` lines 130-143): module teardown
+must not free the host's context.
+
+**Failure mode if violated.** Cross-DLL null-deref, or two live copies of a
+subsystem (e.g. two `NetworkManager`s) that never see each other's state —
+network messages, ECS entities, or config silently vanish across the boundary.
+
+**STATUS (as of 2026-07-07): injection is WIRED IN SOURCE — rebuild stale
+module DLLs to get it into the binaries.** The DLL-side export **has landed**:
+`extern "C" __declspec(dllexport) void SparkModuleInjectEngineContext(void* ctx)`
+that calls `EngineContext::SetInjected(...)` is defined at
+`SparkSDK/Include/Spark/ModuleDllMain.h:88`, and the host consumes it at
+`SparkEngine/Source/Core/ModuleManager.cpp:193` via
+`GetProcAddress(..., "SparkModuleInjectEngineContext")`. This landed in commit
+`52636dda` (an ancestor of the current tree). `SetInjected` + `Get()` preference
+exist on the host side. So in **source**, injection is functionally wired
+end-to-end. The canonical status write-up lives in
+`sparkengine-module-injection-p0-campaign`; consult it before relying on
+injection.
+
+**Remaining genuine gaps (real, keep in mind):**
+- **Stale binaries.** The module DLLs built on disk predate `52636dda`, so they
+  **lack the export until rebuilt**. This is a binary gap, not a source gap —
+  rebuild the modules (see the campaign skill) and verify with `dumpbin /exports`.
+- **`NetworkManager::GetInstance()` static fallback not deleted.** It now routes
+  through the injected context first (`NetworkManager.h:342` / `.cpp:130`), but
+  the dead `static NetworkManager instance;` fallback was not removed.
+- **`MMOWorldSetup.cpp` still uses `SeamlessAreaManager::GetInstance()`** — a
+  streaming singleton, out of the injection-P0 scope. (The MMO DI fix for
+  `MMOPlayerSystem` **has** landed — it resolves via `m_context->GetNetwork()`.)
+
+Do not add **new** naive per-module `GetInstance()` singletons — those are the
+anti-pattern the injection seam removes. The retrofitted context-routing
+`GetInstance()` (which returns the injected host instance) and genuinely-shared
+singletons are acceptable; see Invariant 2's cross-references and the plugin-abi
+skill for the exact rule.
+
+---
+
+## Invariant 3 — ECS systems run in a fixed phase order. There is ONE canonical system-manager, and it is `PhaseSystemManager`.
+
+**Rule (ordering).** The per-frame ECS pipeline runs in this order; downstream
+systems assume upstream ones have already written this frame:
+
+`Physics -> Animation -> AI -> Audio -> Lifecycle -> Render`
+
+The full phase enum (`PhaseSystemManager.h`, `enum class Phase`) is finer-grained
+but a superset of the same order:
+`PrePhysics -> Physics -> PostPhysics -> Animation -> AI -> Audio -> Gameplay
+(Lifecycle) -> PreRender -> Render -> PostRender`.
+
+**Why.** `PhysicsUpdateSystem` writes simulation results back into the
+`Transform` component; `RenderSystem` and `AudioUpdateSystem` *read* Transform.
+If Render runs before Physics, entities render at last frame's positions (visible
+jitter / one-frame lag). AI reads positions produced by Physics + spline
+followers, so it runs after them. This ordering is the pipeline's core
+correctness guarantee, not a style preference.
+
+**Failure mode if violated.** One-frame lag, physics/render desync, AI reacting
+to stale positions, audio emitters attached to not-yet-updated transforms.
+
+**Rule (which manager) — read this honestly: NONE of the three is a cleanly-wired
+home right now.** This is an OPEN architectural weak point. The intended-canonical
+manager is **`PhaseSystemManager`**
+(`SparkEngine/Source/Engine/ECS/Systems/PhaseSystemManager.h`), whose build site
+`EngineSetup.h::CreatePhaseSystemManager()` buckets each system by `Phase::` and
+runs them in enum order in `UpdateAll()`. **But `CreatePhaseSystemManager()` has
+zero callers and `UpdateAll` is never invoked in any `.cpp` — it is
+DEFINED-not-wired, not ticked in the shipping loop.** Meanwhile the loop actually
+ticks `StageBasedExecutor::ExecuteAll(dt)` every frame
+(`GameplayLifecycleShared.cpp:1062`), but nothing calls its `RegisterSystem(...)`,
+so that is a **dead tick** (a live tick over zero registered systems). The
+shipping Core loop drives module systems via `moduleManager->UpdateAll(dt)`.
+Consequence: there is no single obviously-correct place to "add a new ECS system"
+today — flag this and coordinate rather than authoring against a manager that does
+not run. For the executor tick reality see
+**sparkengine-job-system-threading §1c**; for query/registration idioms see
+**sparkengine-ecs-query-patterns**. Keep those three skills telling the same story.
+
+**OPEN / KNOWN-WEAK — three parallel executors (as of 2026-07-07).** There are
+**three** classes doing related jobs, which contradicts CLAUDE.md's own
+anti-bloat rule ("Parallel singleton systems doing the same thing: 0"):
+
+| Class | File | Status |
+|---|---|---|
+| `PhaseSystemManager` | `ECS/Systems/PhaseSystemManager.h` | **INTENDED canonical manager, but DEFINED-not-wired** (zero callers of `CreatePhaseSystemManager`; `UpdateAll` never invoked). Serial, phase-ordered. |
+| `SystemManager` | `ECS/Systems/ECSystems.h` (line 735) | Flat insertion-order manager; **legacy**, no phase guarantee. |
+| `StageBasedExecutor` | `ECS/Systems/ParallelSystemExecutor.h` (line 378) | Parallel stage executor (JobSystem). **EXISTS and its `ExecuteAll(dt)` is ticked every frame** at `GameplayLifecycleShared.cpp:1062`, but **no `RegisterSystem` caller exists → dead tick** (ticks nothing). |
+
+Per `HARDEN_FLEET_HANDOFF.md`, the intended cleanup is to **consolidate** these
+and either register systems into `StageBasedExecutor` or delete it. Until then:
+- **Do not assume any of the three runs your system in the shipping loop.**
+  `PhaseSystemManager` is not ticked at all; `StageBasedExecutor`'s tick is live
+  but has zero registered systems. If you must add a system, verify the tick path
+  end-to-end and raise the wiring gap — this is an unfinished architectural home.
+- Note the parallel-execution history: an earlier path routed every phase through
+  a single global `ParallelSystemExecutor` that batched by component read/write
+  sets *across all phases*, silently discarding phase order (Render could run
+  before Physics). It was removed; `PhaseSystemManager::UpdateAll` now runs
+  **serially** (see its doc comment, `PhaseSystemManager.h` lines 116-121).
+  Correct per-phase parallelism would need one executor **per phase** — that does
+  not exist yet. Do not reintroduce cross-phase parallel batching.
+
+---
+
+## Invariant 4 — Wiring is not optional. A system that exists but is never initialized/called/connected is worse than not existing.
+
+**Rule.** Every `Initialize()` must be called on the startup path; every
+`Update()` / `ProcessCommands()` must appear in the main loop; every sink must
+have a source. If you build a system, you wire it in **in the same change**, or
+you delete it.
+
+**Why.** Dead-but-present code is a trap: it reads as "done," is maintained,
+compiled, and reviewed, but does nothing at runtime — the worst ratio of cost to
+value. This is a stated project doctrine (CLAUDE.md "Wiring Things In"), and the
+codebase has live examples of the failure it prevents.
+
+**Failure mode if violated.** Silent no-ops that look implemented. Concrete
+current instances (from `HARDEN_FLEET_HANDOFF.md`, OPEN as of 2026-07-07):
+- `StageBasedExecutor` has a **dead tick** — never fed systems (Invariant 3).
+- `SequencerManager` audio cues **never fire** — no `AudioCallback` wired.
+- `BTNode::Clone()` deep-copy missing — cloned behavior trees have no root
+  (silent no-op).
+- `WeaponFireEvent.ownerEntity` is always `0` — owner never threaded through.
+- 16 orphan `Test*.cpp` files are **never compiled** (no build registration).
+
+**How to satisfy it.** After adding a system, grep for its `Initialize`/`Update`
+call site and confirm it is on the real path (`EngineSetup.h`, the platform
+`SparkEngine*.cpp` entry files, or the game loop). Wire with a **direct call** to
+the real function — do not wrap it in a new abstraction layer. `tools/check-wiring.sh`
+exists to catch systems whose `Initialize()` is never called.
+
+---
+
+## Invariant 5 — Rendering goes through the RHI; there is always a GPU-less fallback, and it is chosen automatically.
+
+**Rule.** All GPU work goes through the RHI abstraction
+(`SparkEngine/Source/Graphics/RHI/`). D3D11 is the primary backend; D3D12,
+Vulkan, Metal, and OpenGL are experimental. When no GPU backend is usable the
+engine falls back to a software/headless device and **keeps running** — it does
+not abort. Backend selection is centralized in `RHIFactory`
+(`RHI/RHIFactory.cpp`); do not hard-code a device type at a call site.
+
+**Why.** SparkEngine must come up on CI runners, headless servers (AreaServer /
+WorldServer), and CPU-only / sandboxed hosts. A rendering path that assumes a
+real GPU would break headless tests and dedicated-server builds.
+
+**Fallback tiers (verify in `RHIFactory.cpp`):**
+- Priority when `Auto`: D3D11 on Windows, Metal on Apple, Vulkan on Linux,
+  OpenGL as last GPU option.
+- Software substitutes: WARP (D3D11/D3D12), Lavapipe (Vulkan), llvmpipe
+  (OpenGL).
+- `NullRHIDevice` (`RHI/NullRHIDevice.h`) — full headless no-op device when no
+  backend is available.
+- Override with the `SPARK_RHI_BACKEND` env var (`none` forces
+  `NullRHIDevice`); `RHIFactory` also auto-recommends `None` under gVisor/CPU-only
+  detection to avoid Wine signal-handler hangs.
+
+**Failure mode if violated.** Hard-coding `D3D11CreateDevice` (or any concrete
+backend) at a call site breaks Linux/macOS builds, headless CI, and dedicated
+servers — the exact scenarios the abstraction and `NullRHIDevice` exist to serve.
+
+---
+
+## Invariant 6 — Cross-platform types come from `Core/Platform.h`. Do not include DirectX headers unguarded.
+
+**Rule.** Math/vector types and platform stubs are provided by
+`SparkEngine/Source/Core/Platform.h` (DirectXMath is stubbed on Linux). Include
+platform-specific graphics headers only behind the appropriate guards; the
+canonical Linux CI jobs (GCC/Clang) compile the whole engine without the Windows
+SDK.
+
+**Why.** Linux/macOS are supported build targets (there is a `build-macos` CI
+job and Linux GCC/Clang/ASan/TSan/MSan jobs). An unguarded `#include
+<DirectXMath.h>` or `<d3d11.h>` breaks every non-Windows job. Recent commits
+(`2983dd34`, `710f797e`) were fixes for exactly this class of leak.
+
+**Failure mode if violated.** Green on your Windows box, red on
+`build-linux-gcc` / `build-macos` — a `fatal error: DirectXMath.h: No such file`
+that you will only see in CI.
+
+---
+
+## Quick self-check before you commit an architecture-touching change
+
+- [ ] No new `g_*` file-scope subsystem global (Invariant 1).
+- [ ] New subsystem is owned in `EngineRuntime`, registered in `EngineContext`,
+      fetched via `Get()->GetSystem<T>()` (Invariant 1).
+- [ ] Did not add `const` to `GetTypeId<T>()`'s `static char id` (Invariant 1).
+- [ ] Module-side access uses `EngineContext::Get()`, not a new `GetInstance()`
+      fallback (Invariant 2).
+- [ ] New ECS system: you verified the tick path end-to-end (no manager is
+      cleanly wired — `PhaseSystemManager` is not ticked, `StageBasedExecutor`'s
+      tick is live but empty) and flagged the wiring gap (Invariant 3).
+- [ ] Anything with `Initialize()`/`Update()` is actually called on the real
+      path — grep the call site to prove it (Invariant 4).
+- [ ] No concrete GPU device hard-coded outside `RHIFactory` (Invariant 5).
+- [ ] No unguarded DirectX/Windows-only include (Invariant 6).
+
+---
+
+## OPEN known-weak-points register (candidate cleanups, not fixed)
+
+These are architecture-shaped debts recorded in
+`D:\SparkEngine\HARDEN_FLEET_HANDOFF.md` as of 2026-07-07. Stated as **OPEN** —
+do not assume any are resolved without re-checking.
+
+| Item | Nature | Invariant touched |
+|---|---|---|
+| Module EngineContext injection: source LANDED (`52636dda`), but built module DLLs are STALE (predate the export) | rebuild binaries | 2 |
+| `NetworkManager::GetInstance()` static fallback not deleted (now context-routed but the dead `static` remains); `MMOWorldSetup.cpp` still uses `SeamlessAreaManager::GetInstance()` (streaming, out of P0 scope) | anti-pattern cleanup | 2 |
+| `SystemManager`/`PhaseSystemManager`/`StageBasedExecutor` triple | parallel systems, contradicts anti-bloat rule | 3 |
+| `StageBasedExecutor` dead tick (ticked every frame, zero registered systems); `PhaseSystemManager` defined-not-wired (zero callers) | built-not-wired | 3, 4 |
+| Sequencer audio callback never dispatched | built-not-wired | 4 |
+| `BTNode::Clone()` deep-copy missing | silent no-op | 4 |
+| 16 orphan `Test*.cpp` never compiled | built-not-wired | 4 |
+
+---
+
+## Provenance and maintenance
+
+All claims below were verified by reading the repo at commit `710f797e` on
+2026-07-07. Re-verify volatile facts with these one-liners (run from
+`D:\SparkEngine`):
+
+```bash
+# Invariant 1 — registry is the single source of truth; getters delegate
+grep -n "GetSystem<" SparkEngine/Source/Core/EngineContext.h | head
+# Invariant 1 — type-id must stay non-const (do not add const)
+grep -n "static char id" SparkEngine/Source/Core/EngineContext.h
+# Invariant 2 — Get() prefers injected pointer; DLL-side export has LANDED
+grep -n "g_injectedContext\|SetInjected" SparkEngine/Source/Core/EngineContext.cpp
+grep -n "SparkModuleInjectEngineContext" SparkSDK/Include/Spark/ModuleDllMain.h   # a HIT now = LANDED (was OPEN)
+# Invariant 3 — intended manager exists but is NOT wired (expect ZERO callers)
+grep -n "class PhaseSystemManager\|enum class Phase" SparkEngine/Source/Engine/ECS/Systems/PhaseSystemManager.h
+grep -rn "CreatePhaseSystemManager\|->UpdateAll" SparkEngine/Source --include='*.cpp'   # PhaseSystemManager: expect no live callers
+# Invariant 3 — the tick that actually runs (StageBasedExecutor) vs its (absent) registration
+grep -n "StageBasedExecutor::GetInstance().ExecuteAll" SparkEngine/Source/Core/Lifecycle/GameplayLifecycleShared.cpp
+grep -rn "RegisterSystem(" SparkEngine/Source | grep -i stage   # expect only the definition, no callers = dead tick
+grep -n "class SystemManager\|class StageBasedExecutor" \
+  SparkEngine/Source/Engine/ECS/Systems/ECSystems.h \
+  SparkEngine/Source/Engine/ECS/Systems/ParallelSystemExecutor.h
+# Invariant 5 — RHI backend selection + null fallback
+grep -n "NullRHIDevice\|GraphicsBackend::None\|SPARK_RHI_BACKEND" SparkEngine/Source/Graphics/RHI/RHIFactory.cpp | head
+# OPEN register — re-read the handoff for current status
+grep -n "INERT\|consolidate\|GetInstance" D:/SparkEngine/HARDEN_FLEET_HANDOFF.md
+```
+
+If any check above disagrees with this document, the code wins — update this
+skill. Validate edits with the repo-standard skill linter (`skill-lint.ps1`,
+located under `~/.claude/skills/skill-linter/`), pointing `-Path` at this skill
+folder.

--- a/.claude/skills/sparkengine-asset-pipeline/SKILL.md
+++ b/.claude/skills/sparkengine-asset-pipeline/SKILL.md
@@ -1,0 +1,310 @@
+---
+name: sparkengine-asset-pipeline
+description: >-
+  Reference for SparkEngine's asset import/load pipeline in
+  SparkEngine/Source/Graphics — how a source file (.obj/.fbx/.gltf/.glb, .png/.tga/.dds,
+  .wav) becomes a runtime MeshAsset/TextureAsset/AudioAsset, what AssetMetadata tracks
+  (guid, checksum, timestamps, fbx.* custom properties), and the non-obvious Windows/Linux
+  platform-split (AssetPipelineWindows.cpp vs AssetPipelineLinux.cpp, D3D11 vs RHI/tinyobj/cgltf/stb_image).
+  TRIGGER when: adding a new asset type or source format, editing AssetPipeline / AssetTypes /
+  AssetMetadata / FBXImporter / ModelLoading, wondering "why is FBX loading Linux-only?",
+  "why are there two .cpp files per asset class?", or "where does mesh loading actually happen?".
+  DO NOT TRIGGER when: writing render-graph / RHI backend code (that is the RHI layer, not
+  the asset layer — read SparkEngine/Source/Graphics/RHI directly), authoring shaders, or
+  doing runtime ECS/gameplay work — use sparkengine-ecs-query-patterns for ECS instead.
+  Phrases: "import an fbx", "add a texture format", "asset metadata", "hot reload assets",
+  "why two files windows linux graphics".
+trilobite_compatible: true
+trilobite_role: reference
+---
+
+# SparkEngine asset pipeline
+
+Runbook for the code under `SparkEngine/Source/Graphics/Asset*.{h,cpp}`,
+`FBXImporter.{h,cpp}`, and `ModelLoading*.cpp`. It explains how a source
+asset on disk becomes something the renderer can draw, what metadata is
+tracked, and the platform-split file convention that trips up newcomers.
+
+Definitions used once here:
+- **RHI** — Render Hardware Interface, SparkEngine's cross-API graphics
+  abstraction (`SparkEngine/Source/Graphics/RHI/`). The non-Windows path
+  uploads geometry through it instead of raw D3D11.
+- **TU** — translation unit (one `.cpp` as the compiler sees it after
+  preprocessing).
+- **ComPtr** — `Microsoft::WRL::ComPtr`, a smart pointer for D3D11 COM
+  objects (Windows only).
+- **Platform-split** — one logical class implemented across a
+  `*Windows.cpp` + `*Linux.cpp` pair, each fully wrapped in an `#ifdef`
+  so exactly one compiles per platform. Both files are always in the build.
+
+## When NOT to use this skill
+
+- You are changing an **RHI backend** (D3D12/Vulkan/Metal/OpenGL) or the
+  render graph — that is `Graphics/RHI/` and `Graphics/RenderGraph/`, a
+  different layer. This skill stops at "asset produces CPU data + one
+  GPU/RHI buffer".
+- You are touching **ECS components** that reference assets — that is
+  `Engine/ECS/`.
+- You want to author shaders — `SparkShaderCompiler/` and `Graphics/Shader*`.
+
+## 30-second mental model
+
+```
+source file on disk (.obj/.fbx/.gltf/.png/.tga/.wav ...)
+        |
+   AssetPipeline::LoadAsset(path, type)      <- entry point, dedup + cache
+        |  DetectAssetType() picks MeshAsset / TextureAsset / AudioAsset
+        v
+   LoadMeshFromFile / LoadTextureFromFile / LoadAudioFromFile
+        |  constructs the Asset, calls Asset::Load(device)
+        v
+   MeshAsset::Load()  --- parses the file into MeshAssetData (CPU-side)
+        |                 and creates GPU/RHI buffers
+        v
+   stored in m_assets (path -> shared_ptr<Asset>) + AssetCache (LRU)
+        |
+   runtime: BindMesh(path) / DrawBoundMesh(), GraphicsEngine::ProcessDrawList
+```
+
+There is **no separate "cook" / offline-import step and no on-disk
+intermediate/`.meta` file**. Import is done live at load time, in-process,
+every run. "Metadata" is an in-memory `AssetMetadata` struct rebuilt from
+the filesystem on demand — it is not persisted. Do not look for a
+`.import`/`.asset`/`.meta` cache; there isn't one as of 2026-07-07.
+
+## Supported source formats (verified in code)
+
+Two things decide format support, and they differ:
+
+1. **Type detection** (`AssetPipeline::DetectAssetTypeFromExtension`,
+   in `AssetMetadataWindows.cpp` / `AssetMetadataLinux.cpp`) — maps an
+   extension to an `AssetType`.
+2. **Actual parsing** (`MeshAsset::Load` / `TextureAsset::Load` /
+   `AudioAsset::Load`, in `AssetTypesWindows.cpp` / `AssetTypesLinux.cpp`) —
+   what the loader can really decode. These are NOT the same set.
+
+| Asset | Windows parser (`AssetTypesWindows.cpp`) | Linux/macOS parser (`AssetTypesLinux.cpp`) |
+|-------|------------------------------------------|--------------------------------------------|
+| Mesh  | `.obj` only, hand-written OBJ parser; **fallback = unit cube** if unparsed | `.obj` (tinyobjloader), `.fbx` (`FBXImporter`), `.gltf`/`.glb` (cgltf, gated on `SPARK_HAS_CGLTF`); no fallback cube |
+| Texture | `.tga` only (hand-written, image type 2, 24/32bpp); `.dds` logs "requires DirectXTex" and falls back; **fallback = 2x2 checkerboard** | any stb_image format — `.png/.jpg/.tga/.bmp/.hdr` — decoded to RGBA8 (gated on `SPARK_HAS_STB_IMAGE`), uploaded via the RHI bridge |
+| Audio | `.wav` (RIFF/WAVE, PCM `audioFormat==1`); **fallback = 1s silence** | reads raw file bytes into `m_audioData`; no WAV header parse |
+
+Key non-obvious facts (verify before relying on them — see Provenance):
+- **FBX and glTF meshes only actually load on the non-Windows path.**
+  `MeshAsset::Load` in `AssetTypesWindows.cpp` handles `.obj` and then
+  falls back to a cube. FBX/glTF geometry parsing lives in
+  `AssetTypesLinux.cpp` and `ModelLoadingLinux.cpp`. The
+  `AssetPipeline::LoadFBX` / `LoadGLTF` private methods declared in
+  `AssetPipeline.h` are **only defined in `ModelLoadingLinux.cpp`**
+  (grep confirms no `::LoadFBX`/`::LoadGLTF` definition on Windows).
+- `DetectAssetTypeFromExtension` lists `.fbx`, `.dae`, `.gltf`, `.glb`
+  as Mesh on Windows even though the Windows loader won't parse them —
+  detection is broader than parsing. Do not assume "detected => loadable".
+- The two detection tables are **not identical**: Linux additionally maps
+  `.mat/.anim/.prefab/.scene/.glsl/.cso/.bmp/.hdr`; Windows adds `.dae`
+  and `.fx`. Keep both in sync when adding an extension.
+
+### FBX importer specifics
+
+`FBXImporter` (`FBXImporter.h/.cpp`) is a **self-contained binary-FBX
+parser — no Autodesk FBX SDK dependency.** It is a singleton
+(`FBXImporter::GetInstance()`), reads the `"Kaydara FBX Binary  "` magic,
+walks the node tree, and extracts:
+- meshes (`FBXMeshData`: flat vertex/normal/uv float arrays + indices),
+- skeleton bones (`FBXBoneData`, column-major 4x4 bind pose),
+- animation clips (`FBXAnimationData` / `FBXBoneTrack` / `FBXKeyframe`).
+
+Import is configured with `FBXImportOptions` (scaleFactor, triangulate,
+flipUVs, `targetCoordSystem` = LeftHanded/D3D by default, importAnimations).
+`CanImport(path)` checks magic bytes; `GetSupportedExtensions()` returns
+`{".fbx"}`; `ValidateForPipeline(...)` gates on optional skeleton/animation
+requirements. The Linux `MeshAsset::Load` calls `Import` then
+`ValidateForPipeline(result, false, false, &err)` and, on success, copies
+meshes into `MeshAssetData`, calls `GenerateTangents` + `ComputeBounds`,
+and records `fbx.meshCount` / `fbx.boneCount` / `fbx.animationCount` into
+metadata custom properties.
+
+## AssetMetadata — what is tracked
+
+Struct `AssetMetadata` in `AssetPipeline.h` (lines ~140-154). Populated by
+`AssetPipeline::GetAssetMetadata` and inside each `Asset::Load`:
+
+| Field | Meaning | Where set |
+|-------|---------|-----------|
+| `guid` | Unique id string | declared; **not populated by any Load path** as of 2026-07-07 (candidate/unused) |
+| `filePath` | Original source path | GetAssetMetadata, every Load |
+| `name` | `path.stem()` (filename without extension) | GetAssetMetadata, every Load |
+| `type` | `AssetType` enum from extension | DetectAssetType |
+| `fileSize` | `std::filesystem::file_size` | GetAssetMetadata / Load |
+| `memorySize` | `GetMemoryUsage()` result | set at end of each Load |
+| `lastModified` | timestamp; ms since epoch (Win) / `st_mtime` seconds (Linux) | `GetFileTimestamp` |
+| `checksum` | content hash — **NOT cryptographic**: Windows `hash*31+byte` as decimal; Linux `checksum*31+byte` as hex. The two platforms produce different strings for the same file. | `CalculateChecksum` |
+| `dependencies` | asset dependency list | declared; not populated (candidate) |
+| `priority`, `state` | `LoadingPriority` / `StreamingState` | Linux GetAssetMetadata sets defaults; state set in Load |
+| `customProperties` | `map<string,string>`; FBX writes `fbx.meshCount/boneCount/animationCount` here | Linux FBX Load |
+
+Do not describe the checksum as MD5/SHA — the Windows source comment says
+"in production would use MD5/SHA"; it is a rolling multiply-add. Two
+platforms are not comparable.
+
+## The Windows/Linux platform-split convention (read this before editing)
+
+Almost every asset class is spread across a `*Windows.cpp` + `*Linux.cpp`
+pair. **Both files are always compiled** (the engine sources are added with
+`file(GLOB_RECURSE ...)` in the root `CMakeLists.txt`, so nothing is
+excluded per-platform at the CMake level). Instead, each file wraps its
+entire body in a guard:
+
+- Windows file: `#include "Core/Platform.h"` then `#ifdef SPARK_PLATFORM_WINDOWS ... #endif`
+- Linux/macOS file: `#include "Core/Platform.h"` then `#ifndef SPARK_PLATFORM_WINDOWS ... #endif`
+
+So on any given platform, one of the pair is an empty TU. This is why you
+see `AssetPipeline.cpp` / `AssetMetadata.cpp` reduced to a one-comment
+"redirect" stub — the real code moved into the platform files.
+
+The file map:
+
+| Logical unit | Cross-platform | Windows / D3D11 | Linux+macOS / RHI |
+|--------------|----------------|-----------------|-------------------|
+| Pipeline lifecycle, load orchestration, cache, streaming | `AssetPipeline.cpp` (stub) | `AssetPipelineWindows.cpp` | `AssetPipelineLinux.cpp` |
+| Asset classes `Load/Unload/GetMemoryUsage`, `AssetCache` | `AssetTypes.cpp` (ctors/dtors, `SetRHIBuffers/Texture`) | `AssetTypesWindows.cpp` | `AssetTypesLinux.cpp` |
+| Type detection, dir scan, metadata, checksums, enum-to-string | `AssetMetadata.cpp` (stub) | `AssetMetadataWindows.cpp` | `AssetMetadataLinux.cpp` |
+| `LoadMeshFromFile` + format loaders (OBJ/FBX/glTF) + bind/draw | `ModelLoading.cpp` | `ModelLoadingWindows.cpp` | `ModelLoadingLinux.cpp` |
+| Console commands | `AssetPipelineConsoleOps.cpp` (check its own guards) | — | — |
+
+What genuinely differs between the two variants (not just formatting):
+
+1. **GPU upload path.** Windows creates D3D11 `ID3D11Buffer` /
+   `ID3D11Texture2D` directly inside `MeshAsset::Load` /
+   `TextureAsset::Load` via the passed `ID3D11Device*`. Linux/macOS keeps
+   only CPU data in `Load`, then `AssetPipeline::LoadMesh` calls
+   `BuildRHIBuffersForMesh(mesh)` which uploads `mesh.GetMeshData()` into
+   RHI buffers and hands ownership back via `MeshAsset::SetRHIBuffers`.
+   On Windows `BuildRHIBuffersForMesh` is a deliberate **no-op** (defined
+   so callers need no `#ifdef`).
+2. **The RHI members exist on both** (`m_rhiVertexBuffer`,
+   `m_rhiIndexBuffer`, `m_rhiTexture` in `AssetPipeline.h`) but are only
+   populated on the non-Windows path; Windows leaves them `nullptr` and
+   drives the `ComPtr` members instead. Accessors:
+   `GetVertexBuffer()`/`GetSRV()` (D3D11, Windows) vs
+   `GetRHIVertexBuffer()`/`GetRHITexture()` (RHI, non-Windows).
+3. **Format coverage** differs as shown in the format table above (Windows
+   is intentionally minimal + fallback shapes; Linux uses real loader libs).
+4. **Detection tables** differ (see earlier warning).
+5. Small behavioral differences: Linux `ScanDirectory` sorts results and
+   swallows `filesystem_error`; Linux `GetAssetMetadata` first returns a
+   loaded asset's live metadata; Linux `CheckForChangedAssets` actually
+   reloads on timestamp change while the Windows `CheckForChangedAssets` /
+   `RefreshAssetMetadata` bodies are still stubs (comment-only).
+
+Why keep the cross-platform ctor/dtor in `AssetTypes.cpp`? The
+`unique_ptr<Spark::RHI::IRHIBuffer>` members use a **forward-declared**
+type in the header (to keep RHI headers out of every TU). `unique_ptr`
+needs the complete type at ctor-cleanup and dtor, so those special members
+are defined out-of-line in the one TU that includes `RHI/RHIResources.h`.
+Do not move them inline into the header or you drag RHI transitively
+everywhere and risk ODR issues.
+
+## Runbook: add a new source format to an existing asset type
+
+Example: add `.stl` mesh support.
+
+1. **Detection** — add the extension to `DetectAssetTypeFromExtension` in
+   **both** `AssetMetadataWindows.cpp` and `AssetMetadataLinux.cpp` (map to
+   `AssetType::Mesh`). If they drift, the format loads on one OS only.
+2. **Parsing** — add a branch in `MeshAsset::Load`:
+   - `AssetTypesWindows.cpp` for the D3D11 path (fill `m_meshData`, then the
+     existing code creates the D3D11 buffers), and/or
+   - `AssetTypesLinux.cpp` for the RHI path (fill `m_meshData`, call
+     `GenerateTangents` + `ComputeBounds`; buffers are built later by
+     `BuildRHIBuffersForMesh`).
+3. **Third-party loader?** If you pull in a library, wire it in the root
+   `CMakeLists.txt` the same way tinyobj/cgltf/stb are (see lines ~663-1214),
+   gate the include with a `SPARK_HAS_*` define, and add it under
+   `ThirdParty/`. Keep private code out of cloud offload.
+4. **Bounds + tangents** — meshes must end with valid
+   `boundingBoxMin/Max`, `boundingSphere*`, and per-vertex tangents;
+   reuse `ComputeBounds` / `GenerateTangents` (Linux) or the inline bbox
+   loop (Windows).
+5. **Metadata** — optionally record loader stats into
+   `m_metadata.customProperties` (follow the `fbx.*` naming).
+
+## Runbook: add a whole new AssetType
+
+1. Add the enum value to `AssetType` in `AssetPipeline.h`.
+2. Extend `AssetTypeToString` / `StringToAssetType` in **both**
+   `AssetMetadataWindows.cpp` and `AssetMetadataLinux.cpp` (a `default`
+   returning "Unknown" hides missed cases — check every switch).
+3. Add extension mapping in both `DetectAssetTypeFromExtension` bodies.
+4. If it needs a new `Asset` subclass, declare it in `AssetPipeline.h`
+   (mirror `MeshAsset`: out-of-line ctor/dtor if it holds RHI members),
+   define `Load/Unload/GetMemoryUsage` in **both** `AssetTypes*.cpp`
+   guarded by the platform `#ifdef`, and add a `LoadXFromFile` +
+   `switch` case in `LoadAsset` in **both** `AssetPipeline*.cpp`.
+5. Rebuild on Windows AND cross-check the Linux guard compiles (CI job
+   `build-linux-gcc` will catch a missing Linux implementation because the
+   `#ifndef` TU would leave the method undefined at link time).
+
+## Runbook: add a new platform variant (e.g. a real macOS split)
+
+macOS currently rides the `#ifndef SPARK_PLATFORM_WINDOWS` (Linux) path.
+If you need a genuinely separate variant:
+
+1. Check what `SPARK_PLATFORM_*` macros `Core/Platform.h` defines before
+   inventing a new guard.
+2. Follow the existing pattern: new `Asset*Mac.cpp`, whole body inside the
+   platform guard, `#include "Core/Platform.h"` first. GLOB_RECURSE will
+   pick it up automatically — you do **not** add it to CMake explicitly.
+3. Make sure the previous default path's `#ifndef` doesn't also fire for
+   your new platform, or you'll get duplicate-symbol link errors (both TUs
+   non-empty). Adjust the guards to be mutually exclusive.
+
+## Common gotchas
+
+- "My FBX loads a cube on Windows." Expected — Windows `MeshAsset::Load`
+  doesn't parse FBX and falls back to the unit cube. Test FBX/glTF on the
+  Linux/RHI path (or via the CI Linux jobs).
+- "`GetVertexBuffer()` returns null on Linux." Expected — use
+  `GetRHIVertexBuffer()`; the D3D11 ComPtrs are Windows-only.
+- Editing only the Windows file and expecting CI green: the Linux/Clang/GCC
+  and macOS CI jobs compile the `#ifndef` twins. Change both.
+- Checksums are not stable across OS and not cryptographic — do not use
+  them for content-addressing or cross-machine dedup.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against the files below (all under
+`SparkEngine/Source/Graphics/`). Re-verify with:
+
+```bash
+# Confirm the platform-split pairs still exist
+ls SparkEngine/Source/Graphics/Asset*.cpp SparkEngine/Source/Graphics/ModelLoading*.cpp
+
+# Confirm FBX/glTF loaders are defined only on the Linux side
+grep -rn "::LoadFBX\|::LoadGLTF\|::LoadOBJ" SparkEngine/Source/Graphics/
+
+# Confirm the extension->type tables (compare the two)
+grep -n "extension ==" SparkEngine/Source/Graphics/AssetMetadataWindows.cpp SparkEngine/Source/Graphics/AssetMetadataLinux.cpp
+
+# Confirm supported mesh/texture parsers per platform
+grep -n "ext == \|stbi_load\|tinyobj::LoadObj\|cgltf_parse_file\|FBXImporter::GetInstance" \
+  SparkEngine/Source/Graphics/AssetTypesWindows.cpp SparkEngine/Source/Graphics/AssetTypesLinux.cpp
+
+# Confirm third-party loader wiring + feature macros
+grep -n "SPARK_HAS_STB_IMAGE\|SPARK_HAS_CGLTF\|tinyobjloader" CMakeLists.txt
+
+# AssetMetadata field set
+grep -n "std::string\|size_t\|uint64_t\|AssetType\|customProperties" \
+  SparkEngine/Source/Graphics/AssetPipeline.h | sed -n '1,60p'
+```
+
+Volatile claims to re-check if code moved:
+- FBX/glTF being Linux-only in `MeshAsset::Load` (Windows may gain a real
+  importer — then update the format table and gotchas).
+- `guid` / `dependencies` still unpopulated (marked candidate above).
+- Whether Windows `CheckForChangedAssets` / `RefreshAssetMetadata` are still
+  stubs.
+
+Validate this file after edits with the global skill linter
+(`~/.claude/skills/skill-linter`), pointing `-Path` at
+`.claude/skills/sparkengine-asset-pipeline`.

--- a/.claude/skills/sparkengine-config-and-flags/SKILL.md
+++ b/.claude/skills/sparkengine-config-and-flags/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: sparkengine-config-and-flags
+description: >
+  Catalog of every SparkEngine CMake build option (ENABLE_*/SPARK_*/BUILD_*), its real
+  verified default, the C/C++ #define it produces, what code it gates, and the CMakePresets
+  it is set by. TRIGGER when the user asks "what does ENABLE_VULKAN / ENABLE_EDITOR / ENABLE_DXR
+  do", "how do I turn off networking / the editor / tests", "which preset builds shipping",
+  "why is my #ifdef SPARK_* not firing", "what flag maps to which define", or "how do I add a
+  new build toggle correctly". DO NOT TRIGGER for MSVC toolchain setup, vcvars, sccache, or
+  build-error triage (use the global cmake-msvc skill instead) — this skill is only the
+  project's feature-flag surface, not how to run the compiler.
+trilobite_compatible: true
+trilobite_role: reference
+---
+
+# SparkEngine config & flags catalog
+
+SparkEngine's build surface is driven entirely from the **root `D:\SparkEngine\CMakeLists.txt`**
+plus **`D:\SparkEngine\CMakePresets.json`**. This skill is the ground-truth map of that surface:
+which `option()` exists, its verified default, the compile `#define` it emits, and what it gates.
+
+> **Vocabulary** — *option*: a CMake cache boolean/string declared with `option()` or `set(... CACHE ...)`.
+> *compile definition* / *define*: a `-D` / `/D` macro (e.g. `SPARK_VULKAN_SUPPORT`) that C++ code tests
+> with `#ifdef`. In this project an option name (`ENABLE_VULKAN`) and the define it produces
+> (`SPARK_VULKAN_SUPPORT`) are usually **different strings** — do not assume they match.
+
+## When NOT to use this skill
+
+- **Toolchain / build-error problems** (cl.exe not found, `CC=claude.exe`, sccache misses, MSVC
+  Debug caching) → use the global **cmake-msvc** skill. This skill never covers *how to run* the build.
+- **Adding a new subsystem/source file** → that's an anti-bloat / architecture question, not a flag.
+- You only need the *command* to configure a preset → `cmake --preset <name>` then
+  `cmake --build build --config <cfg>`; the preset list is in the table below.
+
+---
+
+## 1. How a flag becomes a `#define` (the plumbing)
+
+Three distinct mechanisms exist in the root `CMakeLists.txt`. Know which one a flag uses before
+you touch it:
+
+| Mechanism | Where | Example |
+|-----------|-------|---------|
+| `list(APPEND FEATURE_DEFINITIONS ...)` → applied `PUBLIC` to `SparkEngineLib` at the end | section 14, ~lines 1916-2027 | `ENABLE_PROFILING` → `PROFILING_ENABLED` |
+| Direct `target_compile_definitions(SparkEngineLib PUBLIC ...)` at point of use | scattered, ~lines 1341-1902 | `ENABLE_VULKAN` → (probe) → `SPARK_VULKAN_SUPPORT` |
+| `add_subdirectory()` gating only — **no define**, just includes/excludes a whole target | ~lines 1403-1499 | `ENABLE_EDITOR`, `ENABLE_LAUNCHER` |
+
+`SparkEngineLib` is the static core; the `SparkEngine` executable and every game-module DLL inherit
+its `PUBLIC` defines. On Linux/macOS game modules link the header-only `SparkEngineInterface` target,
+which re-exports `SparkEngineLib`'s compile definitions (root CMakeLists ~line 1129).
+
+---
+
+## 2. Feature flags — verified catalog
+
+Every row below was read from `D:\SparkEngine\CMakeLists.txt` on **2026-07-07**. "Default" is the
+literal value in the `option()` call, **not** what CLAUDE.md summarizes (a few differ — see notes).
+
+| Option | Verified default | Emits define | Gates / effect |
+|--------|------------------|--------------|----------------|
+| `ENABLE_GRAPHICS` | `ON` | *(none)* | **Declared but INERT** — no `if(ENABLE_GRAPHICS)` and no define consumes it anywhere in the tree. Toggling it does nothing today. (CLAUDE.md lists it among working toggles; this row documents verified CMake reality, which differs from the manifest.) |
+| `ENABLE_PROFILING` | `ON` | `PROFILING_ENABLED` | Profiler instrumentation code paths. |
+| `ENABLE_NETWORKING` | `ON` | `ENABLE_NETWORKING` (+ `SPARK_HAS_CURL` if libcurl found) | UDP sockets, AreaServer/WorldServer, crash-report upload. |
+| `ENABLE_VULKAN` | `ON` | `SPARK_VULKAN_SUPPORT` (only if Vulkan SDK is actually found) | Vulkan RHI backend + links VMA. Experimental. Absent SDK → silently off. |
+| `ENABLE_OPENGL` | `ON` | `SPARK_OPENGL_SUPPORT` (needs OpenGL **and** GLAD); `SPARK_EGL_SUPPORT` if EGL found | OpenGL RHI backend + GLAD loader; EGL enables Linux headless software rendering. Experimental. |
+| `ENABLE_METAL` | `${APPLE}` → **ON on macOS, OFF elsewhere** | `SPARK_METAL_SUPPORT` | Metal RHI backend (macOS only, experimental). CLAUDE.md's "OFF" is only true off-macOS. |
+| `ENABLE_DXR` | `ON` | `SPARK_HARDWARE_RT` (only when `ENABLE_HYBRID_RT` **and** `WIN32` **and** not MinGW) | Hardware DirectX Raytracing via D3D12. Off Windows / on MinGW → SDFGI software fallback. |
+| `ENABLE_HYBRID_RT` | `ON` | `SPARK_HYBRID_RT` | SDFGI software GI + optional hardware RT layer. |
+| `ENABLE_SDL2` | `ON` on non-Windows, `OFF` on Windows | `SPARK_SDL2_AVAILABLE` (if an SDL2 target/pkg resolves) | Cross-platform windowing + input. On Linux, built from `ThirdParty/SDL2` submodule. |
+| `SPARK_HEADLESS_SUPPORT` | `ON` | `SPARK_HEADLESS_SUPPORT` | Headless / dedicated-server mode (NullRHIDevice path). |
+| `ENABLE_RECAST` | `ON` | `SPARK_RECAST_AVAILABLE` (only if `ThirdParty/AI/recastnavigation` present) | Recast/Detour voxel navmesh builder. |
+| `ENABLE_NEURAL_RENDERING` | `ON` | `SPARK_NEURAL_RENDERING=1` | NTC / radiance cache / neural post-processing. When OFF, the define is dropped (primary gate). |
+| `ENABLE_VR` | `OFF` | `SPARK_VR_ENABLED` | VR/AR OpenXR-ready stub. When OFF the define is absent and `VR/VRSystem.cpp` is filtered out. |
+| `ENABLE_MOBILE` | `OFF` | `SPARK_MOBILE_ENABLED` | Touch/gesture/battery-aware scaling. When OFF, `Mobile/MobilePlatform.cpp` is filtered out. |
+| `BUILD_TESTS` | `ON` | *(none)* | Adds `Tests/` (CTest suite) via `add_subdirectory`. |
+| `BUILD_GAME_MODULES` | `ON` | *(none)* | Builds in-tree `GameModules/*` DLLs. Set OFF for engine-only builds. |
+| `SPARK_STRICT_DEPS` | `OFF` | *(none)* | When ON, missing Jolt / ImGui / EnTT becomes `FATAL_ERROR` instead of a warning. |
+| `SPARK_SUPPRESS_THIRDPARTY_WARNINGS` | `ON` | *(none)* | Applies `/w` (MSVC) / `-w` to Jolt and other third-party targets. |
+| `SPARK_DOUBLE_PRECISION_PHYSICS` | `OFF` | forces Jolt `DOUBLE_PRECISION` → `JPH_DOUBLE_PRECISION` | Double-precision physics for large worlds (MMO/open-world). |
+| `ENABLE_EDITOR` | `ON` | *(none)* | Adds `SparkEditor` (ImGui editor). Auto-skips if ImGui / (Linux) SDL2+OpenGL deps are missing. |
+| `ENABLE_LAUNCHER` | `ON` | *(none)* | Builds `SparkLauncher` (project picker). |
+| `ENABLE_SPARKBUILD` | `ON` | *(none)* | Builds `SparkBuild` (terminal-UI CMake configurator). |
+| `ENABLE_INSTALLER` | `ON` | *(none)* | Builds `SparkInstaller` (needs `SparkBuildCore` from SparkBuild). |
+| `ENABLE_CONSOLE_IN_SHIPPING` | `OFF` | `SPARK_CONSOLE_IN_SHIPPING` | Include SparkConsole in Shipping (`MinSizeRel`) builds. |
+| `ENABLE_DEVCOMMANDS_IN_SHIPPING` | `OFF` | `SPARK_DEVCOMMANDS_IN_SHIPPING` | Include dev cheats (god, noclip, ...) in Shipping. |
+| `STRIP_DEBUG_SYMBOLS` | `OFF` | `SPARK_STRIP_DEBUG_SYMBOLS` (+ linker strip in MinSizeRel) | Strip symbols from the final binary. |
+| `SPARK_NATIVE_ARCH` | `OFF` | *(none)* | ON → `/arch:AVX2` (MSVC) or `-march=native`. **Do not ship** native binaries. |
+| `ENABLE_LTO` | `ON` | *(none)* | **Non-MSVC only** (declared inside the GCC/Clang branch, ~line 349). Enables `-flto`. On MSVC, LTO (`/GL`+`/LTCG`) is always on for non-Debug and this option does not exist. |
+| `SPARK_MSVC_TOOLSET` | `""` (empty = auto; `v143` default on Windows) | *(none)* | Pins MSVC toolset. `v143`=VS2022, `v144`=VS2026. |
+| `SPARK_ENGINE_VERSION` | `"1.0.0"` | *(package metadata)* | Semantic version for packaging. |
+
+### Config-derived defines (automatic, not options)
+
+The build type auto-emits exactly one profile define (root CMakeLists ~lines 2018-2023):
+
+| Build type | Define |
+|------------|--------|
+| `Debug` | `SPARK_BUILD_DEBUG` |
+| `RelWithDebInfo` | `SPARK_BUILD_DEVELOPMENT` |
+| `Release` | `SPARK_BUILD_RELEASE` |
+| `MinSizeRel` (Shipping) | `SPARK_BUILD_SHIPPING` |
+
+Other always-on platform/compiler defines: `SPARK_PLATFORM_WINDOWS` / `SPARK_PLATFORM_LINUX` /
+`SPARK_PLATFORM_MACOS`, and `SPARK_COMPILER_VS2022` / `VS2026` / `VS2019` by `_MSC_VER`. Third-party
+availability defines (`SPARK_JOLT_PHYSICS_AVAILABLE`, `SPARK_HAS_IMGUI`, `SPARK_MINIZ_AVAILABLE`,
+`SPARK_ZSTD_AVAILABLE`, `SPARK_HAS_STB_IMAGE`, `SPARK_HAS_CGLTF`, `SPARK_HAS_MINIAUDIO`,
+`SPARK_HAS_NLOHMANN_JSON`, `SPARK_HAS_TINYEXR`, `SPARK_OPENAL_AVAILABLE`) are set from presence probes,
+not options — you cannot force them on; provide the submodule instead.
+
+### MinGW cross-compile special case
+
+Building under MinGW (`linux-mingw-*` presets) excludes the D3D12 + DXR sources and defines
+`SPARK_NO_D3D12` (headers too old); D3D11 remains the primary backend under Wine + DXVK.
+
+---
+
+## 3. Phantom options in presets (WARNING)
+
+`CMakePresets.json` sets several cache variables that **no `option()` declares and no CMake logic
+reads** — they are inert no-ops. Verified 2026-07-07: zero matches in any `CMakeLists.txt`.
+
+- In the `minimal` preset: `ENABLE_AI`, `ENABLE_ANIMATION`, `ENABLE_SAVE_SYSTEM`,
+  `ENABLE_PROCEDURAL`, `ENABLE_CINEMATIC`, `ENABLE_DECALS`, `ENABLE_MESH_LOD`.
+- In `windows-shipping` / `linux-shipping` / `*-development`: `ENABLE_HOT_RELOAD`.
+
+**Do not cite these as working toggles.** Setting `-DENABLE_AI=OFF` changes nothing today. If you
+actually want them to gate code, you must first declare the `option()` and wire a define/exclusion
+(see section 5). Treat them as `candidate` (aspirational), not shipped behaviour.
+
+---
+
+## 4. Presets catalog (`cmake --preset <name>`)
+
+Verified from `CMakePresets.json`. Windows presets require host Windows; `linux-*` require Linux;
+`macos-*` require Darwin (the `condition` blocks enforce this).
+
+| Preset | Build type | Notable non-default cache vars |
+|--------|-----------|-------------------------------|
+| `windows-debug` | Debug | `SPARK_MSVC_TOOLSET=v143`, VS 2022 generator |
+| `windows-release` | Release | `SPARK_MSVC_TOOLSET=v143`, VS 2022 generator |
+| `windows-development` | RelWithDebInfo | `SPARK_NATIVE_ARCH=ON`, console + dev commands ON |
+| `windows-shipping` | MinSizeRel | editor/profiling OFF, `STRIP_DEBUG_SYMBOLS=ON`, `BUILD_TESTS=OFF`, `SPARK_NATIVE_ARCH=OFF` |
+| `linux-gcc-debug` / `linux-gcc-release` | Debug / Release | gcc/g++ |
+| `linux-clang-debug` / `linux-clang-release` | Debug / Release | clang/clang++ |
+| `linux-development` | RelWithDebInfo | gcc, `SPARK_NATIVE_ARCH=ON`, console + dev commands ON |
+| `linux-shipping` | MinSizeRel | gcc, editor/profiling OFF, strip ON, tests OFF |
+| `ci-linux-asan` | Debug (inherits linux-gcc-debug) | `-fsanitize=address,undefined` |
+| `ci-linux-tsan` | Debug (inherits linux-gcc-debug) | `-fsanitize=thread` |
+| `linux-mingw-release` / `linux-mingw-debug` | Release / Debug | MinGW toolchain file; `ENABLE_VULKAN/OPENGL/SDL2=OFF` |
+| `macos-debug` / `macos-release` | Debug / Release | `ENABLE_METAL=ON`, `ENABLE_OPENGL=ON`, `ENABLE_VULKAN=OFF`, `ENABLE_DXR=OFF`, `ENABLE_SDL2=ON` |
+| `macos-metal` | Release | Metal ON, Vulkan OFF |
+| `macos-moltenvk` | Release | Vulkan ON (via MoltenVK), Metal OFF |
+| `minimal` | Release | `ENABLE_NETWORKING=OFF`, `ENABLE_DXR=OFF` + several **phantom** vars (see section 3) |
+
+Override any option on top of a preset:
+`cmake --preset windows-release -DENABLE_NETWORKING=OFF -DENABLE_EDITOR=OFF`
+
+---
+
+## 5. Runbook — add a new `ENABLE_` toggle correctly
+
+Follow every step; a toggle wired in only one place is worse than none (silent no-op like the
+phantom options above).
+
+1. **Declare the option** in root `CMakeLists.txt` section 3 (near lines 117-151):
+   ```cmake
+   option(ENABLE_MYFEATURE "One-line description of what this gates" OFF)
+   ```
+   Pick the default deliberately: `ON` only if the feature is production-ready and its deps are
+   always present.
+
+2. **Emit a define** so C++ can `#ifdef` it. Prefer the `FEATURE_DEFINITIONS` block (section 14,
+   ~line 1916) so it is applied `PUBLIC` to `SparkEngineLib` in one place:
+   ```cmake
+   if(ENABLE_MYFEATURE)
+       list(APPEND FEATURE_DEFINITIONS "SPARK_MYFEATURE_ENABLED")
+   endif()
+   ```
+   (Name the define distinctly — `SPARK_MYFEATURE_ENABLED`, not `ENABLE_MYFEATURE`.) If the feature
+   is a whole optional target instead of `#ifdef`s, gate its `add_subdirectory()` like `ENABLE_EDITOR`
+   (~line 1469) and skip the define.
+
+3. **Guard the C++** with the *define*, never the option name:
+   ```cpp
+   #ifdef SPARK_MYFEATURE_ENABLED
+       // feature code
+   #endif
+   ```
+
+4. **(Optional) exclude sources when OFF** — mirror the VR/Mobile pattern (~lines 1939-1946). Note:
+   in the current tree these `list(FILTER SPARK_ENGINE_LIB_SOURCES ...)` calls run *after*
+   `add_library(SparkEngineLib ...)` (~line 1099), so the **define is the load-bearing gate**;
+   treat source exclusion as best-effort, and if you need a hard exclusion, place the filter
+   *before* the `add_library`.
+
+5. **(Optional) set it in presets** — add to `CMakePresets.json` only for presets that should
+   differ from the option default (e.g. turn it OFF in `windows-shipping`). Setting it to its own
+   default value is noise.
+
+6. **Verify it is not a no-op** before committing:
+   ```bash
+   # option is declared
+   grep -n 'option(ENABLE_MYFEATURE' CMakeLists.txt
+   # a define is actually produced
+   grep -rn 'SPARK_MYFEATURE_ENABLED' CMakeLists.txt
+   # C++ actually reads the define
+   grep -rn 'SPARK_MYFEATURE_ENABLED' SparkEngine/Source
+   ```
+   All three must return hits. (This is exactly the check that exposes the section-3 phantom options.)
+
+7. **Docs** — per CLAUDE.md, adding a build toggle is a code change: run
+   `docs/update-all-docs.sh` and add the flag to the Build section of `D:\SparkEngine\CLAUDE.md`.
+
+---
+
+## 6. Quick answers
+
+- "Turn off networking" → `-DENABLE_NETWORKING=OFF` (drops `ENABLE_NETWORKING` define + curl).
+- "Headless server build" → keep `SPARK_HEADLESS_SUPPORT=ON` (default); optionally `-DENABLE_EDITOR=OFF -DENABLE_GRAPHICS`-is-inert (use `ENABLE_VULKAN/OPENGL/DXR=OFF` to trim GPU backends).
+- "Ship build" → `cmake --preset windows-shipping` (MinSizeRel, no editor/console/tests, stripped).
+- "My `#ifdef SPARK_X` never fires" → confirm the *option* that should emit it is ON **and** its
+  dependency probe succeeded (Vulkan/OpenGL/Recast/curl defines only appear if the lib is found).
+- "Double-precision physics for big worlds" → `-DSPARK_DOUBLE_PRECISION_PHYSICS=ON`.
+
+---
+
+## Provenance and maintenance
+
+- **Verified 2026-07-07** against `D:\SparkEngine\CMakeLists.txt` (2643 lines) and
+  `D:\SparkEngine\CMakePresets.json`. Line numbers are approximate; grep by name if they drift.
+- Re-verify option defaults:
+  `grep -nE 'option\((ENABLE_|SPARK_|BUILD_)' D:/SparkEngine/CMakeLists.txt`
+- Re-verify define mappings:
+  `grep -nE 'FEATURE_DEFINITIONS|target_compile_definitions' D:/SparkEngine/CMakeLists.txt`
+- Re-detect phantom preset options (should list only options NOT declared by `option()`):
+  compare `CMakePresets.json` keys against `grep -oE 'ENABLE_[A-Z_]+' CMakeLists.txt`.
+- Re-list presets: `cmake --list-presets` (from `D:\SparkEngine`).
+- Volatile facts most likely to rot: the phantom-option set (section 3) and `ENABLE_GRAPHICS`
+  being inert — re-run the section-5 step-6 checks if a flag's behaviour is in doubt.
+- Related skill: **cmake-msvc** (global) for toolchain / build-execution issues — this skill does
+  not cover running the compiler.

--- a/.claude/skills/sparkengine-custom-allocator/SKILL.md
+++ b/.claude/skills/sparkengine-custom-allocator/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: sparkengine-custom-allocator
+description: >-
+  Reference for SparkEngine's four hand-rolled memory allocators — FrameAllocator (per-frame bump),
+  LockFreeRingAllocator (producer/consumer ring), HandleAllocator/VersionedHandle (generational
+  handles), and RHI TransientBufferAllocator (GPU vertex/index suballocation). TRIGGER when you are
+  about to write per-frame or transient allocations, ask "which allocator should I use", need the exact
+  method signatures / thread-safety of one of these, wonder why the code uses naked buffers instead of
+  new/delete, or need to prevent use-after-free on recycled slots/indices. DO NOT TRIGGER for hunting an
+  actual leak or use-after-free bug (use the memory-hunt skill), for general std::unique_ptr ownership
+  questions, or for GPU resource lifetime / ComPtr / RHI backend selection.
+trilobite_compatible: true
+trilobite_role: reference
+---
+
+# SparkEngine custom allocators
+
+SparkEngine follows a strict "no naked `new`/`delete`, `std::unique_ptr` owns, raw pointers are
+non-owning" rule (see `D:\SparkEngine\CLAUDE.md` -> Coding Standards). These four allocators are the
+**deliberate, sanctioned exceptions**. Each exists because a general-purpose `new`/`delete` or
+`std::vector` would be too slow, too fragmenting, or unable to detect a specific bug class. This skill
+documents their real APIs, lifetimes, thread-safety, and when to reach for each.
+
+All four live in namespace `Spark` (the RHI one in `Spark::RHI`). All are header-only.
+
+| Allocator | Header | Namespace | Purpose |
+|-----------|--------|-----------|---------|
+| `FrameAllocator` | `SparkEngine/Source/Utils/FrameAllocator.h` | `Spark` | CPU per-frame linear/bump allocation of short-lived POD |
+| `LockFreeRingAllocator<N>` | `SparkEngine/Source/Utils/LockFreeRingAllocator.h` | `Spark` | FIFO producer/consumer ring for streaming data |
+| `HandleAllocator` + `VersionedHandle` | `SparkEngine/Source/Utils/VersionedHandle.h` | `Spark` | Generational index handles that detect use-after-free |
+| `TransientBufferAllocator` | `SparkEngine/Source/Graphics/RHI/TransientBufferAllocator.h` | `Spark::RHI` | GPU vertex/index suballocation for per-frame dynamic geometry |
+
+> When NOT to use this skill: if you are chasing a live leak or use-after-free, use the global
+> **memory-hunt** skill (leak/UAF hunting methodology) instead — this skill only describes the
+> allocator APIs. For plain ownership (`unique_ptr` vs raw pointer) questions, follow CLAUDE.md's
+> Coding Standards, not this document.
+
+---
+
+## Decision guide — which allocator do I reach for?
+
+Answer top-to-bottom; take the first row that matches.
+
+| If you need... | Use | Why |
+|----------------|-----|-----|
+| Scratch CPU memory that lives for exactly one frame and is thrown away wholesale | `FrameAllocator` | O(1) bump alloc, O(1) `Reset()`, zero per-object free cost |
+| GPU-visible vertex/index memory for dynamic geometry drawn this frame (particles, debug lines, UI, decals) | `TransientBufferAllocator` (`Spark::RHI`) | Maps one Dynamic buffer per frame with DISCARD, bumps an offset — no per-object GPU buffer |
+| A stable ID for an object that may be freed and its slot reused, and you must detect stale IDs | `HandleAllocator` + `VersionedHandle` | Generation bump makes an old handle fail `IsValid()` instead of aliasing a new object |
+| A single-producer / single-consumer FIFO stream of variable-size records across threads | `LockFreeRingAllocator<N>` | Lock-free SPSC ring with size-prefixed records; producer allocates, consumer frees in order |
+| Long-lived ownership of a single object | none of these — use `std::unique_ptr` | Custom allocators do not call destructors / do not track lifetime |
+
+Grounded real usages in the engine (non-test):
+
+- `FrameAllocator` — `SparkEngine/Source/Graphics/SceneRenderer.h:187` holds
+  `Spark::FrameAllocator m_frameAllocator{4 * 1024 * 1024};` (4 MB) for the per-frame draw list.
+- `TransientBufferAllocator` — `SparkEngine/Source/Graphics/RHI/RHIDeviceBase.h:45` embeds one per
+  RHI device (`{4 * 1024 * 1024, 2 * 1024 * 1024}`), pumped by each backend's `BeginFrame`/`EndFrame`
+  (e.g. `D3D11Device::BeginFrame` -> `m_transientBuffers.BeginFrame(this)`,
+  `SparkEngine/Source/Graphics/RHI/D3D11/D3D11Device.cpp:1301`).
+- `LockFreeRingAllocator` and `HandleAllocator`/`VersionedHandle` — as of 2026-07-07 have **no
+  non-test call sites** in engine source; they are exercised only by `Tests/`. Treat them as
+  available utilities (`candidate` for wider use), not yet load-bearing in a shipping path.
+
+---
+
+## FrameAllocator — per-frame CPU bump allocator
+
+**What it is:** a fixed-capacity byte buffer with a monotonically increasing offset. Allocation just
+advances the offset; there is no per-object free. You call `Reset()` once per frame to reclaim
+everything at once.
+
+**Why it exists instead of `new`/`delete`:** eliminates heap fragmentation and malloc/free overhead
+for thousands of tiny short-lived objects (render commands, temporary arrays). Freeing is a single
+integer assignment.
+
+### API (verified against the header)
+
+```cpp
+explicit FrameAllocator(size_t capacityBytes = 1024 * 1024);   // allocates via ::operator new(nothrow)
+
+void*  AllocRaw(size_t bytes, size_t alignment = alignof(std::max_align_t)); // nullptr if OOM
+void*  Allocate(size_t size, size_t alignment = 16);           // alias for AllocRaw
+template<typename T> T* Alloc(size_t count = 1);               // uninitialized storage for count T
+template<typename T, typename... Args> T* New(Args&&... args); // placement-new one T
+
+void   Reset();          // O(1): offset = 0. Does NOT run destructors.
+size_t Used()  const;    size_t GetUsed()     const;   // bytes used this frame
+size_t Capacity() const; size_t GetCapacity() const;
+size_t Remaining() const;
+size_t PeakUsed()  const;  // high-water mark
+void   UpdatePeak();       // call before Reset() to record the peak
+```
+
+Move-only (copy deleted, move defined). Non-owning of what you build inside it.
+
+### Critical rules
+
+- **Trivially destructible only.** `Reset()` and the destructor do **not** call your objects'
+  destructors. Only store PODs / trivially-destructible types, or types whose destructors are no-ops.
+- **`New`/`Alloc` return `nullptr` when out of space** — always null-check. There is no growth.
+- Alignment must be a power of two — enforced by `SPARK_EXPECTS` (from `Core/Contracts.h`).
+- Not thread-safe. One `FrameAllocator` per thread, or serialize access externally.
+- Pointers are invalidated by `Reset()`. Never hold a `FrameAllocator` pointer across frames.
+
+### Typical lifecycle
+
+```cpp
+FrameAllocator alloc(4 * 1024 * 1024);   // once at startup / as a member
+// --- each frame ---
+auto* cmds = alloc.Alloc<DrawCommand>(count);   // bump
+// ... fill and consume cmds this frame ...
+alloc.UpdatePeak();
+alloc.Reset();                                   // reclaim all, O(1)
+```
+
+---
+
+## TransientBufferAllocator — GPU per-frame vertex/index suballocation
+
+**What it is (`Spark::RHI`):** the GPU analogue of `FrameAllocator`. It owns one large Dynamic vertex
+buffer and one Dynamic index buffer. Each frame both are mapped with DISCARD, allocations bump an
+offset into the mapped pointer, and at `EndFrame` the buffers are unmapped. Inspired by bgfx's
+transient buffers.
+
+**Why it exists:** dynamic geometry (particles, debug lines, UI, decals) changes every frame. Creating
+a GPU buffer per object each frame would be catastrophic; this suballocates from two persistent buffers
+instead.
+
+### API (verified against the header)
+
+```cpp
+explicit TransientBufferAllocator(uint32_t vertexBudget = 4*1024*1024,
+                                  uint32_t indexBudget  = 2*1024*1024);
+
+bool Initialize(IRHIDevice* device);   // create the two Dynamic buffers; call once at startup
+void Shutdown(IRHIDevice* device);     // release buffers; called by destructor with nullptr
+
+void BeginFrame(IRHIDevice* device);   // resets offsets AND maps both buffers — call before allocating
+void EndFrame(IRHIDevice* device);     // unmaps; allocations from this frame become invalid
+
+TransientAllocation AllocateVertices(uint32_t vertexCount, uint32_t vertexStride);
+TransientAllocation AllocateIndices (uint32_t indexCount,  uint32_t indexStride = sizeof(uint32_t));
+
+bool HasVertexSpace(uint32_t vertexCount, uint32_t vertexStride) const;
+bool HasIndexSpace (uint32_t indexCount,  uint32_t indexStride = sizeof(uint32_t)) const;
+
+uint32_t GetVertexBytesUsed() const;  uint32_t GetIndexBytesUsed() const;
+uint32_t GetVertexBudget()    const;  uint32_t GetIndexBudget()    const;
+```
+
+`TransientAllocation` fields: `IRHIBuffer* buffer`, `void* data` (CPU-writable, valid until
+`EndFrame`), `uint32_t offsetBytes`, `uint32_t sizeBytes`, `bool valid`.
+
+### Critical rules
+
+- **Always check `alloc.valid`.** An over-budget request returns a default `TransientAllocation`
+  (`valid == false`, all pointers null). It does not grow.
+- Allocations are 16-byte aligned (SIMD friendliness); offsets round up to the next 16.
+- The `data` pointer is only valid between `BeginFrame` and `EndFrame`. After `EndFrame` it dangles.
+- You must `BeginFrame` before allocating — if the buffer is not mapped, `AllocateVertices`/`Indices`
+  return `valid == false` (they check `m_vertexMapped`/`m_indexMapped`).
+- Bind for drawing at `alloc.buffer` + `alloc.offsetBytes`.
+
+### Typical lifecycle (matches `RHIDeviceBase` + backends)
+
+```cpp
+// One instance per RHI device (see RHIDeviceBase.h:45). Backend pumps it:
+allocator.Initialize(device);                 // startup
+// --- each frame, inside the backend's BeginFrame ---
+allocator.BeginFrame(device);
+auto v = allocator.AllocateVertices(n, sizeof(Vertex));
+if (v.valid) { std::memcpy(v.data, verts, v.sizeBytes); /* draw at v.buffer + v.offsetBytes */ }
+allocator.EndFrame(device);                   // inside the backend's EndFrame
+```
+
+---
+
+## VersionedHandle + HandleAllocator — use-after-free-safe indirection
+
+**What it is:** a 64-bit handle (`uint32_t index` + `uint32_t generation`) plus an allocator that hands
+out slots and bumps the slot's generation every time it is freed. An old handle to a recycled slot has
+a stale generation, so `IsValid()` returns false instead of silently aliasing a different object.
+
+**The bug class it prevents:** the classic "recycled-slot use-after-free / ABA". Without generations,
+freeing slot 7 and reallocating it hands the same index to a new object; an old reference to slot 7
+would now read/write the wrong object with no error. The generation counter makes the stale handle
+detectably invalid in O(1). This is distinct from `OpaqueHandle`, which wraps a raw `void*`.
+
+### API (verified against the header)
+
+```cpp
+struct VersionedHandle {
+    uint32_t index = 0;
+    uint32_t generation = 0;
+    constexpr bool operator==(const VersionedHandle&) const = default;
+    constexpr bool IsNull() const noexcept;                 // index==UINT32_MAX && generation==0
+    static constexpr VersionedHandle Null() noexcept;       // {UINT32_MAX, 0}
+};
+
+class HandleAllocator {
+    explicit HandleAllocator(uint32_t capacity);            // fixed capacity, all slots free
+    [[nodiscard]] VersionedHandle Allocate();               // Null() if capacity exhausted (warns)
+    void Free(VersionedHandle handle);                      // bumps generation; double-free is a no-op
+    [[nodiscard]] bool IsValid(VersionedHandle handle) const; // index in range AND generation matches
+    [[nodiscard]] uint32_t GetActiveCount() const;
+    [[nodiscard]] uint32_t GetCapacity() const;
+};
+```
+
+### Critical rules
+
+- **Fixed capacity, no growth.** `Allocate()` returns `VersionedHandle::Null()` and logs
+  `SPARK_LOG_WARN` when the free list is empty. Always check `IsValid()` / `IsNull()` before use.
+- **Not thread-safe.** The header states this explicitly; serialize externally if shared.
+- `Free()` is safe against double-free and stale handles: a generation mismatch makes it a logged
+  no-op (`SPARK_LOG_DEBUG`), and an out-of-range index is a logged no-op (`SPARK_LOG_WARN`).
+- The allocator only tracks slot validity — it does **not** store your objects. Keep your object array
+  parallel to the handle indices yourself.
+- Handles are dense from index 0 upward on first fill (the free list is seeded in reverse so index 0
+  is handed out first).
+
+### Pattern
+
+```cpp
+HandleAllocator handles(1024);
+std::array<Entity, 1024> pool;                 // your parallel storage
+
+VersionedHandle h = handles.Allocate();
+if (!h.IsNull()) pool[h.index] = makeEntity();
+
+// later, from anywhere holding h:
+if (handles.IsValid(h)) use(pool[h.index]);    // false after Free(h) — no UAF
+
+handles.Free(h);                               // slot reusable, generation bumped
+```
+
+---
+
+## LockFreeRingAllocator<N> — producer/consumer ring
+
+**What it is:** a fixed-size (compile-time `N`, must be a power of two) ring buffer. `Allocate(size)`
+writes a 4-byte size prefix then the payload and advances a write cursor; `Free()` advances a read
+cursor past the oldest record (FIFO). Wrap-around at the end of the buffer is handled with a zero-size
+"skip" marker.
+
+**Why it exists:** for streaming variable-size records (the header suggests per-frame render command
+data) from one thread to another without a mutex and without per-record heap allocation.
+
+### API (verified against the header)
+
+```cpp
+template <size_t CapacityBytes = (1 << 20)>    // 1 MB default; must be power of 2 (static_assert)
+class LockFreeRingAllocator {
+    static constexpr size_t CAPACITY;          // = CapacityBytes
+    static constexpr size_t HEADER_SIZE;       // = sizeof(uint32_t)
+
+    void*  Allocate(size_t size);   // nullptr if ring full; payload ptr follows a 4-byte size prefix
+    void   Free();                  // advance read cursor past ONE record, in FIFO order
+    void   Reset();                 // zero both cursors — NOT thread-safe, call only when idle
+    size_t GetUsedBytes() const;    size_t GetFreeBytes() const;    bool IsEmpty() const;
+
+    struct Metrics { uint64_t totalAllocations, totalFrees, totalBytesAllocated; size_t currentUsed; };
+    Metrics GetMetrics() const;
+};
+```
+
+### Thread-safety — read this carefully (do not over-trust "lock-free")
+
+What the code actually guarantees, from reading the atomics:
+
+- It is a **single-producer / single-consumer (SPSC)** structure. Exactly **one** thread may call
+  `Allocate()` (the producer/writer) and exactly **one** thread may call `Free()` (the consumer). The
+  header's phrase "single-writer/multi-reader" refers to multiple threads **reading the payload bytes**
+  of already-published records — it does **not** license concurrent `Allocate` calls or concurrent
+  `Free` calls.
+- Ordering: `Allocate` publishes the new write cursor with `memory_order_release`; consumers observe it
+  with `memory_order_acquire`. That release/acquire pair is what makes written payload bytes visible to
+  the reader. The write-side load of its own cursor is `relaxed` (safe: single producer).
+- **`Free()` must be called in allocation (FIFO) order**, once per record. It reads the size prefix to
+  know how far to advance. Calling it more times than there are records, or out of order, corrupts the
+  cursors.
+- **`Reset()` is not thread-safe** — call only when no producer/consumer is active.
+- **The `Metrics` counters (`m_totalAllocations`, `m_totalFrees`, `m_totalBytesAllocated`) are plain
+  non-atomic `uint64_t`.** `Allocate` and `Free` mutate them without synchronization, and `GetMetrics`
+  reads them non-atomically. Reading metrics from a third thread concurrently with Allocate/Free is a
+  data race — use metrics only for single-threaded diagnostics or when quiesced.
+- Cursors are `alignas(64)` to avoid false sharing between producer and consumer cache lines.
+
+> Verification caveat: as of 2026-07-07 there are **no multithreaded tests** for this class
+> (`Tests/TestLockFreeRingAllocator*.cpp` are single-threaded) and **no engine call sites**. The SPSC
+> guarantees above are read from the source, not proven by a stress test. Treat concurrent use as
+> `candidate` and validate under TSan (`build-linux-tsan` CI job) before relying on it.
+
+### Critical rules
+
+- `N` must be a power of two (compile-time `static_assert`).
+- `Allocate()` returns `nullptr` when full (including when a wrap-skip would not fit) — null-check.
+- The returned pointer is the payload, just past the 4-byte size header; do not read/write the header.
+- Do not mix this up with `FrameAllocator`: the ring is FIFO with per-record `Free()`, whereas
+  `FrameAllocator` frees everything at once with `Reset()`.
+
+---
+
+## Common mistakes checklist
+
+- [ ] Storing a non-trivially-destructible type in a `FrameAllocator` (destructor never runs).
+- [ ] Holding a `FrameAllocator`/`TransientBufferAllocator` `data` pointer across `Reset()`/`EndFrame`.
+- [ ] Forgetting to check `alloc.valid` (TransientBuffer), `!= nullptr` (FrameAllocator, ring), or
+      `IsValid()`/`IsNull()` (handles) — none of these grow; they fail by returning empty/null.
+- [ ] Calling `TransientBufferAllocator::Allocate*` before `BeginFrame` (buffer unmapped -> invalid).
+- [ ] Treating `LockFreeRingAllocator` as multi-producer or multi-consumer — it is SPSC only.
+- [ ] Reading `LockFreeRingAllocator::GetMetrics()` from another thread during live Allocate/Free.
+- [ ] Using a handle's `index` after `Free()` without an `IsValid()` guard.
+
+---
+
+## Provenance and maintenance
+
+Facts verified 2026-07-07 against the repo. Re-verify with:
+
+```bash
+# API signatures (the four headers are the ground truth):
+sed -n '38,168p'  SparkEngine/Source/Utils/FrameAllocator.h
+sed -n '30,155p'  SparkEngine/Source/Utils/LockFreeRingAllocator.h
+sed -n '41,157p'  SparkEngine/Source/Utils/VersionedHandle.h
+sed -n '60,240p'  SparkEngine/Source/Graphics/RHI/TransientBufferAllocator.h
+
+# Real (non-test) call sites — re-run to catch new adopters:
+grep -rn "FrameAllocator"            SparkEngine SparkEditor GameModules --include=*.h --include=*.cpp
+grep -rn "TransientBufferAllocator"  SparkEngine --include=*.h --include=*.cpp
+grep -rn "LockFreeRingAllocator"     SparkEngine SparkEditor GameModules --include=*.h --include=*.cpp
+grep -rn "HandleAllocator\|VersionedHandle" SparkEngine SparkEditor GameModules --include=*.h --include=*.cpp
+
+# Confirm the ring still has no multithreaded coverage (expect no matches):
+grep -rn "std::thread" Tests/TestLockFreeRingAllocator*.cpp
+```
+
+If a new engine consumer of `LockFreeRingAllocator` or `HandleAllocator` appears, promote it from
+`candidate` to a documented real usage in the decision guide above. Related: the global **memory-hunt**
+skill covers leak/UAF investigation methodology (not duplicated here).

--- a/.claude/skills/sparkengine-debugging-playbook/SKILL.md
+++ b/.claude/skills/sparkengine-debugging-playbook/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: sparkengine-debugging-playbook
+description: >-
+  SparkEngine subsystem-specific symptom lookup table: you observed a concrete wrong behavior in
+  a SparkEngine subsystem (AI behavior trees, weapons, the ImGui editor, undo/redo, MMO modules,
+  localization, cinematic sequencer, ECS system ticking, or client-side network prediction) and
+  need to know where to look, what the correct code should look like, and a discriminating
+  experiment to confirm the cause before changing anything.
+  TRIGGER when the user says things like "cloned behavior tree does nothing", "weapon damage is
+  attributed to entity 0", "editor crashes when I open a scene", "editor won't prompt to save",
+  "MMO module uses the wrong NetworkManager", "localized string is garbage", "cutscene has no
+  audio", "my ECS system never ticks / never runs", or "multiplayer is rubber-banding / desyncing".
+  DO NOT TRIGGER for generic C++ crashes, undefined-behavior hunts, or compiler/linker error
+  messages (use the global cpp-crash-triage and msvc-error-decoder skills), nor for a chronological
+  "what changed and why" narrative (use the sibling sparkengine-failure-archaeology skill).
+trilobite_compatible: true
+trilobite_role: debugging
+---
+
+# SparkEngine Debugging Playbook
+
+A **symptomatic lookup table** for SparkEngine subsystems: *"You are seeing X. Look at Y. Here is
+how to confirm it's the cause Z before you touch code."* Each entry gives a **discriminating
+experiment** — a cheap check that distinguishes the suspected cause from a look-alike, so you don't
+start editing the wrong file.
+
+Glossary (defined once):
+- **RHI** — Render Hardware Interface, SparkEngine's rendering abstraction (D3D11/D3D12/Vulkan/…).
+- **ECS** — Entity Component System (EnTT-backed). A *system* is a per-frame update over entities.
+- **UAF** — use-after-free.
+- **DI / injected context** — `EngineContext` handed to a game-module DLL via `Initialize(context)`,
+  as opposed to a process-global singleton.
+
+## When to use this skill / when NOT to
+
+| Situation | Use |
+|-----------|-----|
+| A named SparkEngine subsystem misbehaves in a specific way (table below) | **this skill** |
+| Generic segfault / heap corruption / UB with no subsystem lead | global `cpp-crash-triage` |
+| A raw MSVC/clang compile or link error message | global `msvc-error-decoder` |
+| "How did we get here / what was the history of this bug" | sibling `sparkengine-failure-archaeology` |
+| The architecture rules a fix must respect (service locator, wiring, thresholds) | `sparkengine-architecture-contract` |
+
+Do NOT paste generic C++ advice here. This file only carries SparkEngine-specific symptom→cause maps.
+
+## Important: most historical bugs below are already FIXED
+
+This table was built from `HARDEN_FLEET_HANDOFF.md`'s deferred-issue list and then **re-verified
+against the live code on 2026-07-07**. Eight of the nine listed issues have since been fixed. The
+value of the table today is twofold:
+
+1. If you observe the symptom, the row tells you the **fix that should be present** so you can spot a
+   **regression** (someone reverted or broke the fix).
+2. The one **partially-fixed** issue (Sequencer audio) and the ECS ticking model are live gotchas.
+
+Every file/line reference was checked on 2026-07-07 (branch `Working`). Line numbers drift — grep the
+named symbol, do not trust the number blindly.
+
+---
+
+## Triage table
+
+### 1. Cloned behavior tree does nothing / has no root (AI)
+
+- **Symptom**: An AI agent whose behavior tree was produced by cloning a template just idles;
+  the cloned tree appears empty or its root child is missing.
+- **Where to look**: `SparkEngine/Source/Engine/AI/BehaviorTreeTypes.h` (`BTNode::Clone`) and
+  `SparkEngine/Source/Engine/AI/BehaviorTreeNodes.h` (per-node `Clone()` overrides).
+- **Expected (fixed) state**: `Clone()` is **pure virtual** (`virtual std::unique_ptr<BTNode> Clone() const = 0;`).
+  Every node type deep-copies: composites (`SequenceNode`, `SelectorNode`, `ParallelNode`) loop their
+  children calling `child->Clone()`; decorators (`InverterNode`, `RepeaterNode`) clone `m_child`;
+  leaves (`ActionNode`, `ConditionNode`, `WaitNode`) copy their payload.
+- **Discriminating experiment**: Grep the node header for the `Clone()` bodies:
+  ```
+  rg -n "std::unique_ptr<BTNode> Clone" SparkEngine/Source/Engine/AI/BehaviorTreeNodes.h
+  ```
+  If a composite's `Clone()` returns `std::make_unique<SequenceNode>(m_name)` **without** the
+  `for (child) cloned->AddChild(child->Clone())` loop, the deep-copy regressed → cloned trees lose
+  their children. If the loop is present, the bug is elsewhere (check the *template* was populated
+  before cloning, and that `AISystem` actually calls `Clone()` for unseen agent types).
+
+### 2. Weapon damage/kills attributed to entity 0 (Gameplay/FPS)
+
+- **Symptom**: `WeaponFireEvent.ownerEntity` is always `0`; damage/kill attribution, hit markers, or
+  kill feed all credit entity 0.
+- **Where to look**: `SparkEngine/Source/Engine/Gameplay/WeaponManager.cpp` — the call chain
+  `Update` → `ProcessWeapon` → `HandleFiring` → emit `WeaponFireEvent`.
+- **Expected (fixed) state**: the shooter entity id is threaded through the whole chain:
+  `ProcessWeapon(uint32_t ownerEntity, …)` receives the entity from the ECS view
+  (`view.each()` → `ProcessWeapon(static_cast<uint32_t>(entity), …)`), passes it to
+  `HandleFiring(uint32_t ownerEntity, …)`, which sets `event.ownerEntity = ownerEntity;`.
+- **Discriminating experiment**:
+  ```
+  rg -n "ownerEntity" SparkEngine/Source/Engine/Gameplay/WeaponManager.cpp
+  ```
+  Confirm `event.ownerEntity = ownerEntity;` and that `ProcessWeapon`/`HandleFiring` take
+  `ownerEntity` as a parameter (not a hardcoded `0` or a default-constructed local). If the signature
+  still carries the id but the event reads `0`, the loss is at the emit site, not the plumbing.
+
+### 3. Editor crashes / UAF when opening a scene while one is loaded (Editor)
+
+- **Symptom**: The ImGui editor crashes (often a UAF) shortly after `File → Open` while a scene is
+  already loaded; panels reference freed entities/components of the old world.
+- **Where to look**: `SparkEditor/Source/Core/EditorUI.cpp` — `SwapWorld`, `OpenScene`, and the
+  panel-rewire block; `CommandHistory` (undo stack that may close over old entities).
+- **Expected (fixed) state**: `EditorUI::SwapWorld(std::unique_ptr<World>)` is the single funnel:
+  it (a) clears undo history first — `Spark::Editor::CommandHistory::GetInstance().Clear();` — then
+  (b) `m_world = std::move(newWorld);` then (c) rewires every panel's `SetWorld(m_world.get())`.
+  `OpenScene()` and the initial world creation both route through `SwapWorld()`.
+- **Discriminating experiment**:
+  ```
+  rg -n "SwapWorld|OpenScene|CommandHistory::GetInstance\(\)\.Clear" SparkEditor/Source/Core/EditorUI.cpp
+  ```
+  Confirm `OpenScene()` calls `SwapWorld(...)` and does **not** assign `m_world` directly. If any code
+  path sets `m_world = ...` outside `SwapWorld` (bypassing the history-clear + panel-rewire), that
+  path is the UAF source — a stale `CommandHistory` command or panel still points at the freed world.
+
+### 4. Editor won't prompt to save despite real changes (Editor / undo-redo)
+
+- **Symptom**: You make edits, undo back to the saved point, then branch to new edits — and the editor
+  reports "no unsaved changes" (false negative), so you lose work on close.
+- **Where to look**: `SparkEditor/Source/UndoRedo/UndoRedoManager.h` — `HasUnsavedChanges`,
+  `m_editSequence`, `m_savedSequence`.
+- **Expected (fixed) state**: dirty tracking is a **monotonic counter**, not a stack-size compare.
+  `m_editSequence` increments on every mutating op (execute/merge/undo/redo); `MarkSaved` snapshots it
+  into `m_savedSequence`; `HasUnsavedChanges()` returns `m_editSequence != m_savedSequence`.
+- **Discriminating experiment**:
+  ```
+  rg -n "m_editSequence|m_savedSequence|HasUnsavedChanges" SparkEditor/Source/UndoRedo/UndoRedoManager.h
+  ```
+  If `HasUnsavedChanges` compares stack **sizes** or **indices** (e.g. `m_currentIndex != m_savedIndex`)
+  instead of the monotonic sequences, the false-negative bug regressed: undo-to-saved-then-branch
+  produces an equal size/index while the content differs.
+
+### 5. MMO game module uses the wrong / stale subsystem instance (MMO / DI)
+
+- **Symptom**: An MMO module (`SparkGameMMO`) talks to a different `NetworkManager` (or other
+  subsystem) than the one the host injected — messages vanish, or a second stale singleton appears.
+- **Where to look**: `GameModules/SparkGameMMO/Source/Player/MMOPlayerSystem.cpp` and
+  `GameModules/SparkGameMMO/Source/World/MMOWorldSetup.cpp`.
+- **Expected (fixed) state**: the module stores the injected context (`m_context = context;` in
+  `Initialize`) and resolves subsystems through it — e.g. `auto* netMgr = m_context ? m_context->GetNetwork() : nullptr;`
+  — **not** through a process-global `SomeManager::GetInstance()`.
+- **Discriminating experiment**:
+  ```
+  rg -n "m_context->Get|::GetInstance\(\)" GameModules/SparkGameMMO/Source
+  ```
+  `SimpleConsole::GetInstance()` and `SeamlessAreaManager::GetInstance()` are **legitimate** shared
+  singletons — ignore those. The red flag is resolving *network / physics / graphics / the engine
+  context itself* via `GetInstance()` instead of `m_context->GetX()`. If you find that, the DI fix
+  regressed and the module is on a stale instance.
+
+### 6. Localized string is intermittent garbage or crashes (Localization)
+
+- **Symptom**: Reading a localized string occasionally returns corrupted text or crashes, especially
+  under concurrent access.
+- **Where to look**: `SparkEngine/Source/Engine/Localization/LocalizationSystem.h` / `.cpp` —
+  `GetString`, and `Format` (which calls `GetString`).
+- **Expected (fixed) state**: `std::string GetString(const std::string& key) const;` returns **by
+  value**. (Returning `const std::string&` into an internal map after releasing the lock is the classic
+  dangling-reference bug.)
+- **Discriminating experiment**:
+  ```
+  rg -n "GetString" SparkEngine/Source/Engine/Localization/LocalizationSystem.h
+  ```
+  If the signature is `const std::string& GetString(...)` (reference return), the dangling bug is back.
+  Value return is safe. Note `Format` binds `const std::string& tmpl = GetString(key);` — that is a
+  const-ref to a **temporary** (lifetime-extended) and is fine *only while* `GetString` returns by value.
+
+### 7. Cinematic plays visuals but no audio (Sequencer) — PARTIALLY WIRED
+
+- **Symptom**: A `Sequence` plays animation/property/event tracks correctly, but `AudioCue` tracks
+  produce no sound.
+- **Where to look**: `SparkEngine/Source/Engine/Cinematic/Sequencer.h` (`AudioCallback` typedef,
+  `SetAudioCallback`) and `Sequencer.cpp` (the per-frame dispatch loop and `SetAudioCallback`).
+- **Verified current state (2026-07-07)**: the **mechanism exists** — `using AudioCallback = std::function<void(const AudioCue&)>;`,
+  `void SetAudioCallback(AudioCallback)`, and a dispatch loop that fires
+  `m_audioCallback(*cue)` for each triggered cue **only when `m_audioCallback` is set**. BUT: grep
+  finds **no caller** of `SetAudioCallback` anywhere in the engine or game modules. So by default the
+  callback is null and cues silently no-op. This is the one issue that is only *partially* resolved.
+- **Discriminating experiment**:
+  ```
+  rg -n "SetAudioCallback" SparkEngine GameModules SparkEditor
+  ```
+  If the only hits are the declaration (`Sequencer.h`) and definition (`Sequencer.cpp`), then **nothing
+  wires audio** — the fix is to have the cinematic owner call
+  `sequence.SetAudioCallback([audio](const AudioCue& c){ /* play c */ });` at setup. If a caller does
+  exist and audio still fails, check `AudioCueTrack::GetTriggeredCues(prevTime, currentTime)` and that
+  `m_previousTime`/`m_currentTime` actually advance (a zero-length step triggers nothing).
+
+### 8. A registered ECS system silently never ticks (ECS)
+
+- **Symptom**: You added an ECS system, it compiles, but its `Update` never runs — entities aren't
+  processed and no error is raised.
+- **Where to look**: three names historically collided; here is the **verified current model
+  (2026-07-07)** — none of these is a cleanly-wired home, which is exactly why a system can
+  silently never tick:
+  | Class | File | Role |
+  |-------|------|------|
+  | `PhaseSystemManager` | `SparkEngine/Source/Engine/ECS/Systems/PhaseSystemManager.h` | **Intended-canonical, but NOT wired.** `CreatePhaseSystemManager()` has zero callers and `UpdateAll` is never invoked in any `.cpp` — so it does not tick in the shipping loop. Phased execution in `Phase` enum order (if it were driven). |
+  | `SystemManager` | `SparkEngine/Source/Engine/ECS/Systems/ECSystems.h` (line 735) | **Legacy** flat, insertion-order manager. `EngineSetup.h` says it is *replaced* by `PhaseSystemManager`. |
+  | `StageBasedExecutor` | `SparkEngine/Source/Engine/ECS/Systems/ParallelSystemExecutor.h` (line 378) | **EXISTS and is ticked every frame** — `GetInstance().ExecuteAll(dt)` runs from `Core/Lifecycle/GameplayLifecycleShared.cpp:1062`. BUT **no `RegisterSystem(...)` caller exists anywhere**, so it is a **dead tick**: a live per-frame tick over zero registered systems. (The handoff doc's claim that this class is gone is stale — it is present.) |
+  | `ParallelSystemExecutor` | same header | A separate access-set batcher, **not wired** into the live tick; the old global parallel path was removed and `PhaseSystemManager::UpdateAll` was made serial (see its `@note`). See `sparkengine-job-system-threading §1c/§1d`. |
+- **The three ways a system silently doesn't tick**:
+  1. **Registered into a manager that never runs.** The `PhaseSystemManager` set built by
+     `Spark::CreatePhaseSystemManager(ctx)` in `SparkEngine/Source/Core/EngineSetup.h` is **not called
+     anywhere** — that helper has zero callers and the shipping Core loop drives
+     `moduleManager->UpdateAll(dt)` instead (see `SparkEngineWindows.cpp` / `SparkEngineLinux.cpp`). The
+     only live ECS-stage tick is `StageBasedExecutor::ExecuteAll` (above), and nothing is registered
+     into it. So a system added to *any* of these three can dead-tick — verify the tick path
+     end-to-end (see `sparkengine-architecture-contract` Invariant 3, this is a known OPEN weak point).
+  2. **Registered via the flat overload.** `AddSystem<T>(Phase::AI, …)` is phased;
+     `AddSystem<T>(…)` (no `Phase`) drops into the **flat list that runs LAST, after all phases**. If
+     ordering matters (you read another system's output), the flat overload is the cause.
+  3. **Its subsystem dependency was null at registration.** In `CreatePhaseSystemManager`, physics,
+     audio, and render systems are added **only if** `ctx.GetPhysics()/GetAudio()/GetGraphics()` are
+     non-null. In headless / `NullRHIDevice` runs `GetGraphics()` may be null → `RenderSystem` is never
+     registered and never ticks (by design).
+- **Discriminating experiment**:
+  ```
+  rg -n "AddSystem<|UpdateAll" SparkEngine/Source/Core/EngineSetup.h
+  ```
+  Then confirm your system appears with a `Phase::` argument and that the owner of that manager calls
+  `UpdateAll` every frame. To prove it ticks, put a one-shot log at the top of your `Update`; if it
+  never prints, it's cause 1 or 3, not a logic bug inside `Update`.
+
+### 9. Multiplayer rubber-banding / desync on the client (Networking / prediction)
+
+- **Symptom**: The local player snaps/teleports back after moving (rubber-banding), or client and
+  server positions drift apart.
+- **Where to look**: `SparkEngine/Source/Engine/Networking/ClientPrediction.h` / `.cpp` —
+  `Reconcile(serverState, dt)` re-applies un-ACKed inputs after a server correction;
+  `GetLastCorrectionMagnitude()` reports the size of the last correction. It is wired into
+  `GameModules/SparkGameFPS/Source/Game/MultiplayerSystem.cpp` and the MMO/TF nets.
+- **Discriminating experiment**: Log `GetLastCorrectionMagnitude()` each time a server state arrives.
+  - **Consistently large corrections** → the client's local simulation disagrees with the server's
+    (different movement constants, or inputs not being recorded into the buffer before `Reconcile`).
+  - **Corrections spike only under packet loss/latency** → the input buffer isn't retaining enough
+    un-ACKed inputs to replay, or sequence numbers are mismatched. Check that every predicted input is
+    stamped with a monotonic sequence number and stored before it's sent.
+  - **Magnitude ~0 but still visually snapping** → the problem is render interpolation/smoothing, not
+    prediction; look outside `ClientPrediction`.
+
+---
+
+## How to use an entry (workflow)
+
+1. Match your symptom to a row.
+2. Run the row's **discriminating experiment** first — do not edit yet.
+3. If the experiment shows the fix is **present and correct**, the bug is a *look-alike*; follow the
+   "if the loop/signature is present…" branch in that row, or fall back to `cpp-crash-triage`.
+4. If the experiment shows the fix **regressed**, restore the expected state described in the row.
+   Respect `sparkengine-architecture-contract` (service locator, wiring rules) when doing so.
+5. Re-verify with the same grep.
+
+## Provenance and maintenance
+
+- Built from `D:\SparkEngine\HARDEN_FLEET_HANDOFF.md` (handoff deferred-issue list) and re-verified
+  against the live `Working` branch on **2026-07-07**. Result: rows 1–6 verified **FIXED**, row 7
+  (Sequencer audio) verified **partially wired** (mechanism present, no caller), rows 8–9 describe the
+  **current** ECS/prediction model. Note the ECS-manager reality (row 8): `StageBasedExecutor`
+  **exists** (`ParallelSystemExecutor.h:378`) and its `ExecuteAll(dt)` is ticked every frame from
+  `GameplayLifecycleShared.cpp:1062`, but has **no `RegisterSystem` caller** (dead tick);
+  `PhaseSystemManager` is defined-not-wired (zero callers). None of the three managers is a
+  cleanly-wired home — an OPEN architectural weak point (see `sparkengine-architecture-contract`
+  Invariant 3 and `sparkengine-job-system-threading §1c`).
+- Line numbers are advisory; grep the named symbols. One-line re-verification commands:
+  ```
+  # Row 1  BT deep-copy present
+  rg -n "std::unique_ptr<BTNode> Clone" SparkEngine/Source/Engine/AI/BehaviorTreeNodes.h
+  # Row 2  weapon owner threaded
+  rg -n "ownerEntity" SparkEngine/Source/Engine/Gameplay/WeaponManager.cpp
+  # Row 3  editor world-swap funnel
+  rg -n "SwapWorld|OpenScene" SparkEditor/Source/Core/EditorUI.cpp
+  # Row 4  monotonic dirty tracking
+  rg -n "m_editSequence|m_savedSequence" SparkEditor/Source/UndoRedo/UndoRedoManager.h
+  # Row 5  MMO resolves via injected context
+  rg -n "m_context->Get|::GetInstance\(\)" GameModules/SparkGameMMO/Source/Player/MMOPlayerSystem.cpp
+  # Row 6  localization returns by value
+  rg -n "GetString" SparkEngine/Source/Engine/Localization/LocalizationSystem.h
+  # Row 7  is SetAudioCallback ever called? (only decl+def == not wired)
+  rg -n "SetAudioCallback" SparkEngine GameModules SparkEditor
+  # Row 8  ECS managers: intended-but-unwired vs the live-but-empty tick
+  rg -n "AddSystem<|UpdateAll|CreatePhaseSystemManager" SparkEngine/Source/Core/EngineSetup.h
+  rg -n "StageBasedExecutor::GetInstance\(\).ExecuteAll" SparkEngine/Source/Core/Lifecycle/GameplayLifecycleShared.cpp
+  rg -rn "RegisterSystem\(" SparkEngine/Source | rg -i stage   # expect only the definition (dead tick)
+  # Row 9  prediction reconcile + correction magnitude
+  rg -n "Reconcile|GetLastCorrectionMagnitude" SparkEngine/Source/Engine/Networking/ClientPrediction.h
+  ```
+- When you fix a genuinely new subsystem symptom, add a row here (symptom → where → expected state →
+  discriminating experiment) and record durable lessons in the project wiki per `CLAUDE.md`.
+- Validate edits to this file by running the global skill-linter (`~/.claude/skills/skill-linter/`)
+  against this folder: pass `-Path .claude/skills/sparkengine-debugging-playbook`.

--- a/.claude/skills/sparkengine-ecs-query-patterns/SKILL.md
+++ b/.claude/skills/sparkengine-ecs-query-patterns/SKILL.md
@@ -1,0 +1,313 @@
+---
+name: sparkengine-ecs-query-patterns
+description: How to query and iterate the EnTT-based ECS in SparkEngine — building views over component combinations, iterating entities inside a system, the CoreComponents vs domain-header layout, the data-driven archetype/prefab spawn format, and the fixed Physics->Animation->AI->Audio->Lifecycle->Render execution order. TRIGGER when the user says "iterate entities with component X", "write a new ECS system", "loop over all entities that have", "GetEntitiesWith", "registry.view", "EnTT view or group", "how do I spawn a prefab/archetype", "what order do systems run in", "why does my system read a stale Transform", or "where do I add a new component struct". DO NOT TRIGGER for how to REGISTER a component with reflection/editor/save (see sparkengine-reflection-conventions), for AngelScript scripting (see sparkengine-hot-reload-seam), or for generic EnTT questions unrelated to this codebase's conventions.
+trilobite_compatible: true
+trilobite_role: reference
+---
+
+# SparkEngine ECS query patterns
+
+SparkEngine's ECS is a thin wrapper over **EnTT** (`entt::registry`). This skill
+covers how entities and components are *queried and iterated* in this codebase —
+the real idioms used in the shipped systems, not invented EnTT examples. It does
+**not** cover reflection/editor/save registration of component types: for that,
+read the sibling skill **sparkengine-reflection-conventions** first ("how do I
+register a new component type", editor Inspector, `SPARK_REFLECT_*`).
+
+Jargon, defined once:
+- **Entity** — an opaque ID (`entt::entity`, aliased `EntityID`). Just a number.
+- **Component** — a plain data struct (`Transform`, `RigidBodyComponent`, …).
+- **System** — a logic class (`: public ISystem`) that iterates entities holding
+  a specific component combination and updates them each frame.
+- **View** — an EnTT read/write cursor over every entity that has *all* of a given
+  set of components. Cheap to construct; build it fresh each frame, never cache it.
+- **World** — `class World` (in `Components.h`), the thin owner of one
+  `entt::registry`. Every Scene owns exactly one `World`.
+
+## The World API you actually call
+
+`World` (defined in `SparkEngine/Source/Engine/ECS/Components.h`, global scope)
+wraps the registry. Prefer these over touching `entt::registry` directly — they
+add `SPARK_REQUIRE` validity assertions:
+
+| Call | What it does |
+| --- | --- |
+| `world.CreateEntity("name")` | Create an entity; if a name is given, also emplaces a `NameComponent`. |
+| `world.DestroyEntity(e)` | Validity-checked destroy; also unsubscribes the entity from `EntityEventBus`. |
+| `world.AddComponent<T>(e, args...)` | `emplace<T>`. **Asserts the entity does NOT already have `T`** — adding twice is a hard error, not an overwrite. |
+| `world.GetComponent<T>(e)` | Returns `T*` (or `const T*`), `nullptr` if absent. This is `registry.try_get<T>` — never dereference without a null check. |
+| `world.HasComponent<T>(e)` | `all_of<T>`. |
+| `world.RemoveComponent<T>(e)` | Asserts the component is present first. |
+| `world.GetEntitiesWith<A, B, ...>()` | Returns `registry.view<A, B, ...>()` — the primary query entry point. |
+| `world.GetRegistry()` | Escape hatch to the raw `entt::registry&` for calls the wrapper doesn't expose (e.g. `try_get` a *third* component mid-loop, single-component views). |
+
+## Pattern 1 — the standard per-system iteration (use this by default)
+
+Every gameplay/render/physics system in `Systems/ECSystems.cpp` and `Systems/Systems2D.h`
+follows the same shape. Build the view, `for (auto entity : view)`, then pull each
+component with `view.get<T>(entity)` (returns a reference — no null check needed,
+the view guarantees presence). Verbatim from `RenderSystem::Update`
+(`ECSystems.cpp`):
+
+```cpp
+const auto& registry = world.GetRegistry();
+auto view = world.GetEntitiesWith<Transform, MeshRenderer>();
+for (auto entity : view)
+{
+    auto& transform = view.get<Transform>(entity);
+    auto& renderer  = view.get<MeshRenderer>(entity);
+
+    if (!renderer.visible)
+        continue;
+
+    // Optional third component that is NOT part of the view filter:
+    // use the registry's try_get, because the view doesn't hold it.
+    auto* active = registry.try_get<ActiveComponent>(entity);
+    if (active && !active->active)
+        continue;
+
+    XMMATRIX worldMtx = transform.GetWorldMatrix(registry);
+    XMStoreFloat4x4(&renderer.cachedWorldMatrix, worldMtx);
+    renderer.worldMatrixDirty = false;
+}
+```
+
+Rules this codebase follows:
+- **The view filters on the type list; every listed type is guaranteed present**,
+  so `view.get<T>(entity)` returns a live reference. Reach for `registry.try_get<T>`
+  only for an *optional* extra component you did not put in the view type list (like
+  `ActiveComponent` above) — that avoids a second hash lookup through
+  `World::GetComponent`.
+- **Construct the view fresh at the top of `Update()`.** Views are lightweight
+  cursors; they are never stored across frames anywhere in this codebase.
+- **Never hold component references across frames.** `ISystem::Update` gets `World&`
+  each call for exactly this reason (see `ECSystemTypes.h`).
+
+## Pattern 2 — structured-binding `.each()` iteration
+
+EnTT views also expose `.each()`, which yields `[entity, comp, comp...]` tuples so
+you skip the separate `view.get<>` calls. Used in `Systems/FixedTimestepPhysics.h`
+(`StepPhysics`):
+
+```cpp
+auto view = world.GetEntitiesWith<RigidBodyComponent, Transform>();
+for (auto [entity, rb, tf] : view.each())
+{
+    if (rb.type == RigidBodyComponent::Type::Kinematic)
+    {
+        rb.previousPosition = tf.position;
+        rb.previousRotation = tf.rotation;
+    }
+}
+```
+
+Both styles are correct and both appear in the tree. Pick `.each()` when you use
+every component in the type list; pick the `for (auto entity : view)` +
+`view.get<>` style when you need the raw `entity` id often (e.g. for logging,
+`static_cast<uint32_t>(entity)`, or passing to physics/network APIs) or when you
+conditionally touch only some components.
+
+## Pattern 3 — single-component view via the raw registry
+
+For a query on exactly one component, `AbilitySystem::Update` (`ECSystems.cpp`)
+goes straight through the registry rather than `GetEntitiesWith`:
+
+```cpp
+auto view = world.GetRegistry().view<AbilityComponent>();
+for (auto entity : view)
+{
+    auto& ability = view.get<AbilityComponent>(entity);
+    ability.Update(deltaTime);
+}
+```
+
+`world.GetEntitiesWith<AbilityComponent>()` is equivalent and also valid — both
+forward to `registry.view<...>()`. There is no wrapper difference for the query
+itself; use whichever reads clearer.
+
+## Groups — not used here (do not add them casually)
+
+EnTT `registry.group<...>()` (owning/partial-owning groups for tighter iteration)
+is **not** used anywhere in the ECS layer as of this writing — every query is a
+plain `view`. Groups take ownership of component storage layout and can conflict
+with other groups/views over the same types; do not introduce one to "optimize" a
+single system without a measured need and a check that no other system iterates the
+same component set. Views are the house style.
+
+## Component header organization
+
+Component structs are **plain data** and live under
+`SparkEngine/Source/Engine/ECS/Components/`, split by domain for compile speed. Do
+NOT put logic (methods beyond trivial helpers) in them and do NOT scatter
+reflection blocks next to them (reflection lives in one file — see the sibling
+skill).
+
+- **`Components/CoreComponents.h`** — the always-present core: `NameComponent`,
+  `Transform`, `MeshRenderer`, `Camera`, `Script`. Plus the `using EntityID =
+  entt::entity;` alias. Touch this only for genuinely universal components.
+- **Domain headers** (one per subsystem): `PhysicsComponents.h`,
+  `AudioComponents.h`, `LightComponents.h`, `AnimationComponents.h`,
+  `AIComponents.h`, `NetworkComponents.h`, `GameplayComponents.h`,
+  `Sprite2DComponents.h`, `FPSComponents.h`, `SplineComponents.h`,
+  `VolumeComponents.h`, `PlacementComponents.h`, `AdvancedPlacementComponents.h`,
+  `CollisionMaskComponents.h`, `VisibilityComponents.h`, `TerrainComponents.h`.
+- **`Engine/ECS/Components.h`** — the umbrella header. It `#include`s every domain
+  header **and** defines `class World`. Include the specific domain header you need
+  in a system for faster compiles; include the umbrella `Components.h` only when you
+  need `World` itself or many component families at once (its own header comment
+  says to prefer the narrow includes).
+
+New component → put the struct in the closest domain header (or start a new
+`NewDomainComponents.h` for a new subsystem), then follow **sparkengine-reflection-conventions**
+to register it. Adding the struct alone is enough to `view`/`GetEntitiesWith` it;
+reflection is only needed for editor/save/archetype-by-string-name.
+
+## Archetype (prefab) loading — data-driven spawning
+
+`Engine/ECS/EntityArchetypeLoader.cpp` loads text archetype files and spawns
+entities from them, bridging to components by **string name** through the
+reflection `ComponentFactory`. Two data structures back it (`EntityArchetype.h`):
+`Archetype { name, category, vector<ComponentEntry> }` and
+`ComponentEntry { typeName, unordered_map<string,string> properties }`, held in the
+`EntityArchetypeSystem` singleton keyed by name.
+
+### File format (parsed by `LoadArchetypeFromFile`)
+
+Line-based `key = value`. `//` lines and blanks are skipped. Recognized keys:
+
+| Key | Meaning |
+| --- | --- |
+| `name` | Archetype name (required; a file with no `name` is rejected). |
+| `category` | Free-form grouping string (e.g. `Characters`, `Props`). |
+| `component` | One component line. Repeat for each component. |
+
+A `component` value is `TypeName: p0 / p1 / p2 ...` — the part before `:` is the
+component type name; the part after is split on `/` into **positional** parameters
+stored as properties `"p0"`, `"p1"`, …. A bare `TypeName` with no `:` adds the
+component with no properties. Example:
+
+```
+name = GuardNPC
+category = Characters
+// position / rotation / scale, each as "x,y,z"
+component = Transform: 0,0,0 / 0,90,0 / 1,1,1
+component = LightComponent: Point / 1,0.9,0.7 / 4.0 / 12.0
+component = MeshRenderer
+```
+
+### Spawn flow (`SpawnFromArchetype`)
+
+`EntityID SpawnFromArchetype(const std::string& name, World& world)`:
+1. Look up the `Archetype` by name in `EntityArchetypeSystem::GetInstance()`;
+   return `entt::null` and warn if missing.
+2. `world.CreateEntity(archetype->name)` — the entity is named after the archetype.
+3. For each `ComponentEntry`, call `ApplyComponentViaReflection`.
+
+`ApplyComponentViaReflection` picks one of three paths per component:
+- **`NameComponent`** → special-cased (`CreateEntity` may have already added one, so
+  it only adds when absent).
+- **Positional-param legacy path** — if any property key is `p<digit>` AND the type
+  is `Transform` or `LightComponent`, a hand-written `ApplyTransform` /
+  `ApplyLightComponent` parses the compact `"x,y,z / r,g,b / ..."` syntax. This
+  exists because those compact vectors don't map to reflected field *names*.
+- **Reflection path** (everything else) — requires the type to be registered in the
+  reflection `ComponentFactory`:
+  `factory.AddComponent(typeName, &world, entityId)`, then for each property look up
+  the field on `TypeRegistry::Get().FindTypeByName(typeName)` and
+  `SetFieldFromString`. **If the type isn't registered with `ComponentFactory`, the
+  component is silently skipped with a warning** — this is the exact gap that step 3
+  of the reflection skill's checklist prevents.
+
+There is an override overload:
+`SpawnFromArchetype(name, world, unordered_map<string,string> overrides)`. Override
+keys use `"ComponentType.propertyName"` (dot-separated); matching properties on the
+copied component entries are replaced before spawning. Keys without a `.` are
+ignored.
+
+## Execution order invariant
+
+The fixed ECS order (from `D:\SparkEngine\CLAUDE.md`) is:
+
+```
+Physics -> Animation -> AI -> Audio -> Lifecycle -> Render
+```
+
+Rationale, per the system doc comments in `ECSystems.h`: Physics writes `Transform`;
+Animation produces bone matrices; AI *reads* `Transform` and writes velocity/target;
+Audio reads `Transform` to position 3D sources; Lifecycle handles health/death/active;
+Render reads `Transform` + `MeshRenderer` last so it draws the settled frame. Getting
+this wrong produces a one-frame lag / stale-transform read (e.g. AI steering off last
+frame's position), not a crash — which is why it's easy to miss.
+
+**Where the order is actually enforced — know which manager you have:**
+
+- **`SystemManager`** (`ECSystems.h`) is a **flat list, insertion-order** manager.
+  `AddSystem<T>()` does `push_back`; `UpdateAll()` iterates in insertion order with
+  **no sorting**. The order is therefore enforced *by the caller registering systems
+  in the correct order* — it is a convention, not an automatic guarantee. The header's
+  `## System execution order` comment documents the required sequence and its `@code`
+  block shows the correct registration order.
+- **`PhaseSystemManager`** (`Systems/PhaseSystemManager.h`) is the deterministic
+  alternative: `AddSystem<T>(Phase, ...)` buckets systems by a `Phase` enum
+  (`PrePhysics, Physics, PostPhysics, Animation, AI, Audio, Gameplay, PreRender,
+  Render, PostRender`) and `UpdateAll()` runs phase buckets **in enum order
+  regardless of insertion order** (unphased systems run last). It is the *intended*
+  structural home. Note its comment records that an earlier parallel-execution path
+  was **removed** because it batched across all phases and silently broke phase
+  ordering — it runs serially today.
+
+> **Wiring reality — do not assume any of these ticks (verified 2026-07-07).** None of
+> these managers is cleanly wired into the shipping loop right now, so registering a
+> system into one does **not** guarantee it runs. `PhaseSystemManager` is
+> **defined-not-wired** (`CreatePhaseSystemManager` has zero callers, `UpdateAll` is
+> never invoked); a third class, `StageBasedExecutor` (`ParallelSystemExecutor.h`),
+> **is** ticked every frame (`GameplayLifecycleShared.cpp:1062`) but has zero registered
+> systems (dead tick); the shipping Core loop drives module systems via
+> `moduleManager->UpdateAll(dt)`. This is a known OPEN architectural weak point — if you
+> add a system, verify the tick path end-to-end and flag the gap. See
+> `sparkengine-architecture-contract` Invariant 3 and `sparkengine-job-system-threading §1c`.
+
+**`SplineFollowerSystem`** slots between Animation and AI:
+`Physics -> Animation -> SplineFollower -> AI -> Audio -> Lifecycle -> Render`
+(so spline-driven entities are positioned before AI reads their transforms).
+
+### Gotcha: the ordering unit test is a standalone mock
+
+`Tests/TestECSystemOrdering.cpp` asserts that adding systems in the *wrong* order
+still executes Physics->…->Render, i.e. it "sorts by priority". That test is a
+**standalone reimplementation** (its own file header says: "mirrors
+Spark::ECS::SystemManager and ISystem without engine dependencies for CI/Linux
+compatibility") — its auto-sorting behavior is the *mock's*, **not** the real
+`SystemManager`, which does not sort. Do not rely on the real flat `SystemManager`
+to reorder for you; register in order, or use `PhaseSystemManager`.
+
+## When NOT to use this skill
+
+- Registering a component for the editor/save/network/archetype-by-name →
+  **sparkengine-reflection-conventions**.
+- AngelScript-side entity access / hot reload → **sparkengine-hot-reload-seam**.
+- Scene file save/load format → **sparkengine-serialization-format**.
+
+## Provenance and maintenance
+
+Verified by Read/Grep against these files on **2026-07-07** (branch
+`claude/forge-sonnet5-skills` @ `9fb17e63`):
+`Engine/ECS/Components.h`, `Engine/ECS/Components/CoreComponents.h`,
+`Engine/ECS/EntityArchetype.h`, `Engine/ECS/EntityArchetypeLoader.cpp`,
+`Engine/ECS/Systems/ECSystemTypes.h`, `Engine/ECS/Systems/ECSystems.h`,
+`Engine/ECS/Systems/ECSystems.cpp`, `Engine/ECS/Systems/Systems2D.h`,
+`Engine/ECS/Systems/FixedTimestepPhysics.h`,
+`Engine/ECS/Systems/PhaseSystemManager.h`, `Tests/TestECSystemOrdering.cpp`.
+
+Re-verify commands (run from repo root):
+- View/query idioms still current:
+  `grep -rn "GetEntitiesWith\|\.each()\|GetRegistry().view" SparkEngine/Source/Engine/ECS`
+- Groups still unused (expect no ECS-layer hits):
+  `grep -rn "registry.group<\|\.group<" SparkEngine/Source/Engine/ECS`
+- Flat SystemManager still has no sort (should show only push_back / ordered iterate):
+  `grep -n "std::sort\|stable_sort\|push_back" SparkEngine/Source/Engine/ECS/Systems/ECSystems.h`
+- Domain component headers inventory:
+  `ls SparkEngine/Source/Engine/ECS/Components/`
+- Archetype format keys unchanged:
+  `grep -n "key ==" SparkEngine/Source/Engine/ECS/EntityArchetypeLoader.cpp`
+- Validate this skill with the skill-linter (see the global skill-linter tool under `~/.claude/skills/skill-linter`).

--- a/.claude/skills/sparkengine-failure-archaeology/SKILL.md
+++ b/.claude/skills/sparkengine-failure-archaeology/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: sparkengine-failure-archaeology
+description: >-
+  Chronological case-file of SparkEngine's hardest, already-solved bugs — each with symptom,
+  root cause, the exact fix commit, and current landed/open status. TRIGGER when you are about to
+  re-investigate something that "feels like it was fixed before", when you say "has this ICF /
+  type-id / C++23 gate / blue-screen / macOS build / camera race / AngelScript hot-reload thing
+  happened before", when a Windows Release-only CI failure reappears, when you want the STORY and
+  commit hash of a past incident, or when auditing which harden-fleet items are still deferred.
+  DO NOT TRIGGER for a brand-new live symptom you just hit and want a fix recipe for — use the
+  sibling sparkengine-debugging-playbook (symptom->fix triage) instead; this skill is a history
+  book, not a first-responder.
+trilobite_compatible: true
+trilobite_role: archaeology
+---
+
+# SparkEngine Failure Archaeology
+
+This is a **chronological case-file**, not a triage table. Each entry tells the *story* of a bug that
+already cost real investigation time: what broke, why, the commit that fixed it, and whether it is
+still fixed today. Read it to avoid re-solving a solved problem and to know the exact commit to `git
+show` for the full reasoning.
+
+## When to use this / when NOT to
+
+| Use this skill when… | Use a sibling instead |
+|---|---|
+| "Didn't we already fix a Release-only service-locator bug?" | New crash with no history → `sparkengine-debugging-playbook` |
+| A Windows Release CI test fails but Debug passes | You need a symptom→fix decision tree → `sparkengine-debugging-playbook` |
+| You want the commit hash + full reasoning of a past incident | You're doing a normal build → global `cmake-msvc` (toolchain) / `ci-troubleshoot` (CI) |
+| Auditing which harden-fleet P1/P2 items are still deferred | — |
+
+**Jargon defined once:**
+- **ICF** = Identical COMDAT Folding, MSVC linker flag `/OPT:ICF` (on in Release, off in Debug). It merges byte-identical read-only data/functions to one address.
+- **TU** = translation unit (one `.cpp`/`.mm` after preprocessing).
+- **UAF** = use-after-free.
+- **`.mm`** = Objective-C++ source (macOS Metal backends only).
+- **trilobite** = this repo's ad-hoc name for a deferred-verification queue / cross-cutting audit pass (see `HARDEN_FLEET_HANDOFF.md`). There is no central registry file; `trilobite_*` frontmatter is the local convention.
+- **harden-fleet** = a multi-agent hardening branch (`claude/harden-fleet`), merged into `Working`.
+
+All commits below are confirmed ancestors of `Working` HEAD unless marked otherwise. Verify any entry with `git show <hash>`.
+
+---
+
+## Era 1 — The 2026-06-08 Windows-Release-CI unblock sprint
+
+One day, one engineer (Krill), a cascade of Release-only failures on `build-windows-vs2022`. These
+are the classic "passes in Debug, fails in Release" traps. Ordered by commit time that day.
+
+### 1. C++23 feature gate wrongly rejected MSVC  — `d8685a2a` (14:28)
+- **Symptom:** After merging dependabot/feature branches, the engine refused to compile on the
+  *supported* MSVC toolchain — the `#error` C++23 gate in `Core/Platform.h` fired even though the
+  compiler had the needed features.
+- **Root cause:** MSVC reports `_MSVC_LANG == 202004L` for `/std:c++latest` until VS 2022 17.12, so
+  it never reaches the `202100L` C++23 threshold the gate checked. The gate contradicted its own
+  `#error` text (which documents MSVC 19.36+ / VS 2022 17.6+ as supported).
+- **Fix:** Detect MSVC C++23 via `_MSC_VER >= 1936` in addition to `_MSVC_LANG`. Same commit also
+  re-pinned `ThirdParty/UI/imgui` from the no-docking 1.92.8 tag back to the docking-branch tip
+  (dependabot had dropped `DockSpace`/`ImGuiCol_Docking*` that SparkEditor needs).
+- **Status:** **Landed.** Still present — `Core/Platform.h:115` today reads
+  `_MSVC_LANG >= 202100L || (_MSVC_LANG > 202002L && ... _MSC_VER >= 1936)`.
+
+### 2. `/OPT:ICF` collapsed all `GetTypeId<T>()` to one address  — `21b1a689` (15:42)
+- **Symptom:** In **Release only**, the `EngineContext` service locator returned the *wrong*
+  subsystem pointer. 14 tests failed (`ServiceLocator_*`, `Reflection_*`, `SubsystemInit_*`,
+  `Adversarial_*`); the editor's play-mode hung. Debug was fine.
+- **Root cause:** `GetTypeId<T>()` returned the address of a per-type `static const char id = 0`.
+  Every `T` produced a byte-identical read-only COMDAT, so `/OPT:ICF` (Release-on, Debug-off) folded
+  them all to a single address — making `GetTypeId<A>() == GetTypeId<B>()` for all types.
+- **Fix:** Use a **non-const** `static char id;`. Writable data is not ICF-folded, so each `T` keeps a
+  distinct address. Applied to `Core/EngineContext.h` and the three test helpers that mirror the
+  pattern (`TestAdversarialEngine.cpp`, `TestEngineContext.cpp`, `TestReflection.cpp`).
+- **Status:** **Landed.** `EngineContext.h:66` today is `static char id;` with a load-bearing comment
+  at line 60 warning it must stay non-const. This is also captured in user memory `opt-icf-typeid-gate.md`.
+- **Rule that came out of it:** type-id marker statics must be **non-const**; never "tidy" them to `const`.
+
+### 3. Scene View blue-screened the whole editor  — `28f4ae8f` (16:21)
+- **Symptom:** Opening the editor with the **Scene View** tab active turned the entire editor window
+  a flat blue (clear color) with no visible UI. **Game View worked**; switching to Scene View broke it.
+- **Root cause:** `SceneViewPanel::RenderSceneContent()` rendered to its own texture on the editor's
+  shared D3D11 immediate context, then called `OMSetRenderTargets(0, nullptr, nullptr)` — leaving the
+  render target **unbound**. Because the panel renders *inside* ImGui's frame build, the following
+  `ImGui_ImplDX11_RenderDrawData()` drew to no target, so only the clear color showed. Game View was
+  immune because it only uses ImGui draw lists and never touches the RT (this exactly matched the report).
+- **Fix (two layers):** (a) `SceneViewPanel` saves the bound RT with `OMGetRenderTargets` and restores
+  it afterward instead of unbinding; (b) `EditorApplication::Render()` re-binds the backbuffer right
+  before `ImGui::Render()` as defense-in-depth. Files: `SparkEditor/Source/Core/EditorApplicationWindows.cpp`,
+  `SparkEditor/Source/Panels/SceneViewPanel.cpp`.
+- **Status:** **Landed.**
+
+### 4. `Training_GradientCheckHuber` flaky in Release  — `368c20fb` (20:03)
+- **Symptom:** `build-windows-vs2022 (Release)` failed on exactly one test. Passed locally under
+  VS 17.10.
+- **Root cause:** *Not* an engine bug. Floating-point cancellation in the central-difference gradient
+  check. Relative error is U-shaped in the perturbation step (measured: eps `1e-4`→0.021, `1e-3`→0.0044,
+  `1e-2`→0.00042). The `1e-3` step sat in the roundoff-dominated region with only ~2x margin and
+  tipped over the `1e-2` bound under CI's MSVC Release toolset. `Training_HuberLossSwitchesAtDelta`
+  (exact values) passed, proving the gradient itself was correct.
+- **Fix:** Move the Huber finite-difference check to a `1e-2` step (~24x margin, the sweet spot). MSE
+  check keeps `1e-3` (smoother gradients). File: `Tests/TestCpuNeuralTraining.cpp`.
+- **Status:** **Landed.**
+- **Lesson:** a gradient-check failure is usually the *epsilon*, not the gradient — confirm with an
+  exact-value sibling test before touching the math.
+
+### 5–7. macOS Metal/OpenAL compile cascade (`.mm`-only, continue-on-error CI)
+These only compile on macOS, so the bugs were latent until the `build-macos` job (which is
+`continue-on-error` — does **not** gate the required matrix) surfaced them. Fixed in layers the same evening:
+
+| Commit | Time | Bug | Fix |
+|---|---|---|---|
+| `1b531e9f` | 20:47 | `PlatformTypes.h` `using BOOL = int` clashed with Objective-C's `typedef bool BOOL` in `.mm` TUs → "type alias redefinition (bool vs int)". Also `MetalRayTracing.mm` used `SPARK_LOG_*` without including `Utils/LogMacros.h`. | Guard the `BOOL` alias with `#ifndef __OBJC__`; add the `LogMacros.h` include. |
+| `409c84e8` | 21:24 | `OpenALAudioEngine.h` forward-declared `typedef struct ALCdevice ALCdevice`; Apple's `alc.h` uses `struct ALCdevice_struct` → "typedef redefinition with different types". Plus `MetalRayTracing.mm` missing `<cstdio>` for `snprintf`. | Forward-declare `ALCdevice` per platform so the tag matches; add `<cstdio>`. |
+| `0d0dae01` | 22:13 | Two `SPARK_LOG_*` calls in `MetalRayTracing.mm` passed a `std::string` as the format arg; the macro forwards to `snprintf(...fmt...)` needing `const char*` → "no matching function for call to snprintf". | Pass `"%s"` + `.c_str()`. |
+
+- **Status:** all three **Landed**.
+- **Still-open platform decision (NOT a bug):** `CMakeLists.txt` pins
+  `CMAKE_OSX_DEPLOYMENT_TARGET=11.0` (Big Sur), but C++23 `std::format<float>` needs libc++'s float
+  `to_chars`, available only on **macOS 13.3+**. This blocks every `std::format<float>` TU on macOS.
+  Deliberately **deferred** to a maintainer with a Mac (raise the floor to 13.3, or swap to fmtlib).
+  Documented in `0d0dae01`'s commit body. `build-macos` is continue-on-error so it does not gate CI.
+- **Earlier related macOS commit:** `a40ac4aa` (2026-04-20) fixed system-vs-Homebrew OpenAL header
+  paths (`OpenAL/al.h` vs `AL/al.h`), a `RHIStatistics` field mismatch in `MetalDevice.mm`, and a
+  `/MT` vs `/MD` CRT clash (`LNK1169`) in `SparkBuild/CMakeLists.txt`.
+
+---
+
+## Era 2 — The 2026-07-06/07 harden-fleet audit (14 lanes, 130 findings)
+
+A multi-agent hardening pass on branch `claude/harden-fleet`, later merged into `Working`. It found
+real concurrency/lifetime bugs and left a documented deferred queue.
+
+### 8. Data race in `SparkEngineCamera` state callback  — `0d3cbcbf` (checkpoint, 2026-07-06 20:19)
+- **Symptom:** Concurrency finding (audit "camera/profiler races"). `m_isTransitioning` and callback
+  dispatch were accessed inconsistently w.r.t. `m_stateMutex`; firing `NotifyStateChange()` *inside*
+  the lock risked re-entrant deadlock (the callback can re-enter the camera, e.g. `Console_GetState`,
+  and `m_stateMutex` is non-recursive).
+- **Root cause:** State callbacks were invoked while holding the non-recursive `m_stateMutex`;
+  `m_isTransitioning` lacked a documented locking discipline.
+- **Fix:** In `SetPosition` (and the transition path), mutate state under the lock, then release and
+  call `NotifyStateChange()` **outside** the lock. `m_isTransitioning` documented as "always accessed
+  under `m_stateMutex`". Files: `Camera/SparkEngineCamera.cpp`, `Camera/SparkEngineCamera.h`.
+- **Status:** **Landed.** Today `SparkEngineCamera.cpp` fires `NotifyStateChange()` outside the lock
+  ("Fire the callback outside the lock (see NotifyStateChange)"). Note: the "line 162" locator from
+  the audit lead is approximate — the file was heavily rewritten in this commit (~389 lines changed);
+  match on the *comment/pattern*, not the line number.
+
+### 9. AngelScript hot-reload left live scripts dangling  — `0d3cbcbf` (same commit)
+- **Symptom:** A single typo in a script during hot-reload could corrupt/dangle all live entity
+  scripts of that module (use-after-free class): the old approach detached and recompiled first, so a
+  failed compile left entity scripts referencing a discarded module.
+- **Root cause:** `ReloadScript` detached instances and discarded/recompiled the module **before**
+  knowing the new source compiled. A compile error then left live `asIScriptObject`s pointing into a
+  gone module.
+- **Fix:** Pre-validate — compile the new source into a throwaway staging module
+  (`moduleName + "$hotreload_stage"`) **before touching any live instances**; on failure, abort with
+  `SetLastError` and leave all live scripts intact; only on success detach/recompile/re-attach.
+  Also added per-class `[server]`/`[client]`/`[shared]` context recording. File:
+  `Engine/Scripting/AngelScriptEngine.cpp` / `.h`.
+- **Status:** **Landed.** Note: per-instance script state is **not** preserved across reload
+  (constructors re-run, fields reset) — by design, no `Serialize`/`Deserialize` hooks.
+
+### 10. The deferred "trilobite" queue  — handoff `1e45b87b`, mostly resolved by `52636dda`
+`HARDEN_FLEET_HANDOFF.md` (committed at `1e45b87b`, 2026-07-06 20:41) listed P0-inert and deferred
+P1/P2 items. **That doc is now stale** — most were fixed the next hour in `52636dda`
+(2026-07-06 21:44, "Phase 3 deferred cross-cutting fixes", suite green 5933 OK / 0 fail). Current status:
+
+| Item (from handoff) | Fixed in | Verified-present today | Status |
+|---|---|---|---|
+| Module `EngineContext` DLL-side export | `52636dda` | `SparkModuleInjectEngineContext` at `SparkSDK/Include/Spark/ModuleDllMain.h:88` | **Landed (part 1)** |
+| BT `Clone()` deep-copy no-op | `52636dda` | `BehaviorTreeNodes.h` / `BehaviorTreeTypes.h` | **Landed** |
+| `WeaponManager` `ownerEntity` always 0 | `52636dda` | `WeaponManager.cpp/.h` | **Landed** |
+| EditorUI UAF funnel (`SwapWorld`) | `52636dda` | `EditorUI::SwapWorld(...)` at `EditorUI.h:335` | **Landed** |
+| `HasUnsavedChanges` false-negative | `52636dda` | `UndoRedoManager.h` edit-sequence counter | **Landed** |
+| MMO DI `GetInstance()` fallback | `52636dda` | `MMOPlayerSystem.cpp`, `MMOWorldSetup.cpp` | **Landed** |
+| Localization `GetString` dangling ref | `52636dda` | `GetString`/`GetEntry` return `std::string` by value (`LocalizationSystem.h:71,137`) | **Landed** |
+| Sequencer audio never wired | `52636dda` | `Sequencer.cpp/.h` audio-cue dispatch | **Landed** |
+
+**Still genuinely deferred (open):**
+- **`NetworkManager::GetInstance()` per-module fallback removal** — `52636dda` explicitly kept it:
+  "load-bearing in bootstrap". Still present at `Networking/NetworkManager.cpp:130`. **Open / intentional.**
+- **ECS `SystemManager`/`PhaseSystemManager`/`StageBasedExecutor` triple** — the handoff asked to
+  consolidate; it is **NOT done**. All three still exist: `SystemManager` (`ECSystems.h:735`),
+  `PhaseSystemManager` (`PhaseSystemManager.h`), and `StageBasedExecutor`
+  (`ParallelSystemExecutor.h:378`). Worse, none is a cleanly-wired home: `StageBasedExecutor::ExecuteAll(dt)`
+  **is ticked every frame** (`GameplayLifecycleShared.cpp:1062`) but has **zero `RegisterSystem`
+  callers** (dead tick), while `PhaseSystemManager` is **defined-not-wired** (`CreatePhaseSystemManager`
+  has zero callers, `UpdateAll` never invoked). The shipping Core loop drives module systems via
+  `moduleManager->UpdateAll(dt)`. **Open** — an unresolved architectural weak point; see
+  `sparkengine-architecture-contract` Invariant 3 and `sparkengine-job-system-threading §1c`.
+- **Tooling/tests hygiene** (split `ConsoleApp.cpp`, single-source version string, wire 16 orphan
+  `Test*.cpp`) — treat as **open** unless a later commit says otherwise.
+
+### 11. Pre-existing Debug test-suite abort blocker (not from harden-fleet)
+- **Symptom:** The full **Debug** test run aborts at `TestConstantBufferRing_InitializeNullDeviceFails`
+  — `Initialize(nullptr)` hits `Assert::Fail` → `std::abort()` (asserts are active in Debug). Because
+  harden tests register last, they never execute in Debug.
+- **Workaround (from the handoff):** run the suite in **Release** (asserts are no-ops), or guard/skip
+  the null-device assert tests. This is a pre-existing condition on `Working`, not introduced by the branch.
+- **Status:** **Open** (workaround known). Re-check whether still present before relying on this.
+
+---
+
+## How to add a new entry (keep this file honest)
+
+When a hard bug is solved, append an entry with **all** of: symptom, root cause, fix commit hash +
+one-line description, and current status (Landed / Open / Candidate). **Never** write a claim you did
+not confirm with `git show`. Prefer matching on comment/pattern over line numbers — this codebase
+rewrites files wholesale during audits.
+
+---
+
+## Provenance and maintenance
+
+- **Authored:** 2026-07-07. All commit hashes confirmed ancestors of `Working` HEAD (`710f797e`) at
+  that date via `git merge-base --is-ancestor <hash> HEAD`.
+- **Not independently verifiable from this Windows host:** the macOS `.mm` fixes (`1b531e9f`,
+  `409c84e8`, `0d0dae01`, `a40ac4aa`) rely on `build-macos` CI; their commit bodies are the evidence.
+- **Could NOT locate in git history / left out:** no separate commit was found isolating the
+  "AngelScript UAF" or "camera race" as standalone fixes — both were part of the `0d3cbcbf` checkpoint
+  and are attributed there, not to a distinct "trilobite" commit (the word appears only in
+  `1e45b87b`'s message and `HARDEN_FLEET_HANDOFF.md`).
+
+Re-verify any entry with these one-liners (run from repo root, Git Bash):
+
+```bash
+# Full reasoning of any incident:
+git show 21b1a689   # ICF type-id      | git show d8685a2a  # C++23 gate
+git show 28f4ae8f   # editor bluescreen | git show 368c20fb  # Huber epsilon
+git show 0d3cbcbf   # camera race + AngelScript hot-reload (harden-fleet checkpoint)
+git show 52636dda   # Phase 3 deferred-queue fixes
+
+# Confirm a hash is still in Working:
+git merge-base --is-ancestor <hash> HEAD && echo IN || echo NOT
+
+# Spot-check that named fixes are still in the tree:
+grep -n "static char id" SparkEngine/Source/Core/EngineContext.h                 # ICF fix present
+grep -n "_MSC_VER >= 1936" SparkEngine/Source/Core/Platform.h                    # C++23 gate present
+grep -n "SwapWorld" SparkEditor/Source/Core/EditorUI.h                           # editor UAF funnel present
+grep -n "SparkModuleInjectEngineContext" SparkSDK/Include/Spark/ModuleDllMain.h  # module DLL export present
+grep -n "GetInstance" SparkEngine/Source/Engine/Networking/NetworkManager.cpp    # still-open fallback
+
+# The (now-stale) deferred queue:
+cat HARDEN_FLEET_HANDOFF.md
+```
+
+Before committing, lint this skill with the `skill-linter` skill (its script lives under
+`~/.claude/skills/skill-linter/`), passing `-Path` = this skill's folder.

--- a/.claude/skills/sparkengine-hot-reload-seam/SKILL.md
+++ b/.claude/skills/sparkengine-hot-reload-seam/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: sparkengine-hot-reload-seam
+description: >-
+  Reference for how SparkEngine's AngelScript hot-reload and client/server
+  script context separation actually work, and a checklist for exposing a new
+  scripted type/function so it survives a reload. TRIGGER when the user says
+  "script hot-reload", "reload the .as script", "why didn't my AngelScript
+  change take effect", "[server]/[client] script tag", "SetScriptContext",
+  "AttachScript returns false", "script state got wiped on reload", or "I added
+  a new function/type callable from AngelScript". DO NOT TRIGGER for C++ game
+  module hot-reload (that is the `ModuleHotReload` C++ class, a different code
+  path, not this skill), shader hot-reload (the `ShaderHotReload` C++ class), or
+  AngelScript sandbox/security questions (see the sandbox code directly) — those
+  are separate seams.
+trilobite_compatible: true
+trilobite_role: reference
+---
+
+# SparkEngine hot-reload seam (AngelScript scripts + client/server contexts)
+
+Runbook for the AngelScript scripting reload path in SparkEngine. Use it to
+answer "what happens to my script state when the file reloads", "why is my
+`[server]` class not attaching", and "I exposed a new native function/type — what
+do I have to do so it keeps working across a reload".
+
+**Jargon defined once:**
+- **Module** — one compiled AngelScript translation unit. Named after the `.as`
+  file's stem (e.g. `EnemyAI.as` -> module `EnemyAI`). Holds the compiled script
+  classes.
+- **Script instance** — one live object of a script class, bound to one ECS
+  `EntityID`. Holds an `asIScriptObject`, an `asIScriptContext`, and cached
+  pointers to `Start()/Update(float)/OnCollision(EntityID)`.
+- **Engine (native) API** — the C++ functions/types registered onto the
+  AngelScript engine (`print`, `getTransform`, `Vector3`, `Transform`, ...).
+  Registered **once** at `Initialize()`, and persists for the engine's lifetime.
+- **Script context** — `Shared` / `Server` / `Client`. A multiplayer authority
+  tag on a script class *and* a current-mode setting on the engine.
+
+## When NOT to use this skill — pick the right sibling
+
+| You are dealing with… | Go to instead |
+|---|---|
+| Reloading a compiled **C++ game module DLL** (`GameModules/`) | `SparkEngine/Source/Core/ModuleHotReload.cpp` |
+| Reloading **shaders** (HLSL/`.hlsl`) at runtime | `SparkEngine/Source/Graphics/ShaderHotReload.cpp` (+ `ShaderCompilation*.cpp`) |
+| AngelScript **sandbox / security levels / whitelists** | `SparkEngine/Source/Engine/Scripting/ScriptSandbox.{h,cpp}` |
+| **Visual scripting** graph -> AngelScript codegen | `SparkEngine/Source/Engine/Scripting/VisualScriptCompiler.cpp` |
+
+This skill is scoped to **AngelScript source (`.as`) hot-reload and script
+execution contexts only.**
+
+---
+
+## The two halves of AngelScript hot-reload (and the gap between them)
+
+Hot-reload is split across **two independent pieces** that are *not* wired
+together in the current tree. Know both, and know that the seam between them is
+currently **open** (candidate, not proven end-to-end).
+
+### Half 1 — the file watcher: `ScriptHotReloadManager`
+`SparkEngine/Source/Engine/Scripting/ScriptHotReload.{h,cpp}`
+
+- Polls tracked files on the **main thread** via `PollChanges()` (call once per
+  frame). It compares `std::filesystem::last_write_time` **and** `file_size`
+  against a stored snapshot; a change in either marks the file dirty.
+- **Debounces** with a default of **300 ms** (`m_debounceMs`, settable via
+  `SetDebounceMs`) so a mid-save editor write doesn't trigger a half-written
+  recompile. The debounce timer resets each time the file changes again.
+- Watches extensions **`.as`** and **`.angelscript`** by default
+  (`SetWatchExtensions` to override).
+- It does **not** compile anything itself. When a debounced change fires, it
+  calls whatever you handed to `SetRecompileCallback(...)`, which must return a
+  `RecompileResult`. Errors are pushed to `SetErrorCallback` and a bounded
+  ring of the last 10 errors (`MaxRecentErrors`).
+- Console: the `script_hotreload_status` command
+  (`SubsystemConsoleCommandsExt.cpp`) prints `Console_GetStatus()` if a
+  `ScriptHotReloadManager` is registered as an engine system.
+
+### Half 2 — the actual reload: `AngelScriptEngine::HotReloadModule`
+`SparkEngine/Source/Engine/Scripting/AngelScriptEngine.cpp` (private method, ~line 585)
+
+Given a module name, it does a **compile-first, swap-second** dance:
+
+1. Collect every entity script whose `moduleName` matches (entity + className).
+2. **Pre-validate**: compile the new source into a throwaway staging module
+   named `"<module>$hotreload_stage"`, then `Discard()` it. This is a compile
+   *probe only*.
+3. If the probe **fails**, abort: sets last-error, returns `false`, and **leaves
+   every live script untouched**. Nothing is detached. This is the key safety
+   property — a syntax typo during editing never wipes running scripts.
+4. If the probe **succeeds**: `DetachScript` each collected entity, recompile the
+   file under its canonical module name via `CompileScriptFile`, then
+   `AttachScript` each entity again with the same `className`.
+
+### The open seam (state this honestly)
+
+There is **no production call site** connecting Half 1's `SetRecompileCallback`
+to Half 2's `HotReloadModule`, and no production code registers a
+`ScriptHotReloadManager` or calls `HotReloadModule` outside its own class. The
+only production reference is the read-only `script_hotreload_status` console
+command. `HotReloadModule`'s behavior is exercised by a **mock reimplementation**
+in `Tests/TestAngelScriptEngine.cpp` (that file is a standalone mock — header
+comment: "Standalone reimplementation for CI testing without the AngelScript
+SDK"), not by the real class.
+
+> Status: **open / candidate.** Both halves exist and work in isolation; the
+> automatic file-watch -> recompile -> re-attach pipeline is **not currently
+> wired**. If you need it live, wire the watcher's recompile callback to call
+> `HotReloadModule(moduleStem)` and register the manager as an engine system.
+> Do not tell the user "just save the file and it reloads" — verify the wiring
+> first with the grep in Provenance.
+
+---
+
+## What state is preserved vs reset across a reload
+
+The header is explicit (`AngelScriptEngine.h`, `HotReloadModule` `@note`):
+**per-instance script state is NOT preserved. Constructors re-run and all fields
+reset. There are no `Serialize()`/`Deserialize()` hooks.**
+
+| Thing | Across `HotReloadModule` |
+|---|---|
+| Script object fields / member variables | **RESET** — the default factory `ClassName @ClassName()` re-runs from scratch |
+| `asIScriptObject` + `asIScriptContext` | **Recreated** (old ones `Release()`d in `CleanupScriptInstance`) |
+| Cached `Start()/Update(float)/OnCollision(EntityID)` pointers | **Rebuilt** by `CacheScriptMethods` |
+| Entity -> script binding (same `EntityID`, same `className`) | **Re-established** (detach then re-attach) |
+| `Start()` "already ran" flag | **Lost** — after reload `CallStart` will run `Start()` again if you call it |
+| Module -> file path map (`m_moduleFilePaths`) | **Survives** (re-set by `CompileScriptFile`) |
+| Class context tags (`m_classContexts`) | **Refreshed** — `RecordModuleContexts` re-reads tags; a class that *dropped* its `[server]`/`[client]` tag reverts to `Shared` |
+| Native/engine API (functions, `Vector3`, `Transform`) | **Untouched** — registered once at `Initialize()`; a module reload never re-registers them |
+
+**Gotchas:**
+- **No state migration.** If a script accumulates runtime state (health, timers,
+  AI blackboard) in member fields, that state is gone after a reload. Persist it
+  in the C++/ECS side if it must survive.
+- **Re-attach requires an exact-signature default factory.** `AttachScript`
+  looks up `"<Class> @<Class>()"`. If your edit renamed the class or removed the
+  default constructor, re-attach fails and the entity ends up scriptless.
+- **Method lookups are exact-decl.** `CacheScriptMethods` uses
+  `GetMethodByDecl("void Start()")`, `"void Update(float)"`,
+  `"void OnCollision(EntityID)"`. A signature that drifts (e.g.
+  `Update(double)`) silently won't be cached and won't be called.
+- **Constructors run under the sandbox.** The factory call installs the sandbox
+  line callback, so a runaway/expensive constructor can be aborted
+  (`asEXECUTION_ABORTED` + `WasTerminated()`).
+
+---
+
+## Client/server script context separation
+
+### The model
+- `enum class AngelScriptEngine::ScriptContext : uint8_t { Shared, Server, Client }`.
+- The **engine** has a current context `m_scriptContext` (default `Shared`),
+  set with `SetScriptContext(...)`.
+- Each **script class** is tagged in `.as` source with a metadata annotation
+  written **immediately before** the class declaration:
+  ```angelscript
+  [server] class SpawnController { /* ... */ }
+  [client] class Hud            { /* ... */ }
+  [shared] class Pickup         { /* ... */ }   // or no tag at all -> Shared
+  ```
+  Tags are matched **case-insensitively** (`RecordModuleContexts`). Untagged
+  classes are `Shared`.
+- After a module builds, `RecordModuleContexts` reads
+  `builder.GetMetadataForType(...)` and stores the result keyed as
+  `"module::class"` in `m_classContexts`. `Shared` results are *erased* from the
+  map (Shared is the implicit default).
+
+### The enforcement rule (READ THIS — real behavior differs from the naive reading)
+`AttachScript` calls `IsClassContextAllowed(classContext)`, which is exactly:
+
+```cpp
+if (classContext == ScriptContext::Shared) return true;   // Shared/untagged: always
+return classContext == m_scriptContext;                    // tagged: must match engine mode
+```
+
+So a **tagged** class attaches **only when the engine's current context is set to
+that same tag**. Consequences:
+
+| Engine `m_scriptContext` | `[shared]`/untagged class | `[server]` class | `[client]` class |
+|---|---|---|---|
+| `Shared` (**default**) | attaches | **REFUSED** | **REFUSED** |
+| `Server` | attaches | attaches | REFUSED |
+| `Client` | attaches | REFUSED | attaches |
+
+> Note the top-left/middle: under the **default** `Shared` engine context, a
+> `[server]` or `[client]` class is **refused**, because `Server != Shared`. The
+> mock in `Tests/TestAngelScriptEngine.cpp` has a looser "current==Shared runs
+> everything" rule (`ShouldRunScript`) — **the real engine does not.** Do not
+> rely on the mock's behavior.
+
+When refused, `AttachScript` returns `false` and logs an info-level message like
+`"Skipped attaching 'X': its [server] context conflicts with the current script
+execution context."` — it is **not** an error, so it's easy to miss.
+
+### Why it exists / what breaks if you get it wrong
+This is the multiplayer authority boundary: it keeps client-only logic (HUD,
+input feel, cosmetics) off the dedicated server, and server-only logic
+(spawning, authoritative damage, loot rolls) off clients. Failure modes:
+- **Forgot to call `SetScriptContext`.** Engine stays `Shared`, so **every**
+  `[server]`/`[client]` class silently fails to attach — the game runs with only
+  untagged scripts. `SetScriptContext(...)` is currently **not called anywhere in
+  production** (verify with the grep in Provenance), so this is the likely
+  default-state footgun.
+- **Set the wrong mode.** A dedicated server left in `Client` mode would refuse
+  its `[server]` authority scripts; a client in `Server` mode could run
+  server-authoritative logic locally (cheating / desync surface).
+
+---
+
+## Checklist: exposing a new AngelScript-callable type or function
+
+All native registration lives in `AngelScriptEngine.cpp` inside the
+`#ifdef SPARK_ANGELSCRIPT_SUPPORT` block and runs **once** from `Initialize()`
+via `RegisterEngineAPI()` (order: `RegisterMathTypes` -> `RegisterComponentTypes`
+-> `RegisterGlobalFunctions` -> `AutoRegisterReflectedTypes`). Because it runs at
+init and the engine is never torn down by a module reload, **anything you
+register here automatically survives hot-reload** — the reload only rebuilds the
+`.as` module, not the native API.
+
+### Adding a global function callable from scripts
+1. Write the native C++ function (convention: `ASYourFn`) and declare its
+   prototype in `AngelScriptEngine.h` (see the `ASPrint`, `ASGetTransform`,
+   ... block near the bottom).
+2. Register it in `RegisterGlobalFunctions()` (or `AutoRegisterReflectedTypes()`
+   for reflection helpers) via the guarded helper — **do not** call
+   `m_engine->RegisterGlobalFunction` directly:
+   ```cpp
+   RegisterGuardedFunction("float getStamina(EntityID)", "getStamina",
+                           asFUNCTION(ASGetStamina));
+   ```
+3. The **second argument (`scriptVisibleName`) must exactly match** the function
+   name in the declaration string. It is the key the sandbox uses for
+   whitelist/blacklist lookups (`m_sandbox->IsFunctionAllowed`).
+4. **Sandbox gotcha:** in **Strict** security mode only whitelisted names are
+   registered. If your function isn't on the allow list it is silently *not
+   bound*, and a script calling it fails at `BuildModule()` with an
+   undefined-symbol compile error. Add it via `ConfigureSandboxSecurity(level,
+   {"getStamina", ...})` **before** `Initialize()` (the sandbox is consulted once,
+   at registration time; configuring after `Initialize()` cannot retroactively
+   register or unregister anything).
+
+### Adding a value type (POD, like `Vector3`)
+In `RegisterMathTypes()`:
+```cpp
+m_engine->RegisterObjectType("MyVec", sizeof(MyVec),
+    asOBJ_VALUE | asOBJ_POD | asGetTypeTraits<MyVec>());
+m_engine->RegisterObjectProperty("MyVec", "float x", asOFFSET(MyVec, x));
+```
+
+### Adding a reference type (engine-owned, like `Transform`)
+In `RegisterComponentTypes()`:
+```cpp
+m_engine->RegisterObjectType("MyComp", 0, asOBJ_REF | asOBJ_NOCOUNT);
+m_engine->RegisterObjectProperty("MyComp", "Vector3 value", asOFFSET(MyComp, value));
+```
+`asOBJ_NOCOUNT` means AngelScript won't refcount it — only expose engine-owned
+objects returned by a native accessor (e.g. `getTransform`) this way.
+
+### Prefer reflection over hand-registration for components
+`getComponentField` / `setComponentField` / `hasComponent` are **generic and
+reflection-driven** (`AutoRegisterReflectedTypes`, backed by `ComponentFactory`
+and `TypeRegistry`). If your new component type is already reflected, scripts can
+read/write **any** of its fields by name **without touching AngelScriptEngine at
+all**. Only add a hand-written binding when you need a typed, ergonomic accessor.
+
+### Make sure it survives a reload (script-side checklist)
+Since the native side persists, the only reload risks are in the `.as` file:
+- [ ] Class keeps a **default factory** `ClassName @ClassName()` (no
+      argument-taking-only constructor).
+- [ ] Lifecycle methods keep **exact** signatures: `void Start()`,
+      `void Update(float)`, `void OnCollision(EntityID)`.
+- [ ] Class **name is unchanged** (re-attach uses the stored `className`).
+- [ ] Any `[server]`/`[client]` tag is intentional and the engine is in the
+      matching `SetScriptContext(...)` mode where the script must attach.
+- [ ] No reliance on member state persisting across reload (it won't).
+
+---
+
+## Fast reference — key symbols and files
+
+| Symbol / file | Role |
+|---|---|
+| `SparkEngine/Source/Engine/Scripting/ScriptHotReload.{h,cpp}` | File watcher (`PollChanges`, debounce, callbacks) |
+| `AngelScriptEngine::HotReloadModule` (`AngelScriptEngine.cpp:~585`) | Stage-compile, detach, recompile, re-attach |
+| `AngelScriptEngine::AttachScript` (`~800`) | Instantiates a class onto an entity; enforces context |
+| `AngelScriptEngine::RecordModuleContexts` (`~740`) | Reads `[server]/[client]/[shared]` metadata after build |
+| `AngelScriptEngine::IsClassContextAllowed` (`~421`) | The Shared-always / tag-must-match-engine rule |
+| `AngelScriptEngine::RegisterGuardedFunction` (`~1096`) | Sandbox-gated global-function registration |
+| `AngelScriptEngine::CacheScriptMethods` (`~1251`) | Exact-decl lookup of Start/Update/OnCollision |
+| `AngelScriptEngine::SetScriptContext / GetScriptContext` (`.h`) | Set/read engine's Shared/Server/Client mode |
+
+---
+
+## Provenance and maintenance
+
+Verified against the repo on **2026-07-07** (branch `Working`) by reading the
+source; all line numbers are approximate anchors, not exact addresses.
+
+Re-verify with these one-liners (run from `D:\SparkEngine`):
+
+```bash
+# Reload logic (staging compile, detach, re-attach) still lives here:
+grep -n "hotreload_stage\|DetachScript(binding\|AttachScript(binding" \
+  SparkEngine/Source/Engine/Scripting/AngelScriptEngine.cpp
+
+# The real context-enforcement rule (Shared-always / tag==engine):
+grep -n "IsClassContextAllowed\|classContext == m_scriptContext" \
+  SparkEngine/Source/Engine/Scripting/AngelScriptEngine.cpp
+
+# Metadata tags recognised for [server]/[client]/[shared]:
+grep -n "\"server\"\|\"client\"\|\"shared\"" \
+  SparkEngine/Source/Engine/Scripting/AngelScriptEngine.cpp
+
+# CONFIRM the open seam is still open (expect: only a console status ref;
+# NO production SetRecompileCallback->HotReloadModule wiring, NO SetScriptContext call):
+grep -rn "HotReloadModule\|SetRecompileCallback\|SetScriptContext" \
+  --include=*.cpp SparkEngine/Source SparkEditor/Source SparkConsole/src GameModules \
+  | grep -v "AngelScriptEngine.cpp:"
+
+# Default watch extensions + debounce:
+grep -n "\.angelscript\|m_debounceMs" \
+  SparkEngine/Source/Engine/Scripting/ScriptHotReload.h
+
+# Native API registration entry point + guarded helper:
+grep -n "RegisterEngineAPI\|RegisterGuardedFunction\|RegisterObjectType" \
+  SparkEngine/Source/Engine/Scripting/AngelScriptEngine.cpp
+```
+
+If the last grep starts returning a production call that hands the watcher's
+recompile callback to `HotReloadModule` (or calls `SetScriptContext` at
+startup), update the "open seam" and "forgot to call SetScriptContext" notes —
+the pipeline would then be wired and those caveats retired.

--- a/.claude/skills/sparkengine-job-system-threading/SKILL.md
+++ b/.claude/skills/sparkengine-job-system-threading/SKILL.md
@@ -1,0 +1,389 @@
+---
+name: sparkengine-job-system-threading
+description: >-
+  SparkEngine concurrency and threading-discipline runbook: the real JobSystem /
+  ThreadSafeQueue / StageBasedExecutor / ParallelPerception APIs, the ECS phase
+  barriers, per-subsystem thread-safety rules, and a checklist for parallelizing a
+  new system without data races. TRIGGER when: "parallelize this system", "is it
+  safe to call from a worker thread", "add a job", "JobSystem", "Submit / ParallelFor",
+  "which stage does my system run in", "data race / crash under TSan", "can I touch the
+  ECS from a background thread", "thread-safe queue", "Jolt physics threads". DO NOT
+  TRIGGER for: performance profiling / measuring / optimizing hot paths (use the global
+  perf-hotpath skill), rendering-backend RHI work, or networking protocol logic.
+trilobite_compatible: true
+trilobite_role: concurrency
+---
+
+# SparkEngine — Job System & Threading Discipline
+
+This is a **correctness runbook** for concurrency in SparkEngine. It tells you which
+threading primitives actually exist, where the synchronization barriers are, what each
+subsystem's thread-safety contract is, and how to add parallel work without introducing
+a data race. It is not a performance guide — for measuring or tuning hot paths use the
+global **perf-hotpath** skill instead.
+
+Jargon defined once:
+- **Job** — a callable (lambda) handed to the thread pool to run on a worker thread.
+- **Worker thread** — one of N background threads owned by `JobSystem` that pull jobs.
+- **Main thread** — the game/render thread that owns the ECS registry, physics, and D3D.
+- **Barrier / join point** — a place where the main thread waits for all outstanding
+  jobs to finish (`future.get()`) before continuing. This is what makes parallel code
+  deterministic between phases.
+- **ECS stage/phase** — a bucket in the fixed engine update order.
+
+---
+
+## 0. The one invariant you must never break
+
+The ECS update order is fixed and load-bearing (stated in `CLAUDE.md`, enforced by
+`SystemStage` in `ParallelSystemExecutor.h`):
+
+```
+Physics -> Animation -> AI -> Audio -> Lifecycle -> Render
+```
+
+Systems **within** one stage may run in parallel. Stages **never** overlap: the engine
+joins all jobs from a stage before starting the next. Do not reorder stages, and do not
+let one stage's work leak into the next without a join.
+
+---
+
+## 1. The real primitives (read the headers, don't invent)
+
+There is **no** custom "task graph" or "fiber" abstraction. There are exactly these
+building blocks. Every claim below was verified against the source on 2026-07-07.
+
+### 1a. `Spark::JobSystem` — the one thread pool
+`SparkEngine/Source/Utils/JobSystem.h` (header-only singleton).
+
+| Call | Signature | Notes |
+|------|-----------|-------|
+| Get | `JobSystem& JobSystem::Get()` | Meyers singleton. |
+| Submit | `auto Submit(F&& f, Args&&...) -> std::future<...>` | Enqueue one job, get a future. |
+| ParallelFor | `void ParallelFor(int begin, int end, Func&& body, int minBatchSize = 1)` | Splits `[begin,end)` into batches, submits each, **blocks until all done**. Runs inline if no workers or range `<= minBatchSize`. |
+| WaitForAll | `void WaitForAll()` | Submits an empty barrier job and blocks on it. |
+| GetWorkerCount | `uint32_t GetWorkerCount() const` | 0 means "no pool — run inline". |
+| IsInitialized | `bool IsInitialized() const` | Check before dispatching. |
+| GetPendingJobCount | `size_t GetPendingJobCount() const` | Queue depth snapshot. |
+| Initialize | `void Initialize(uint32_t numThreads = 0)` | `0` = `hardware_concurrency() - 1`. **You almost never call this** — see below. |
+| Shutdown | `void Shutdown()` | Joins all workers; pending jobs are drained first. |
+
+Lifecycle you do NOT own:
+- Initialized **once** at engine boot via `EngineBootstrap` in
+  `SparkEngine/Source/Core/EngineSetup.h` (`js.Initialize(0)`).
+- Shut down in `SparkEngine/Source/Core/SparkEngine.cpp` (`JobSystem::Get().Shutdown()`),
+  after all subsystems that submit jobs. **Do not call `Initialize` or `Shutdown`
+  yourself** in gameplay/system code — just `Get()` and use it.
+
+Safety properties baked into the pool (verified in `JobSystem.h`):
+- A job that throws does **not** kill the worker: the worker `try/catch`es and logs via
+  `SPARK_LOG_ERROR`. A fire-and-forget exception is swallowed after logging; an exception
+  in a `Submit`-with-future job is re-thrown at `future.get()`.
+- The pool has a **fixed** worker count. See the deadlock rule in §5.
+
+### 1b. `Spark::ThreadSafeQueue<T>` — producer/consumer FIFO
+`SparkEngine/Source/Utils/ThreadSafeQueue.h`.
+
+Mutex-guarded bounded FIFO. **No condition variable** — consumers poll or drain each
+frame; nobody blocks waiting for an item. Verified signatures (note: pop is
+out-parameter + `bool`, NOT `std::optional`):
+
+```cpp
+bool TryPush(T item);      // false if at capacity
+void ForcePush(T item);    // ignores capacity
+bool TryPop(T& out);       // false if empty (never blocks)
+void PopAll(std::vector<T>& out);  // drain all, batch-efficient
+size_t Size() const; bool IsEmpty() const; void Clear();
+```
+
+Constructor: `explicit ThreadSafeQueue(size_t maxSize = 0)` — `0` = unbounded.
+Used by `NetworkManager` (message I/O), `JobSystem` distribution, and audio command
+buffering.
+
+### 1c. `Spark::ECS::StageBasedExecutor` — the live ECS stage runner
+`SparkEngine/Source/Engine/ECS/Systems/ParallelSystemExecutor.h` + `.cpp` (singleton).
+
+This is the executor actually ticked by the main loop. Runs systems **within** a stage
+in parallel on `JobSystem`, joins, then advances to the next stage — preserving the §0
+order.
+
+```cpp
+enum class SystemStage : uint8_t { Physics, Animation, AI, Audio, Lifecycle, Render, Count };
+
+StageBasedExecutor& StageBasedExecutor::GetInstance();
+void RegisterSystem(const std::string& name, SystemStage stage, std::function<void(float)> fn);
+void ExecuteAll(float dt);   // stages sequential; systems in a stage parallel-then-joined
+void Shutdown();
+std::string Console_GetStatus() const;
+```
+
+Wiring status (verified 2026-07-07): `ExecuteAll(dt)` **is** called every frame from
+`SparkEngine/Source/Core/Lifecycle/GameplayLifecycleShared.cpp`
+(`StageBasedExecutor::GetInstance().ExecuteAll(dt)`), and `Shutdown()` is called on
+teardown. **However, no `RegisterSystem(...)` call exists anywhere in the codebase**
+(only the definition). So today this is a **dead tick**: the executor is invoked but has
+zero registered systems. This is exactly the ECS-consolidation debt called out in
+`HARDEN_FLEET_HANDOFF.md` ("register systems into `StageBasedExecutor` (dead tick)").
+If you are adding a system to run in a stage, this is the API to register it against —
+but be aware nothing else is registered yet, so verify the tick path end-to-end.
+
+### 1d. `Spark::ECS::ParallelSystemExecutor` — access-set batching (present, NOT wired)
+Same header. A **different, non-singleton** class that auto-derives parallel batches
+from declared component read/write sets (not from stages):
+
+```cpp
+void DeclareAccess(ISystem*, unordered_set<type_index> reads, unordered_set<type_index> writes);
+template<class...> void DeclareReads(ISystem*);   // convenience
+template<class...> void DeclareWrites(ISystem*);
+void BuildSchedule();                 // groups into conflict-free batches
+void Execute(World& world, float dt); // batches sequential; systems in a batch parallel-joined
+size_t GetBatchCount() const;
+std::string Console_GetScheduleInfo() const;
+```
+
+Conflict rule enforced by `CanAddToBatch`: two systems may share a batch only if there
+is **no** write-write, write-read, or read-write overlap on any component type.
+
+Wiring status (verified 2026-07-07): defined and configured by
+`ConfigureParallelExecution(...)` in `SparkEngine/Source/Engine/ECS/ECSIntegration.h`,
+but `ConfigureParallelExecution` is **never called** from any `.cpp`, and no live
+`Execute(world, dt)` call exists. Treat this class as **candidate / not wired into the
+live tick** — do not assume registering here runs anything. `StageBasedExecutor` (§1c) is
+the live path.
+
+> Relationship note (accurate, not a guess): the handoff's phrase
+> "`SystemManager`/`PhaseSystemManager`/`StageBasedExecutor`" refers to three *ordering*
+> managers. `ParallelSystemExecutor` is a **fourth**, related class — the access-set
+> batcher. `PhaseSystemManager` (`PhaseSystemManager.h`) once dispatched through a single
+> global `ParallelSystemExecutor` and that parallel path was **removed** because batching
+> across all phases silently discarded phase ordering (Render could beat Physics); it now
+> runs **serially** (see the `UpdateAll` note in `PhaseSystemManager.h`). Correct
+> per-phase parallelism would need one executor per phase.
+
+### 1e. `Spark::AI::ParallelPerceptionSystem` — gather / process / writeback (WIRED)
+`SparkEngine/Source/Engine/AI/ParallelPerception.h` + `.cpp`. This is the reference
+example of doing ECS work in parallel **safely**:
+
+1. `RebuildSpatialIndex(world)` — main thread builds an Octree from entity positions.
+2. `GatherAgentData(world)` — main thread snapshots each agent into an `AgentPerceptionJob`
+   struct. **Workers never touch the ECS registry.**
+3. `UpdateAllAgents(world, time)` — dispatches `JobSystem::ParallelFor` over the agent
+   array; each worker reads the immutable Octree and writes only its own job struct.
+4. `WriteBackResults(world)` — main thread copies results back into ECS components.
+
+Wired 2026-04-14: owned/ticked by `Spark::AI::AIIntegratedSystem` (`AIIntegration.h`),
+initialized from `GameplayLifecycleShared.cpp`. `SetMinBatchSize(int)` gates against
+thread-pool overhead for small agent counts.
+
+### 1f. Jolt physics job pool (separate from `Spark::JobSystem`)
+`SparkEngine/Source/Physics/PhysicsSystem.cpp` creates its **own** internal pool:
+`JPH::JobSystemThreadPool(cMaxPhysicsJobs, cMaxPhysicsBarriers, hardware_concurrency()-1)`.
+This is Jolt's internal parallelism for the simulation step — it is **not**
+`Spark::JobSystem`, and you do not submit to it. See §3 for the caller-facing contract.
+
+---
+
+## 2. Where the barriers are
+
+A "barrier" here = the main thread blocking until a group of jobs finishes. Know these
+so you never read a result before it's produced:
+
+| Barrier | Code | What it guarantees |
+|---------|------|--------------------|
+| Between ECS stages | `StageBasedExecutor::ExecuteAll` loops stages; per stage it `Submit`s each system then `for (f : futures) f.get();` before the next stage | Stage N fully completes before stage N+1 starts. |
+| Between access-batches | `ParallelSystemExecutor::Execute` joins each batch's futures before the next batch | No conflicting batch overlaps (when wired). |
+| End of a parallel loop | `JobSystem::ParallelFor` collects all batch futures and `.get()`s them before returning | Every index processed before the call returns. |
+| Explicit drain | `JobSystem::WaitForAll()` | All currently-queued jobs done (submits a sentinel and blocks). |
+| Any single result | `future.get()` on the future from `Submit` | That one job is done; re-throws its exception if it threw. |
+
+Single-system stages/batches run **inline on the main thread** (no dispatch), so their
+"barrier" is trivially the function returning.
+
+Fault isolation wrapper: system updates dispatched by the executors are wrapped in
+`SPARK_GUARDED_UPDATE(name, category, { ... })` (`SparkEngine/Source/Core/FaultIsolation.h`).
+It `try/catch`es the body and reports the fault instead of propagating — so an exception
+in a stage system is contained, not a crash. Wrap your own dispatched system body the
+same way for parity.
+
+---
+
+## 3. Per-subsystem thread-safety contract
+
+From `CLAUDE.md`, cross-checked against the actual code. "Main-thread-only" means: call
+its public methods **only** from the game/render thread, never from a `JobSystem` worker.
+
+| Subsystem | Contract | Verified detail |
+|-----------|----------|-----------------|
+| `Spark::JobSystem` | Thread-safe to `Submit`/query from any thread | Mutex + CV around the queue. |
+| `Spark::ThreadSafeQueue<T>` | Thread-safe | Single mutex; no CV (poll/drain). |
+| `SimpleConsole` | Thread-safe | Mutex-guarded log sink. |
+| `Logger` / `SPARK_LOG_*` | Thread-safe from any thread | Async writer thread + atomic levels. |
+| `NetworkManager` | Queue mutex for message I/O + handler registration | `CLAUDE.md`. The wiki documents a 4-mutex lock order (`state -> queue -> handler`, with `clients`/`input` separate) — treat that ordering as the deadlock-avoidance rule if you touch it. |
+| `GraphicsEngine` | **Main-thread render**; `std::atomic` frame state | Do not issue draws/resource creation off-thread. |
+| `PhysicsSystem` | **Public API is main-thread-only**, even though the *simulation* is multithreaded | `CLAUDE.md` says "supports multithreaded job dispatch" — that refers to Jolt's **internal** `JPH::JobSystemThreadPool` used during the step, NOT the caller API. All raycasts, body edits, and queries must come from the main thread. Do not call `PhysicsSystem` from a worker. |
+| ECS registry (EnTT `World`) | **Main-thread-only** | Never read/iterate/mutate from a worker. Use the gather/writeback pattern (§1e). |
+| `ParallelSystemExecutor` / `StageBasedExecutor` | The executor object is **not** thread-safe; call from main thread only. The *systems it dispatches* run on workers. | Header `@threadsafety` note. |
+| `ParallelPerceptionSystem` | Gather/Writeback on main; per-agent processing on workers | Workers touch only snapshot structs + immutable Octree. |
+| `CoroutineScheduler` | Main-thread-only | Resumes on main thread each frame. |
+
+The single most common bug this skill prevents: **touching the EnTT `World` or
+`PhysicsSystem` from inside a `JobSystem::Submit`/`ParallelFor` body.** Don't. Snapshot on
+the main thread first.
+
+---
+
+## 4. Checklist — "I want to parallelize a new system safely"
+
+Work top to bottom. Stop at the first row that says stop.
+
+1. **Do you even need threads?** If the work is < a few hundred microseconds or touches
+   the ECS/physics/graphics directly, keep it on the main thread. Parallelism has join
+   overhead. (For "is it actually a hot path", measure first — see **perf-hotpath**.)
+
+2. **Does your job body touch shared mutable state?** The EnTT `World`, `PhysicsSystem`,
+   `GraphicsEngine`, any singleton without a documented thread-safe contract in §3?
+   - If **yes** → you cannot dispatch it as-is. Use the **gather / process / writeback**
+     pattern: on the main thread, copy the inputs each job needs into per-job POD structs
+     (see `AgentPerceptionJob` in `ParallelPerception.h`); dispatch jobs that read only
+     those structs + immutable shared data; write results back on the main thread after
+     the join. Each job must write only to **its own** slot — never a shared container
+     without a lock.
+   - If **no** (pure computation over private/snapshot data) → continue.
+
+3. **Pick the dispatch primitive:**
+   - Uniform work over an index range → `JobSystem::Get().ParallelFor(0, n, body, minBatch)`.
+     Set `minBatch` so tiny ranges run inline (perception uses 4).
+   - A handful of independent one-off tasks → `JobSystem::Get().Submit(lambda)` per task,
+     then `future.get()` each before you use results (pattern used in
+     `GameplayLifecycleShared.cpp` `UpdateNonECSSystems`).
+   - A whole ECS system that should run inside a stage → register it with
+     `StageBasedExecutor::GetInstance().RegisterSystem(name, SystemStage::X, fn)`.
+     **Caveat (see §1c):** this is the *intended-but-unfinished* parallel path.
+     Its `ExecuteAll(dt)` tick is live (called every frame from
+     `GameplayLifecycleShared.cpp`), but **zero other systems are registered into
+     it today**, and the intended-canonical `PhaseSystemManager` is not wired at
+     all — so "where an ECS system runs" is a known OPEN architectural weak point
+     (see `sparkengine-architecture-contract` Invariant 3). Registering here does
+     tick, but verify the whole path end-to-end and flag the wiring gap rather
+     than assuming this is a settled home.
+
+4. **Gate on pool availability.** Before dispatching, check
+   `jobs.IsInitialized() && jobs.GetWorkerCount() > 0`; fall back to an inline loop
+   otherwise (this is exactly what `StageBasedExecutor::ExecuteAll` and
+   `UpdateNonECSSystems` do). `ParallelFor` already handles the zero-worker case.
+
+5. **Never block a worker on another job.** Do not call `future.get()` (or otherwise wait
+   on other jobs) *from inside* a job body. The pool has a fixed worker count; a job that
+   waits for a job that has no free worker to run = deadlock (deadlock rule 3 in the wiki).
+   Fan out and join **only** on the main thread.
+
+6. **Respect the stage boundary.** Anything that reads another stage's output must run in
+   a later stage (or after the join). Do not assume ordering *within* a parallel batch.
+
+7. **Wrap the dispatched body** in `SPARK_GUARDED_UPDATE(name, category, { ... })` if it's
+   an engine system update, so a fault is isolated rather than crashing (matches §2).
+
+8. **Prove it.** Build and run the ASan and TSan CI jobs — `build-linux-asan` and
+   `build-linux-tsan` (see `CLAUDE.md` CI table). TSan is the one that catches data
+   races. Add/adjust a test under `Tests/`.
+
+Copy-paste skeleton (snapshot + ParallelFor + writeback):
+
+```cpp
+// --- main thread ---
+std::vector<MyJobData> jobs;                 // POD snapshot, one slot per work item
+GatherInputsFromECS(world, jobs);            // main-thread reads only
+
+auto& js = Spark::JobSystem::Get();
+if (js.IsInitialized() && js.GetWorkerCount() > 0)
+{
+    js.ParallelFor(0, (int)jobs.size(),
+        [&jobs](int i) { ProcessOne(jobs[i]); },   // touches ONLY jobs[i] + const data
+        /*minBatchSize*/ 4);                        // ParallelFor joins before returning
+}
+else
+{
+    for (auto& j : jobs) ProcessOne(j);          // inline fallback
+}
+
+WriteResultsBackToECS(world, jobs);          // main-thread writes only
+```
+
+---
+
+## 5. Quick "is this safe?" decision table
+
+| You want to... | Safe? | Do this |
+|----------------|-------|---------|
+| Read the ECS `World` inside a `Submit`/`ParallelFor` body | NO | Snapshot on main thread first (§1e/§4). |
+| Call any `PhysicsSystem` method from a worker | NO | Queue it; run on main thread. |
+| Issue a D3D draw / create a GPU resource off-thread | NO | Main thread only. |
+| `SPARK_LOG_*` from a worker | YES | Logger is async + thread-safe. |
+| Push/pop a `ThreadSafeQueue` from two threads | YES | That's its job. |
+| `future.get()` inside a worker job | NO | Deadlock risk (fixed pool). Join on main. |
+| Reorder ECS stages to "optimize" | NO | §0 invariant. |
+| Register a system into `StageBasedExecutor` and expect it to tick | PARTIAL | The tick is called, but nothing is registered yet (§1c) — verify end-to-end. |
+
+---
+
+## 6. When NOT to use this skill (use a sibling instead)
+
+- **Measuring/optimizing a hot path, picking what to parallelize for speed** → global
+  **perf-hotpath** skill. This skill only covers *correctness* of concurrency.
+- **RHI / render-backend threading, GPU command lists** → no dedicated skill in this
+  tree; read `SparkEngine/Source/Graphics/RHI/` directly (`RHIFactory`, backend devices).
+- **Network protocol, packet handling, AreaServer/WorldServer logic** → no dedicated
+  skill in this tree; read `SparkEngine/Source/Engine/Networking/` and
+  `wiki/advanced/Threading-Model.md` (this skill only states `NetworkManager`'s
+  thread-safety contract).
+- **Full threading reference / every primitive in the engine** → the wiki page
+  `wiki/advanced/Threading-Model.md` is the exhaustive catalog; this skill is the
+  action-oriented subset for adding parallel work safely.
+
+---
+
+## Provenance and maintenance
+
+All facts verified against source on **2026-07-07** (branch `Working`). Re-verify with:
+
+```bash
+# JobSystem API surface (Submit / ParallelFor / Initialize / Shutdown)
+grep -nE 'Submit|ParallelFor|void (Initialize|Shutdown)|GetWorkerCount|IsInitialized' \
+  SparkEngine/Source/Utils/JobSystem.h
+
+# ThreadSafeQueue signatures (TryPop is bool + out-param, not optional)
+grep -nE 'TryPush|ForcePush|TryPop|PopAll' SparkEngine/Source/Utils/ThreadSafeQueue.h
+
+# Stage order + StageBasedExecutor / ParallelSystemExecutor API
+grep -nE 'enum class SystemStage|RegisterSystem|ExecuteAll|DeclareReads|DeclareWrites|BuildSchedule|void Execute' \
+  SparkEngine/Source/Engine/ECS/Systems/ParallelSystemExecutor.h
+
+# Is StageBasedExecutor still a DEAD TICK? (definition should be the ONLY hit)
+grep -rn 'RegisterSystem(' SparkEngine/Source | grep -i stage
+
+# Confirm the live tick site
+grep -n 'StageBasedExecutor::GetInstance().ExecuteAll' \
+  SparkEngine/Source/Core/Lifecycle/GameplayLifecycleShared.cpp
+
+# Is ParallelSystemExecutor wired yet? (ConfigureParallelExecution should have NO .cpp caller)
+grep -rn 'ConfigureParallelExecution' SparkEngine/Source --include='*.cpp'
+
+# Jolt's own thread pool (separate from Spark::JobSystem)
+grep -n 'JobSystemThreadPool' SparkEngine/Source/Physics/PhysicsSystem.cpp
+
+# Where the Spark JobSystem is actually initialized/shut down (do NOT do this yourself)
+grep -n 'js.Initialize' SparkEngine/Source/Core/EngineSetup.h
+grep -n 'JobSystem::Get().Shutdown' SparkEngine/Source/Core/SparkEngine.cpp
+```
+
+Volatile claims to re-check when they may have changed:
+- **`StageBasedExecutor` dead-tick status** (§1c) — flips the moment someone adds a
+  `RegisterSystem` call. Re-run the grep above.
+- **`ParallelSystemExecutor` unwired status** (§1d) — flips when `ConfigureParallelExecution`
+  gets a caller.
+- **`PhaseSystemManager` serial-only** (§1d note) — re-read the `UpdateAll` comment in
+  `PhaseSystemManager.h`; per-phase parallelism was an open item.
+
+Companion reference (exhaustive, not a substitute): `wiki/advanced/Threading-Model.md`,
+`wiki/subsystems/Job-System.md`. If this skill and the wiki disagree, trust the **header
+source** and update both.

--- a/.claude/skills/sparkengine-module-injection-p0-campaign/SKILL.md
+++ b/.claude/skills/sparkengine-module-injection-p0-campaign/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: sparkengine-module-injection-p0-campaign
+description: >-
+  Decision-gated campaign to finish and verify the SparkEngine "module EngineContext
+  injection" P0 — the cross-DLL fix that makes EngineContext::Get() inside a game-module
+  DLL resolve to the host engine's live context instead of a dead per-image copy.
+  TRIGGER when: someone says the module DI / EngineContext injection P0 is "landed but inert",
+  when module-side service-locator lookups (NetworkManager, GetNetwork) return null or a wrong
+  singleton inside a GameModules DLL, when a HARDEN_FLEET / trilobite handoff lists
+  "SparkModuleInjectEngineContext export still needed", or when a rebuilt module DLL must be
+  proven to export the injection hook. DO NOT TRIGGER for general "how do I add a new module DLL"
+  questions (use sparkengine-plugin-abi), for the ImGui or console injection hooks specifically
+  (those already shipped), or for non-Windows builds (this whole seam is #if defined(_WIN32) only).
+trilobite_compatible: true
+trilobite_role: campaign
+---
+
+# SparkEngine — Module EngineContext Injection P0 Campaign
+
+## Status as of 2026-07-07: this P0 is ALREADY COMPLETE at source level
+
+Do not fabricate remaining work. Read this section first, run Gate 0, then decide.
+
+The handoff doc `HARDEN_FLEET_HANDOFF.md` (branch `claude/harden-fleet`) lists this as
+"P0 landed but INERT — finish first". That doc is **stale**. As verified against the live
+tree on 2026-07-07, commit `52636dda` ("feat(harden-fleet): Phase 3 deferred cross-cutting
+fixes") landed the missing pieces and is **in the current `HEAD` history**. Specifically:
+
+| Piece the handoff said was missing | Reality now | Where |
+|---|---|---|
+| DLL-side export `SparkModuleInjectEngineContext` | **EXISTS** | `SparkSDK/Include/Spark/ModuleDllMain.h` lines ~88-91 |
+| Host-side `GetProcAddress` lookup | **EXISTS**, symbol name matches exactly | `SparkEngine/Source/Core/ModuleManager.cpp` lines ~191-196 |
+| `EngineContext::SetInjected` + `Get()` preference | **EXISTS** | decl `EngineContext.h:143`; def `EngineContext.cpp:29-43` |
+| MMO DI (`MMOPlayerSystem.cpp`, `MMOWorldSetup.cpp`) | **FIXED** — both call `m_context->GetNetwork()` | see Gate 4 |
+| Remove NetworkManager's dead per-module `GetInstance()` fallback | **PARTIAL** — routed through context first; static fallback still present (see "Open item") | `NetworkManager.cpp:130-145` |
+
+**The only load-bearing gap left is the built binaries, not the source.** The shipped module
+DLLs in `build/windows-release/bin/` are dated 2026-07-05 — *older than* the 2026-07-07 export
+commit. They carry `SparkModuleInjectConsole` and `SparkModuleInjectImGui` but **not**
+`SparkModuleInjectEngineContext`. Until you rebuild, the export is dead in the binaries even
+though it is live in source. **Finishing this P0 today = rebuild + verify + wire-in check, not
+new code.**
+
+This skill doubles as documented precedent: the "if you find it NOT done" branches below record
+exactly what the campaign *was*, so the next inert-P0 (there are more in the handoff's Deferred
+list) can follow the same gated shape.
+
+For general module-DLL ABI/conventions (how to author a *new* module, `SPARK_IMPLEMENT_MODULE`,
+export naming), see the sibling skill **`sparkengine-plugin-abi`**. This skill is only the
+finish-and-verify campaign for the EngineContext-injection P0.
+
+---
+
+## Vocabulary (defined once)
+
+- **Module DLL** — a `GameModules/SparkGame*/` shared library, statically linked against
+  `SparkEngineLib`. Because the link is static, every DLL gets its *own private copy* of engine
+  globals (`g_engineContext`, `GImGui`, the console singleton).
+- **Per-image copy** — a global that exists once *per loaded binary image* (the .exe and each
+  .dll each have their own). The module's `g_engineContext` is null because only the host .exe
+  ever populated *its* copy.
+- **Injection hook** — an `extern "C" __declspec(dllexport)` function the host calls via
+  `GetProcAddress` right after `LoadLibrary`, handing the DLL a raw pointer to a host-owned
+  object so the DLL's per-image global points at the real thing.
+- **Service locator** — `EngineContext::Get()->GetX()`. Inside a module this is the ONLY
+  correct way to reach a subsystem; the DI fix is what makes it work there.
+- **Inert / dead-in-binary** — code that is correct in source but not present in the compiled
+  artifact because the artifact is stale.
+
+---
+
+## The campaign, gate by gate
+
+Run every gate in order. Each gate has an **EXPECTED** observation. If the observation matches,
+advance. If it does not, take the labeled **FAIL branch**.
+
+### Gate 0 — Confirm which world you are in (30 seconds)
+
+```bash
+# From repo root D:\SparkEngine
+git merge-base --is-ancestor 52636dda HEAD && echo "P0-COMMIT-PRESENT" || echo "P0-COMMIT-ABSENT"
+```
+
+- **EXPECTED (normal case):** `P0-COMMIT-PRESENT`. The source-level P0 is done; skip to Gate 3
+  (rebuild) — Gates 1-2 are just confirmation you can spot-check.
+- **FAIL branch (`P0-COMMIT-ABSENT`):** you are on a branch that predates the fix (e.g. a fork
+  of the raw `claude/harden-fleet` checkpoint). The source work below is genuinely undone — do
+  Gates 1-2 as *edits*, using the exact code blocks, then continue.
+
+### Gate 1 — DLL-side export exists
+
+```bash
+grep -n "SparkModuleInjectEngineContext" SparkSDK/Include/Spark/ModuleDllMain.h
+```
+
+- **EXPECTED:** one hit at the `extern "C" __declspec(dllexport)` definition (~line 88). The
+  body must be exactly:
+
+  ```cpp
+  extern "C" __declspec(dllexport) void SparkModuleInjectEngineContext(void* ctx)
+  {
+      EngineContext::SetInjected(static_cast<EngineContext*>(ctx));
+  }
+  ```
+
+  It must sit **inside** the file's `#if defined(_WIN32)` block, and the file must
+  `#include "Core/EngineContext.h"` above it (present at ~line 76). No new include of your own
+  is needed — module TUs already have the engine `Source/` tree on their include path.
+
+- **FAIL branch (missing):** add the block above immediately after the existing
+  `SparkModuleInjectConsole` export (mirror its shape — same file already exports Console and
+  ImGui hooks, so the pattern is right there). Add the `#include "Core/EngineContext.h"` if
+  absent. Do **not** put this in a new file — it must compile into the module's DllMain TU
+  (`GameModules/SparkGame*/Source/Core/Main.cpp`, which `#include <Spark/ModuleDllMain.h>` and
+  calls `SPARK_IMPLEMENT_MODULE`). Putting the export elsewhere risks it being stripped or
+  duplicated.
+
+### Gate 2 — Host side calls the exact symbol name, and the setter exists
+
+```bash
+grep -n "SparkModuleInjectEngineContext\|InjectContextFn\|SetInjected\|g_injectedContext" \
+  SparkEngine/Source/Core/ModuleManager.cpp SparkEngine/Source/Core/EngineContext.cpp
+```
+
+- **EXPECTED — host lookup** (`ModuleManager.cpp` ~191-196, inside `#ifdef _WIN32`, after the
+  Console-inject block and before the ImGui-inject block):
+
+  ```cpp
+  using InjectContextFn = void (*)(void*);
+  if (auto injectCtx = reinterpret_cast<InjectContextFn>(
+          GetProcAddress(static_cast<HMODULE>(handle), "SparkModuleInjectEngineContext")))
+  {
+      injectCtx(EngineContext::Get());
+  }
+  ```
+
+  The string literal `"SparkModuleInjectEngineContext"` must be **byte-identical** to the
+  exported symbol from Gate 1 — a single typo makes `GetProcAddress` return null and the whole
+  fix silently no-ops (the `if` just skips). This is the #1 way this class of bug hides.
+
+- **EXPECTED — setter / preference** (`EngineContext.cpp`): a file-scope
+  `static EngineContext* g_injectedContext = nullptr;`, `Get()` returns `g_injectedContext`
+  when non-null else `g_engineContext.get()`, and `SetInjected(ctx)` assigns `g_injectedContext`.
+  The injected pointer is deliberately **raw / non-owning** — module teardown must never free
+  the host context.
+
+- **FAIL branch (host lookup missing):** insert the lookup block between the existing Console
+  and ImGui injection blocks in `ModuleManager::LoadModule`. **FAIL branch (setter missing):**
+  add `static void SetInjected(EngineContext* ctx);` to `EngineContext.h` (public, next to
+  `Get()`), the file-scope `g_injectedContext`, the `Get()` preference, and the setter def in
+  `EngineContext.cpp`. Never make `g_injectedContext` a `unique_ptr`.
+
+### Gate 3 — Rebuild so the export lands in the binary (the real remaining work)
+
+This box is MSVC-via-vcvars with `CC=claude.exe` poisoning CMake — build through the pinned
+one-call helper (per global CLAUDE.md), or a Dev Command Prompt. Run a **RAM preflight first**
+(16 GB box, thrashes):
+
+```powershell
+powershell -NoProfile -File "C:\Users\natew\.claude\scripts\fleet-preflight.ps1"   # want GO
+powershell -File "C:\Users\natew\.claude\scripts\build.ps1" "cmake --build build/windows-release --config Release --target SparkGameMMO"
+```
+
+Only `SparkGameMMO` is needed to prove the fix; rebuild all modules before shipping. If the
+`windows-release` build dir does not exist yet: `cmake --preset windows-release` first.
+
+- **EXPECTED:** build succeeds, 0 errors. `build/windows-release/bin/SparkGameMMO.dll` mtime is
+  now today, not 2026-07-05.
+- **FAIL branch (build error in `ModuleDllMain.h`):** the most likely error is an unresolved
+  `EngineContext::SetInjected` or an incomplete-type `EngineContext` — means the
+  `#include "Core/EngineContext.h"` is missing or the module's include path lost the engine
+  `Source/` root. Confirm the module target links `SparkEngineLib` and has `Source/` on its
+  includes (it does by default via the shared CMake module setup — see `sparkengine-plugin-abi`).
+
+### Gate 4 — Verify the export is actually in the DLL (the binary gate)
+
+Two equivalent checks; pick by what your shell can reach.
+
+**Canonical (needs vcvars / a Developer Command Prompt):**
+
+```
+dumpbin /exports build\windows-release\bin\SparkGameMMO.dll
+```
+
+**vcvars-free, git-bash-friendly (an ASCII scan of the export-name table — this is the check
+this skill actually ran and trusts):**
+
+```bash
+for h in SparkModuleInjectEngineContext SparkModuleInjectConsole SparkModuleInjectImGui; do
+  printf '%-32s ' "$h"; grep -acE "$h" build/windows-release/bin/SparkGameMMO.dll
+done
+```
+
+- **EXPECTED (after Gate 3 rebuild):** all three names report `1`. In particular
+  `SparkModuleInjectEngineContext` = `1`.
+- **DIAGNOSTIC — what a STALE binary looks like:** on the un-rebuilt 2026-07-05 DLLs this exact
+  scan reports `SparkModuleInjectEngineContext 0`, `SparkModuleInjectConsole 1`,
+  `SparkModuleInjectImGui 1`. If you see the `0`, you skipped or under-scoped Gate 3 — rebuild
+  the right target into the right `bin/`.
+- **FAIL branch (still `0` after a clean rebuild):** the export is being stripped. Confirm it is
+  compiled into the DllMain TU (the file that has `SPARK_IMPLEMENT_MODULE`), that it is not
+  wrapped in an `#else`/non-`_WIN32` branch, and that no `.def` file or `/EXPORT` allowlist is
+  overriding `__declspec(dllexport)` for this target.
+
+### Gate 5 — Prove the injection is live end-to-end (behavioral gate)
+
+The export existing is necessary but not sufficient; confirm the host actually calls it and a
+module-side lookup resolves. Cheapest signal: the MMO module resolves networking through the
+injected context.
+
+```bash
+grep -n "m_context->GetNetwork\|GetNetworkService\|GetInstance" \
+  GameModules/SparkGameMMO/Source/Player/MMOPlayerSystem.cpp \
+  GameModules/SparkGameMMO/Source/World/MMOWorldSetup.cpp
+```
+
+- **EXPECTED:** every networking access reads `m_context->GetNetwork()` (guarded
+  `m_context ? m_context->GetNetwork() : nullptr`), with a comment noting "through the injected
+  engine context, not the global singleton". Verified today: `MMOPlayerSystem.cpp` lines ~49 and
+  ~166; `MMOWorldSetup.cpp` lines ~239, ~288, ~334. Any surviving
+  `NetworkManager::GetInstance()` in *networking* paths here is the bug.
+- **Runtime signal (optional):** launch the engine with the MMO module and watch the log — with
+  the fix, module-side `GetNetwork()` returns the host's `NetworkManager` (the same instance the
+  host registered via `SetNetwork`). Without it, module lookups return null or a second, empty
+  singleton and MMO replication is silently dead.
+- **FAIL branch:** a networking call still uses `GetInstance()` — replace it with
+  `m_context->GetNetwork()` (thread the `Spark::IEngineContext* m_context` captured in the
+  system's `Initialize(context)`; both MMO systems already store it).
+
+### Known-wrong paths — do not take these
+
+- **Do NOT** make the module reach a subsystem by calling `SubsystemName::GetInstance()` and
+  hoping the static local is shared. Statically-linked singletons are **per-image**; the module's
+  copy is a different object from the host's. This is the exact bug the P0 fixes. The only
+  cross-DLL-correct path is `m_context->GetX()` (or `EngineContext::Get()->GetX()` once injected).
+- **Do NOT** store the injected `EngineContext*` in a `unique_ptr` or otherwise take ownership.
+  The module must never free the host context; teardown/`FreeLibrary` would double-free.
+- **Do NOT** rename the export or the `GetProcAddress` string to "fix" a null lookup without
+  checking both ends match byte-for-byte first. A mismatch degrades to a silent no-op, not a
+  crash — so it looks like "the fix didn't work" rather than "I typo'd".
+- **Do NOT** try to verify the export against the stale `build/.../bin/*.dll` without rebuilding.
+  The pre-2026-07-07 binaries legitimately lack the symbol; a `0` there means "old binary", not
+  "broken source".
+- **Do NOT** port this seam to Linux/macOS as-is. The entire mechanism is `#if defined(_WIN32)`
+  because the per-image-global problem is specific to static-linking each DLL on Windows; POSIX
+  `dlopen` with a shared engine .so does not reproduce it. Leave the non-Windows path alone.
+
+### Open item (honest, not oversold)
+
+The handoff asked to **remove** NetworkManager's "dead per-module `GetInstance()` fallback".
+Current `NetworkManager::GetInstance()` (`NetworkManager.cpp:130-145`) does the *intended* thing
+— it resolves through `EngineContext::Get()->GetNetworkService()` first — but it **still keeps**
+the `static NetworkManager instance;` as a last-resort fallback rather than deleting it. So the
+literal handoff instruction ("remove the fallback") is only **partially** satisfied: the fallback
+is now unreachable whenever a context is injected, but it was not deleted. Treat full removal as a
+`candidate` cleanup, not a done item — and note that some non-module/test call sites may still
+depend on the fallback existing, so do not delete it without checking callers
+(`grep -rn "NetworkManager::GetInstance" SparkEngine Tests GameModules`).
+
+Separately: `MMOWorldSetup.cpp` still calls `Spark::Streaming::SeamlessAreaManager::GetInstance()`
+(lines ~135, ~230). That is a **streaming** singleton, outside this networking-DI P0's scope — do
+not conflate it with the P0. If it needs the same treatment, that is its own task.
+
+---
+
+## Validation and promotion — route through this project's change control
+
+This repo enforces its own gates (see `D:\SparkEngine\CLAUDE.md`). Promote the finished P0 through
+them; do not hand-wave past CI.
+
+0. **Sync first, then work (CLAUDE.md "Git Sync Workflow"):** the upstream branch is `Working`,
+   not `main`. Before you touch anything and again before you commit/push, `git fetch origin Working`
+   and `git rebase origin/Working` if behind — **never commit or push while behind the base branch.**
+   **Concurrency caveat:** a hardening fleet may be editing the very files this P0 touches on branch
+   `claude/harden-fleet` (`SparkSDK/Include/Spark/ModuleDllMain.h`,
+   `SparkEngine/Source/Core/ModuleManager.cpp`, `EngineContext.cpp`, and the MMO files). Coordinate
+   and rebase — do **not** race concurrent edits into those files, and use targeted `git add` paths
+   (never `git add -A`) while a fleet is writing.
+1. **Wiring rule (CLAUDE.md "Wiring Things In"):** the fix is only "done" if the export is
+   *called*. Gates 2 and 5 are your wiring proof — a system that exists but is never invoked is
+   "worse than not existing".
+2. **Format (CI `check-format` is blocking):** any C++ you touched must pass clang-format:
+   ```bash
+   clang-format --dry-run --Werror SparkSDK/Include/Spark/ModuleDllMain.h \
+     SparkEngine/Source/Core/ModuleManager.cpp SparkEngine/Source/Core/EngineContext.cpp \
+     GameModules/SparkGameMMO/Source/Player/MMOPlayerSystem.cpp
+   ```
+3. **Build both compilers locally if you edited source** — CI runs GCC + Clang + MSVC; the Linux
+   jobs will still compile the file even though the injection body is `_WIN32`-gated (the gate
+   must keep them clean). `cmake --preset linux-gcc-release && cmake --build build --config Release`.
+4. **Tests:** `cd build && ctest --output-on-failure`. There is no dedicated injection unit test
+   today (cross-DLL load is hard to unit-test); the behavioral proof is Gate 5 + a live module
+   launch. If you add a test, register it (unregistered `Test*.cpp` never compile — see the
+   handoff's "Tests wiring" note).
+5. **Docs:** if you record this as solved, add/update a page under `wiki/advanced/` (non-obvious
+   codebase fact) per CLAUDE.md's wiki rules, then `docs/sync-wiki.sh sync`. Do not create a
+   parallel note outside the wiki.
+6. **PR + CI poll:** after pushing, `gh pr checks --watch --fail-fast`; `check-format`,
+   `build-windows-vs2022`, and the Linux builds are blockers.
+
+## Provenance and maintenance
+
+Verified against the live tree on **2026-07-07** (commit `52636dda` in `HEAD`; working tree clean
+for all five files). Re-verify with:
+
+```bash
+# Is the P0 source commit still in history?
+git merge-base --is-ancestor 52636dda HEAD && echo present || echo absent
+# Export defined in the SDK header?
+grep -n "SparkModuleInjectEngineContext" SparkSDK/Include/Spark/ModuleDllMain.h
+# Host looks up the exact symbol?
+grep -n "SparkModuleInjectEngineContext" SparkEngine/Source/Core/ModuleManager.cpp
+# Setter + Get() preference present?
+grep -n "SetInjected\|g_injectedContext" SparkEngine/Source/Core/EngineContext.cpp
+# MMO DI uses the context, not GetInstance?
+grep -n "m_context->GetNetwork\|GetInstance" \
+  GameModules/SparkGameMMO/Source/Player/MMOPlayerSystem.cpp \
+  GameModules/SparkGameMMO/Source/World/MMOWorldSetup.cpp
+# Is the export actually in the built DLL yet? (0 = stale binary, rebuild)
+grep -acE "SparkModuleInjectEngineContext" build/windows-release/bin/SparkGameMMO.dll
+```
+
+Lint this skill: `powershell -NoProfile -File C:\Users\natew\.claude\skills\skill-linter\scripts\skill-lint.ps1 -Path D:\SparkEngine\.claude\skills\sparkengine-module-injection-p0-campaign`

--- a/.claude/skills/sparkengine-plugin-abi/SKILL.md
+++ b/.claude/skills/sparkengine-plugin-abi/SKILL.md
@@ -1,0 +1,319 @@
+---
+name: sparkengine-plugin-abi
+description: >-
+  SparkEngine game-module DLL plugin ABI reference — how ModuleManager discovers
+  and loads GameModules/*.dll, the extern "C" injection hooks a module must export
+  (SparkModuleInjectEngineContext / Console / ImGui), and the exact checklist for
+  adding a new game module DLL. TRIGGER when the user says "add a new game module",
+  "my module's EngineContext::Get() returns null", "module console commands don't
+  work", "module ImGui draws nothing / crashes", "CreateModule not found", "how does
+  ModuleManager load DLLs", "why is my module's NetworkManager a dead singleton", or
+  asks how the plugin/module ABI works. DO NOT TRIGGER for finishing the specific
+  EngineContext-injection P0 step-by-step (use sparkengine-module-injection-p0-campaign),
+  for engine-internal subsystem wiring unrelated to DLLs, or for AngelScript hot-reload
+  (that is scripting, not the native module ABI).
+trilobite_compatible: true
+trilobite_role: reference
+---
+
+# SparkEngine Plugin / Module DLL ABI
+
+This is the reference for SparkEngine's **native game-module plugin system**: how the
+engine finds, loads, and talks to the DLLs under `GameModules/` (and standalone game
+projects). Read this when adding a module, or when a loaded module behaves as if it
+cannot see the engine (null context, dead singletons, invisible console commands,
+blank ImGui).
+
+**Jargon defined once:**
+- **Module DLL** — a shared library (`.dll` on Windows, `.so` on Linux, `.dylib` on
+  macOS) that implements `Spark::IModule` and exports factory functions. Each folder
+  in `GameModules/` builds one. Ten ship in-tree (SparkGame, SparkGameFPS,
+  SparkGameMMO, RPG, ARPG, RTS, Racing, Platformer, OpenWorld, VisualScript).
+- **`ModuleManager`** — the host-side loader (`SparkEngine/Source/Core/ModuleManager.{h,cpp}`).
+  Owned by the engine runtime; finds, loads, sorts, initializes, updates, and unloads modules.
+- **`IModule`** — the module interface (`SparkSDK/Include/Spark/IModule.h`). Lifecycle:
+  `OnLoad → OnUpdate/OnFixedUpdate/OnRender/OnImGui → OnUnload`.
+- **`IEngineContext` / `EngineContext`** — the engine service locator. `EngineContext::Get()`
+  is the module's window into engine subsystems (graphics, input, physics, network, etc.).
+- **`SparkEngineLib`** — the engine as a **static** library. It is linked into the
+  executable **and into every module DLL**. This is the root cause of every injection
+  hook below: any global inside `SparkEngineLib` (the `g_engineContext` pointer, the
+  `SimpleConsole` singleton, ImGui's `GImGui`) exists as a **separate per-image copy**
+  inside each module, disconnected from the host's copy until the host injects across
+  the DLL boundary.
+
+## When NOT to use this skill
+
+| Situation | Use instead |
+|-----------|-------------|
+| You need to *finish* the EngineContext-injection P0 step-by-step | `sparkengine-module-injection-p0-campaign` |
+| AngelScript hot-reload / script context questions | scripting skills (not the native ABI) |
+| Wiring an engine-internal subsystem that is not a DLL | engine wiring / `CLAUDE.md` "Wiring Things In" |
+
+---
+
+## 1. How ModuleManager discovers and loads DLLs
+
+The host resolves modules from three sources, in `ModuleManager` (verified in
+`ModuleManager.cpp`):
+
+1. **Manifest** — `LoadModulesFromManifest(path)` reads a `spark.modules.json`-style
+   file. Minimal parser: it scans for `"path"` keys and loads each. Relative paths
+   resolve against the manifest directory. (No root manifest ships in-tree today —
+   directory scan is the live path.)
+2. **Directory scan (fallback)** — `LoadModulesFromDirectory(dir)`. This is what the
+   shipping engine uses: `SparkEngineWindows.cpp` / `SparkEngineLinux.cpp` call
+   `LoadModulesFromManifest` if a manifest exists, else `LoadModulesFromDirectory(exeDir)`.
+3. **Explicit** — `LoadModule(path)` for a single DLL (used by manifest/scan and the editor).
+
+### Directory-scan candidate rules (verified `ModuleManager.cpp` ~line 405)
+
+A file in the scanned directory is loaded only if **all** hold:
+- Extension matches the platform: `.dll` (Windows) / `.so` (Linux) / `.dylib` (macOS).
+- Filename **contains** `Game`, `Module`, or `Plugin`.
+- Filename is **not** a system/runtime DLL: rejected if it starts with `d3d`,
+  `vcruntime`, `msvcp`, `ucrtbase`, or contains `SparkConsole` / `SparkEngine`.
+- **Windows only:** the file is first mapped with `LoadLibraryExA(..., DONT_RESOLVE_DLL_REFERENCES)`
+  — which maps the image **without** running `DllMain` or resolving imports — and is
+  skipped unless it actually exports `CreateModule` or `CreateGameModule`. This stops
+  unrelated third-party DLLs (overlays, middleware) whose names merely contain "Game"
+  from being loaded and their `DllMain` executed.
+
+Paths containing `..` are rejected outright (traversal guard, `LoadModule`).
+
+### Load sequence inside `LoadModule` (order matters)
+
+```
+LoadLibraryA / dlopen(path)
+  └─ (Windows) GetProcAddress + call, BEFORE CreateModule:
+       SparkModuleInjectConsole(&SimpleConsole::GetInstance())   // host console
+       SparkModuleInjectEngineContext(EngineContext::Get())      // host context
+       SparkModuleInjectImGui(ctx, alloc, free, userData)        // host ImGui (if set)
+  └─ GetProcAddress("CreateModule") / ("DestroyModule")   // new API, preferred
+       └─ instance = CreateModule()
+       └─ IsSDKCompatible(info.sdkVersion)  // reject on mismatch, then FreeLibrary
+  └─ else GetProcAddress("CreateGameModule") / ("DestroyGameModule")  // legacy API
+       └─ wrapped in LegacyModuleAdapter (IGameModule → IModule)
+  └─ SortModules()   // numeric loadOrder, or topological if dependencies declared
+```
+
+The three injection hooks are called via `GetProcAddress` and are **each optional** —
+a module missing a hook simply skips it (no error). They run **before** `CreateModule()`
+so the module's constructor and `OnLoad` already see the host's console/context/ImGui.
+
+> The injection hooks are Windows-only in both the host (`#ifdef _WIN32` in `LoadModule`)
+> and the SDK (`#if defined(_WIN32)` in `ModuleDllMain.h`). On Linux/macOS the engine
+> links modules so that the static `SparkEngineLib` symbols resolve from the executable
+> (`ENABLE_EXPORTS`, no `NEEDED` dependency — see `CMakeLists.txt` ~line 1419), so there
+> is a single shared copy and no per-image injection is needed.
+
+### Lifecycle calls (all iterate loaded modules in load order)
+
+`InitializeAll(ctx)` → `UpdateAll(dt)` / `FixedUpdateAll(fixedDt)` / `RenderAll()` /
+`ImGuiAll()` / `ResizeAll(w,h)` → `ShutdownAll()` (reverse order) → `UnloadAll()`.
+`InitializeAll` is driven from `SparkEngineWindows.cpp` / `SparkEngineLinux.cpp` via
+`GetEngineRuntime().moduleManager->InitializeAll(EngineContext::Get())`.
+
+---
+
+## 2. The injection ABI — what a module must export
+
+All three hooks are generated for you by including **one** header in **exactly one**
+`.cpp` per module:
+
+```cpp
+#include <Spark/ModuleDllMain.h>   // defines DllMain + the 3 inject hooks (Windows)
+```
+
+`ModuleDllMain.h` (verified) emits these `extern "C" __declspec(dllexport)` functions:
+
+| Export | Signature | What it fixes |
+|--------|-----------|---------------|
+| `SparkModuleInjectConsole` | `void(void* hostConsole)` | Points the module's per-image `SimpleConsole` at the host's, so module console-command registrations are visible to the engine. Without it, module commands are silently dead on Windows. |
+| `SparkModuleInjectEngineContext` | `void(void* ctx)` | Calls `EngineContext::SetInjected((EngineContext*)ctx)`. Points the module's `EngineContext::Get()` at the host's live context. Without it, `Get()` returns the module's null per-image `g_engineContext` and every service lookup (network, physics, world…) fails or falls back to a dead per-module singleton. |
+| `SparkModuleInjectImGui` | `void(void* ctx, void* alloc, void* free, void* userData)` | Sets the module's ImGui allocator functions and current context to the exe-owned ones. Without it, module `OnImGui()` draws nothing or crashes (per-image `GImGui`). No-op if the module is built without `SPARK_HAS_IMGUI`. |
+
+### How `EngineContext::Get()` resolves (verified `EngineContext.cpp`)
+
+```cpp
+EngineContext* EngineContext::Get() {
+    if (g_injectedContext) return g_injectedContext;  // host-injected, preferred
+    return g_engineContext.get();                     // per-image owning global
+}
+void EngineContext::SetInjected(EngineContext* ctx) { g_injectedContext = ctx; }
+```
+
+`g_injectedContext` is a **non-owning** raw pointer — module teardown / `FreeLibrary`
+must never free the host's context. Never pass the owning `unique_ptr` to `SetInjected`.
+
+### Consuming engine services from inside a module
+
+Prefer the context passed to `OnLoad(IEngineContext* context)` — store it and use its
+named getters (`context->GetPhysics()`, `context->GetEventBus()`, …). For free functions
+and console-command lambdas that have no context in scope, call
+`EngineContext::Get()->GetX()` (works once injection has run). Example from a shipping
+module (`SparkGameFPS/Source/Core/Main.cpp`):
+
+```cpp
+auto* ctx = EngineContext::Get();
+auto* weather = ctx ? ctx->GetWeather() : nullptr;   // always null-check
+```
+
+Singletons that were retrofitted to prefer the injected context — e.g.
+`NetworkManager::GetInstance()` (verified `NetworkManager.cpp`) — do this internally:
+
+```cpp
+NetworkManager& NetworkManager::GetInstance() {
+    if (auto* ctx = EngineContext::Get())
+        if (auto* svc = ctx->GetNetworkService())
+            if (auto* net = dynamic_cast<NetworkManager*>(svc))
+                return *net;              // host's real, registered NetworkManager
+    static NetworkManager instance;       // fallback (no service registered)
+    return instance;
+}
+```
+
+Once `SparkModuleInjectEngineContext` has run, a module's `NetworkManager::GetInstance()`
+returns the **host's** registered manager, not the dead per-image `static`.
+
+> **The single GetInstance rule (consistent across the sparkengine skills):** do **not**
+> add *new* naive per-module `GetInstance()` singletons — those are the cross-DLL
+> anti-pattern the injection seam removes. What *is* acceptable: (a) the retrofitted
+> context-routing `GetInstance()` shown above, which returns the injected host instance;
+> and (b) genuinely-shared singletons like `SimpleConsole` and
+> `SeamlessAreaManager::GetInstance()`. Prefer `context->GetX()` / `EngineContext::Get()->GetX()`
+> at the call site whenever you have it. (See `sparkengine-architecture-contract` Invariant 2
+> and `sparkengine-debugging-playbook` row 5 for the same rule.)
+
+---
+
+## 3. Checklist — adding a NEW game module DLL
+
+Drop a folder into `GameModules/<YourModule>/` — CMake auto-discovers any
+`GameModules/*/CMakeLists.txt` when `BUILD_GAME_MODULES=ON` (default; verified
+`CMakeLists.txt` ~line 1403). Then:
+
+- [ ] **Module class** — subclass `Spark::IModule` (`SparkSDK/Include/Spark/IModule.h`).
+      Implement `GetModuleInfo()`, `OnLoad(IEngineContext*)`, `OnUnload()`,
+      `OnUpdate(float)`. Override `OnFixedUpdate/OnRender/OnImGui/OnResize/OnPause/OnResume`
+      as needed (they default to no-ops).
+- [ ] **`GetModuleInfo()`** — set `name`, `version`, `loadOrder` (lower loads first;
+      default 1000). Leave `sdkVersion = SPARK_SDK_VERSION` (the default) so the host's
+      `IsSDKCompatible` check passes. `name`/`version` must be module-owned storage —
+      string literals are simplest (the engine copies them at registration).
+- [ ] **Dependencies (optional)** — declare with `SPARK_MODULE_DEPENDENCIES(info, "OtherModule", ...)`
+      inside `GetModuleInfo()` (`ModuleRegistry.h`). ModuleManager topologically sorts
+      declared deps; within a level it falls back to `loadOrder`.
+- [ ] **Factory exports** — in exactly one `.cpp`, either write them by hand:
+      ```cpp
+      extern "C" {
+        SPARK_MODULE_API Spark::IModule* CreateModule()            { return new YourModule(); }
+        SPARK_MODULE_API void            DestroyModule(Spark::IModule* m) { delete m; }
+      }
+      ```
+      or use the macro `SPARK_IMPLEMENT_MODULE(YourModule)` (`ModuleRegistry.h`).
+- [ ] **Injection hooks + DllMain** — in that same `.cpp` add:
+      ```cpp
+      #include <Spark/ModuleDllMain.h>
+      ```
+      This is **required** on Windows for the module to see the host console, EngineContext,
+      and ImGui. Include it in **one** TU only — a second inclusion is a duplicate-`DllMain`
+      link error (by design).
+- [ ] **CMake** — a `GameModules/<YourModule>/CMakeLists.txt` that builds a `SHARED`
+      library and defines `SPARK_MODULE_DLL` (and `SPARK_GAME_DLL` if you also export the
+      legacy API). This turns `SPARK_MODULE_API` / `SPARK_GAME_API` into `dllexport`
+      (`SparkExport.h`). Link `SparkEngineLib` (Windows) and add `Source`,
+      `SparkEngine/Source`, and `SparkSDK/Include` to the include path. The in-tree
+      modules copy `GameModules/SparkGameFPS/CMakeLists.txt`; a standalone project uses
+      the `spark_add_game_module(<Target> <sources>)` helper in `cmake/SparkGameModule.cmake`.
+- [ ] **SDK version** — do not override `info.sdkVersion` unless you know why; a mismatch
+      makes `LoadModule` reject the DLL with an "SDK version mismatch" error and unload it.
+- [ ] **Legacy path (optional)** — if you also want the old ABI, subclass `IGameModule`
+      and export `CreateGameModule` / `DestroyGameModule`; the host wraps it in
+      `LegacyModuleAdapter`. New modules should prefer `IModule`.
+
+### Common failure → cause map
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `"Module '…' has no recognized exports"` | No `CreateModule`/`CreateGameModule` export | Add factory exports (or `SPARK_IMPLEMENT_MODULE`) and ensure `SPARK_MODULE_DLL` is defined so they export |
+| `"SDK version mismatch"` in log, module unloaded | `info.sdkVersion` differs from engine | Leave it at the `SPARK_SDK_VERSION` default; rebuild against current SDK |
+| `EngineContext::Get()` returns null inside module | `ModuleDllMain.h` not included → no `SparkModuleInjectEngineContext` export | `#include <Spark/ModuleDllMain.h>` in one `.cpp` |
+| Module console commands never appear | Missing `SparkModuleInjectConsole` (same missing include) | same fix |
+| Module ImGui blank / crash | Missing `SparkModuleInjectImGui`, or host never called `SetImGuiInjection` | include `ModuleDllMain.h`; host sets injection in `SparkEngineWindows.cpp` game-ImGui layer |
+| DLL in output dir but never loaded | Filename lacks `Game`/`Module`/`Plugin`, or matches a system-DLL prefix | rename so the scan picks it up, or load via manifest |
+
+---
+
+## 4. EngineContext-injection P0 — current state (verified)
+
+The `HARDEN_FLEET_HANDOFF.md` doc (root of repo) lists the module EngineContext injection
+as **"P0 landed but INERT — finish first"**, needing the DLL-side
+`SparkModuleInjectEngineContext` export added and the `NetworkManager` dead fallback removed.
+
+**Re-verified against the code on 2026-07-07 — that handoff note is now stale on the export:**
+
+- **DLL-side export: LANDED.** `SparkModuleInjectEngineContext(void* ctx)` calling
+  `EngineContext::SetInjected(...)` **is present** in
+  `SparkSDK/Include/Spark/ModuleDllMain.h` (lines ~88–91). It was added in commit
+  `52636dda` (2026-07-07, "feat(harden-fleet): Phase 3 deferred cross-cutting fixes").
+- **Host side: LANDED.** `ModuleManager::LoadModule` `GetProcAddress`es and calls the
+  hook (`ModuleManager.cpp` ~line 191); `EngineContext::Get()` prefers `g_injectedContext`;
+  `SetInjected` exists (`EngineContext.{h,cpp}`).
+- **All 10 in-tree modules include `<Spark/ModuleDllMain.h>`**, so every module DLL now
+  exports the hook. So the injection is **functionally wired end-to-end at the source
+  level.** Caveat: the *shipped binaries are stale* — the module DLLs built on disk
+  predate the `52636dda` export commit and therefore **lack the export until rebuilt**,
+  so the runtime "end-to-end" claim holds only after a rebuild. For the full status,
+  the rebuild/verify gates, and the exact binary check, defer to the companion skill
+  **`sparkengine-module-injection-p0-campaign`** (the canonical status book) rather than
+  re-deriving it here.
+- **Still open (cleanup, harmless):** the `static NetworkManager instance;` fallback in
+  `NetworkManager::GetInstance()` (`NetworkManager.cpp` ~line 143) has **not** been
+  removed. It is now dead in practice — the context branch above it wins once injection
+  runs — but the handoff's "remove the dead fallback" line is not yet done.
+- **Still open (per handoff):** MMO dependency-injection cleanup — `MMOWorldSetup.cpp`
+  still calls `Spark::Streaming::SeamlessAreaManager::GetInstance()` (~lines 135, 230)
+  rather than routing through the injected context. Verify before relying on it.
+
+To **finish** the remaining cleanup step by step, use the companion skill
+**`sparkengine-module-injection-p0-campaign`** — do not improvise the removal here.
+
+To re-check the P0 state yourself, see the commands in Provenance below.
+
+---
+
+## Provenance and maintenance
+
+Ground-truth files (all read to author this skill, 2026-07-07):
+`SparkEngine/Source/Core/ModuleManager.{h,cpp}`, `SparkEngine/Source/Core/EngineContext.{h,cpp}`,
+`SparkSDK/Include/Spark/{ModuleDllMain,IModule,ModuleRegistry,SparkExport}.h`,
+`SparkEngine/Source/Engine/Networking/NetworkManager.{h,cpp}`,
+`GameModules/SparkGameFPS/{CMakeLists.txt,Source/Core/Main.cpp}`,
+`cmake/SparkGameModule.cmake`, `CMakeLists.txt` (~line 1397), `HARDEN_FLEET_HANDOFF.md`.
+
+Re-verify the volatile claims (run from repo root, Git Bash):
+
+```bash
+# P0 export present? (expect the extern "C" line + SetInjected call)
+grep -n "SparkModuleInjectEngineContext" SparkSDK/Include/Spark/ModuleDllMain.h
+
+# Which commit added it / when
+git log -1 --format='%h %ci %s' -S SparkModuleInjectEngineContext -- SparkSDK/Include/Spark/ModuleDllMain.h
+
+# Every module still includes the hook header?
+grep -rl "ModuleDllMain.h" GameModules
+
+# Is the NetworkManager dead fallback still there? (still open as of 2026-07-07)
+grep -n "static NetworkManager instance" SparkEngine/Source/Engine/Networking/NetworkManager.cpp
+
+# MMO GetInstance DI cleanup still pending?
+grep -n "SeamlessAreaManager::GetInstance" GameModules/SparkGameMMO/Source/World/MMOWorldSetup.cpp
+
+# Directory-scan candidate/system-DLL rules unchanged?
+grep -n "contains(\"Game\")\|DONT_RESOLVE_DLL_REFERENCES" SparkEngine/Source/Core/ModuleManager.cpp
+```
+
+If `ModuleDllMain.h` gains/loses a hook, or the scan rules in `LoadModulesFromDirectory`
+change, update sections 1–2. If `NetworkManager::GetInstance()`'s fallback is removed or
+the MMO DI cleanup lands, update section 4.

--- a/.claude/skills/sparkengine-reflection-conventions/SKILL.md
+++ b/.claude/skills/sparkengine-reflection-conventions/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: sparkengine-reflection-conventions
+description: How to register a new reflected ECS component type in SparkEngine's hand-rolled, no-RTTI reflection system (Core/Reflection.h + Core/ComponentReflection.cpp). TRIGGER when the user says "add a reflected field", "expose this component to the editor inspector", "why isn't my component showing up in the Inspector", "add SPARK_REFLECT", "make this field replicated/serialized", "register a new component type", "TypeRegistry", "ComponentFactory", or "reflection macro". DO NOT TRIGGER for AngelScript scripting reflection (see sparkengine-hot-reload-seam), for scene-file save/load mechanics beyond the reflected-field bridge (see sparkengine-serialization-format), or for generic C++ RTTI/dynamic_cast questions unrelated to this system.
+trilobite_compatible: true
+trilobite_role: reference
+---
+
+# SparkEngine reflection conventions
+
+## What this system is (and isn't)
+
+`SparkEngine/Source/Core/Reflection.h` is a **lightweight, compile-time, no-RTTI**
+type reflection system (ezEngine-inspired), used for: editor Inspector rendering,
+scene save/load, network replication field marking, and data-driven archetype
+(prefab) spawning. It does **not** use `dynamic_cast`/`typeid` — type identity is
+the same `TypeId`/`GetTypeId<T>()` pattern used by `EngineContext` (defined in
+`Core/EngineContext.h`, reused here rather than duplicated — a duplicate
+definition causes an "already defined" error on MSVC).
+
+There is exactly **one file** where every ECS component gets reflected:
+`SparkEngine/Source/Core/ComponentReflection.cpp`. Reflection blocks are NOT
+scattered next to each component's own header/cpp — this is a deliberate
+single-file convention so `TypeRegistry`/`ComponentFactory` registration order
+and coverage is auditable in one place.
+
+## Core types (`Core/Reflection.h`)
+
+| Type | Purpose |
+| --- | --- |
+| `Spark::FieldType` (enum) | `Bool, Int, Float, Double, String, Vector2, Vector3, Vector4, Enum, Custom` |
+| `Spark::FieldInfo` | One field's metadata: name, offset (`offsetof`), size, type, plus editor/network/save attributes (below) |
+| `Spark::TypeInfo` | One type's metadata: name, `TypeId`, size, alignment, `baseType`, schema `version`, `fields` vector |
+| `Spark::TypeRegistry` | Global singleton; `RegisterType()`, `FindType(TypeId)`, `FindTypeByName()`, `GetAllTypes()`, `GetDerivedTypes<Base>()` |
+| `Spark::ComponentFactory` | Global singleton; type-erased `add`/`has`/`remove`/`getRaw` callbacks keyed by component **name string** — bridges data-driven code (archetype files) to the compile-time `World::AddComponent<T>()` API |
+
+`FieldInfo` extended attributes you can set per-field:
+
+| Attribute | Meaning |
+| --- | --- |
+| `rangeMin`/`rangeMax`/`hasRange` | Editor slider clamp (set via `SPARK_REFLECT_FIELD_RANGE`) |
+| `readOnly` | Inspector shows but doesn't allow editing |
+| `tooltip` | Editor hover text |
+| `category` | Inspector grouping (e.g. `"Physics"`, `"Rendering"`) |
+| `isAssetPath` | Shows an asset picker instead of a text box |
+| `replicated` | Included in network replication (networking code queries this) |
+| `serialized` | Included in scene save/load — **defaults to `true`** |
+| `enumNames` | Dropdown labels for `Enum` fields |
+| `visibleWhenField`/`visibleWhenValue` | Conditional Inspector visibility — this field only renders when another named field equals a value |
+
+**Thread safety** (stated in the header): registration happens at static-init
+time (single-threaded, before `main`), both registries are read-only after
+startup and safe to query from any thread.
+
+## Registration macros
+
+All defined at the bottom of `Reflection.h`, used together inside a per-type
+block in `ComponentReflection.cpp`:
+
+```cpp
+SPARK_REFLECT_TYPE(Transform)
+SPARK_REFLECT_FIELD_ATTR_AS(Transform, position, "Position", Spark::FieldType::Vector3, field.replicated = true;)
+SPARK_REFLECT_FIELD_ATTR_AS(Transform, rotation, "Rotation", Spark::FieldType::Vector3, field.replicated = true;)
+SPARK_REFLECT_FIELD_ATTR_AS(Transform, scale,    "Scale",    Spark::FieldType::Vector3, field.replicated = true;)
+SPARK_REFLECT_END(Transform)
+```
+
+| Macro | When to use |
+| --- | --- |
+| `SPARK_REFLECT_TYPE(Type)` | Start a block. One .cpp registration per type (a static initializer struct is generated named `SparkReflect_<Type>`). |
+| `SPARK_REFLECT_TYPE_BASE(Type, BaseType)` | Same, but also records `baseType` for `GetDerivedTypes<Base>()` queries. |
+| `SPARK_REFLECT_FIELD(Type, member, "Display Name")` | Plain field; `FieldType` auto-deduced via `DeduceFieldType<T>()`. |
+| `SPARK_REFLECT_FIELD_RANGE(Type, member, "Display Name", min, max)` | Adds an editor range clamp. |
+| `SPARK_REFLECT_FIELD_ATTR(Type, member, "Display Name", <stmts>)` | Auto-deduced type + arbitrary `field.<attr> = ...;` statements (set `tooltip`/`category`/`replicated`/etc). |
+| `SPARK_REFLECT_FIELD_ATTR_AS(Type, member, "Display Name", FieldType::X, <stmts>)` | Explicit `FieldType` + arbitrary attribute statements — **use this for DirectXMath vectors** (see gotcha below). |
+| `SPARK_REFLECT_FIELD_AS(Type, member, "Display Name", FieldType::X)` | Explicit `FieldType`, no extra attributes. Defined locally in `ComponentReflection.cpp` (not `Reflection.h`) — same shape as `SPARK_REFLECT_FIELD` but skips auto-deduction. |
+| `SPARK_REFLECT_FIELD_VISIBLE_WHEN(Type, member, "Display Name", controlMember, controlVal)` | Field only shows in Inspector when `controlMember == controlVal`. |
+| `SPARK_REFLECT_VERSION(ver)` | Set `TypeInfo::version` (schema version, for save-file migration) — place before `SPARK_REFLECT_END`. |
+| `SPARK_REFLECT_END(Type)` | Close the block. `Type` here must match the opening macro's argument. |
+
+## Checklist: adding a new reflected component
+
+1. Define the component struct in its own `Components*.h` header as usual (not
+   in `ComponentReflection.cpp`).
+2. In `SparkEngine/Source/Core/ComponentReflection.cpp`, add one
+   `SPARK_REFLECT_TYPE(YourType) ... SPARK_REFLECT_END(YourType)` block,
+   grouped under the matching `// --- Category ---` comment section (Core,
+   Physics, Audio, Light, Animation, AI, Networking, Gameplay, FPS, Spline,
+   Volumes, Terrain, 2D/Sprite, Placement, Advanced Placement, Collision Mask,
+   Visibility — pick the closest match or start a new section).
+3. Inside `ComponentFactoryRegistrar`'s constructor (same file, bottom
+   `namespace { ... }` block), add `SPARK_REGISTER_COMPONENT(YourType)` in the
+   matching category section. **Skipping this step means the type reflects
+   fine (Inspector/save work) but data-driven archetype spawning
+   (`EntityArchetypeLoader.cpp`) can't `AddComponent`/`HasComponent` it by
+   string name** — a silent gap, not a compile error.
+4. **DirectXMath vector fields (`XMFLOAT2`/`XMFLOAT3`/`XMFLOAT4`) always need
+   explicit typing.** `DeduceFieldType<T>()` only recognizes `bool`,
+   integral types, `float`, `double`, `std::string`, and `enum` — anything
+   else (including `XMFLOAT3`) deduces to `FieldType::Custom` and silently
+   won't serialize/display correctly. Use `SPARK_REFLECT_FIELD_AS` (or
+   `_ATTR_AS` if you also need attributes) with the explicit
+   `Spark::FieldType::Vector2/3/4`.
+5. Set `field.replicated = true` for any field the network layer must sync
+   (via `SPARK_REFLECT_FIELD_ATTR`/`_ATTR_AS`); set `field.serialized = false`
+   to explicitly exclude a field from scene save/load (default is `true`,
+   i.e. saved unless you opt out).
+6. Build once — registration is compile-checked (macro references
+   `offsetof(Type, member)`, so a typo'd member name fails to compile, not
+   silently at runtime).
+
+## `enum class` gotcha (real bug, now fixed — know the pattern)
+
+`DeduceFieldType<T>()` maps any `enum` to `FieldType::Enum`, but a plain
+`enum class` with no explicit underlying type has no reflectable storage type
+at the ABI level — MSVC lays it out as `int`. `SetFieldFromString`/
+`GetFieldAsString` in `ComponentReflection.cpp` therefore round-trip `Enum`
+fields via `int` explicitly. A code comment at both call sites notes this
+used to fall through to the `default:` case and **silently drop the write**
+(scene reload would reset the field) — if you ever see an enum-typed
+Inspector field that won't stick across a scene reload, this is the first
+thing to check: is it going through the `FieldType::Enum` case, and is that
+case actually doing the int round-trip, not falling through?
+
+## Where reflected data gets consumed
+
+- **Scene save/load**: `SparkEngine/Source/SceneManager/ReflectedSceneSerializer.cpp`
+  — walks `TypeRegistry::Get().FindTypeByName(...)`, skips fields where
+  `!f.serialized`.
+- **Data-driven archetype/prefab spawning**: `SparkEngine/Source/Engine/ECS/EntityArchetypeLoader.cpp`
+  — parses a text archetype file, resolves component type + field names via
+  `TypeRegistry`, and adds components via `ComponentFactory` (string-keyed,
+  not templated) — this is why step 3 of the checklist above matters.
+- **Editor Inspector panel**: consumes `category`/`tooltip`/`isAssetPath`/
+  `visibleWhenField`/`rangeMin`/`rangeMax` for rendering (panel code not
+  covered by this skill — see the editor panel registry if extending
+  Inspector rendering itself).
+
+## Known stale-doc trap (candidate, unverified)
+
+`ComponentReflection.cpp` has two section comments — `// --- Spline (missing
+reflection) ---` (around `SplineComponent`) and `// --- Volumes (missing
+reflection) ---` (around `LODGroupComponent`) — that read like leftover work markers,
+but both types **are** fully reflected in the blocks directly below those
+comments as of this writing. Treat the comment text as stale, not as a real
+gap; if you're asked to "finish" Spline/LODGroup reflection, verify first
+rather than assuming work remains.
+
+## Provenance and maintenance
+
+- Verified against `SparkEngine/Source/Core/Reflection.h`,
+  `SparkEngine/Source/Core/ComponentReflection.cpp`,
+  `SparkEngine/Source/SceneManager/ReflectedSceneSerializer.cpp`, and
+  `SparkEngine/Source/Engine/ECS/EntityArchetypeLoader.cpp` on 2026-07-07
+  (branch `claude/forge-sonnet5-skills`, based on `Working` @ `9fb17e63`).
+- Re-verify component count / registration parity:
+  `grep -c "SPARK_REFLECT_TYPE(" SparkEngine/Source/Core/ComponentReflection.cpp`
+  vs. `grep -c "SPARK_REGISTER_COMPONENT(" SparkEngine/Source/Core/ComponentReflection.cpp`
+  — these should track closely; a growing gap means new types are being
+  reflected but not registered with `ComponentFactory` (step 3 above).
+- Re-verify the stale-comment claim:
+  `grep -n "missing reflection" SparkEngine/Source/Core/ComponentReflection.cpp`

--- a/.claude/skills/sparkengine-run-and-operate/SKILL.md
+++ b/.claude/skills/sparkengine-run-and-operate/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: sparkengine-run-and-operate
+description: >-
+  Runbook for launching and operating the built SparkEngine binaries — the engine
+  (SparkEngine.exe), the ImGui editor (SparkEditor.exe), the standalone SparkConsole
+  subprocess, and the 10 game-module DLLs — plus where logs, crash dumps, saves and
+  screenshots land. TRIGGER when: "how do I run/launch/start the engine or editor",
+  "which executable do I run", "what are the command-line flags", "run headless /
+  dedicated server", "load a specific game module with -game", "the console subprocess
+  isn't receiving my commands", "where do crash dumps / SparkCrash .dmp / logs / save
+  files go", "how does the SparkConsole IPC pipe work". DO NOT TRIGGER when: you need to
+  compile/configure/build (use global cmake-msvc / ci-troubleshoot), diagnose a compiler
+  or CMake error, write engine C++ code, or debug rendering/physics internals — this skill
+  is about operating already-built binaries, not producing them.
+trilobite_compatible: true
+trilobite_role: operations
+---
+
+# SparkEngine: Run and Operate
+
+Operate the already-built SparkEngine binaries. This skill assumes a successful build
+exists. If you have not built yet, build first (`cmake --build build --config Release`)
+— that is a separate concern; this runbook does not cover compile/link errors.
+
+Term key (defined once):
+- **RHI** — Rendering Hardware Interface, the engine's API-agnostic render backend layer.
+- **NullRHIDevice** — the GPU-less fallback backend; auto-activates headless when no GPU.
+- **Game module** — a gameplay DLL (e.g. `SparkGameFPS.dll`) loaded at runtime by the engine.
+- **SparkConsole subprocess** — a *separate* console UI process the engine spawns and talks
+  to over a stdin/stdout pipe. Distinct from `SimpleConsole`, the in-process log buffer.
+
+## 1. Where the binaries land
+
+CMake sets `CMAKE_RUNTIME_OUTPUT_DIRECTORY` to `${CMAKE_BINARY_DIR}/bin`
+(`CMakeLists.txt:171`). So for the standard `build/` tree, **every executable and every
+game-module DLL lands in `build/bin/`** (single-config generators) — the SparkConsole
+search paths and module directory-scan both assume co-location there.
+
+| Target | Binary (Windows) | Source of truth | Notes |
+|--------|------------------|-----------------|-------|
+| Engine | `SparkEngine.exe` | `CMakeLists.txt:1139` (`WIN32` GUI subsystem) | The thing you usually run. |
+| Editor | `SparkEditor.exe` | `SparkEditor/CMakeLists.txt:40` (`WIN32`) | ImGui editor; does NOT spawn SparkConsole. |
+| Console UI | `SparkConsole.exe` | `SparkConsole/CMakeLists.txt:33` | Spawned by the engine; can also run standalone. |
+| Launcher | `SparkLauncher.exe` | `SparkLauncher/CMakeLists.txt:28` | Optional front-end launcher. |
+| Daemon | `SparkDaemon.exe` | `SparkDaemon/CMakeLists.txt:38` | Shared shader-cache service (opt-in). |
+| Crash reporter | `SparkCrashReporter.exe` | `SparkCrashReporter/CMakeLists.txt:26` | Watchdog launched on crash if present. |
+| Shader compiler | `SparkShaderCompiler.exe` | `SparkShaderCompiler/CMakeLists.txt:57` | Offline tool. |
+| Game modules (10) | `SparkGame*.dll` | e.g. `add_library(SparkGameFPS SHARED …)` `GameModules/SparkGameFPS/CMakeLists.txt:93` | DLLs, auto-discovered. |
+
+On Linux/macOS drop the `.exe`; game modules become `.so`/`.dylib`. On multi-config
+generators (Visual Studio/Ninja Multi-Config) binaries land under
+`build/bin/<Config>/` — but this repo pins the same `bin` dir for all configs
+(`CMakeLists.txt:178`), so they stay in `build/bin`.
+
+## 2. Launching — startup order and combinations
+
+**Run the engine from `build/bin` (so relative asset/console/module paths resolve):**
+
+```powershell
+cd build/bin
+./SparkEngine.exe
+```
+
+The engine is a self-contained process. On startup it (Windows path, `SparkEngineWindows.cpp`):
+1. Parses flags from the command line (`WinMain`, ~`:1157`–`:1163`).
+2. Creates the window + graphics/input/timer (`InitInstance`, `:1217`).
+3. `InitializeWindowedSubsystems` — sets up EngineContext, then `InitConsole()`
+   (which may spawn `SparkConsole.exe`), then loads game modules.
+4. Enters `RunWindowedMainLoop` (`:1192`) which ticks every frame.
+
+You do **not** launch SparkConsole yourself for the normal case — the engine spawns it.
+The editor (`SparkEditor.exe`) is an independent process and does **not** use the
+SparkConsole subprocess at all (verified: no `ConsoleProcessManager` references under
+`SparkEditor/Source/`).
+
+### Choosing a game module
+
+Module load priority (`LoadGameModules`, `SparkEngineWindows.cpp:446`):
+1. `-game <path>` on the command line → loads that single module DLL.
+2. `spark.modules.json` manifest next to the engine exe → loads listed modules.
+3. Otherwise: directory scan of the exe dir for `*Game*.dll` / `*Module*.dll`.
+
+```powershell
+# Run the FPS module explicitly
+./SparkEngine.exe -game SparkGameFPS.dll
+```
+
+### Common launch flags (verified in source)
+
+| Flag | Effect | Where parsed |
+|------|--------|--------------|
+| `-game <path>` | Load one specific module DLL | `SparkEngineWindows.cpp:423`, `SparkEngineLinux.cpp:180` |
+| `-headless` / `-dedicated` | Run without a window (NullRHIDevice / software), dedicated-server style | `SparkEngineWindows.cpp:246,251`; `SparkEngineLinux.cpp:1220` |
+| `-no-subprocess` | Skip spawning `SparkConsole.exe`; keep in-process `SimpleConsole` | `SparkEngine.cpp:345`, parsed `SparkEngineWindows.cpp:1158` |
+| `-minimal-init` | Skip non-essential init (debug/gameplay systems, daemon) to reach the main loop fast | `SparkEngine.cpp:347`, `:1160` |
+| `-threads N` | Cap JobSystem worker threads (`-threads 1` for flaky sandboxes) | `SparkEngineWindows.cpp:126`, `SparkEngineLinux.cpp:139` |
+| `-test-frames N` | Auto-exit after N frames (smoke testing) | `SparkEngine.cpp:323`, `SparkEngineWindows.cpp:102` |
+| `-test-seconds S` | Auto-exit after S seconds | `SparkEngineWindows.cpp:1142` |
+| `-window-size WxH` | Override window dimensions | `SparkEngineLinux.cpp:149` |
+| `-no-jobsystem` | Disable the JobSystem thread pool | `SparkEngineWindows.cpp:1161` |
+
+Headless run for CI/servers:
+
+```powershell
+./SparkEngine.exe -headless -no-subprocess -test-frames 300
+```
+
+## 3. The SparkConsole IPC wiring (concrete)
+
+CLAUDE.md states the rule; here is the actual mechanism, so you can reason about it.
+
+**Roles**
+- `ConsoleProcessManager` (singleton, `SparkEngine/Source/Utils/ConsoleProcessManager.{h,cpp}`)
+  launches `SparkConsole.exe` and owns the stdin/stdout pipe.
+- `SimpleConsole` is only the engine-side in-memory log sink — it does NOT own the pipe.
+- Platform process/pipe details are delegated to `Spark::Process`
+  (`ConsoleProcessManagerWin32.cpp` is intentionally empty — `:6`).
+
+**Initialize — one call site.** `InitConsole()` calls
+`ConsoleProcessManager::GetInstance().Initialize()` at `SparkEngine.cpp:174`, guarded by
+`if (!g_noSubprocess)` (`:171`). `InitConsole()` runs during subsystem init, before module
+loading, so modules can register console commands.
+
+`Initialize()` (`ConsoleProcessManager.cpp:164`):
+- Resolves the console binary by trying, in order (`:198`–`:205`):
+  `SparkConsole.exe`, `<exeDir>/SparkConsole.exe`, `<exeDir>/../SparkConsole/SparkConsole.exe`,
+  `bin/Debug/SparkConsole.exe`, `bin/Release/SparkConsole.exe`, `./SparkConsole.exe`.
+- If **none exist**, it returns `true` anyway with `m_consoleRunning == false` and prints
+  `[ConsoleProcessManager] SparkConsole not found. Using fallback logging.` (`:220`). This
+  is the silent-degrade path — the engine keeps running with no console UI.
+- On success it launches the child with piped stdin+stdout
+  (`Process::Builder(path).CaptureStdin().CaptureStdout().Launch()`, `:299`), sets
+  `m_consoleRunning = true`, and starts a background reader thread `ConsoleThreadMain`.
+
+**Per-frame pump — main-loop call sites (all four verified):**
+
+| Platform / mode | Call site |
+|-----------------|-----------|
+| Windows windowed loop | `SparkEngineWindows.cpp:676` |
+| Windows headless loop | `SparkEngineWindows.cpp:1058` |
+| Linux (two loops) | `SparkEngineLinux.cpp:269`, `:532` |
+
+Each frame the loop runs, inside a `SPARK_GUARDED_UPDATE("Console", …)` block:
+
+```cpp
+Spark::ConsoleProcessManager::GetInstance().ProcessCommands();
+console.Update();
+```
+
+**Protocol / data flow**
+- Background thread `ConsoleThreadMain` (`:347`) loops: `ReadFromConsole()` pulls one
+  line via `Process::TryReadLine` and pushes it onto `m_commandQueue` (`:315`–`:331`);
+  `ProcessQueuedMessages()` drains `m_messageQueue` and writes each as `msg + "\n"` to the
+  child's stdin (`WriteToConsole`, `:333`).
+- `ProcessCommands()` (`:371`, main thread) returns immediately if `!m_consoleRunning`,
+  else swaps out `m_commandQueue` under a mutex and runs each line through
+  `m_commandRegistry->ExecuteCommand`; non-empty results are logged back to the child as
+  `[RESULT] …`.
+- Built-in commands registered in the constructor (`:58`–`:135`): `help`, `quit`,
+  `assert_test`, `assert_mode <on|off>`, and (debug builds only) `crash_test`.
+- Shutdown (`:241`): sets `m_shouldStopThread`, joins the thread, closes the child's stdin
+  to signal EOF, waits 500 ms for exit, then kills if still running. Called from
+  `ShutdownEngine` (`SparkEngine.cpp:272`, `:304`).
+
+## 4. Data and artifact conventions
+
+All of these are **relative to the process working directory** (so where you `cd` before
+launch determines where they land). Run from `build/bin` to keep artifacts out of the
+source tree.
+
+| Artifact | Location / name | Source |
+|----------|-----------------|--------|
+| Crash minidump | `SparkCrash<timestamp>.dmp` (CWD) | prefix set `SparkEngine.cpp:401`; written `CrashHandler.cpp:394` |
+| Crash log | `SparkCrash<timestamp>.log` | `CrashHandler.cpp:395` |
+| Crash screenshot | `SparkCrash<timestamp>.png` | `CrashHandler.cpp:396` |
+| Crash bundle | `SparkCrash<timestamp>.zip` | `CrashHandler.cpp:397` |
+| Assert log | `SparkCrash<timestamp>_assert.log` | `CrashHandler.cpp:1240` |
+| Save files | `Saves/<slot>.spark_save` | `SaveSystem::Initialize("Saves")` `SparkEngineWindows.cpp:583`, default `SaveSystem.h:350` |
+| Screenshots | `Screenshots/` | `ScreenCapture` default dir `ScreenCapture.h:14` |
+| Settings | `settings.ini` (`[CrashReporting]`, `[Graphics]`, `SavesDirectory`, …) | `EngineSettings::Load()` `SparkEngineWindows.cpp:1224` |
+
+Crash reporting reads `[CrashReporting]` from `settings.ini` with env-var overrides:
+`SPARK_GITHUB_REPO`, `SPARK_GITHUB_TOKEN`, `SPARK_CRASH_PROXY_URL`, `SPARK_CRASH_UPLOAD_URL`
+(`SparkEngine.cpp:393`). If `SparkCrashReporter.exe` sits next to the engine exe, the
+crash handler launches it in watchdog mode (`CrashHandler.cpp:224`).
+
+**Known mess (housekeeping):** running from the repo root historically dumped ~1.4 GB of
+stale `SparkCrash_*.dmp` plus loose `Logs*.log` / `ci_*.txt` into the repo root (all
+untracked). See `D:\SparkEngine\HARDEN_FLEET_HANDOFF.md`. Prefer launching from
+`build/bin`, and clear stale untracked dumps before they pile up.
+
+## 5. Troubleshooting: "the console subprocess isn't receiving my commands"
+
+Work down this list — it maps directly to the call sites above.
+
+1. **Was the subprocess even spawned?** If you passed `-no-subprocess`, `Initialize()` is
+   skipped entirely (`SparkEngine.cpp:171`) — there is no child to receive commands, only
+   the in-process `SimpleConsole`. Remove the flag.
+2. **Was `SparkConsole.exe` found?** If none of the search paths (§3) resolve,
+   `Initialize()` degrades silently with `m_consoleRunning == false`. Look for
+   `SparkConsole not found. Using fallback logging.` on stderr. **Fix:** run the engine
+   from `build/bin` where `SparkConsole.exe` is co-located, or copy it next to the engine
+   exe. With `m_consoleRunning == false`, `ProcessCommands()` early-returns at `:373` and
+   nothing is dispatched.
+3. **Did the child die?** `ConsoleThreadMain` sets `m_consoleRunning = false` if the child
+   process is no longer running (`:358`). `IsConsoleRunning()` reflects this. A crashed or
+   exited `SparkConsole.exe` silently disables command intake.
+4. **Is the main loop actually pumping?** Commands are queued by the background thread but
+   only *executed* by `ProcessCommands()` on the main thread (§3). If the engine is not
+   ticking its main loop (stalled during init, wrong mode, or a `SPARK_GUARDED_UPDATE`
+   "Console" guard tripped), the `m_commandQueue` fills but never drains. Confirm the
+   process reached `RunWindowedMainLoop`/the headless loop.
+5. **Is the command registered?** `ProcessCommands` runs each line through
+   `m_commandRegistry->ExecuteCommand`; an unknown command yields whatever
+   `ExecuteCommand` returns for misses. Built-ins are `help`, `quit`, `assert_test`,
+   `assert_mode`, `crash_test` (debug). Game/subsystem commands only exist if the owning
+   module/subsystem registered them (module load happens *after* `InitConsole`, so
+   registration timing matters).
+6. **Startup progress breadcrumbs.** `InitConsole` emits `SPARK_LOG_INFO` markers
+   ("InitConsole: ConsoleProcessManager::Initialize", "InitConsole: complete", etc.,
+   `SparkEngine.cpp:162`–`:210`) via the Logger's stderr sink — visible even when the
+   console UI is absent. Use them to see exactly how far init got.
+
+## When NOT to use this skill / siblings
+
+- Build, CMake, preset, or compiler/link errors → global `cmake-msvc` / `ci-troubleshoot`, not this one.
+- Writing or changing engine C++ (systems, RHI, ECS) → `sparkengine-architecture-contract`.
+- Diagnosing a specific crash's root cause from a dump → `sparkengine-debugging-playbook`; this skill
+  only tells you *where the dump lands* and *how to spawn the crash reporter*.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against the repo at `D:\SparkEngine` (branch `Working`).
+Re-verify volatile facts with:
+
+```powershell
+# Executable/target names
+rg -n "add_executable\(Spark|add_library\(SparkGame\w+ SHARED" CMakeLists.txt SparkEditor/CMakeLists.txt SparkConsole/CMakeLists.txt GameModules
+# Runtime output dir
+rg -n "CMAKE_RUNTIME_OUTPUT_DIRECTORY" CMakeLists.txt
+# Initialize() call site (must stay in InitConsole, guarded by g_noSubprocess)
+rg -n "ConsoleProcessManager::GetInstance\(\).Initialize" SparkEngine/Source/Core/SparkEngine.cpp
+# Per-frame ProcessCommands() call sites (expect 4: 2 Windows, 2 Linux)
+rg -n "ConsoleProcessManager::GetInstance\(\).ProcessCommands" SparkEngine/Source/Core
+# Console binary search paths + early-return guard
+rg -n "searchPaths|m_consoleRunning|SparkConsole not found" SparkEngine/Source/Utils/ConsoleProcessManager.cpp
+# Crash/save/screenshot artifact names
+rg -n "dumpPrefix|Initialize\(\"Saves\"\)|Initialize\(\"Screenshots\"\)" SparkEngine/Source
+# Launch flags
+rg -n "no-subprocess|-headless|-dedicated|-minimal-init|-test-frames|-game " SparkEngine/Source/Core
+```
+
+Lint this skill with the skill-linter under `~/.claude/skills/skill-linter/` (pass
+`-Path .claude/skills/sparkengine-run-and-operate`).

--- a/.claude/skills/sparkengine-serialization-format/SKILL.md
+++ b/.claude/skills/sparkengine-serialization-format/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: sparkengine-serialization-format
+description: The SparkEngine save-game and world-persistence formats — the SaveSystem `.spark_save` binary layout (magic, versioning, per-component string properties) and the AsyncDatabase persistence layer (async future/callback/sync API, shared-connection threading, file-backed key-value fallback). TRIGGER when the user says "add a field to the save file", "why isn't my component saved", "save/load format", "spark_save", "SaveSystem", "quicksave/autosave", "AsyncDatabasePool", "async query", "ProcessCallbacks", "prepared statement", "MMO persistence", "save version / migration", or "database won't persist". DO NOT TRIGGER for scene/entity file serialization or the reflection macros (see sparkengine-reflection-conventions), for AngelScript hot-reload state (see sparkengine-hot-reload-seam), or for network replication wire format.
+trilobite_compatible: true
+trilobite_role: reference
+---
+
+# SparkEngine serialization: save-games and persistence
+
+This skill covers **two distinct persistence subsystems**:
+
+1. **SaveSystem** — full game-state save/load to `.spark_save` files
+   (`SparkEngine/Source/Engine/SaveSystem/`).
+2. **AsyncDatabase** — a thread-pooled key-value persistence layer
+   (`SparkEngine/Source/Engine/Persistence/`), used by e.g. the MMO module for
+   character/inventory storage.
+
+## Scope — what this is NOT
+
+- **Scene/entity `.scene` files and the `SPARK_REFLECT_*` macros** are a
+  different serializer entirely — see **`sparkengine-reflection-conventions`**
+  and `SceneManager/ReflectedSceneSerializer.cpp`. Do not conflate them.
+  (SaveSystem *reuses* the reflection registry to auto-generate serializers for
+  reflected components — that bridge is described below — but the on-disk
+  format, versioning, and API are its own.)
+- Network replication wire format is separate (the `replicated` field attribute
+  lives in the reflection skill).
+
+---
+
+## Part 1 — SaveSystem (`.spark_save`)
+
+### What it does
+
+`SaveSystem` (singleton, `SaveSystem::GetInstance()`) serializes an ECS `World`
+(entities + components + a free-form key/value `customState`) to a **custom,
+uncompressed binary file** per save slot. It is initialized at engine startup
+(`SparkEngineWindows.cpp` calls `SaveSystem::GetInstance().Initialize("Saves")`
+and registers it on `EngineContext` via `SetSaveSystem`). Debug-console commands
+`save_list` and `save_info <slot>` are wired in `EngineConsoleCommands.cpp`.
+
+Public API (all return `bool` success unless noted; **not thread-safe — call
+from the main thread**):
+
+| Method | Purpose |
+| --- | --- |
+| `Initialize(dir = "Saves")` | Create save dir, register all built-in serializers. Call once. |
+| `Save(slot, world, meta)` | Serialize `world` + `meta`, write `<dir>/<slot>.spark_save`. |
+| `Load(slot, world)` | Parse file, **clear `world`**, rebuild entities. |
+| `QuickSave/QuickLoad(world[, meta])` | Uses reserved slot `"__quicksave"`. |
+| `AutoSave(world, meta)` | Rotates slots `"__autosave_0".."__autosave_{N-1}"` (N = `SetMaxAutoSaves`, default 3). |
+| `SaveExists / DeleteSave / GetSaveSlots / GetSaveMetadata` | Slot management + metadata-only reads for UI. |
+| `SerializeWorld(world, meta)` → `SaveData` | In-memory snapshot, no disk I/O (for undo/checkpoint). |
+| `DeserializeWorld(data, world)` → bool | Restore from an in-memory `SaveData` (clears `world` first). |
+
+**Slot-name rules** (`IsValidSlotName`): non-empty, ≤ 64 chars, only
+`[A-Za-z0-9_-]`. Anything else is rejected (returns false / empty path). Do not
+use `__quicksave` or `__autosave_*` for user-facing slots.
+
+### On-disk binary layout (format version 1)
+
+Verified against `WriteToFile` / `ReadFromFile` in `SaveSystem.cpp`. All
+integers are written **raw via `reinterpret_cast` in host byte order** (little-
+endian on all supported x86/x64/ARM64 targets) — saves are **not byte-swapped
+and therefore not portable across opposite-endian machines**.
+
+```
+"SPRK"                     4 bytes  magic (rejected on load if mismatched)
+uint32  version            = data.metadata.version (currently 1)
+uint32  metaSize
+bytes[metaSize]  metadata text block  (newline-delimited, see below)
+uint32  entityCount        (load caps at 1,000,000)
+  repeat entityCount times:
+    uint16  nameLen  + name bytes          (load caps nameLen at 4096)
+    uint16  compCount
+      repeat compCount times:
+        uint16  typeLen + typeName bytes    (load caps typeLen at 4096)
+        uint16  propCount
+          repeat propCount times:
+            uint16 keyLen + key bytes
+            uint16 valLen + value bytes
+uint32  customStateCount   (optional/trailing; load caps at 100,000)
+  repeat: uint16 keyLen+key, uint16 valLen+value
+```
+
+The **metadata text block** is newline/whitespace-delimited, read back in this
+exact order (first 3 via `getline`, rest via `operator>>`):
+`saveName`, `sceneName`, `playerClass`, `timestamp`, `playTime`,
+`playerHealth`, `playerArmor`, `playerPosition.x y z`, `playerKills`,
+`playerDeaths`.
+
+**Writer safety rejections** (a save is *refused*, not silently corrupted, when):
+- any of the first three metadata fields contains an embedded `\n`/`\r` (would
+  desync the `getline` parse on load);
+- any string exceeds `uint16` max (65535) — component/property counts too.
+
+**Atomicity**: writes go to `<path>.tmp` then `std::filesystem::rename` over the
+target, so a crash mid-write cannot corrupt an existing save.
+
+### Versioning and migration
+
+- Current version constant: `kCurrentSaveVersion = 1` (top of `SaveSystem.cpp`).
+- On load: a file with `version > kCurrentSaveVersion` is **rejected** (forward-
+  incompatible). A file with `version < kCurrentSaveVersion` logs a migration
+  message and falls through the **migration hook** in `ReadFromFile`.
+- The migration hook currently has **no actual upgrade branches** — version 1 is
+  the baseline. When you change the layout, bump `kCurrentSaveVersion` and add a
+  `if (version < N)` branch that fixes up the parsed fields.
+
+### How components get saved — the two-step rule (important gotcha)
+
+A component type participates in save/load only if **both** hold:
+
+1. **A serializer is registered** for its type-name string, via one of:
+   - a hand-written pair in `RegisterCoreSerializers` /
+     `RegisterPhysicsSerializers` / `RegisterGameplaySerializers`
+     (`ComponentSerializerRegistry::Register(name, serializeFn, deserializeFn)`),
+     where each field is encoded as a **string property** (e.g. Transform writes
+     `px/py/pz`, `rx/ry/rz`, `sx/sy/sz` via `std::to_string`); **or**
+   - **auto-generated** by `RegisterReflectedSerializers()` — for every type in
+     `ComponentFactory::GetRegisteredNames()` that has reflected fields and no
+     hand-written serializer, it builds lambdas using `GetFieldAsString` /
+     `SetFieldFromString` keyed by the C++ member name. (This is the reflection
+     bridge; see `sparkengine-reflection-conventions` for how to reflect a type.)
+   All of the above run from `RegisterBuiltins()`, called by `Initialize()`.
+
+2. **The type is walked at save time.** `SaveSystem::SerializeWorld` iterates a
+   **hard-coded list** of `TrySerialize<T>(...)` calls (Transform, MeshRenderer,
+   HealthComponent, LightComponent, AudioSourceComponent, Camera, Script,
+   RigidBodyComponent, ColliderComponent, ParticleEmitterComponent,
+   AnimationController, NetworkIdentity, TagComponent, ActiveComponent — plus
+   `NameComponent` for the entity name).
+
+> **Consequence:** registering a serializer (even via reflection) is **not
+> enough**. If your new component type is not in the `SerializeWorld`
+> `TrySerialize<>` list, it is **silently never written to the save**. To add a
+> savable component you must add both the serializer *and* a
+> `TrySerialize<YourType>(world, entity, serializerRegistry, "YourType", se.components);`
+> line in `SaveSystem::SerializeWorld`.
+
+Load is symmetric: `DeserializeWorld` reads each component's `typeName` and
+dispatches to the registered deserializer (unknown type-names are skipped).
+Deserializers use `SafeGetFloat/SafeGetUint32/SafeGetString` helpers that
+default missing/oversized values rather than throwing.
+
+### `customState` is effectively unused via the public API (observation)
+
+The format reserves a trailing `customState` key/value block, but
+`SerializeWorld` **never populates it**, and `WriteToFile` is private. So through
+the public `Save()` path `customState` is always empty on disk. To use it you
+would need to construct a `SaveData` and write it yourself (no public writer
+exists today). Treat the `SaveData::customState` field as a reserved,
+not-yet-wired data slot, not a working feature. (`open`)
+
+### Stale in-code documentation to ignore (verified mismatches)
+
+These doc-comments contradict the actual code — trust the code:
+
+| Says | Reality |
+| --- | --- |
+| `SaveSystem.cpp` file header: "JSON serialization"; `SaveSystemTypes.h`: "JSON representation on disk", `SerializedComponent` shows a JSON example | Format is the **custom binary** layout above. No JSON is written. |
+| `SaveMetadata` doxygen: "compressed save file", "decompressing" | Files are **uncompressed**. |
+| `SaveSystem.h`: console commands `save list` / `save info` | Actual command names are `save_list` / `save_info` (underscores). |
+
+---
+
+## Part 2 — AsyncDatabase (`Spark::Persistence`)
+
+### What it is (and what the backend really is)
+
+`AsyncDatabasePool` is a thread-pool persistence layer (TrinityCore-inspired:
+`DatabaseWorkerPool`→pool, `PreparedStatement`→prepared-query-by-ID, results via
+`std::future` or callback). The header comment says "Uses SQLite by default" —
+but **the only `IDatabaseConnection` implementation is `SQLiteConnection`, which
+is a file-backed key-value store, not real SQLite / not real SQL.** It persists
+as tab-separated `key\tvalue\n` lines and understands only four command verbs via
+`ExecuteRaw`:
+
+| Command (case-insensitive) | Effect |
+| --- | --- |
+| `SET <key> <value…>` | Store value (rest of line, verbatim incl. newlines). Flushes to disk immediately unless in a transaction. |
+| `GET <key>` | Returns 1 row, 1 column (the value) if present. |
+| `DELETE <key>` | Remove key. Immediate flush if it removed something. |
+| `KEYS [prefix]` | Return all keys (optionally prefix-filtered), one row each. |
+
+Any other verb → `success = false`, `errorMessage = "Unsupported command…"`.
+
+### Prepared statements and parameter substitution
+
+- Register SQL by ID: `PrepareStatement(id, sql)` (may be called before or after
+  `Open`; call before issuing queries).
+- Parameters are referenced in the SQL string as **`?N` — zero-indexed**
+  (`?0`, `?1`, …), substituted left-to-right in a single pass by
+  `SQLiteConnection::Execute`. String params are single-quote-escaped (`'`→`''`).
+  A `?N` with no matching bound param is emitted **verbatim**. Multi-digit
+  indices work (`?10` is distinct from `?1` — this is a fixed regression, covered
+  by `TestAsyncDatabaseRegressions.cpp`).
+- Bind params by index with `PreparedStatementData::SetInt/SetDouble/SetString/
+  SetNull`, or pass a `std::vector<PreparedStatementParam>` directly to the query
+  calls.
+
+### The three ways to run a query and get results
+
+| Call | Returns result via | Threading |
+| --- | --- | --- |
+| `AsyncQuery(id, params)` | `std::future<QueryResult>` — call `.get()` (blocks) or poll | Runs on a worker thread. A query that throws sets the future's exception (rethrown on `.get()`). |
+| `AsyncQueryWithCallback(id, params, cb)` | `cb(QueryResult)` dispatched **on the main thread** | You **must call `ProcessCallbacks()` once per frame** on the main loop or callbacks never fire. On exception, `cb` gets `success=false, errorMessage="Query threw exception"`. |
+| `SyncQuery(id, params)` | `QueryResult` directly | Blocks the calling thread. Returns a failure result if the pool is closed. |
+| `AsyncTransaction(tx)` | `std::future<QueryResult>` | Atomic batch (all-or-nothing): begins a transaction, runs each query, commits on success / rolls back on first failure. |
+
+`QueryResult` fields: `success`, `errorMessage`, `rows` (`vector<QueryRow>`),
+`affectedRows`, `lastInsertId`. `QueryRow::GetInt/GetDouble/GetString/IsNull(col)`
+are bounds-checked and log + return a default on type/range mismatch (they do
+**not** throw, despite the header doc-comment claiming `std::bad_variant_access`).
+
+### Threading model — one shared connection, not one-per-worker
+
+The header says "Each worker thread owns a dedicated database connection." **The
+implementation deliberately does the opposite:** `Open()` creates a *single*
+`m_syncConnection` and leaves the per-worker `m_connections` vector empty; every
+query — async worker *and* `SyncQuery` — executes through that one connection
+under `m_syncMutex`. This is intentional (in-code comment explains it): the
+file-backed store keeps data in memory, so independent per-worker connections
+would each hold a divergent copy and the last flush on `Close` would clobber the
+others. **Net effect: all DB operations are fully serialized;** the worker pool
+exists to service the async future/callback API, not to parallelize DB access.
+
+- `AsyncDatabasePool` is **non-copyable and non-movable**.
+- Lifecycle: `Open(connStr, poolSize=2)` → issue queries → `Close()` (joins
+  workers, flushes, closes). Destructor calls `Close()` if still open.
+- Transactions in the fallback store: `BeginTransaction` snapshots the map;
+  `Commit` flushes; `Rollback` restores the snapshot. Non-transactional
+  `SET`/`DELETE` flush immediately.
+
+### Primary real-world consumer
+
+`GameModules/SparkGameMMO/Source/Persistence/MMOPersistenceSystem.cpp` owns an
+`AsyncDatabasePool`, prepares ~30 statements (characters, inventory, currency,
+reputation, achievements, crafting, guilds, lockouts, boss kills), and calls
+`m_db->ProcessCallbacks()` each tick. Use it as the reference integration
+example.
+
+---
+
+## Open items and candidates (do not assert as fixed)
+
+- **`%N` vs `?N` parameter-token mismatch (candidate / needs investigation).**
+  `SQLiteConnection::Execute` substitutes **`?N` (0-indexed)** — that is the only
+  parameter syntax it understands. But `MMOPersistenceSystem.cpp` prepares its
+  statements with **`%1`/`%2`… (`%N`, 1-indexed)** tokens (e.g.
+  `"SET character_%1 %2|1|0|…"`). Those `%N` tokens are **not** what `Execute`
+  substitutes, so on the engine code path they would pass through verbatim. This
+  looks like a real latent bug (all characters could collide on a literal
+  `character_%1` key), **but I did not fully trace the MMO runtime path** to
+  confirm impact or find a manual substitution step. Verify before relying on MMO
+  persistence, and before "fixing" either side. (`candidate`)
+- **Test coverage — mock vs real (as of 2026-07-07).** The `HARDEN_FLEET_HANDOFF`
+  item asking for "real (non-mock) AsyncDatabase … tests" is **partly
+  addressed**:
+
+  | Test file | Exercises real code? |
+  | --- | --- |
+  | `Tests/TestAsyncDatabase.cpp` | **No — mock.** Standalone reimplementation of `QueryRow/QueryResult/PreparedStatementData/Transaction` in an anon namespace; never links the real types. |
+  | `Tests/TestSaveSystem.cpp` | **No — mock.** Uses a local `TestBuffer`; does not touch `SaveSystem`. |
+  | `Tests/TestAsyncDatabaseRegressions.cpp` | **Yes** — real `SQLiteConnection` (synchronous). |
+  | `Tests/harden/Test_persistence_AsyncDatabasePool.cpp` | **Yes** — real `AsyncDatabasePool` incl. worker threads, async↔sync visibility, close/reopen. |
+  | `Tests/harden/Test_persistence_AsyncDatabaseParams.cpp` | Registered in `Tests/CMakeLists.txt` as a real-path test (body not inspected here). |
+  | `Tests/harden/Test_persistence_SaveSystem.cpp` | **Yes but narrow** — only `GetSaveMetadata` via hand-crafted binary files. |
+
+- **No full Save/Load round-trip test (gap).** Nothing exercises
+  `SerializeWorld`→`WriteToFile`→`ReadFromFile`→`DeserializeWorld` against a real
+  ECS `World`. The `SerializeWorld` fixed-`TrySerialize`-list gotcha above is
+  therefore not guarded by a test. (`open`)
+
+---
+
+## Provenance and maintenance
+
+Verified by reading the following on **2026-07-07** (branch `Working`, tip
+`710f797e`):
+`SparkEngine/Source/Engine/SaveSystem/SaveSystem.{h,cpp}`,
+`SaveSystemTypes.h`,
+`SparkEngine/Source/Engine/Persistence/AsyncDatabase.{h,cpp}`,
+`GameModules/SparkGameMMO/Source/Persistence/MMOPersistenceSystem.cpp`,
+`SparkEngine/Source/Core/EngineConsoleCommands.cpp`,
+`SparkEngine/Source/Core/SparkEngineWindows.cpp`, and the test files listed above.
+
+Re-verification one-liners (run from repo root):
+
+- Current save format version:
+  `grep -n "kCurrentSaveVersion" SparkEngine/Source/Engine/SaveSystem/SaveSystem.cpp`
+- The hard-coded save component walk (the two-step-rule list):
+  `grep -n "TrySerialize<" SparkEngine/Source/Engine/SaveSystem/SaveSystem.cpp`
+- Confirm the shared-connection threading model persists:
+  `grep -n "m_syncConnection\|m_syncMutex" SparkEngine/Source/Engine/Persistence/AsyncDatabase.cpp`
+- Parameter-token syntax (`?N`) in the DB layer vs `%N` in MMO:
+  `grep -n "'?'" SparkEngine/Source/Engine/Persistence/AsyncDatabase.cpp` and
+  `grep -n "%1\|%2" GameModules/SparkGameMMO/Source/Persistence/MMOPersistenceSystem.cpp`
+- Which persistence tests are mocks vs real:
+  `grep -rn "Standalone reimplementation\|using namespace Spark::Persistence" Tests/`
+- Lint this skill with the repo/global skill-linter (see the global CLAUDE.md
+  "Skill validation" note for the exact invocation).

--- a/.claude/skills/sparkengine-shader-compiler-internals/SKILL.md
+++ b/.claude/skills/sparkengine-shader-compiler-internals/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: sparkengine-shader-compiler-internals
+description: >-
+  Architecture and internals of SparkShaderCompiler, SparkEngine's in-house
+  offline shader-compilation CLI tool (SparkShaderCompiler/src/main.cpp).
+  Covers what input languages it accepts (HLSL and GLSL, SPIR-V passthrough),
+  its CLI flags, the RHI CompileShader pipeline stages, output artifacts
+  (.cso / .spv / .glsl) and where they land, filename-based stage inference,
+  and how to add a new backend/stage or extend the tool. TRIGGER when the user
+  asks "how does the shader compiler tool work", "how do I run
+  SparkShaderCompiler", "what flags does the shader compiler take", "how do I
+  batch-compile shaders", "where do compiled shaders go", "how do I add a new
+  shader stage/backend to the compiler", or "why is my .cso just HLSL text".
+  DO NOT TRIGGER for runtime shader debugging (why a shader renders wrong,
+  pixel/HLSL debugging) — use the global shader-debug skill instead.
+trilobite_compatible: true
+trilobite_role: reference
+---
+
+# SparkShaderCompiler internals
+
+`SparkShaderCompiler` is SparkEngine's **standalone offline shader-compilation
+CLI tool**. It is a thin command-line front-end over the engine's RHI (Render
+Hardware Interface — the multi-API graphics abstraction) cross-compilation
+functions. This skill documents the *tool's own architecture*: its inputs,
+CLI, pipeline stages, output format, and how to extend it.
+
+Everything here is verified against source as of **2026-07-07**. See
+`## Provenance and maintenance` for re-verification commands.
+
+## When to use this skill / when NOT to
+
+| Use this skill for | Use something else |
+|---|---|
+| "How do I invoke `SparkShaderCompiler`?" | Runtime "my shader looks wrong" -> global `shader-debug` skill |
+| "What input languages / flags does it accept?" | Pixel/HLSL step-through debugging -> `shader-debug` |
+| "Where do compiled artifacts go?" | The engine's *runtime* shader loader (`Shader.h`) -> read that header directly |
+| "How do I add a stage/backend to the tool?" | The **Slang** compiler interface (`SlangShaderInterface.h`) — a *separate*, parallel system NOT used by this tool |
+
+**Critical scope note:** this tool does **not** use `SlangShaderInterface.h`.
+Slang is a separate, target-agnostic compiler interface in the engine. The CLI
+tool routes exclusively through `Spark::RHI::CompileShader` (see below).
+
+## The two load-bearing files
+
+| File | Role |
+|---|---|
+| `SparkShaderCompiler/src/main.cpp` | The entire CLI tool: arg parsing, stage inference, single + batch compile loops. ~578 lines, one translation unit. |
+| `SparkEngine/Source/Graphics/RHI/RHIFactory.{h,cpp}` | Defines `ShaderCompileOptions`, `ShaderCompileResult`, `CompileShader()`, `SaveCompiledShader()`, `ReflectSPIRV()`, `GetShaderExtension()`. **This is where the real work is delegated.** |
+
+The tool builds *only* `main.cpp` plus a hand-picked list of RHI `.cpp` files
+(see `SparkShaderCompiler/CMakeLists.txt`) — it does not link the whole engine.
+
+## CLI reference (verified against `main.cpp` PrintUsage + ParseArgs)
+
+```
+SparkShaderCompiler <input> [options]
+```
+
+| Flag | Meaning | Default |
+|---|---|---|
+| `-o <path>` | Output file path (in `-batch` mode, an output **directory**) | inferred from input name + backend |
+| `-stage <stage>` | Shader stage (see table below) | inferred from filename |
+| `-backend <api>` | `d3d11` / `d3d12` / `vulkan` / `opengl` / `auto` | `auto` |
+| `-entry <name>` | Entry-point function name | `main` |
+| `-D<DEFINE>` | Add a preprocessor define (no space: `-DFOO=1`) | — |
+| `-I<path>` | Add an include search path (no space: `-IShaders/inc`) | — |
+| `-O` | Enable optimization | on |
+| `-Od` | Disable optimization | — |
+| `-Zi` | Enable debug info | off |
+| `-validate` | Compile but do **not** write output | off |
+| `-reflect` | Print shader reflection data (see caveat) | off |
+| `-batch <dir>` | Recursively compile every shader file under `<dir>` | — |
+| `-v` | Verbose (prints stage/backend/entry/timing) | off |
+| `-h`, `--help` | Print usage and exit | — |
+
+Backend aliases accepted by `ParseBackend`: `dx11`=`d3d11`, `dx12`=`d3d12`,
+`vk`=`vulkan`, `gl`=`opengl`. Unknown backend -> warns, falls back to `auto`.
+
+### Stage names (verified in `ParseStage`)
+
+Each stage has aliases. Unknown stage -> warns, defaults to `vertex`.
+
+| Canonical | Aliases |
+|---|---|
+| `vertex` | `vert`, `vs` |
+| `pixel` | `frag`, `ps` |
+| `geometry` | `geom`, `gs` |
+| `hull` | `hs` |
+| `domain` | `ds` |
+| `compute` | `cs` |
+| `raygen` | `rgen`, `raygeneration` |
+| `closesthit` | `rchit`, `chs` |
+| `miss` | `rmiss` |
+| `anyhit` | `rahit` |
+| `intersection` | `rint` |
+| `callable` | `rcall` |
+
+### Examples (from the tool's own `--help`, paths verified to exist)
+
+```bash
+# Single file, explicit stage + backend, explicit output
+SparkShaderCompiler Shaders/HLSL/BasicVS.hlsl -stage vertex -backend d3d11 -o BasicVS.cso
+
+# Pixel shader to a Vulkan target
+SparkShaderCompiler Shaders/HLSL/BasicPS.hlsl -stage pixel -backend vulkan -o BasicPS.spv
+
+# Validate only (no output written)
+SparkShaderCompiler Shaders/HLSL/BasicVS.hlsl -backend opengl -validate
+
+# Batch-compile a whole directory for one backend
+SparkShaderCompiler -batch Shaders/HLSL -backend vulkan
+```
+
+Real sample shaders live in `Shaders/HLSL/` (e.g. `BasicVS.hlsl`,
+`BasicPS.hlsl`, `Compute/GPUCull.hlsl`).
+
+## Pipeline: what actually happens on `CompileSingleShader`
+
+1. **Arg parse** (`ParseArgs`) builds a `CompilerConfig`.
+2. **Stage inference** (`InferStageFromFilename`) if `-stage` was not given —
+   see the inference rules below.
+3. Config is copied into a `Spark::RHI::ShaderCompileOptions` struct.
+4. `Spark::RHI::CompileShader(options)` does the real work
+   (`RHIFactory.cpp`):
+   - **Source language** is auto-detected from extension: `.hlsl`/`.fx` -> HLSL,
+     `.glsl`/`.vert`/`.frag` -> GLSL, `.spv` -> SPIR-V. Default HLSL.
+   - **Target language** is derived from `-backend`: D3D11/D3D12 -> HLSL,
+     Vulkan -> SPIR-V, OpenGL -> GLSL. Unknown backend -> passthrough
+     (target = source).
+   - The source file is read from disk (binary).
+   - It then dispatches on the (source -> target) pair (see the truth table).
+5. On success, unless `-validate`, the bytecode is written with
+   `Spark::RHI::SaveCompiledShader` (a raw binary `ofstream` write).
+6. Output path, if `-o` omitted, comes from `InferOutputPath`.
+
+### Output artifact naming (`InferOutputPath`)
+
+| Backend | Extension |
+|---|---|
+| Vulkan | `.spv` |
+| D3D11 / D3D12 | `.cso` |
+| OpenGL / other | `GetShaderExtension(backend)` -> `.glsl` (D3D fallback `.hlsl`) |
+
+The output is written to **wherever `-o` points, or next to the input file**
+(same directory, extension swapped). The tool has **no built-in default asset
+directory** — it writes relative to CWD / the input path. (The `bin/Shaders`
+directory you may see under `build/` is populated by the CMake build, not by
+this tool.)
+
+### Filename-based stage inference (`InferStageFromFilename`)
+
+Used when `-stage` is omitted, and always in `-batch` mode. Non-obvious
+conventions worth knowing:
+
+- The **bare stem** (no dir, no extension) is examined, lowercased.
+- Distinctive full words match **anywhere** in the stem: `vert`, `frag`,
+  `pixel`, `geom`, `hull`, `domain`, `compute`, `raygen`, `closesthit`, etc.
+- The **two-letter codes** (`vs`/`ps`/`gs`/`hs`/`ds`/`cs`) are deliberately
+  restrictive to avoid false hits (e.g. "Physics" contains "cs"). They match
+  **only** as an uppercase suffix in the original name (`BasicPS`) or as a
+  whole `_`/`-` delimited final token (`blur_cs`).
+- No match -> defaults to **Vertex**.
+
+So `BasicPS.hlsl` -> Pixel, `blur_cs.hlsl` -> Compute, but `Physics.hlsl` -> Vertex.
+
+## Truth table — what compiles vs. what is a stub (VERIFY-DO-NOT-OVERSELL)
+
+The RHI layer these functions live in is **partly a shim**. Do not assume the
+tool produces real GPU bytecode for every backend. Verified in
+`RHIFactory.cpp`:
+
+| Source -> Target | Behaviour | Real? |
+|---|---|---|
+| HLSL -> HLSL (D3D11/D3D12 target) | **Passthrough**: source text copied verbatim into the output bytes | NO — the `.cso` is literally the HLSL **text**, not compiled DXBC/DXIL |
+| GLSL -> GLSL (OpenGL, matching) | Passthrough: source copied verbatim | (text copy) |
+| HLSL -> GLSL (OpenGL target) | Naive keyword substitution (`float4`->`vec4`, `lerp`->`mix`, `SV_Position`->`gl_Position`, ...) | Partial — simple shaders only; `mul()`/`clip()` left as comment markers |
+| HLSL -> SPIR-V (Vulkan target) | `CrossCompileHLSLtoSPIRV` logs "DXC not integrated" and returns **empty** -> compile **fails** | NO — DXC (`dxcompiler.dll`) not linked |
+| GLSL -> SPIR-V (Vulkan target) | `CompileGLSLtoSPIRV` logs "glslang not integrated" and returns **empty** -> compile **fails** | NO — glslang not linked |
+
+Consequences you must communicate to users:
+
+- **`-backend vulkan` currently fails** for HLSL/GLSL inputs (empty bytecode)
+  until DXC / glslang are integrated at build time.
+- A `.cso` produced by this tool for a D3D backend is **HLSL source text**, not
+  a compiled D3D blob. Anything downstream expecting real DXBC must not assume
+  this tool produced it.
+- `-reflect` runs `ReflectSPIRV`, which only checks the SPIR-V magic number
+  (`0x07230203`) and then logs "SPIRV-Reflect not integrated" and returns
+  **empty** reflection. So `-reflect` prints `Inputs: 0 / Resources: 0`
+  regardless of shader content.
+
+These are labelled in-source as intentional integration points ("Link
+dxcompiler.dll to enable" / "Link glslang to enable"), i.e. **candidate**
+future work — not bugs to file.
+
+## Batch mode specifics (`main`)
+
+- Recurses `-batch <dir>` with `recursive_directory_iterator`.
+- Recognised extensions: `.hlsl .glsl .vert .frag .comp .geom .tesc .tese .vs
+  .ps .gs .cs .rgen .rmiss .rchit .rahit .rint .rcall` (case-insensitive).
+- Each file's stage is re-inferred from its filename (ignores any `-stage`).
+- With `-o <dir>`, that directory is `create_directories`'d up front and each
+  output lands inside it (input basename, extension swapped).
+- Prints a `=== Batch Compilation Summary ===` with total/success/failed/time;
+  process exit code is `1` if any file failed, else `0`.
+
+Exit codes: single-file success `0`, failure `1`; bad args -> `1`.
+
+## Building the tool
+
+Target name is `SparkShaderCompiler`; it builds as part of the normal CMake
+configure (its `CMakeLists.txt` is picked up by the top-level build).
+
+```bash
+# Configure (pick your preset — see CLAUDE.md build section)
+cmake --preset windows-release      # or linux-gcc-release, etc.
+
+# Build just this tool
+cmake --build build --config Release --target SparkShaderCompiler
+```
+
+Output binary lands in `${CMAKE_BINARY_DIR}/bin` (set via
+`RUNTIME_OUTPUT_DIRECTORY`; IDE folder "Tools").
+
+**What the tool links** (from `CMakeLists.txt`) — it does NOT link the whole
+engine, only:
+`RHIFactory.cpp`, `DebugHookManager.cpp`, `Logger.cpp`, `WineDetection.cpp`,
+plus backend device `.cpp`s guarded by platform/availability:
+- Windows: `D3D11Device.cpp` always; `D3D12Device.cpp` + `D3D12CommandList.cpp`
+  only when **not** MinGW (MinGW's `d3d12.h` is too old -> `SPARK_NO_D3D12`).
+- `SPARK_VULKAN_AVAILABLE` -> Vulkan device sources.
+- `SPARK_OPENGL_AVAILABLE` -> OpenGL device source.
+
+Windows link libs: `d3d11 dxgi dxguid d3dcompiler dbghelp` (+ `d3d12 opengl32`
+when not MinGW). `WineDetection.cpp` is a **hard** dependency because
+`GetRecommendedBackend()` calls `IsRunningUnderGvisor()` to pick NullRHIDevice.
+
+## How to extend the tool
+
+Because the CLI is one file, most extensions are local edits to `main.cpp`.
+
+**Add a new CLI stage alias:** edit `ParseStage` (add the string), and if it is
+a new *engine* stage also add it to `RHIShaderStage` in
+`SparkEngine/Source/Graphics/RHI/RHITypes.h`, plus `StageToString` and the
+`InferStageFromFilename` rules in `main.cpp`.
+
+**Add a new backend to the CLI:** edit `ParseBackend` (accept the string) and
+`GraphicsBackend` in `RHITypes.h`. Then wire the real behaviour in
+`RHIFactory.cpp`'s `CompileShader` target-language switch, `InferOutputPath`,
+and `GetShaderExtension`. Add the backend's device `.cpp` to
+`SparkShaderCompiler/CMakeLists.txt` under the appropriate `if()` guard.
+
+**Enable real SPIR-V / DXBC output:** integrate DXC (`dxcompiler.dll`, via
+`IDxcCompiler3`) into `CrossCompileHLSLtoSPIRV`, and glslang into
+`CompileGLSLtoSPIRV`, then link the libs in the CLI's `CMakeLists.txt`. These
+are the two documented integration seams. This is **candidate** work — do not
+claim the tool emits real SPIR-V until those are wired.
+
+**Add a new shader (asset, not tool code):** drop the `.hlsl`/`.glsl` under
+`Shaders/` following the naming convention so stage inference works
+(`*VS`/`*PS`/`*_cs`, or a distinctive word like `Compute`). Then compile via
+the CLI, or rely on the engine's runtime shader path (`Shader.h`) — that runtime
+path is out of scope here (see the `shader-debug` skill for runtime concerns).
+
+## Related but distinct systems (do not confuse)
+
+- `SparkEngine/Source/Graphics/ShaderCrossCompiler.h` — an **in-engine**,
+  cache-backed cross-compile manager (`ShaderTarget` DXIL/DXBC/SPIRV/GLSL/MSL/
+  WGSL). Its `CompileToDXBC/SPIRV/...` methods are currently stubs returning
+  `success=true` with empty bytecode. The **CLI tool does not use this class** —
+  it calls the free functions in `RHIFactory`. Header notes it "may be
+  superseded by `SlangShaderInterface.h`" (open decision).
+- `SparkEngine/Source/Graphics/SlangShaderInterface.h` — a separate
+  target-agnostic **Slang** compiler interface (DXIL/SPIRV/MSL/HLSL/CUDA/WGSL).
+  Also not used by the CLI tool.
+
+## Provenance and maintenance
+
+Verified 2026-07-07 against SparkEngine `Working` branch. Re-verify with:
+
+```bash
+# CLI flags, stage/backend parsers, batch logic
+sed -n '69,255p' SparkShaderCompiler/src/main.cpp
+
+# The real compile delegate + stub warnings (DXC/glslang not integrated)
+grep -n 'not integrated\|passthrough\|GetShaderExtension\|SaveCompiledShader' \
+  SparkEngine/Source/Graphics/RHI/RHIFactory.cpp
+
+# What the tool links / build guards
+sed -n '13,122p' SparkShaderCompiler/CMakeLists.txt
+
+# Enum ground truth (stages, backends, languages)
+grep -n 'enum class GraphicsBackend\|enum class RHIShaderStage\|enum class ShaderLanguage' \
+  SparkEngine/Source/Graphics/RHI/RHITypes.h
+
+# Confirm sample shaders still live here
+ls Shaders/HLSL/BasicVS.hlsl Shaders/HLSL/BasicPS.hlsl
+```
+
+If DXC or glslang get integrated (the two `"not integrated"` warnings in
+`RHIFactory.cpp` disappear), update the truth table above — the "currently
+fails for Vulkan" and "`.cso` is text" caveats will no longer hold.
+
+Lint this file with the global skill-linter (see
+`~/.claude/skills/skill-linter/`), passing `-Path` pointing at this skill's
+folder `.claude/skills/sparkengine-shader-compiler-internals`.


### PR DESCRIPTION
Fable-5 skill-forge run: distill SparkEngine's non-obvious subsystem conventions into a project-local .claude/skills/ library so Sonnet-class models can debug/extend the engine after top-tier models retire.

14 SparkEngine-specific skills (SKILL.md each), all lint-clean:
- reflection-conventions, ecs-query-patterns, job-system-threading, custom-allocator, plugin-abi, hot-reload-seam, serialization-format, asset-pipeline, shader-compiler-internals (subsystem references)
- architecture-contract, config-and-flags, run-and-operate (contracts/ops)
- debugging-playbook, failure-archaeology (triage + chronology)
- module-injection-p0-campaign (decision-gated finish-the-P0 runbook)

Each authored ground-truth-verified against the repo, then run through the 3-reviewer (factual/doctrine/usability) + fixer pipeline. Review caught and corrected stale HARDEN_FLEET_HANDOFF-derived claims: the EngineContext module-injection P0 DLL export has in fact LANDED (ModuleDllMain.h:88, commit 52636dda) and the ECS executor reality (StageBasedExecutor exists + ticks dead; PhaseSystemManager defined but unwired) is now stated consistently across all skills.

Registry convention: repo has no central skill/agent registry, so each SKILL.md carries trilobite_compatible: true + a trilobite_role tag for fleet enlistment. Engine source untouched (read-only inspection only).


Claude-Session: https://claude.ai/code/session_01RR5epyxEbBXHGUKe2KWaWW